### PR TITLE
feat: expose the raw cluster configuration for debugging

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -29,6 +29,8 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationJsonSerializer;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
@@ -59,7 +61,9 @@ import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -134,6 +138,51 @@ public class ClusterEndpoint {
   public ResponseEntity<?> listConfigurationChanges() {
     try {
       return withCurrentConfiguration(ClusterApiUtils::mapConfigurationChangesResponse);
+    } catch (final Exception error) {
+      return ClusterApiUtils.mapError(error);
+    }
+  }
+
+  /**
+   * Dumps the configuration the cluster gossips and persists, bypassing the mapping to the
+   * published API types that every other endpoint here applies. Meant for debugging: when a
+   * response from those endpoints looks wrong, this shows whether the configuration or the mapping
+   * is at fault.
+   *
+   * <p>The shape is the configuration model's own, so it changes whenever the model does.
+   * Deliberately absent from {@code api/cluster/cluster-api.yaml} for that reason: a debugging aid
+   * rather than a contract.
+   */
+  @GetMapping(path = "/dump", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> dumpConfigurationAsJson() {
+    try {
+      return withCurrentConfiguration(
+          configuration ->
+              ResponseEntity.ok()
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .body(ClusterConfigurationJsonSerializer.toJson(configuration)));
+    } catch (final Exception error) {
+      return ClusterApiUtils.mapError(error);
+    }
+  }
+
+  /**
+   * The same configuration as {@link #dumpConfigurationAsJson()}, in the binary protobuf encoding
+   * the cluster actually gossips and persists. Decodable with {@code protoc --decode
+   * topology_protocol.CurrentClusterConfiguration}.
+   */
+  @GetMapping(path = "/dump", produces = MediaType.APPLICATION_PROTOBUF_VALUE)
+  public ResponseEntity<?> dumpConfigurationAsProtobuf() {
+    try {
+      return withCurrentConfiguration(
+          configuration ->
+              ResponseEntity.ok()
+                  .contentType(MediaType.APPLICATION_PROTOBUF)
+                  // Keeps a bare `curl` from spraying binary into the terminal, and makes
+                  // `curl -OJ` write a file instead.
+                  .header(
+                      HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"cluster-config.pb\"")
+                  .body(new ProtoBufSerializer().encodeCurrentClusterConfiguration(configuration)));
     } catch (final Exception error) {
       return ClusterApiUtils.mapError(error);
     }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationJsonSerializer;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -45,8 +47,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 
 final class ClusterEndpointTest {
 
@@ -417,6 +421,73 @@ final class ClusterEndpointTest {
       assertThat(body).isNotNull();
       assertThat(body.getChanges()).extracting(ConfigurationChange::getId).containsExactly(2L);
       verify(sender).getTopology();
+    }
+  }
+
+  @Nested
+  class DumpEndpoint {
+
+    @Test
+    void shouldDumpTheConfigurationAsJson() {
+      // given
+      final var configuration = configuration();
+      final var endpoint = new ClusterEndpoint(senderReturning(configuration));
+
+      // when
+      final var response = endpoint.dumpConfigurationAsJson();
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+      assertThat(response.getBody())
+          .asInstanceOf(InstanceOfAssertFactories.STRING)
+          .isEqualTo(ClusterConfigurationJsonSerializer.toJson(configuration));
+    }
+
+    @Test
+    void shouldDumpTheSameConfigurationAsProtobuf() {
+      // given
+      final var configuration = configuration();
+      final var endpoint = new ClusterEndpoint(senderReturning(configuration));
+
+      // when
+      final var response = endpoint.dumpConfigurationAsProtobuf();
+
+      // then — the two encodings describe the same configuration, which is the point of deriving
+      // both from the schema the cluster itself uses
+      assertThat(response.getStatusCode().value()).isEqualTo(200);
+      assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_PROTOBUF);
+      assertThat(response.getBody())
+          .isEqualTo(new ProtoBufSerializer().encodeCurrentClusterConfiguration(configuration));
+    }
+
+    @Test
+    void shouldOfferProtobufAsAnAttachment() {
+      // given — a bare curl would otherwise write binary straight to the terminal
+      final var endpoint = new ClusterEndpoint(senderReturning(configuration()));
+
+      // when
+      final var response = endpoint.dumpConfigurationAsProtobuf();
+
+      // then
+      assertThat(response.getHeaders().getContentDisposition().isAttachment()).isTrue();
+    }
+
+    private CurrentClusterConfiguration configuration() {
+      return CurrentClusterConfiguration.fromLegacy(
+          ClusterConfiguration.init()
+              .addMember(
+                  MemberId.from("0"),
+                  MemberState.initializeAsActive(
+                      Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))));
+    }
+
+    private ClusterConfigurationManagementRequestSender senderReturning(
+        final CurrentClusterConfiguration configuration) {
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      when(sender.getTopology())
+          .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
+      return sender;
     }
   }
 

--- a/docs/zeebe/dynamic_scaling.md
+++ b/docs/zeebe/dynamic_scaling.md
@@ -207,6 +207,49 @@ When the first partition asks for a *snapshot for bootstrap*, on partition 1 the
 - Global state (process definitions, decisions, forms) marked with `ColumnFamilyScope.GLOBAL` is automatically included in new partitions
 - Partition-specific state (process instances, jobs, message subscriptions) remains on original partitions until the relocation phase is implemented
 
+### Dumping the raw configuration
+
+Every other `/actuator/cluster` endpoint maps `CurrentClusterConfiguration` onto the published API
+types before answering. When a response looks wrong, that mapping is as likely a suspect as the
+configuration itself, so `/actuator/cluster/dump` skips it and serializes the in-memory model
+directly:
+
+```bash
+curl -s 'http://localhost:9600/actuator/cluster/dump' | jq
+```
+
+The document is the model: record components and nothing else, so derived helpers like
+`clusterSize()` or `isUninitialized()` do not appear. Records that share the same components —
+`PartitionJoinOperation` and `PartitionLeaveOperation`, for instance — carry an `@type` naming which
+one they are. Neither of those is configured per type: `ClusterConfigurationJsonSerializer` tells
+Jackson that a sealed type carries its type name and that a record's properties are its components,
+and both rules then hold for whatever the model grows. Identifiers are the one thing named
+individually: `MemberId` and `OperationId` render as scalars, in map keys and values alike, so the
+same identifier does not read one way as a key and another as a value.
+
+The JSON round-trips. `ClusterConfigurationJsonSerializer.fromJson` reads a dump back into the
+model, and a property test over generated configurations asserts that what comes back equals what
+went out. That is what the format is held to: a value rendered as an empty object, a dropped
+component, an identifier flattened to the wrong shape, or a variant that cannot be told apart from
+its siblings all fail there rather than in front of whoever is reading a dump during an incident.
+
+Setting `Accept: application/x-protobuf` returns the same configuration in the binary encoding
+brokers gossip and persist, which is the form to attach to a ticket:
+
+```bash
+curl -sOJ -H 'Accept: application/x-protobuf' 'http://localhost:9600/actuator/cluster/dump'
+protoc --decode topology_protocol.CurrentClusterConfiguration \
+  proto/topology.proto < cluster-config.pb
+```
+
+`proto/topology.proto` ships on the classpath, so it is available wherever the distribution is
+unpacked. Any other `Accept` value is refused with a 406.
+
+The JSON shape is the internal model and changes whenever the model does. That is why the endpoint
+is deliberately absent from `dist/src/main/resources/api/cluster/cluster-api.yaml` — it is a
+debugging aid, not a contract. Note also that the configuration is always fetched from the
+coordinator, so querying different nodes returns the same content.
+
 ## Current Limitations
 
 - **Subscription Migration**: Message and signal subscriptions are not migrated during scaling, but only when relocating.

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -44,6 +44,21 @@
     </dependency>
 
     <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.serializer;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.KeyDeserializer;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.ToStringSerializer;
+
+/**
+ * Reads and writes {@link CurrentClusterConfiguration} as JSON, shaped by the model itself rather
+ * than by any published API type. Written for the {@code /actuator/cluster/dump} actuator endpoint:
+ * when a mapped response from the other cluster endpoints looks wrong, this shows whether the
+ * configuration or the mapping is at fault.
+ *
+ * <p>This is the readable counterpart to {@link ProtoBufSerializer}, which produces the encoding
+ * the cluster gossips and persists. JSON is not a wire format here - nothing in the cluster
+ * exchanges it - but reading is offered alongside writing, because a document that reads back
+ * unchanged is a document that demonstrably lost nothing. That is what {@code
+ * ClusterConfigurationJsonSerializerPropertyTest} holds it to.
+ *
+ * <p>Nothing about the model is named here. One rule in {@link SealedTypeIntrospector} and one
+ * {@link MapperFeature} cover it, and both are properties of the model's own shape rather than
+ * lists to keep in step with it.
+ */
+@NullMarked
+public final class ClusterConfigurationJsonSerializer {
+
+  private static final ObjectMapper JSON =
+      JsonMapper.builder()
+          .annotationIntrospector(new SealedTypeIntrospector())
+          // A record's properties are its components, and nothing else. The model is rich in
+          // derived helpers - clusterSize(), isUninitialized(), getMembers() - which are
+          // conclusions drawn from the state rather than part of it, and which a reader would
+          // have nowhere to put.
+          .enable(MapperFeature.INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY)
+          .addModule(
+              new SimpleModule("cluster-configuration")
+                  // MemberId is an identifier, not a structure: it exposes id() rather than a bean
+                  // getter, so Jackson would otherwise treat it as an object with no properties.
+                  .addSerializer(MemberId.class, ToStringSerializer.instance)
+                  .addDeserializer(MemberId.class, new MemberIdDeserializer())
+                  .addKeyDeserializer(MemberId.class, new MemberIdKeyDeserializer())
+                  // OperationId is likewise an identifier. It appears as a map key in a dependency
+                  // plan and as a value in dependsOn, so it is rendered as a scalar in both places
+                  // rather than as an object in one and a key string in the other.
+                  .addSerializer(OperationId.class, ToStringSerializer.instance)
+                  .addDeserializer(OperationId.class, new OperationIdDeserializer())
+                  .addKeyDeserializer(OperationId.class, new OperationIdKeyDeserializer()))
+          // Fail on a type Jackson cannot introspect rather than render it as an empty object: a
+          // document that quietly omits state is worse than no document at all. Off by default
+          // since Jackson 3, so it has to be asked for.
+          .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .build();
+
+  private ClusterConfigurationJsonSerializer() {}
+
+  public static String toJson(final CurrentClusterConfiguration configuration) {
+    return JSON.writeValueAsString(configuration);
+  }
+
+  public static CurrentClusterConfiguration fromJson(final String json) {
+    return JSON.readValue(json, CurrentClusterConfiguration.class);
+  }
+
+  /** Mirrors {@link OperationId#toString()}, which is the form written above. */
+  private static OperationId toOperationId(final String text) {
+    return OperationId.of(Integer.parseInt(text.startsWith("#") ? text.substring(1) : text));
+  }
+
+  /**
+   * A sealed type carries its concrete type name, so that no individual type has to be annotated,
+   * listed or registered. Several variants have identical components - a {@code
+   * PartitionJoinOperation} is otherwise indistinguishable from a {@code PartitionLeaveOperation} -
+   * and some have none at all, so without a name they could not be read back. Jackson resolves the
+   * names from the permitted subclasses on its own.
+   */
+  private static final class SealedTypeIntrospector extends JacksonAnnotationIntrospector {
+
+    @Override
+    public JsonTypeInfo.@Nullable Value findPolymorphicTypeInfo(
+        final MapperConfig<?> config, final Annotated annotated) {
+      final var declared = super.findPolymorphicTypeInfo(config, annotated);
+      if (declared != null) {
+        return declared;
+      }
+      return annotated.getAnnotated() instanceof final Class<?> type && type.isSealed()
+          ? JsonTypeInfo.Value.construct(Id.SIMPLE_NAME, As.PROPERTY, "@type", null, false, null)
+          : null;
+    }
+  }
+
+  private static final class OperationIdDeserializer extends ValueDeserializer<OperationId> {
+
+    @Override
+    public OperationId deserialize(final JsonParser parser, final DeserializationContext context) {
+      return toOperationId(parser.getString());
+    }
+  }
+
+  private static final class OperationIdKeyDeserializer extends KeyDeserializer {
+
+    @Override
+    public Object deserializeKey(final String key, final DeserializationContext context) {
+      return toOperationId(key);
+    }
+  }
+
+  private static final class MemberIdDeserializer extends ValueDeserializer<MemberId> {
+
+    @Override
+    public MemberId deserialize(final JsonParser parser, final DeserializationContext context) {
+      return MemberId.from(parser.getString());
+    }
+  }
+
+  private static final class MemberIdKeyDeserializer extends KeyDeserializer {
+
+    @Override
+    public Object deserializeKey(final String key, final DeserializationContext context) {
+      return MemberId.from(key);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializerPropertyTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.util.ClusterTopologyDomain;
+import java.util.Map;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.domains.Domain;
+import net.jqwik.api.domains.DomainContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-tripping is what makes the JSON trustworthy, because it cannot hold while anything is
+ * missing: a value the writer renders as an empty object, a component dropped by a misconfigured
+ * mapper, an identifier flattened to the wrong shape, or a sealed variant that cannot be told apart
+ * from its siblings all fail here, rather than in front of whoever is reading a dump during an
+ * incident. Generated configurations reach corners hand-written examples do not.
+ */
+final class ClusterConfigurationJsonSerializerPropertyTest {
+
+  private static final String EQUALITY_HINT =
+      """
+      Configuration read back from JSON must equal the one written.
+      If both look the same, compare the collection types: jqwik generates sorted sets and maps, and \
+      a reader that builds unsorted ones yields an unequal-but-identical-looking configuration.""";
+
+  @Property(tries = 100)
+  @Domain(ClusterTopologyDomain.class)
+  @Domain(DomainContext.Global.class)
+  void shouldWriteAndReadBackAnyConfiguration(
+      @ForAll final CurrentClusterConfiguration configuration) {
+    // when
+    final var json = ClusterConfigurationJsonSerializer.toJson(configuration);
+
+    // then
+    assertThat(ClusterConfigurationJsonSerializer.fromJson(json))
+        .describedAs(EQUALITY_HINT)
+        .isEqualTo(configuration);
+  }
+
+  @Test
+  void shouldWriteAndReadBackTheNeverUpdatedSentinel() {
+    // given — brokers that have not been updated yet carry Instant.MIN, which is what a freshly
+    // started or uninitialized cluster looks like. The generated configurations above use ordinary
+    // timestamps, so this is the one corner they never reach, and it is the corner most likely to
+    // be dumped: it is not a valid RFC3339 or protobuf timestamp, and formats have refused it
+    // before (see ClusterApiUtils#mapInstantToDateTime and camunda/camunda#16256).
+    final var configuration =
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(
+                    MemberId.from("0"),
+                    MemberState.initializeAsActive(
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))));
+
+    // when
+    final var json = ClusterConfigurationJsonSerializer.toJson(configuration);
+
+    // then
+    assertThat(ClusterConfigurationJsonSerializer.fromJson(json)).isEqualTo(configuration);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationJsonSerializerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.dynamic.config.state.TenantAvailability;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Round-tripping proves the document loses nothing, but not that it is worth reading. These pin the
+ * two rules the serializer teaches Jackson, both of which are about what the document looks like to
+ * a person rather than about fidelity.
+ */
+final class ClusterConfigurationJsonSerializerTest {
+
+  private static final Instant TIMESTAMP = Instant.parse("2026-08-21T10:15:30Z");
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final JsonMapper PARSER = JsonMapper.builder().build();
+
+  @Test
+  void shouldOmitDerivedHelpers() {
+    // given
+    final var configuration = configuration(new RoundRobinConfig());
+
+    // when
+    final var json = parse(configuration);
+
+    // then — clusterSize() and getMembers() are conclusions drawn from the components below them,
+    // not part of the configuration, and a reader would have nowhere to put them
+    assertThat(json.propertyNames())
+        .containsExactlyInAnyOrder(
+            "version", "globalConfiguration", "partitionGroups", "phasedChangeState");
+    assertThat(json.at("/globalConfiguration").propertyNames()).doesNotContain("uninitialized");
+    assertThat(json.at("/partitionGroups/default").propertyNames())
+        .doesNotContain("disabled", "removed");
+    // a DependencyChangePlan answers pendingOperations(), completedOperations(), operations() and
+    // hasPendingChanges() from the graph it holds, so only the graph itself is state
+    assertThat(json.at("/partitionGroups/default/pendingChanges").propertyNames())
+        .containsExactlyInAnyOrder("id", "status", "startedAt", "graph", "completed");
+  }
+
+  @Test
+  void shouldDistinguishVariantsThatShareTheirComponents() {
+    // given — a join and a leave operation are indistinguishable by their fields alone
+    final var configuration = configuration(new RoundRobinConfig());
+
+    // when
+    final var json = parse(configuration);
+
+    // then
+    final var operations = json.at("/partitionGroups/default/pendingChanges/graph/operations");
+    assertThat(operations.at("/#0/operation/@type").asString()).isEqualTo("PartitionJoinOperation");
+    assertThat(operations.at("/#1/operation/@type").asString())
+        .isEqualTo("PartitionLeaveOperation");
+  }
+
+  @Test
+  void shouldNameVariantsThatCarryNoComponents() {
+    // given — RoundRobinConfig is an empty record, so the type name is all that identifies it
+    final var configuration = configuration(new RoundRobinConfig());
+
+    // when
+    final var json = parse(configuration);
+
+    // then
+    assertThat(json.at("/globalConfiguration/partitionDistributorConfig/@type").asString())
+        .isEqualTo("RoundRobinConfig");
+  }
+
+  @Test
+  void shouldNotNameConcreteTypes() {
+    // given
+    final var configuration = configuration(new RoundRobinConfig());
+
+    // when
+    final var json = parse(configuration);
+
+    // then — a record's declared type already says what it is, so a name there is only noise
+    assertThat(json.propertyNames()).doesNotContain("@type");
+    assertThat(json.at("/globalConfiguration/members/0").propertyNames()).doesNotContain("@type");
+  }
+
+  @Test
+  void shouldRenderOperationIdsTheSameWayInEveryPosition() {
+    // given — a sequential graph, so the second operation depends on the first
+    final var configuration = configuration(new RoundRobinConfig());
+
+    // when
+    final var json = parse(configuration);
+
+    // then — an operation id keys the graph and also appears inside dependsOn, and a reader should
+    // not have to recognise two renderings of the same identifier
+    final var operations = json.at("/partitionGroups/default/pendingChanges/graph/operations");
+    assertThat(operations.propertyNames()).containsExactly("#0", "#1");
+    assertThat(operations.at("/#1/dependsOn/0").asString()).isEqualTo("#0");
+  }
+
+  @Test
+  void shouldKeepTheModelsShape() {
+    // given
+    final var configuration = configuration(new RoundRobinConfig());
+
+    // when
+    final var json = parse(configuration);
+
+    // then — field names and nesting are the model's own, unlike the mapped /actuator/cluster
+    // response where these same values appear as a flat list of brokers. Member ids read as
+    // strings, both as map keys and as values.
+    assertThat(json.at("/globalConfiguration/clusterId").asString()).isEqualTo("test-cluster");
+    assertThat(json.at("/globalConfiguration/members").propertyNames()).containsExactly("0");
+    assertThat(
+            json.at(
+                    "/partitionGroups/default/pendingChanges/graph/operations/#0/operation/memberId")
+                .asString())
+        .isEqualTo("1");
+    assertThat(json.at("/partitionGroups/default/members/0/partitions/1/priority").asInt())
+        .isEqualTo(1);
+  }
+
+  private JsonNode parse(final CurrentClusterConfiguration configuration) {
+    return PARSER.readTree(ClusterConfigurationJsonSerializer.toJson(configuration));
+  }
+
+  private static CurrentClusterConfiguration configuration(final RoundRobinConfig distributor) {
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            7,
+            Optional.of("test-cluster"),
+            Map.of(MEMBER_0, new BrokerState(3, TIMESTAMP, BrokerState.State.ACTIVE)),
+            Optional.of(distributor),
+            Optional.of(
+                new ClusterChangePlan(
+                    9,
+                    2,
+                    Status.IN_PROGRESS,
+                    TIMESTAMP,
+                    List.of(),
+                    List.of(new MemberJoinOperation(MEMBER_1)))),
+            Optional.empty());
+
+    final var partitionGroup =
+        new PartitionGroupConfiguration(
+            5,
+            2,
+            new TreeMap<>(
+                Map.of(
+                    MEMBER_0,
+                    new BrokerPartitionState(
+                        4,
+                        TIMESTAMP,
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())),
+                        Mode.PROCESSING))),
+            Optional.of(new RoutingState(3, new AllPartitions(2), new HashMod(2))),
+            Optional.of(
+                new DependencyChangePlan(
+                    11,
+                    Status.IN_PROGRESS,
+                    TIMESTAMP,
+                    OperationGraph.sequential(
+                        List.of(
+                            new PartitionJoinOperation(MEMBER_1, 2, 1),
+                            new PartitionLeaveOperation(MEMBER_0, 1, 1))),
+                    new TreeMap<>())),
+            Optional.empty(),
+            TenantAvailability.enabled());
+
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, partitionGroup),
+        PhasedChangeState.empty());
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterConfigurationDumpIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterConfigurationDumpIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationJsonSerializer;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@code /actuator/cluster/dump} against a running broker. The serialization itself is
+ * covered by the round-trip property in {@code ClusterConfigurationJsonSerializerPropertyTest};
+ * what only a real broker can show is that both encodings survive the management context's MVC
+ * layer - the JSON is handed over pre-serialized, and the protobuf needs a byte[] converter and a
+ * content type no other endpoint here uses - and which encoding content negotiation actually
+ * settles on.
+ */
+@ZeebeIntegration
+final class ClusterConfigurationDumpIT {
+
+  @TestZeebe(initMethod = "initTestStandaloneBroker")
+  static TestStandaloneBroker broker;
+
+  @SuppressWarnings("unused")
+  static void initTestStandaloneBroker() {
+    broker =
+        new TestStandaloneBroker()
+            .withUnifiedConfig(cfg -> cfg.getCluster().setClusterId("dumped-cluster"));
+  }
+
+  @Test
+  void shouldDumpTheConfigurationWhenJsonIsAccepted() throws IOException, InterruptedException {
+    // when
+    final var response = get("application/json", BodyHandlers.ofString());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(contentTypeOf(response)).contains("application/json");
+    // the model's own field names, unlike the mapped /actuator/cluster response where these
+    // same values appear as a flat list of brokers
+    assertThat(response.body())
+        .contains("\"globalConfiguration\"")
+        .contains("\"partitionGroups\"")
+        .contains("dumped-cluster");
+  }
+
+  @Test
+  void shouldDumpDecodableProtobufWhenProtobufIsAccepted()
+      throws IOException, InterruptedException {
+    // when
+    final var response = get("application/x-protobuf", BodyHandlers.ofByteArray());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(contentTypeOf(response)).contains("application/x-protobuf");
+
+    final var body = response.body();
+    final var decoded = new ProtoBufSerializer().decodeCurrentClusterConfiguration(body);
+    assertThat(decoded.globalConfiguration().clusterId()).contains("dumped-cluster");
+    assertThat(decoded.getMembers()).hasSize(1);
+    assertThat(decoded.partitionGroups()).containsOnlyKeys("default");
+  }
+
+  @Test
+  void shouldDescribeTheSameConfigurationInBothEncodings()
+      throws IOException, InterruptedException {
+    // when
+    final var asJson = get("application/json", BodyHandlers.ofString());
+    final var asProtobuf = get("application/x-protobuf", BodyHandlers.ofByteArray());
+
+    // then — the two encodings are two views of one fetched configuration, so decoding the
+    // binary one and rendering it has to reproduce the JSON one
+    final var fromProtobuf =
+        new ProtoBufSerializer().decodeCurrentClusterConfiguration(asProtobuf.body());
+    assertThat(asJson.body()).isEqualTo(ClusterConfigurationJsonSerializer.toJson(fromProtobuf));
+  }
+
+  @Test
+  void shouldDumpJsonWhenNothingIsAccepted() throws IOException, InterruptedException {
+    // when — what a bare `curl` sends, so this pins which encoding content negotiation picks when
+    // the client expresses no preference. Binary would be a poor answer for an interactive request.
+    final var response = get(null, BodyHandlers.ofString());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(contentTypeOf(response)).contains("application/json");
+  }
+
+  @Test
+  void shouldRejectAnUnsupportedEncoding() throws IOException, InterruptedException {
+    // when
+    final var response = get("application/xml", BodyHandlers.ofString());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(406);
+  }
+
+  private String contentTypeOf(final HttpResponse<?> response) {
+    return response.headers().firstValue("content-type").orElse("");
+  }
+
+  private <T> HttpResponse<T> get(final String accept, final BodyHandler<T> bodyHandler)
+      throws IOException, InterruptedException {
+    final var request = HttpRequest.newBuilder().uri(broker.actuatorUri("cluster", "dump"));
+    if (accept != null) {
+      request.header("Accept", accept);
+    }
+    try (final var client = HttpClient.newHttpClient()) {
+      return client.send(request.build(), bodyHandler);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Every endpoint under `/actuator/cluster` maps `CurrentClusterConfiguration` onto the generated API types before answering, so a wrong-looking response never shows whether the configuration or the mapping is at fault. `GET /actuator/cluster/dump` serializes the coordinator's in-memory model directly:

```bash
curl -s 'http://localhost:9600/actuator/cluster/dump' | jq

# the encoding brokers gossip and persist
curl -sOJ -H 'Accept: application/x-protobuf' 'http://localhost:9600/actuator/cluster/dump'
protoc --decode topology_protocol.CurrentClusterConfiguration proto/topology.proto < cluster-config.pb
```

Any other `Accept` gets a 406. The endpoint is deliberately absent from `cluster-api.yaml` — the JSON shape is the internal model and changes with it.

The JSON round-trips: a jqwik property test asserts that any generated configuration reads back equal, so a dump demonstrably loses nothing. Jackson needs only two model-wide rules — a record's properties are its components (stock `MapperFeature`), and sealed-typed properties carry an `@type` discriminator (one introspector rule). Nothing in the model is annotated or registered, and the rules held when the model moved under this branch: the new sealed `ChangePlan` hierarchy, `DependencyChangePlan`/`OperationGraph`, and the renamed phase types needed no serializer change.

Only identifiers are named individually. `MemberId` and `OperationId` render as scalars in map keys and values alike, so the same identifier does not read one way as a key and another as a value — `OperationId` needed this because it keys a dependency plan's graph and also appears inside `dependsOn`. The property test is what surfaced it.

## Notes for the reviewer

Alternatives rejected: ProtoJSON cannot print the `Instant.MIN` "never updated" sentinel that `BrokerState` stores; Jackson's `activateDefaultTyping` keys on non-concrete types and stamps non-instantiable collection classes into the document; `@JsonTypeInfo` on the sealed interfaces produces identical output while touching ~7 model files.

## Testing

- `ClusterConfigurationJsonSerializerPropertyTest` — round-trip of generated configurations, plus the `Instant.MIN` sentinel the generators do not produce.
- `ClusterConfigurationJsonSerializerTest` — pins the document shape: derived helpers omitted, `@type` placement, member ids as strings.
- `ClusterEndpointTest` and `ClusterConfigurationDumpIT` — content negotiation (JSON by default, protobuf on request, 406 otherwise) and attachment disposition, unit-level and against a running broker.
