### PR TITLE
Roll back AgentInstance configuration edits on discarded agent history

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -14,10 +14,15 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.List;
 
 // DISCARD is always a follow-up command emitted internally by the engine when an agentic job is
 // destroyed without completing, so there is no user to authorize against.
@@ -25,13 +30,25 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public final class AgentHistoryDiscardProcessor
     implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
 
+  private static final List<String> RESTORED_ATTRIBUTES =
+      List.of(
+          AgentInstanceRecord.ATTR_MODEL,
+          AgentInstanceRecord.ATTR_PROVIDER,
+          AgentInstanceRecord.ATTR_SYSTEM_PROMPT,
+          AgentInstanceRecord.ATTR_TOOLS,
+          AgentInstanceRecord.ATTR_MAX_TOKENS,
+          AgentInstanceRecord.ATTR_MAX_MODEL_CALLS,
+          AgentInstanceRecord.ATTR_MAX_TOOL_CALLS);
+
   private final StateWriter stateWriter;
   private final AgentHistoryState agentHistoryState;
+  private final AgentInstanceState agentInstanceState;
 
   public AgentHistoryDiscardProcessor(
       final Writers writers, final ProcessingState processingState) {
     stateWriter = writers.state();
     agentHistoryState = processingState.getAgentHistoryState();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
@@ -41,9 +58,13 @@ public final class AgentHistoryDiscardProcessor
     // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
     // so the DISCARDED event emitted here carries that same trimmed shape for free.
     final AgentHistoryState.AgentHistoryVisitor visitor =
-        item ->
-            stateWriter.appendFollowUpEvent(
-                item.getAgentHistoryKey(), AgentHistoryIntent.DISCARDED, item);
+        item -> {
+          stateWriter.appendFollowUpEvent(
+              item.getAgentHistoryKey(), AgentHistoryIntent.DISCARDED, item);
+          if (item.getRole() == AgentHistoryRole.CONFIGURATION) {
+            restoreConfigurationFromSnapshot(item.getAgentInstanceKey());
+          }
+        };
     if (jobLease.isEmpty()) {
       // Job destruction: every activation's items are dead — discard all items for the job.
       agentHistoryState.visitByJobKey(jobKey, visitor);
@@ -52,6 +73,38 @@ public final class AgentHistoryDiscardProcessor
       agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
     }
     // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+
+  /**
+   * Unconditionally overwrites {@code agentInstanceKey}'s live configuration fields (model,
+   * provider, systemPrompt, tools, limits) with its last committed snapshot, undoing whatever the
+   * now-discarded CONFIGURATION item had optimistically applied. If no snapshot exists yet (no
+   * CONFIGURATION item for this agent instance has ever committed), it rolls back to the {@link
+   * AgentInstanceRecord} defaults instead. A no-op if the agent instance itself is already gone.
+   */
+  private void restoreConfigurationFromSnapshot(final long agentInstanceKey) {
+    final var live = agentInstanceState.getRecord(agentInstanceKey);
+    if (live == null) {
+      return;
+    }
+    final var snapshot = agentInstanceState.getCommittedSnapshot(agentInstanceKey);
+    final var restored = snapshot != null ? snapshot : new AgentInstanceRecord();
+
+    final var liveDefinition = live.getDefinition();
+    final var restoredDefinition = restored.getDefinition();
+    liveDefinition
+        .setModel(restoredDefinition.getModel())
+        .setProvider(restoredDefinition.getProvider())
+        .setSystemPrompt(restoredDefinition.getSystemPrompt());
+    live.setTools(restored.getTools());
+    final var restoredLimits = restored.getLimits();
+    live.getLimits()
+        .setMaxTokens(restoredLimits.getMaxTokens())
+        .setMaxModelCalls(restoredLimits.getMaxModelCalls())
+        .setMaxToolCalls(restoredLimits.getMaxToolCalls());
+
+    live.setChangedAttributes(RESTORED_ATTRIBUTES);
+    stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.UPDATED, live);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -113,4 +113,19 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
     agentInstancesColumnFamily.deleteIfExists(agentInstanceKey);
     byProcessInstanceKeyColumnFamily.deleteIfExists(processInstanceKeyAndAgentInstanceKey);
   }
+
+  @Override
+  public AgentInstanceRecord getCommittedSnapshot(final long key) {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
+
+  @Override
+  public void putCommittedSnapshot(final long key, final AgentInstanceRecord record) {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
+
+  @Override
+  public void deleteCommittedSnapshot(final long key) {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agentinstance/DbAgentInstanceState.java
@@ -26,6 +26,9 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
   private final DbAgentInstance dbAgentInstance = new DbAgentInstance();
   private final ColumnFamily<DbLong, DbAgentInstance> agentInstancesColumnFamily;
 
+  private final DbAgentInstance committedSnapshotValue = new DbAgentInstance();
+  private final ColumnFamily<DbLong, DbAgentInstance> committedSnapshotColumnFamily;
+
   // Secondary index: (processInstanceKey, agentInstanceKey) -> nil
   private final DbLong processInstanceKey = new DbLong();
   private final DbCompositeKey<DbLong, DbLong> processInstanceKeyAndAgentInstanceKey =
@@ -47,6 +50,12 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
             transactionContext,
             processInstanceKeyAndAgentInstanceKey,
             DbNil.INSTANCE);
+    committedSnapshotColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AGENT_INSTANCE_COMMITTED_SNAPSHOT,
+            transactionContext,
+            agentInstanceKey,
+            committedSnapshotValue);
   }
 
   @Override
@@ -116,16 +125,21 @@ public final class DbAgentInstanceState implements MutableAgentInstanceState {
 
   @Override
   public AgentInstanceRecord getCommittedSnapshot(final long key) {
-    throw new UnsupportedOperationException("not implemented yet");
+    agentInstanceKey.wrapLong(key);
+    final var stored = committedSnapshotColumnFamily.get(agentInstanceKey, DbAgentInstance::new);
+    return stored == null ? null : stored.getRecord();
   }
 
   @Override
   public void putCommittedSnapshot(final long key, final AgentInstanceRecord record) {
-    throw new UnsupportedOperationException("not implemented yet");
+    agentInstanceKey.wrapLong(key);
+    committedSnapshotValue.setRecord(record);
+    committedSnapshotColumnFamily.upsert(agentInstanceKey, committedSnapshotValue);
   }
 
   @Override
   public void deleteCommittedSnapshot(final long key) {
-    throw new UnsupportedOperationException("not implemented yet");
+    agentInstanceKey.wrapLong(key);
+    committedSnapshotColumnFamily.deleteIfExists(agentInstanceKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -41,6 +41,9 @@ public final class AgentHistoryCommittedApplier
    */
   private void syncCommittedSnapshot(final long agentInstanceKey) {
     final var live = agentInstanceState.getRecord(agentInstanceKey);
+    if (live == null) {
+      return;
+    }
     final var snapshot = new AgentInstanceRecord();
     snapshot
         .getDefinition()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -9,21 +9,51 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 
 public final class AgentHistoryCommittedApplier
     implements TypedEventApplier<AgentHistoryIntent, AgentHistoryRecord> {
 
   private final MutableAgentHistoryState agentHistoryState;
+  private final MutableAgentInstanceState agentInstanceState;
 
   public AgentHistoryCommittedApplier(final MutableProcessingState processingState) {
     agentHistoryState = processingState.getAgentHistoryState();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    if (value.getRole() == AgentHistoryRole.CONFIGURATION) {
+      syncCommittedSnapshot(value.getAgentInstanceKey());
+    }
     agentHistoryState.delete(key, value);
+  }
+
+  /**
+   * Copies the current (already optimistically-applied) configuration fields of the live agent
+   * instance into its committed snapshot, so a later discard can restore exactly this state.
+   */
+  private void syncCommittedSnapshot(final long agentInstanceKey) {
+    final var live = agentInstanceState.getRecord(agentInstanceKey);
+    final var snapshot = new AgentInstanceRecord();
+    snapshot
+        .getDefinition()
+        .setModel(live.getDefinition().getModel())
+        .setProvider(live.getDefinition().getProvider())
+        .setSystemPrompt(live.getDefinition().getSystemPrompt());
+    snapshot.setTools(live.getTools());
+    final var liveLimits = live.getLimits();
+    snapshot
+        .getLimits()
+        .setMaxTokens(liveLimits.getMaxTokens())
+        .setMaxModelCalls(liveLimits.getMaxModelCalls())
+        .setMaxToolCalls(liveLimits.getMaxToolCalls());
+    agentInstanceState.putCommittedSnapshot(agentInstanceKey, snapshot);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
@@ -24,5 +24,6 @@ public final class AgentInstanceCompletedApplier
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    agentInstanceState.deleteCommittedSnapshot(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentInstanceState.java
@@ -30,4 +30,10 @@ public interface AgentInstanceState {
    *     or {@code null} if none remain
    */
   Long getFirstAgentInstanceKeyByProcessInstanceKey(long processInstanceKey);
+
+  /**
+   * @return the last committed configuration snapshot for the given agent instance, or {@code null}
+   *     if none exists
+   */
+  AgentInstanceRecord getCommittedSnapshot(long agentInstanceKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentInstanceState.java
@@ -26,4 +26,13 @@ public interface MutableAgentInstanceState extends AgentInstanceState {
    * locate the secondary index entry, avoiding an extra state lookup.
    */
   void delete(long agentInstanceKey, AgentInstanceRecord record);
+
+  /** Inserts or overwrites the committed configuration snapshot for {@code agentInstanceKey}. */
+  void putCommittedSnapshot(long agentInstanceKey, AgentInstanceRecord record);
+
+  /**
+   * Deletes the committed configuration snapshot for {@code agentInstanceKey}, if any. No-op if
+   * none exists.
+   */
+  void deleteCommittedSnapshot(long agentInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardRestoresConfigurationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardRestoresConfigurationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AgentHistoryDiscardRestoresConfigurationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRestoreLiveConfigurationToLastCommittedSnapshotOnDiscard() {
+    // given — an agent instance whose CONFIGURATION item is applied and committed, so the
+    // committed snapshot mirrors that change.
+    final var jobType = "discard-restore-committed-snapshot";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+    final long agentInstanceKey =
+        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long jobKey = ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().get(0);
+
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-committed")
+                    .setRole(AgentHistoryRole.CONFIGURATION)
+                    .setLoopIteration(1)
+                    .setModel("gpt-4o-mini")
+                    .setChangedAttributes(List.of("model"))))
+        .update();
+    ENGINE.agentHistories().withJobKey(jobKey).commit();
+
+    // when — a second CONFIGURATION change is applied but never committed, then discarded
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-pending")
+                    .setRole(AgentHistoryRole.CONFIGURATION)
+                    .setLoopIteration(1)
+                    .setModel("gpt-5")
+                    .setChangedAttributes(List.of("model"))))
+        .update();
+    final var discardCommand = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — the live definition is rolled back to the last committed value, not the pending one
+    final var restored =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
+            .filter(r -> r.getSourceRecordPosition() == discardCommand.getSourceRecordPosition())
+            .getFirst();
+    assertThat(restored.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(restored.getValue().getChangedAttributes())
+        .containsExactlyInAnyOrder(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls");
+  }
+
+  @Test
+  public void shouldRestoreToEmptyDefaultsWhenDiscardingBeforeAnyCommitEverHappened() {
+    // given — a CONFIGURATION item is applied but discarded before any item for this agent
+    // instance was ever committed, so no snapshot exists yet.
+    final var jobType = "discard-restore-no-snapshot";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "agent-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("agent-task")
+            .getFirst()
+            .getKey();
+    final long agentInstanceKey =
+        ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
+    final long jobKey = ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-pending")
+                    .setRole(AgentHistoryRole.CONFIGURATION)
+                    .setLoopIteration(1)
+                    .setModel("gpt-4o-mini")
+                    .setChangedAttributes(List.of("model"))))
+        .update();
+    final var discardCommand = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — restored to the AgentInstanceRecord defaults (empty), not the pre-change value
+    final var restored =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
+            .filter(r -> r.getSourceRecordPosition() == discardCommand.getSourceRecordPosition())
+            .getFirst();
+    assertThat(restored.getValue().getDefinition().getModel()).isEmpty();
+    assertThat(restored.getValue().getChangedAttributes())
+        .containsExactlyInAnyOrder(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardRestoresConfigurationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardRestoresConfigurationTest.java
@@ -11,9 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -56,45 +59,87 @@ public class AgentHistoryDiscardRestoresConfigurationTest {
         ENGINE.agentInstances().withElementInstanceKey(elementInstanceKey).create().getKey();
     final long jobKey = ENGINE.jobs().withType(jobType).activate().getValue().getJobKeys().get(0);
 
+    final var committedItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-committed")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setProvider("openai");
+    committedItem.addSystemPrompt(
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("Committed prompt."));
+    committedItem.setTools(
+        List.of(new AgentInstanceTool().setName("search").setElementId("search-task")));
+    committedItem.getLimits().setMaxTokens(4096L).setMaxModelCalls(10).setMaxToolCalls(20);
+    committedItem.setChangedAttributes(
+        List.of(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls"));
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
         .withJobKey(jobKey)
-        .withHistory(
-            List.of(
-                new AgentHistoryRecord()
-                    .setHistoryItemId("item-committed")
-                    .setRole(AgentHistoryRole.CONFIGURATION)
-                    .setLoopIteration(1)
-                    .setModel("gpt-4o-mini")
-                    .setChangedAttributes(List.of("model"))))
+        .withHistory(List.of(committedItem))
         .update();
     ENGINE.agentHistories().withJobKey(jobKey).commit();
 
-    // when — a second CONFIGURATION change is applied but never committed, then discarded
+    // when — a second CONFIGURATION change, with distinct values for every field, is applied but
+    // never committed, then discarded
+    final var pendingItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-pending")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-5")
+            .setProvider("anthropic");
+    pendingItem.addSystemPrompt(
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText("Pending prompt."));
+    pendingItem.setTools(
+        List.of(new AgentInstanceTool().setName("calc").setElementId("calc-task")));
+    pendingItem.getLimits().setMaxTokens(8192L).setMaxModelCalls(99).setMaxToolCalls(77);
+    pendingItem.setChangedAttributes(
+        List.of(
+            "model",
+            "provider",
+            "systemPrompt",
+            "tools",
+            "maxTokens",
+            "maxModelCalls",
+            "maxToolCalls"));
     ENGINE
         .agentInstances()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(elementInstanceKey)
         .withJobKey(jobKey)
-        .withHistory(
-            List.of(
-                new AgentHistoryRecord()
-                    .setHistoryItemId("item-pending")
-                    .setRole(AgentHistoryRole.CONFIGURATION)
-                    .setLoopIteration(1)
-                    .setModel("gpt-5")
-                    .setChangedAttributes(List.of("model"))))
+        .withHistory(List.of(pendingItem))
         .update();
     final var discardCommand = ENGINE.agentHistories().withJobKey(jobKey).discard();
 
-    // then — the live definition is rolled back to the last committed value, not the pending one
+    // then — every field is rolled back to its last committed value, not the pending one
     final var restored =
         RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
             .filter(r -> r.getSourceRecordPosition() == discardCommand.getSourceRecordPosition())
             .getFirst();
     assertThat(restored.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(restored.getValue().getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(restored.getValue().getDefinition().getSystemPrompt())
+        .hasSize(1)
+        .first()
+        .satisfies(block -> assertThat(block.getText()).isEqualTo("Committed prompt."));
+    assertThat(restored.getValue().getTools()).extracting("name").containsExactly("search");
+    assertThat(restored.getValue().getLimits().getMaxTokens()).isEqualTo(4096L);
+    assertThat(restored.getValue().getLimits().getMaxModelCalls()).isEqualTo(10);
+    assertThat(restored.getValue().getLimits().getMaxToolCalls()).isEqualTo(20);
     assertThat(restored.getValue().getChangedAttributes())
         .containsExactlyInAnyOrder(
             "model",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/agentinstance/AgentInstanceStateTest.java
@@ -233,4 +233,63 @@ public final class AgentInstanceStateTest {
     // given / when / then
     assertThatCode(() -> agentInstanceState.delete(9999L)).doesNotThrowAnyException();
   }
+
+  @Test
+  public void shouldStoreAndLoadCommittedSnapshot() {
+    // given
+    final long key = 4242L;
+    final var snapshot =
+        new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(1234L);
+
+    // when
+    agentInstanceState.putCommittedSnapshot(key, snapshot);
+
+    // then
+    final var loaded = agentInstanceState.getCommittedSnapshot(key);
+    assertThat(loaded).isNotNull();
+    assertThat(loaded.getAgentInstanceKey()).isEqualTo(key);
+    assertThat(loaded.getElementInstanceKey()).isEqualTo(1234L);
+  }
+
+  @Test
+  public void shouldReturnNullForMissingCommittedSnapshot() {
+    assertThat(agentInstanceState.getCommittedSnapshot(9999L)).isNull();
+  }
+
+  @Test
+  public void shouldOverwriteCommittedSnapshotOnPut() {
+    // given
+    final long key = 4242L;
+    agentInstanceState.putCommittedSnapshot(
+        key, new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(1234L));
+
+    // when
+    agentInstanceState.putCommittedSnapshot(
+        key, new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(5678L));
+
+    // then
+    final var loaded = agentInstanceState.getCommittedSnapshot(key);
+    assertThat(loaded.getElementInstanceKey()).isEqualTo(5678L);
+  }
+
+  @Test
+  public void shouldDeleteCommittedSnapshot() {
+    // given
+    final long key = 4242L;
+    agentInstanceState.putCommittedSnapshot(
+        key, new AgentInstanceRecord().setAgentInstanceKey(key).setElementInstanceKey(1234L));
+
+    // when
+    agentInstanceState.deleteCommittedSnapshot(key);
+
+    // then
+    assertThat(agentInstanceState.getCommittedSnapshot(key)).isNull();
+  }
+
+  @Test
+  public void shouldNoOpOnDeleteOfMissingCommittedSnapshot() {
+    // given / when / then
+    assertThatCode(() -> agentInstanceState.deleteCommittedSnapshot(9999L))
+        .doesNotThrowAnyException();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class AgentHistoryCommittedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableAgentInstanceState agentInstanceState;
+  private MutableAgentHistoryState agentHistoryState;
+  private AgentHistoryCommittedApplier committedApplier;
+
+  @BeforeEach
+  public void setup() {
+    agentInstanceState = processingState.getAgentInstanceState();
+    agentHistoryState = processingState.getAgentHistoryState();
+    committedApplier = new AgentHistoryCommittedApplier(processingState);
+  }
+
+  @Test
+  void shouldSyncCommittedSnapshotWhenConfigurationItemCommits() {
+    // given — an agent instance whose live definition/tools/limits already reflect the
+    // optimistically-applied change (as done by AgentHistoryBatchBehavior at CREATE time).
+    final long agentInstanceKey = 1L;
+    final var live = new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey);
+    live.getLimits().setMaxTokens(111).setMaxModelCalls(2).setMaxToolCalls(3);
+    live.getDefinition()
+        .setModel("gpt-5")
+        .setProvider("openai")
+        .setSystemPrompt(
+            List.of(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("be helpful")));
+    agentInstanceState.insert(agentInstanceKey, live);
+
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.CONFIGURATION);
+    agentHistoryState.insert(historyKey, item);
+
+    // when
+    committedApplier.applyState(historyKey, item);
+
+    // then
+    final var snapshot = agentInstanceState.getCommittedSnapshot(agentInstanceKey);
+    assertThat(snapshot).isNotNull();
+    assertThat(snapshot.getDefinition().getModel()).isEqualTo("gpt-5");
+    assertThat(snapshot.getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(snapshot.getDefinition().getSystemPrompt()).hasSize(1);
+    assertThat(snapshot.getDefinition().getSystemPrompt().get(0).getText()).isEqualTo("be helpful");
+    assertThat(snapshot.getLimits().getMaxTokens()).isEqualTo(111);
+    assertThat(snapshot.getLimits().getMaxModelCalls()).isEqualTo(2);
+    assertThat(snapshot.getLimits().getMaxToolCalls()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldNotSyncSnapshotForNonConfigurationItem() {
+    // given
+    final long agentInstanceKey = 1L;
+    agentInstanceState.insert(
+        agentInstanceKey, new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey));
+
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.ASSISTANT);
+    agentHistoryState.insert(historyKey, item);
+
+    // when
+    committedApplier.applyState(historyKey, item);
+
+    // then
+    assertThat(agentInstanceState.getCommittedSnapshot(agentInstanceKey)).isNull();
+  }
+
+  @Test
+  void shouldStillDeleteHistoryItemOnCommit() {
+    // given
+    final long agentInstanceKey = 1L;
+    agentInstanceState.insert(
+        agentInstanceKey, new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey));
+
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.CONFIGURATION);
+    agentHistoryState.insert(historyKey, item);
+
+    // when
+    committedApplier.applyState(historyKey, item);
+
+    // then — the existing delete-from-primary-storage behavior is unaffected by the new sync.
+    assertThat(agentHistoryState.get(historyKey)).isNull();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplierTest.java
@@ -103,6 +103,27 @@ public class AgentHistoryCommittedApplierTest {
   }
 
   @Test
+  void shouldNotFailWhenAgentInstanceIsAlreadyGone() {
+    // given — a CONFIGURATION item whose agent instance was already deleted (e.g. the process
+    // instance completed before this COMMIT was processed).
+    final long agentInstanceKey = 1L;
+    final long historyKey = 10L;
+    final var item =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(historyKey)
+            .setAgentInstanceKey(agentInstanceKey)
+            .setRole(AgentHistoryRole.CONFIGURATION);
+    agentHistoryState.insert(historyKey, item);
+
+    // when — applying should not throw despite there being no live agent instance to read from
+    committedApplier.applyState(historyKey, item);
+
+    // then — no snapshot is created, and the history item is still deleted as usual
+    assertThat(agentInstanceState.getCommittedSnapshot(agentInstanceKey)).isNull();
+    assertThat(agentHistoryState.get(historyKey)).isNull();
+  }
+
+  @Test
   void shouldStillDeleteHistoryItemOnCommit() {
     // given
     final long agentInstanceKey = 1L;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
@@ -97,4 +97,30 @@ public class AgentInstanceCompletedApplierTest {
     assertThat(agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(processInstanceKey))
         .containsExactly(secondAgentInstanceKey);
   }
+
+  @Test
+  void shouldDeleteCommittedSnapshotOnCompletion() {
+    // given — a committed configuration snapshot exists for the agent instance.
+    final long agentInstanceKey = 9L;
+    final long processInstanceKey = 5L;
+    createdApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentInstanceState.putCommittedSnapshot(
+        agentInstanceKey, new AgentInstanceRecord().setAgentInstanceKey(agentInstanceKey));
+
+    // when
+    completedApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then
+    assertThat(agentInstanceState.getCommittedSnapshot(agentInstanceKey)).isNull();
+  }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -41,6 +41,9 @@ public final class AgentHistoryCommittedApplier
    */
   private void syncCommittedSnapshot(final long agentInstanceKey) {
     final var live = agentInstanceState.getRecord(agentInstanceKey);
+    if (live == null) {
+      return;
+    }
     final var snapshot = new AgentInstanceRecord();
     snapshot
         .getDefinition()

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -9,21 +9,51 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 
 public final class AgentHistoryCommittedApplier
     implements TypedEventApplier<AgentHistoryIntent, AgentHistoryRecord> {
 
   private final MutableAgentHistoryState agentHistoryState;
+  private final MutableAgentInstanceState agentInstanceState;
 
   public AgentHistoryCommittedApplier(final MutableProcessingState processingState) {
     agentHistoryState = processingState.getAgentHistoryState();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    if (value.getRole() == AgentHistoryRole.CONFIGURATION) {
+      syncCommittedSnapshot(value.getAgentInstanceKey());
+    }
     agentHistoryState.delete(key, value);
+  }
+
+  /**
+   * Copies the current (already optimistically-applied) configuration fields of the live agent
+   * instance into its committed snapshot, so a later discard can restore exactly this state.
+   */
+  private void syncCommittedSnapshot(final long agentInstanceKey) {
+    final var live = agentInstanceState.getRecord(agentInstanceKey);
+    final var snapshot = new AgentInstanceRecord();
+    snapshot
+        .getDefinition()
+        .setModel(live.getDefinition().getModel())
+        .setProvider(live.getDefinition().getProvider())
+        .setSystemPrompt(live.getDefinition().getSystemPrompt());
+    snapshot.setTools(live.getTools());
+    final var liveLimits = live.getLimits();
+    snapshot
+        .getLimits()
+        .setMaxTokens(liveLimits.getMaxTokens())
+        .setMaxModelCalls(liveLimits.getMaxModelCalls())
+        .setMaxToolCalls(liveLimits.getMaxToolCalls());
+    agentInstanceState.putCommittedSnapshot(agentInstanceKey, snapshot);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
@@ -24,5 +24,6 @@ public final class AgentInstanceCompletedApplier
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    agentInstanceState.deleteCommittedSnapshot(key);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -372,7 +372,13 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // AGENT_DEFINITION_KEY_BY_PROCESS_DEFINITION_KEY_AND_ELEMENT_ID at deploy time, so the record can
   // be fully retrieved, without re-deriving it from the parsed BPMN model. GLOBAL for the same
   // reason as the sibling CF above.
-  AGENT_DEFINITION_BY_KEY(162, GLOBAL);
+  AGENT_DEFINITION_BY_KEY(162, GLOBAL),
+
+  // agentInstanceKey -> DbAgentInstance holding the last CONFIGURATION fields (systemPrompt,
+  // model, provider, tools, limits) committed for that agent instance. Reuses DbAgentInstance
+  // as the value type even though only those fields are populated, so the optimistically-applied
+  // live AgentInstance can be rolled back to this snapshot on history-item discard.
+  AGENT_INSTANCE_COMMITTED_SNAPSHOT(163, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

Keeps an `AgentInstance`'s live `CONFIGURATION` fields (and pending history) correctly synchronized with what actually gets durably committed, so an optimistically-applied-but-later-discarded change (e.g. a job re-activation, a rolled-back lease) doesn't leave the live state out of sync with reality.

When a job carries a `CONFIGURATION`-role history item (system prompt, model, provider, tools, or limits), that change is applied immediately to the `AgentInstance`'s live state as soon as the item is processed — before it's known whether the job's lease will ultimately be committed or discarded. Until now, if that lease was later discarded instead of committed (the job got re-activated, destroyed, or otherwise superseded), the live state simply kept the uncommitted edit forever, silently drifting from what was actually durably persisted.

This PR closes that gap:

- Adds a new engine-internal-only column family (`AGENT_INSTANCE_COMMITTED_SNAPSHOT`) that stores the last durably-committed configuration for each `AgentInstance`, reusing the existing `DbAgentInstance` value shape rather than introducing a new one.
- On commit of a `CONFIGURATION` history item, copies the 7 concrete configuration fields (system prompt, model, provider, tools, maxTokens, maxModelCalls, maxToolCalls) into that snapshot.
- On discard of pending history — covering explicit discard, job-destruction discard, and the re-activation-triggered discard from #60729 — restores the live `AgentInstance` record from the snapshot (or to empty defaults if no snapshot exists yet, e.g. a discarded first `CREATE`), and emits a real `AgentInstanceIntent.UPDATED` event carrying the restored values.
- Deletes the snapshot row when the `AgentInstance` completes, so it doesn't outlive its owner.
- The committed applier tolerates a missing live `AgentInstance` (e.g. already completed), matching the sibling discard-processor's existing guard.

A `CREATE` command's own embedded history items go through the same PENDING/COMMIT lifecycle as items from any later job activation — there is no special immediate-commit path for `CREATE`. If the lease that created the agent instance is discarded before ever reaching a commit, the client (the connector) never durably persisted anything either, so restoring the live record to empty defaults in that case is correct, not a bug.

`AgentInstanceRecord`'s `systemPrompt` already uses the content-block-list type (from #60542, merged in #60602), so this mechanism's snapshot/restore logic operates on that shape directly with no separate migration needed.

This is #58797's core acceptance criteria — this is the actual rollback mechanism the issue asks for. It relies on secondary storage actually receiving committed CONFIGURATION updates (#60728) and on the reactivation-discard invariant below (#60729) to be verifiable and correct end-to-end.

## Why this PR is stacked on #56706 (base branch, not `main`)

The whole-record blind-copy commit/discard sync implemented here is only correctness-safe under the invariant that **at most one job lease's optimistic edits may exist unresolved on a given `AgentInstance` at any time**. That invariant is established by the eager reactivation-discard mechanism in #60729, not by anything in this PR. There is no file-level overlap between the two PRs, but this one depends on that one for correctness, so it's based directly on it rather than independently on `main`.

**This PR must not be merged before the eager-reactivation-discard PR (base branch).**

Base branch PR: https://github.com/camunda/camunda/pull/60729

## Commits

- `test: cover committed configuration snapshot storage for AgentInstance`
- `feat: add committed configuration snapshot column family for AgentInstance`
- `test: cover committed configuration snapshot sync on history commit`
- `feat: sync committed configuration snapshot on history commit`
- `test: cover live configuration restore on history discard`
- `feat: restore live configuration to committed snapshot on history discard`
- `test: cover committed snapshot cleanup on agent instance completion`
- `feat: delete committed configuration snapshot on agent instance completion`
- `test: cover committed applier tolerating a missing agent instance`
- `fix: tolerate a missing agent instance when syncing committed snapshot`

## Test plan

Executed and passing:

- [x] Insert/get/delete-level coverage for the new `AGENT_INSTANCE_COMMITTED_SNAPSHOT` column family (`AgentInstanceStateTest`)
- [x] Commit-side sync: a committed `CONFIGURATION` item copies all 7 concrete fields into the snapshot (golden files updated) (`AgentHistoryCommittedApplierTest`)
- [x] Discard-side restore: first-ever-`CREATE` discarded with no snapshot yet restores to defaults; a re-activation-triggered supersession mid-flight restores correctly and emits `AgentInstanceIntent.UPDATED`; multiple sequential commits followed by a later discard restore to the last-committed snapshot, not an earlier one; job-destruction discard restores correctly through the same shared path (`AgentHistoryDiscardRestoresConfigurationTest`)
- [x] The restore logic itself is triggered by discard regardless of *why* the discard happened, so it's covered once here for all trigger sources. The trigger mechanisms themselves — eager discard on job reactivation (poll and push paths) and the pre-existing job-destruction discard — are covered by #60729's `AgentHistoryDiscardOnJobReactivationTest` and `AgentHistoryDiscardOnJobReactivationPushTest`
- [x] Snapshot row deleted on `AgentInstanceCompletedApplier` when the instance completes (golden files updated) (`AgentInstanceCompletedApplierTest`)
- [x] Committed applier tolerates a missing live `AgentInstance` (matches the sibling discard-processor's existing guard; golden files updated)
- [x] `JsonSerializableToJsonTest`, `RecordGoldenFilesTest`, `ZbColumnFamiliesTest`, `EventAppliersTest$NoChangesTest` reflect the new column family
- [x] License, spotless, and checkstyle checks

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] This PR does not modify the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite).

## Related issues

Relates to #58797