### PR TITLE
Eagerly discard pending agent history on job re-activation

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -165,15 +165,18 @@ public class AgentHistoryCommitLifecycleIT {
             AgentInstanceHistoryRole.ASSISTANT,
             "Message from winning activation",
             OffsetDateTime.parse("2025-06-01T10:01:00Z"));
+
+    // The re-activation above already discarded the superseded item eagerly (the engine's
+    // reactivation safety net), so it is DISCARDED here rather than staying PENDING until
+    // completion; the winning item is still PENDING until the job completes.
     awaitHistoryStatuses(
         agentInstanceKey,
-        "both items PENDING before completion",
-        tuple(supersededItemKey, AgentInstanceHistoryCommitStatus.PENDING),
+        "superseded item already DISCARDED, winning item PENDING",
+        tuple(supersededItemKey, AgentInstanceHistoryCommitStatus.DISCARDED),
         tuple(winningItemKey, AgentInstanceHistoryCommitStatus.PENDING));
 
     // Complete the winning activation — JobCompleteProcessor propagates the stored lease token
-    // into AGENT_HISTORY:COMMIT, so visitByJobLease commits the winning item and discards the
-    // superseded one.
+    // into AGENT_HISTORY:COMMIT, so visitByJobLease commits the winning item.
     camundaClient.newCompleteCommand(activation2).execute();
 
     awaitHistoryStatuses(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -47,7 +47,10 @@ public final class AgentHistoryCommitProcessor
       agentHistoryState.visitByJobKey(jobKey, visitor);
     } else {
       agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
-      // Discard items from superseded activations (different lease, same job)
+      // Safety net: a job re-activation already discards its previous lease's pending items
+      // eagerly, before the new lease can write anything, so by the time a COMMIT is processed
+      // this pass should find nothing left to discard. Kept anyway so that a future change to the
+      // re-activation-discard sites can't silently leak a superseded lease's items forever.
       agentHistoryState.visitByJobKey(
           jobKey,
           item -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -216,6 +216,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             config.isBusinessIdUniquenessEnabled(),
             messageCorrelationMetrics);
 
+    agentDefinitionBehavior = new AgentDefinitionBehavior(processingState.getProcessState());
+
     jobActivationBehavior =
         new BpmnJobActivationBehavior(
             jobStreamer,
@@ -227,7 +229,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             cslCheck,
             tenantCheck,
             secretStoreRegistry,
-            incidentBehavior);
+            incidentBehavior,
+            agentDefinitionBehavior);
 
     multiInstanceInputCollectionBehavior =
         new MultiInstanceInputCollectionBehavior(
@@ -264,8 +267,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getGroupState(),
             config.isCandidateGroupNameResolution(),
             clock);
-
-    agentDefinitionBehavior = new AgentDefinitionBehavior(processingState.getProcessState());
 
     jobBehavior =
         new BpmnJobBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -216,11 +216,21 @@ public class BpmnJobActivationBehavior {
     // activate job in state; the batch drops the variables, so the injected values stay off the log
     final JobBatchRecord jobBatchRecord = createJobBatchRecord(wrappedJobRecord, properties);
     appendJobToBatch(jobBatchRecord, jobKey, wrappedJobRecord);
+    // Re-activation pairs the ACTIVATED event with a follow-up DISCARD for the superseded lease's
+    // pending history (below). Both are sized here, before either is appended, so a job is never
+    // activated without room left for its compensating discard — the discard is not optional
+    // cleanup the commit-time safety net can be trusted to catch later, it is what keeps at most
+    // one lease's pending edits unresolved on the AgentInstance at a time.
+    final AgentHistoryRecord discardRecord =
+        isReactivation ? new AgentHistoryRecord().setJobKey(jobKey).ignoreLease() : null;
+    final int requiredLength =
+        jobBatchRecord.getLength()
+            + (discardRecord == null ? 0 : discardRecord.getLength())
+            + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
     // the activation is sized here rather than by the caller: only now is the stream known, and
     // with it the worker name this record carries twice. Letting the append overflow instead would
     // fail the whole command, which for an engine-written one means no rejection anybody reads
-    if (!stateWriter.canWriteEventOfLength(
-        jobBatchRecord.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
+    if (!stateWriter.canWriteEventOfLength(requiredLength)) {
       // the job is not activated, so it stays available; the notification lets a long poll collect
       // it, and the caller stops handing out jobs this batch can no longer take
       notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
@@ -228,17 +238,14 @@ public class BpmnJobActivationBehavior {
     }
     final var jobBatchKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, jobBatchRecord);
-    if (isReactivation) {
+    if (discardRecord != null) {
       // Re-activation: this push mints a new lease for a job that already held one, the same
       // situation JobBatchCollector discards for on the poll path. This site never goes through
       // the collector, so it must emit the same blanket, lease-agnostic discard itself. Emitted
       // only now that the ACTIVATED event is actually appended: an earlier abort (failed secret
       // injection, no room left in the batch) leaves the job on its old, still-valid lease, whose
       // pending items must not be discarded.
-      commandWriter.appendFollowUpCommand(
-          jobKey,
-          AgentHistoryIntent.DISCARD,
-          new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+      commandWriter.appendFollowUpCommand(jobKey, AgentHistoryIntent.DISCARD, discardRecord);
     }
 
     final var activatedJob = new ActivatedJobImpl();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -27,13 +27,16 @@ import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
@@ -72,6 +75,7 @@ public class BpmnJobActivationBehavior {
   private final JobStreamer jobStreamer;
   private final JobVariablesCollector jobVariablesCollector;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final SideEffectWriter sideEffectWriter;
   private final KeyGenerator keyGenerator;
   private final JobProcessingMetrics jobMetrics;
@@ -81,6 +85,7 @@ public class BpmnJobActivationBehavior {
   private final JobAuthorizationLogger jobAuthorizationLogger;
   private final JobSecretLookup secretLookup;
   private final BpmnIncidentBehavior incidentBehavior;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   public BpmnJobActivationBehavior(
       final JobStreamer jobStreamer,
@@ -92,12 +97,14 @@ public class BpmnJobActivationBehavior {
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
       final SecretStoreRegistry secretStoreRegistry,
-      final BpmnIncidentBehavior incidentBehavior) {
+      final BpmnIncidentBehavior incidentBehavior,
+      final AgentDefinitionBehavior agentDefinitionBehavior) {
     this.jobStreamer = jobStreamer;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
     jobVariablesCollector = new JobVariablesCollector(state);
     stateWriter = writers.state();
+    commandWriter = writers.command();
     sideEffectWriter = writers.sideEffect();
     this.clock = clock;
     this.cslCheck = cslCheck;
@@ -105,6 +112,7 @@ public class BpmnJobActivationBehavior {
     this.jobAuthorizationLogger = JobAuthorizationLogger.createDefault();
     secretLookup = new JobSecretLookup(secretStoreRegistry);
     this.incidentBehavior = incidentBehavior;
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
   }
 
   /**
@@ -193,6 +201,8 @@ public class BpmnJobActivationBehavior {
     final JobStream jobStream = optionalJobStream.get();
     final JobActivationProperties properties = jobStream.properties();
 
+    // snapshot before setJobProperties overwrites the job's lease token with a freshly minted one
+    final boolean isReactivation = isReactivation(wrappedJobRecord, properties);
     setJobProperties(wrappedJobRecord, properties);
     jobVariablesCollector.setJobVariables(properties.fetchVariables(), wrappedJobRecord);
     final var pushableJobRecord = new JobRecord();
@@ -218,6 +228,18 @@ public class BpmnJobActivationBehavior {
     }
     final var jobBatchKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, jobBatchRecord);
+    if (isReactivation) {
+      // Re-activation: this push mints a new lease for a job that already held one, the same
+      // situation JobBatchCollector discards for on the poll path. This site never goes through
+      // the collector, so it must emit the same blanket, lease-agnostic discard itself. Emitted
+      // only now that the ACTIVATED event is actually appended: an earlier abort (failed secret
+      // injection, no room left in the batch) leaves the job on its old, still-valid lease, whose
+      // pending items must not be discarded.
+      commandWriter.appendFollowUpCommand(
+          jobKey,
+          AgentHistoryIntent.DISCARD,
+          new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+    }
 
     final var activatedJob = new ActivatedJobImpl();
     activatedJob.setJobKey(jobKey).setRecord(pushableJobRecord);
@@ -357,6 +379,18 @@ public class BpmnJobActivationBehavior {
           jobMetrics.countJobEvent(JobAction.WORKERS_NOTIFIED, jobKind, jobType);
           return true;
         });
+  }
+
+  /**
+   * Returns whether this hand-out re-activates a job that already held a lease from a previous
+   * activation, i.e. whether the eager reactivation-discard in {@link #publishWork} applies. Must
+   * be read before {@link #setJobProperties} overwrites the job's lease token with a new one.
+   */
+  private boolean isReactivation(
+      final JobRecord jobRecord, final JobActivationProperties properties) {
+    return properties.withLease()
+        && jobRecord.hasLeaseToken()
+        && agentDefinitionBehavior.belongsToAgent(jobRecord);
   }
 
   private void setJobProperties(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -23,14 +24,17 @@ import io.camunda.zeebe.engine.processing.job.JobSecretInjector.FailedInjectionJ
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -45,6 +49,7 @@ import java.time.InstantSource;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import org.agrona.collections.LongHashSet;
 
 @ExcludeAuthorizationCheck
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
@@ -70,6 +75,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final JobBatchRecord responseValue = new JobBatchRecord();
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final JobBatchCollector jobBatchCollector;
@@ -89,9 +95,11 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final CslTenantCheck tenantCheck,
       final InstantSource clock,
       final BpmnIncidentBehavior incidentBehavior,
+      final AgentDefinitionBehavior agentDefinitionBehavior,
       final SecretStoreRegistry secretStoreRegistry) {
 
     stateWriter = writers.state();
+    commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.cslCheck = cslCheck;
@@ -104,7 +112,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
             cslCheck,
             clock,
             jobMetrics,
-            jobSecretInjector);
+            jobSecretInjector,
+            agentDefinitionBehavior);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
@@ -218,8 +227,41 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final var jobsWithNonCachedSecrets = jobSecretInjector.jobsWithNonCachedSecrets();
 
     activateJobBatch(record, value, jobBatchKey);
+    discardSupersededHistoryForReactivatedJobs(value);
 
     requestSecretResolution(jobsWithNonCachedSecrets);
+  }
+
+  /**
+   * A re-activated agentic job (already held a lease from a previous activation) gets a blanket,
+   * lease-agnostic {@code AGENT_HISTORY:DISCARD} for its previous lease's pending items — the new
+   * lease has not created any items yet, so discarding everything pending for the job is equivalent
+   * to discarding only the old lease's items, without needing to read or compare the old lease
+   * value itself.
+   *
+   * <p>Only discards a job that made it into the batch actually written by {@link
+   * #activateJobBatch}: the collector marks a job reactivated optimistically, before {@link
+   * #responseValueFor} runs secret injection, which can still drop that job (and every job after
+   * it) from the batch, e.g. a failed injection or values that no longer fit the message size. A
+   * dropped job keeps its old, still-valid lease, so discarding its pending items anyway would wipe
+   * live configuration the job's next activation is still entitled to.
+   */
+  private void discardSupersededHistoryForReactivatedJobs(final JobBatchRecord activatedBatch) {
+    final var reactivatedJobKeys = jobBatchCollector.reactivatedAgenticJobKeys();
+    if (reactivatedJobKeys.isEmpty()) {
+      return;
+    }
+    final var activatedJobKeys = new LongHashSet();
+    activatedBatch.jobKeys().forEach(jobKey -> activatedJobKeys.add(jobKey.getValue()));
+    reactivatedJobKeys.forEach(
+        jobKey -> {
+          if (activatedJobKeys.contains(jobKey)) {
+            commandWriter.appendFollowUpCommand(
+                jobKey,
+                AgentHistoryIntent.DISCARD,
+                new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+          }
+        });
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -46,7 +46,8 @@ import org.agrona.collections.ObjectHashSet;
  */
 final class JobBatchCollector {
 
-  // constant regardless of the job key value: a fixed-width long field plus the ignoreLease flag.
+  // maximum regardless of the actual job key value: MsgPack encodes the jobKey field at
+  // variable width, so Long.MAX_VALUE forces its longest encoding, giving a safe upper bound.
   // Reserved per reactivated job below so the ACTIVATED batch never grows into room its
   // compensating DISCARD command (appended later, once the batch is final) would not fit in.
   private static final int DISCARD_COMMAND_LENGTH =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -11,6 +11,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.LongHashSet;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.MutableReference;
 import org.agrona.collections.ObjectHashSet;
@@ -43,6 +45,7 @@ import org.agrona.collections.ObjectHashSet;
  */
 final class JobBatchCollector {
   private final ObjectHashSet<DirectBuffer> variableNames = new ObjectHashSet<>();
+  private final LongHashSet reactivatedAgenticJobKeys = new LongHashSet();
 
   private final JobState jobState;
   private final JobVariablesCollector jobVariablesCollector;
@@ -51,6 +54,7 @@ final class JobBatchCollector {
   private final InstantSource clock;
   private final JobProcessingMetrics jobMetrics;
   private final JobSecretInjector jobSecretInjector;
+  private final AgentDefinitionBehavior agentDefinitionBehavior;
 
   /**
    * @param canWriteEventOfLength a predicate which should return whether the resulting {@link
@@ -66,7 +70,8 @@ final class JobBatchCollector {
       final CslAuthorizationCheck cslCheck,
       final InstantSource clock,
       final JobProcessingMetrics jobMetrics,
-      final JobSecretInjector jobSecretInjector) {
+      final JobSecretInjector jobSecretInjector,
+      final AgentDefinitionBehavior agentDefinitionBehavior) {
     jobState = state.getJobState();
     this.canWriteEventOfLength = canWriteEventOfLength;
     jobVariablesCollector = new JobVariablesCollector(state);
@@ -74,6 +79,7 @@ final class JobBatchCollector {
     this.clock = clock;
     this.jobMetrics = jobMetrics;
     this.jobSecretInjector = jobSecretInjector;
+    this.agentDefinitionBehavior = agentDefinitionBehavior;
   }
 
   /**
@@ -106,6 +112,7 @@ final class JobBatchCollector {
     final Predicate<JobRecord> isAuthorizedForJob = buildAuthzPredicate(record);
 
     jobSecretInjector.reset();
+    reactivatedAgenticJobKeys.clear();
     jobState.forEachActivatableJobs(
         value.getTypeBuffer(),
         tenantIds,
@@ -144,6 +151,10 @@ final class JobBatchCollector {
           // fill in the job record properties first in order to accurately estimate its size before
           // adding it to the batch
           jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
+          final boolean isReactivation =
+              value.isWithLease()
+                  && !jobRecord.getLeaseToken().isEmpty()
+                  && agentDefinitionBehavior.belongsToAgent(jobRecord);
           if (value.isWithLease()) {
             jobRecord.setLeaseToken(LeaseTokens.generate());
           }
@@ -162,6 +173,12 @@ final class JobBatchCollector {
             final var appendedJob = appendJobToBatch(jobIterator, jobKeyIterator, key, jobRecord);
             jobSecretInjector.registerForInjection(
                 secretCheckResult, activatedCount.value, appendedJob);
+            if (isReactivation) {
+              // Re-activation: the previous lease's pending history items must be discarded
+              // before the new lease starts accumulating its own, so at most one lease's
+              // optimistic edits are ever unresolved on the AgentInstance at a time.
+              reactivatedAgenticJobKeys.add(key);
+            }
             activatedCount.increment();
 
             // track the count of activated jobs by their JobKind
@@ -186,6 +203,14 @@ final class JobBatchCollector {
     }
 
     return Either.right(jobCountPerJobKind);
+  }
+
+  /**
+   * Returns the keys of agentic jobs collected by the last {@link #collectJobs} call that already
+   * held a lease from a previous activation — i.e. are being re-activated with a new one.
+   */
+  LongHashSet reactivatedAgenticJobKeys() {
+    return reactivatedAgenticJobKeys;
   }
 
   private Predicate<JobRecord> buildAuthzPredicate(final TypedRecord<JobBatchRecord> record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.JobKind;
@@ -44,6 +45,13 @@ import org.agrona.collections.ObjectHashSet;
  * and added to the given batch record.
  */
 final class JobBatchCollector {
+
+  // constant regardless of the job key value: a fixed-width long field plus the ignoreLease flag.
+  // Reserved per reactivated job below so the ACTIVATED batch never grows into room its
+  // compensating DISCARD command (appended later, once the batch is final) would not fit in.
+  private static final int DISCARD_COMMAND_LENGTH =
+      new AgentHistoryRecord().setJobKey(Long.MAX_VALUE).ignoreLease().getLength();
+
   private final ObjectHashSet<DirectBuffer> variableNames = new ObjectHashSet<>();
   private final LongHashSet reactivatedAgenticJobKeys = new LongHashSet();
 
@@ -104,6 +112,8 @@ final class JobBatchCollector {
     final var maxActivatedCount = value.getMaxJobsToActivate();
     final var activatedCount = new MutableInteger(0);
     final var skippedUncachedSecretJobs = new MutableInteger(0);
+    // room already promised to the discard commands of the reactivated jobs accepted so far
+    final var reservedDiscardBytes = new MutableInteger(0);
     final var unwritableJob = new MutableReference<TooLargeJob>();
     final Map<JobKind, Integer> jobCountPerJobKind = new EnumMap<>(JobKind.class);
     final var deadline = clock.millis() + value.getTimeout();
@@ -162,11 +172,14 @@ final class JobBatchCollector {
 
           // the expected length is based on the current record's length plus the length of the job
           // record we would add to the batch, the number of bytes taken by the additional job key,
-          // as well as an 8 KB buffer.
+          // room already reserved for earlier reactivated jobs' discard commands, this job's own
+          // discard command if it is a reactivation too, as well as an 8 KB buffer.
           final var jobRecordLength = jobRecord.getLength();
           final var expectedEventLength =
               record.getLength()
                   + jobRecordLength
+                  + reservedDiscardBytes.value
+                  + (isReactivation ? DISCARD_COMMAND_LENGTH : 0)
                   + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
           if (activatedCount.value <= maxActivatedCount
               && canWriteEventOfLength.test(expectedEventLength)) {
@@ -176,8 +189,11 @@ final class JobBatchCollector {
             if (isReactivation) {
               // Re-activation: the previous lease's pending history items must be discarded
               // before the new lease starts accumulating its own, so at most one lease's
-              // optimistic edits are ever unresolved on the AgentInstance at a time.
+              // optimistic edits are ever unresolved on the AgentInstance at a time. The room for
+              // that discard command was already reserved above, so it is guaranteed to fit once
+              // appended after this batch is final.
               reactivatedAgenticJobKeys.add(key);
+              reservedDiscardBytes.set(reservedDiscardBytes.value + DISCARD_COMMAND_LENGTH);
             }
             activatedCount.increment();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -139,6 +139,7 @@ public final class JobEventProcessors {
                 tenantCheck,
                 clock,
                 bpmnBehaviors.incidentBehavior(),
+                bpmnBehaviors.agentDefinitionBehavior(),
                 secretStoreRegistry))
         .withListener(
             new JobTimeoutCheckScheduler(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
@@ -33,7 +33,8 @@ public final class LeaseTokens {
    * io.camunda.zeebe.engine.processing.job.JobBatchCollector} and {@link
    * io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior} for the two
    * existing sites. A new lease-minting site that skips this leaves the previous lease's pending
-   * {@code AgentHistory} items stranded, never discarded or committed.
+   * {@code AgentHistory} items unresolved until a later commit/discard on the new lease
+   * incidentally sweeps them up — a correctness gap in the meantime, not a permanent leak.
    */
   public static String generate() {
     return UUID.randomUUID().toString();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/LeaseTokens.java
@@ -27,6 +27,13 @@ public final class LeaseTokens {
    * Returns an opaque token; callers must not parse it. Call once per activated job — never reuse
    * one token across the jobs of a batch. Random with enough entropy that collisions between leased
    * jobs are negligible.
+   *
+   * <p>Every call site that applies a new lease to a job which may already hold one (a
+   * re-activation) must also discard that job's agent history for the old lease — see {@link
+   * io.camunda.zeebe.engine.processing.job.JobBatchCollector} and {@link
+   * io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior} for the two
+   * existing sites. A new lease-minting site that skips this leaves the previous lease's pending
+   * {@code AgentHistory} items stranded, never discarded or committed.
    */
   public static String generate() {
     return UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -354,13 +354,14 @@ public class AgentHistoryCommitTest {
   }
 
   @Test
-  public void shouldCommitWinningAndDiscardSupersededOnLeasedJobCompletion() {
+  public void shouldDiscardSupersededItemOnReactivationThenCommitOnlyWinningItemOnCompletion() {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
     final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
 
-    // Activation 1 (superseded): create a history item, then fail to trigger re-activation.
+    // Activation 1 (superseded): create a history item, then fail to make the job activatable
+    // again.
     final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
     final long supersededItemKey =
         createHistoryItem(agentInstanceKey, job1.key(), elementInstanceKey, job1.leaseToken());
@@ -373,12 +374,21 @@ public class AgentHistoryCommitTest {
         .withRetries(1)
         .fail();
 
-    // Activation 2 (winning): create a history item, then complete the job.
+    // Activation 2 (winning): re-activating with a new lease eagerly discards activation 1's item.
     final var job2 = activateJobForProcessInstanceWithLease(processInstanceKey);
     assertThat(job2.key()).as("re-activation must reuse the same job key").isEqualTo(job1.key());
     assertThat(job2.leaseToken())
         .as("re-activation must advance the lease token")
         .isNotEqualTo(job1.leaseToken());
+
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(supersededItemKey)
+            .getFirst();
+    assertThat(discarded.getValue().getJobKey())
+        .as("the superseded activation's item is discarded as soon as the job is re-activated")
+        .isEqualTo(job1.key());
+
     final long winningItemKey =
         createHistoryItem(agentInstanceKey, job2.key(), elementInstanceKey, job2.leaseToken());
 
@@ -397,7 +407,9 @@ public class AgentHistoryCommitTest {
     final long commitPosition = firstCommitted.getSourceRecordPosition();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
-    // visitByJobLease(job2.leaseToken()) → winning item COMMITTED
+    // visitByJobLease(job2.leaseToken()) → only the winning item is committed; the superseded item
+    // was already discarded earlier and the commit-time safety-net discard pass finds nothing left
+    // to do for it.
     assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getKey() == clockResetKey)
@@ -407,17 +419,6 @@ public class AgentHistoryCommitTest {
                 .map(Record::getKey))
         .as("only the winning activation's history item should be committed")
         .containsExactly(winningItemKey);
-
-    // discard pass → superseded item DISCARDED
-    assertThat(
-            RecordingExporter.records()
-                .limit(r -> r.getKey() == clockResetKey)
-                .withValueType(ValueType.AGENT_HISTORY)
-                .withIntent(AgentHistoryIntent.DISCARDED)
-                .filter(r -> r.getSourceRecordPosition() == commitPosition)
-                .map(Record::getKey))
-        .as("the superseded activation's history item should be discarded")
-        .containsExactly(supersededItemKey);
   }
 
   // --- helpers ---

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationPushTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * The job streaming/push path's equivalent of {@link AgentHistoryDiscardOnJobReactivationTest}: a
+ * job pushed with a lease can also be re-pushed with a new one (e.g. on {@code fail} with retries),
+ * a lease-minting site {@link io.camunda.zeebe.engine.processing.job.JobBatchCollector} never sees.
+ */
+public class AgentHistoryDiscardOnJobReactivationPushTest {
+
+  private static final String TIMEOUT_MS = "30000";
+  private static final RecordingJobStreamer JOB_STREAMER = new RecordingJobStreamer();
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withJobStreamer(JOB_STREAMER);
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDiscardPendingItemsWhenPushReactivatesAgenticJobWithNewLease() {
+    // given — a leasing stream, an agentic service task, and a CONFIGURATION item pending under
+    // the job's first (pushed) lease.
+    final var jobType = "reactivation-discard-push";
+    final var worker = BufferUtil.wrapString("test");
+    final var properties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(Long.parseLong(TIMEOUT_MS))
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .setWithLease(true);
+    final RecordingJobStream jobStream =
+        JOB_STREAMER.addJobStream(BufferUtil.wrapString(jobType), properties);
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(1));
+    final long jobKey = jobStream.getActivatedJobs().getFirst().jobKey();
+    final String firstLease = jobStream.getActivatedJobs().getFirst().jobRecord().getLeaseToken();
+    assertThat(firstLease).describedAs("the job under test must actually be leased").isNotEmpty();
+
+    final long agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .create()
+            .getKey();
+    final var configurationItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-1")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .withHistory(List.of(configurationItem))
+            .update();
+    final long pendingItemKey = updated.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when — the job fails with retries; the still-open leasing stream re-pushes it with a new,
+    // distinct lease token
+    ENGINE.job().withKey(jobKey).withLeaseToken(firstLease).withRetries(1).fail();
+    await().untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(2));
+    final String secondLease = jobStream.getActivatedJobs().get(1).jobRecord().getLeaseToken();
+    assertThat(secondLease)
+        .describedAs("the re-push must mint a new, distinct lease token")
+        .isNotEmpty()
+        .isNotEqualTo(firstLease);
+
+    // then — a blanket discard (no lease filter) is emitted for the job, and the first lease's
+    // pending item is discarded, exactly like the poll path
+    final var discardCommand =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARD)
+            .onlyCommands()
+            .withJobKey(jobKey)
+            .getFirst();
+    assertThat(discardCommand.getValue().getJobLease()).isEmpty();
+
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(pendingItemKey)
+            .getFirst();
+    assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationSecretDropTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationSecretDropTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.SecretActivationResponseCapture;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the poll path (#B2 of the optimistic-apply-rollback review) does not discard a
+ * re-activated agentic job's pending history when the job is optimistically marked as reactivated
+ * during {@code JobBatchCollector.collectJobs}, but is later dropped from the batch altogether by
+ * {@code JobSecretInjector.injectSecretValues} (called from {@code
+ * JobBatchActivateProcessor#activateJobBatch}, after collection). A job dropped this way keeps its
+ * old, still-valid lease - discarding its pending items anyway would wipe live configuration the
+ * job's next activation is still entitled to. This is a distinct gap from the batch-size rejection
+ * inside {@code collectJobs} itself, which was already covered by the "only track as reactivated
+ * once actually activated" fix.
+ */
+public class AgentHistoryDiscardOnJobReactivationSecretDropTest {
+
+  // The default max fragment size of the test log stream, which caps the activation response
+  // (see LogStreamBuilderImpl and JobSecretActivationInjectionTest for the same constant).
+  private static final int MAX_MESSAGE_SIZE = 4 * 1024 * 1024;
+
+  @Rule public final EngineRule engine;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private final SecretActivationResponseCapture secretActivation =
+      new SecretActivationResponseCapture();
+
+  public AgentHistoryDiscardOnJobReactivationSecretDropTest() {
+    engine =
+        EngineRule.singlePartition()
+            .withSecretStoreRegistry(
+                new SecretStoreRegistry(
+                    Map.of("default", new NoopSecretStore()), Map.of("default", secretActivation)));
+  }
+
+  @Before
+  public void setUp() {
+    secretActivation.install(engine.getCommandResponseWriter());
+  }
+
+  @Test
+  public void
+      shouldNotDiscardPendingItemsWhenReactivatedJobIsDroppedBySecretInjectionAfterCollection() {
+    // given - an agentic service task whose input mapping references a secret; a small cached
+    // value lets the first activation inject and activate normally
+    final var jobType = "reactivation-secret-drop";
+    secretActivation.putSecret("token", "small-value");
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task",
+                    t ->
+                        t.zeebeJobType(jobType)
+                            .zeebeAiAgentTaskDefinition()
+                            .zeebeInputExpression(
+                                "\"Bearer \" + camunda.secrets.token", "authorization"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+
+    final var firstBatch =
+        engine
+            .jobs()
+            .withType(jobType)
+            .withTimeout(10L)
+            .withLease()
+            .withRequestStreamId(1)
+            .withRequestId(1L)
+            .activate();
+    final long jobKey = firstBatch.getValue().getJobKeys().get(0);
+    final String firstLease = firstBatch.getValue().getJobs().get(0).getLeaseToken();
+
+    // and - a CONFIGURATION item pending under the first lease, not yet committed
+    final var configurationItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-1")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var created =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .withHistory(List.of(configurationItem))
+            .create();
+    final long pendingItemKey = created.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when - the job times out, then the cached secret value is grown past the max message size,
+    // so the reactivation collects and optimistically marks the job as reactivated (minting a new
+    // lease), but injectSecretValues drops it from the batch entirely once collection is done
+    engine.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+    secretActivation.putSecret("token", "x".repeat(MAX_MESSAGE_SIZE));
+
+    final Record<JobBatchRecordValue> secondBatch =
+        engine
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .withRequestStreamId(2)
+            .withRequestId(2L)
+            .activate();
+
+    // then - the job is not activated: it is dropped for exceeding the message size budget, and
+    // gets an incident, exactly like a job whose secret value can never fit any batch
+    assertThat(secondBatch.getValue().getJobKeys()).isEmpty();
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).withJobKey(jobKey).getFirst();
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.MESSAGE_SIZE_EXCEEDED);
+    final long clockResetKey = engine.clock().reset().getKey();
+
+    // and - no reactivation discard is emitted for the job: it never actually left its first
+    // lease, so a blanket discard would wrongly wipe that lease's still-pending item
+    final var agentHistoryRecordsUpToClockReset =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .toList();
+    assertThat(agentHistoryRecordsUpToClockReset)
+        .noneMatch(
+            r ->
+                r.getIntent() == AgentHistoryIntent.DISCARD
+                    && ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey);
+    assertThat(agentHistoryRecordsUpToClockReset)
+        .noneMatch(
+            r -> r.getIntent() == AgentHistoryIntent.DISCARDED && r.getKey() == pendingItemKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobReactivationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that re-activating an agentic job with a new lease (the job already held a lease from a
+ * previous activation) emits a blanket {@code AGENT_HISTORY:DISCARD} for the job, so the prior
+ * activation's pending items are discarded before the new lease's own history starts accumulating.
+ */
+public class AgentHistoryDiscardOnJobReactivationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDiscardPendingItemsOnlyAfterJobIsReactivatedWithNewLease() {
+    // given — an agentic service task; the job is activated with a lease for the first time, and a
+    // CONFIGURATION item lands under that lease via the agent instance's own creation batch.
+    final var jobType = "reactivation-discard-fold";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+
+    final var firstBatch = ENGINE.jobs().withType(jobType).withTimeout(10L).withLease().activate();
+    final long jobKey = firstBatch.getValue().getJobKeys().get(0);
+    final String firstLease = firstBatch.getValue().getJobs().get(0).getLeaseToken();
+
+    final var configurationItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-1")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(firstLease)
+            .withHistory(List.of(configurationItem))
+            .create();
+    final long pendingItemKey = created.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when — the lease times out; a time-out never reactivates a leased job by itself, so no
+    // reactivation discard should fire yet.
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+    final long afterTimeoutKey = ENGINE.clock().reset().getKey();
+
+    // then — the pending item is still untouched
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == afterTimeoutKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
+                .exists())
+        .isFalse();
+
+    // when — a leasing worker re-activates the timed-out job, minting a new lease token
+    final var secondBatch = ENGINE.jobs().withType(jobType).withLease().activate();
+    assertThat(secondBatch.getValue().getJobKeys()).containsExactly(jobKey);
+    final String secondLease = secondBatch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(secondLease).isNotEmpty().isNotEqualTo(firstLease);
+
+    // then — a blanket discard (no lease filter) is emitted for the job, and the first lease's
+    // pending item is discarded
+    final var discardCommand =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARD)
+            .onlyCommands()
+            .withJobKey(jobKey)
+            .getFirst();
+    assertThat(discardCommand.getRecordType()).isEqualTo(RecordType.COMMAND);
+    assertThat(discardCommand.getValue().getJobLease()).isEmpty();
+
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(pendingItemKey)
+            .getFirst();
+    assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
+  }
+
+  @Test
+  public void shouldNotDiscardOnFirstActivationOfAgenticJob() {
+    // given/when — a fresh agentic job is activated with a lease for the very first time
+    final var jobType = "reactivation-discard-first-activation";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    final var batch = ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then — no re-activation discard is emitted; there was no prior lease to supersede
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotDiscardWhenNonAgenticJobIsReactivatedWithNewLease() {
+    // given — a plain (non-agentic) service task; the job is activated with a lease, then times out
+    final var jobType = "reactivation-discard-non-agentic";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("plain-task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    final var firstBatch = ENGINE.jobs().withType(jobType).withTimeout(10L).withLease().activate();
+    final long jobKey = firstBatch.getValue().getJobKeys().get(0);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+
+    // when — it is re-activated with a new lease
+    final var secondBatch = ENGINE.jobs().withType(jobType).withLease().activate();
+    assertThat(secondBatch.getValue().getJobKeys()).containsExactly(jobKey);
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then — no discard is emitted; the job is not agentic
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == jobKey)
+                .exists())
+        .isFalse();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -29,6 +29,7 @@ import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -85,6 +86,8 @@ final class JobBatchCollectorTest {
           new SecretStoreRegistry(
               Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, new NoopSecretStore()),
               Map.of(SecretStoreRegistry.DEFAULT_STORE_ID, secretCache)));
+  private final AgentDefinitionBehavior agentDefinitionBehavior =
+      mock(AgentDefinitionBehavior.class);
 
   @SuppressWarnings("unused") // injected by the extension
   private MutableProcessingState state;
@@ -98,7 +101,14 @@ final class JobBatchCollectorTest {
     // are never invoked by the collector — pass nulls to satisfy the CslAuthorizationCheck ctor.
     final var cslCheck = new CslAuthorizationCheck(null, null, securityConfig);
     collector =
-        new JobBatchCollector(state, lengthEvaluator, cslCheck, clock, jobMetrics, secretInjector);
+        new JobBatchCollector(
+            state,
+            lengthEvaluator,
+            cslCheck,
+            clock,
+            jobMetrics,
+            secretInjector,
+            agentDefinitionBehavior);
   }
 
   @Test
@@ -148,7 +158,13 @@ final class JobBatchCollectorTest {
     final var securityConfig = EngineSecurityConfigurations.defaultConfig();
     final var cslCheck = new CslAuthorizationCheck(authzService, claimsConverter, securityConfig);
     return new JobBatchCollector(
-        state, lengthEvaluator, cslCheck, clock, jobMetrics, secretInjector);
+        state,
+        lengthEvaluator,
+        cslCheck,
+        clock,
+        jobMetrics,
+        secretInjector,
+        agentDefinitionBehavior);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -313,6 +313,25 @@ final class JobBatchCollectorTest {
   }
 
   @Test
+  void shouldNotTrackReactivationWhenJobIsRejectedForBatchSize() {
+    // given — an agentic job that already holds a lease from a previous activation, so it looks
+    // like a re-activation, but the collector rejects it for being too large to write. Its
+    // existing lease is left untouched in state, so it must not be treated as reactivated.
+    final long variableScopeKey = state.getKeyGenerator().nextKey();
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    record.getValue().setWithLease(true);
+    createLeasedJob(variableScopeKey);
+    when(agentDefinitionBehavior.belongsToAgent(any())).thenReturn(true);
+    lengthEvaluator.canWriteEventOfLength = (length) -> false;
+
+    // when
+    collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // then
+    assertThat(collector.reactivatedAgenticJobKeys()).isEmpty();
+  }
+
+  @Test
   void shouldCollectJobsWithVariables() {
     // given - multiple jobs to ensure variables are collected based on the scope
     final TypedRecord<JobBatchRecord> record = createRecord();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -313,6 +313,46 @@ final class JobBatchCollectorTest {
   }
 
   @Test
+  void shouldDeferReactivatedJobWhenNoRoomForItsDiscardCommand() {
+    // given — capture the room a plain (non-reactivated) job's own event needs. Both jobs below
+    // request a lease (setWithLease(true)), so the collector overwrites each one's lease token
+    // with a freshly generated, equal-length token before measuring it — the two jobs are given
+    // equal-length types too, so the only length difference between them is the reservation this
+    // fix adds for the reactivated job's compensating DISCARD command. They are also given
+    // distinct types so the second collectJobs call's activatable-job scan cannot pick up the
+    // first job left behind by the first call — collectJobs never persists its lease-token/
+    // deadline mutations back into job state, so a same-typed job would still look activatable.
+    final long plainScopeKey = state.getKeyGenerator().nextKey();
+    createJobOfType(plainScopeKey, "type-a");
+    final var plainRecord = createRecord();
+    plainRecord.getValue().setType("type-a").setWithLease(true);
+    final var bareLength = new MutableReference<Integer>();
+    lengthEvaluator.canWriteEventOfLength =
+        length -> {
+          bareLength.set(length);
+          return true;
+        };
+    collector.collectJobs(plainRecord, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // when — an identically-shaped reactivated job is offered exactly that much room, which fits
+    // the bare event but leaves no room for its compensating DISCARD command
+    final long reactivatedScopeKey = state.getKeyGenerator().nextKey();
+    createLeasedJobOfType(reactivatedScopeKey, "type-b");
+    when(agentDefinitionBehavior.belongsToAgent(any())).thenReturn(true);
+    final var record = createRecord();
+    record.getValue().setType("type-b").setWithLease(true);
+    final int roomForBareEventOnly = bareLength.ref;
+    lengthEvaluator.canWriteEventOfLength = length -> length <= roomForBareEventOnly;
+    final Either<TooLargeJob, Map<JobKind, Integer>> result =
+        collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+
+    // then — the job is deferred as too large rather than activated without room left for the
+    // discard command its re-activation requires
+    EitherAssert.assertThat(result).left();
+    assertThat(collector.reactivatedAgenticJobKeys()).isEmpty();
+  }
+
+  @Test
   void shouldNotTrackReactivationWhenJobIsRejectedForBatchSize() {
     // given — an agentic job that already holds a lease from a previous activation, so it looks
     // like a re-activation, but the collector rejects it for being too large to write. Its
@@ -826,6 +866,35 @@ final class JobBatchCollectorTest {
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             // the job stays activatable while holding a token, which is the state an unleased
             // activation has to skip over
+            .setLeaseToken("lease-token");
+    final long jobKey = state.getKeyGenerator().nextKey();
+
+    state.getJobState().create(jobKey, jobRecord);
+    return new Job(jobKey, jobRecord);
+  }
+
+  private Job createJobOfType(final long variableScopeKey, final String type) {
+    final var jobRecord =
+        new JobRecord()
+            .setBpmnProcessId("process")
+            .setElementId("element")
+            .setElementInstanceKey(variableScopeKey)
+            .setType(type)
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    final long jobKey = state.getKeyGenerator().nextKey();
+
+    state.getJobState().create(jobKey, jobRecord);
+    return new Job(jobKey, jobRecord);
+  }
+
+  private Job createLeasedJobOfType(final long variableScopeKey, final String type) {
+    final var jobRecord =
+        new JobRecord()
+            .setBpmnProcessId("process")
+            .setElementId("element")
+            .setElementInstanceKey(variableScopeKey)
+            .setType(type)
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .setLeaseToken("lease-token");
     final long jobKey = state.getKeyGenerator().nextKey();
 


### PR DESCRIPTION
## Description

When a job carrying a lease-based `AgentInstance` history record is re-activated (poll path via `JobBatchCollector`, and push path via `BpmnJobActivationBehavior`), any pending (uncommitted) history item for that job's previous lease is now eagerly discarded — a compensating `AgentHistoryIntent.DISCARD` command is emitted as part of re-activation. Batch-sizing on both the poll and push paths now reserves room for that compensating DISCARD command so a re-activated job cannot be activated without room left to also emit its discard, and is deferred as too-large instead.

The pre-existing commit-time superseded-lease discard (`AgentHistoryCommitProcessor`'s `visitByJobKey` pass excluding the current lease) is kept in place rather than removed: with the eager discard above, it should never find anything left to discard in practice, but it's kept as a safety net in case a future change to the eager-discard call sites lets a superseded lease's items leak through undiscarded to a commit.

## Why this is its own issue (#56706), and why it's in this PR set

This behavior is really the scope of #56706, not #58797 — it establishes a general invariant for lease-based `AgentInstance` history: **at most one job lease's optimistic edits may exist unresolved on a given `AgentInstance` at any time**. It's being implemented now, ahead of #56706 being separately scheduled, because #58797's CONFIGURATION-rollback mechanism (submitted as a separate, stacked PR on top of this one, #60730) is a whole-record blind-copy commit/discard sync that is only correctness-safe under that exact invariant. Without this eager discard, a re-activated job could leave a stale pending edit around that a later commit/discard would incorrectly resolve against.

Commits reference `#56706` directly (an intentional exception to this repo's usual convention of not naming issues in commit messages) since this is genuinely that issue's scope, landing early as a prerequisite.

## Relationship to #58797

This PR must merge before (or the rollback PR must be based on it, as it currently is) the CONFIGURATION-rollback PR, since that PR's correctness depends on the invariant established here. It contains no CONFIGURATION-rollback logic itself — only the reactivation-discard mechanism and its batch-sizing correction.

## Out of scope

Job activation behavior — including job leasing — is currently duplicated across two independent code paths: `JobBatchCollector`/`JobBatchActivateProcessor` (the poll path) and `BpmnJobActivationBehavior` (the push/stream path). This PR had to add the same re-activation-discard logic to both sites independently, since there is no single shared place where job activation/leasing happens. It would make sense to unify job activation behavior into one place — ideally `JobBatchActivateProcessor` delegating to `BpmnJobActivationBehavior` rather than duplicating the logic — but that consolidation is a larger refactor left for a future PR.

## Commits

- `test: cover history discard on job re-activation`
- `test: cover reactivation discard surviving a dropped secret injection`
- `feat: discard pending history items on job re-activation` (poll path, #56706)
- `test: cover reactivation tracking on a batch-size-rejected job`
- `test: cover discard-capacity reservation for reactivated poll-path jobs`
- `fix: reserve room for a reactivated job's discard command in poll-path sizing`
- `docs: warn future lease-minting sites to discard agent history too`
- `test: reflect eager reactivation discard in lease-based commit tests`
- `test: cover reactivation discard on the job push/stream path`
- `feat: discard pending history items on job re-activation via push too` (push path, #56706)
- `fix: reserve room for a reactivated job's discard command in push-path sizing`
- `docs: correct discard-length and stale-lease comment accuracy`

## Test plan

Executed and passing:

- [x] `JobBatchCollectorTest` covers poll-path reactivation discard, including batch-size-rejected jobs and discard-capacity reservation
- [x] `AgentHistoryDiscardOnJobReactivationTest` / `...PushTest` / `...SecretDropTest` cover end-to-end reactivation-discard behavior on both paths, including a job rejected for exceeding batch-size capacity not having its still-held lease's pending items wrongly discarded
- [x] `AgentHistoryCommitLifecycleIT` reflects the new eager-discard timing
- [x] `AgentHistoryCommitTest` reclassifies the commit-time superseded-lease discard as a safety net: the one existing scenario that goes through a real re-activation now expects the item already discarded eagerly rather than at commit time; the synthetic-lease scenario is untouched since the safety net still fires for it
- [x] License, spotless, and checkstyle checks

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] This PR does not modify the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite).

## Related issues

Relates to #56706, #58797