### PR TITLE
ci: share Docker image across integration test shards

### DIFF
--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -21,6 +21,11 @@ on:
         type: boolean
         required: false
         default: false
+      use-shared-docker-test-image:
+        description: "Load the Camunda Docker test image from the run-scoped GCS build-cache instead of building it locally. Set by ci.yml only; leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       runFeTests:
@@ -36,6 +41,11 @@ on:
         type: boolean
         required: false
         default: false
+      use-shared-docker-test-image:
+        description: "Load the Camunda Docker test image from the run-scoped GCS build-cache instead of building it locally. Set by ci.yml only; leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -48,6 +58,7 @@ env:
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Tasklist
   CLIENT_DIR: tasklist/client
+  GCS_BUILD_CACHE_BUCKET: camunda-monorepo-ci-artifacts
 
 jobs:
   # run this test every time the workflow is triggered
@@ -470,7 +481,9 @@ jobs:
     name: "Integration / Docker ITs"
     runs-on: gcp-core-4-default
     timeout-minutes: 30
-    permissions: {}  # GITHUB_TOKEN unused in this job
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
     env:
       TEST_TYPE: Integration
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
@@ -498,11 +511,37 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+      - name: Authenticate to GCS build-cache
+        if: inputs.use-shared-docker-test-image
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/restore-shared-m2
+        if: inputs.use-shared-docker-test-image
       - id: build-backend
+        if: ${{ !inputs.use-shared-docker-test-image }}
         uses: ./.github/actions/build-zeebe
         with:
           maven-extra-args: -D skip.fe.build -D skipOptimize
+      - name: Load shared camunda docker test image
+        if: inputs.use-shared-docker-test-image
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 3
+          shell: bash
+          command: |
+            set -euo pipefail
+            gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-docker-test-image.tar.gz" "${RUNNER_TEMP}/"
+            docker load -i "${RUNNER_TEMP}/camunda-docker-test-image.tar.gz"
+            docker tag "camunda/camunda:${TASKLIST_TEST_DOCKER_IMAGE_TAG}" "${TASKLIST_TEST_DOCKER_IMAGE}:${TASKLIST_TEST_DOCKER_IMAGE_TAG}"
+            docker push "${TASKLIST_TEST_DOCKER_IMAGE}:${TASKLIST_TEST_DOCKER_IMAGE_TAG}"
       - uses: ./.github/actions/build-platform-docker
+        if: ${{ !inputs.use-shared-docker-test-image }}
         with:
           repository: ${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
           version: ${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,96 @@ jobs:
     uses: ./.github/workflows/ci-build-distball-reusable.yml
     secrets: inherit
 
+  build-camunda-docker-test-image:
+    name: "Build / Camunda Docker Test Image"
+    # POC: package the already-shared distball into the test image once, then let
+    # integration-test shards load it instead of rebuilding the same image.
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes, build-distball ]
+    runs-on: ${{ 'gcp-perf-core-8-default' }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    env:
+      DOCKER_IMAGE_TAG: current-test
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        timeout-minutes: 1
+        with:
+          persist-credentials: false
+      - name: Check for fork
+        id: is-fork
+        uses: ./.github/actions/is-fork
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+        with:
+          test_product: "Camunda Docker"
+      - uses: ./.github/actions/setup-build
+        if: steps.is-fork.outputs.is-fork != 'true'
+        with:
+          dockerhub-readonly: true
+          maven-cache-key-modifier: build-shared
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - name: Authenticate to GCS build-cache
+        if: steps.is-fork.outputs.is-fork != 'true'
+        timeout-minutes: 3
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Create dist/target
+        if: steps.is-fork.outputs.is-fork != 'true'
+        shell: bash
+        run: mkdir -p dist/target
+      - name: Download distball from GCS
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 2
+          shell: bash
+          command: gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
+      - uses: ./.github/actions/build-platform-docker
+        if: steps.is-fork.outputs.is-fork != 'true'
+        with:
+          repository: camunda/camunda
+          version: ${{ env.DOCKER_IMAGE_TAG }}
+          dockerfile: camunda.Dockerfile
+          platforms: linux/amd64
+          push: false
+      - name: Save and upload test image to GCS
+        if: steps.is-fork.outputs.is-fork != 'true'
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 3
+          shell: bash
+          command: |
+            set -euo pipefail
+            docker save "camunda/camunda:${DOCKER_IMAGE_TAG}" | gzip > camunda-docker-test-image.tar.gz
+            ls -lh camunda-docker-test-image.tar.gz
+            gcloud storage cp camunda-docker-test-image.tar.gz \
+              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-docker-test-image.tar.gz"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   build-platform-frontend:
     # Runs when the frontend changed, OR on any non-PR event targeting main/stable
     # (push/schedule/workflow_dispatch) so the snapshot deploy jobs — which download
@@ -1398,7 +1488,7 @@ jobs:
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs (${{ matrix.stressRun }})"
-    needs: [ detect-changes, setup-tests, build-distball ]
+    needs: [ detect-changes, setup-tests, build-distball, build-camunda-docker-test-image ]
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1517,8 +1607,22 @@ jobs:
         if: steps.is-fork.outputs.is-fork == 'true'
         with:
           maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Load shared camunda docker test image
+        if: ${{ matrix.docker-file != '' && steps.is-fork.outputs.is-fork != 'true' }}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 3
+          shell: bash
+          command: |
+            set -euo pipefail
+            gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-docker-test-image.tar.gz" "${RUNNER_TEMP}/"
+            docker load -i "${RUNNER_TEMP}/camunda-docker-test-image.tar.gz"
+            docker tag "camunda/camunda:${DOCKER_IMAGE_TAG}" "${{ matrix.docker-repository }}:${DOCKER_IMAGE_TAG}"
+            docker push "${{ matrix.docker-repository }}:${DOCKER_IMAGE_TAG}"
       - uses: ./.github/actions/build-platform-docker
-        if: ${{ matrix.docker-file != '' }}
+        if: ${{ matrix.docker-file != '' && steps.is-fork.outputs.is-fork == 'true' }}
         with:
           repository: ${{ matrix.docker-repository }}
           version: ${{ env.DOCKER_IMAGE_TAG }}
@@ -2618,6 +2722,7 @@ jobs:
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - archunit-tests
+      - build-camunda-docker-test-image
       - build-distball
       - build-platform-frontend
       - c8-e2e-test-suite
@@ -2682,9 +2787,9 @@ jobs:
         with:
           github_token: ${{ github.token }}
           has_failures: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
-      # Clean up the run-scoped GCS objects (distball + m2 tarball) only when build-distball
-      # succeeded and no other job failed or was cancelled. If any did, keep them so
-      # "Re-run failed jobs" can re-fetch the distball (build-distball won't re-run, so it won't
+      # Clean up the run-scoped GCS objects (distball + m2 tarball + Docker test image) only when
+      # build-distball succeeded and no other job failed or was cancelled. If any did, keep them so
+      # "Re-run failed jobs" can re-fetch the artifacts (producer jobs won't re-run, so they won't
       # re-upload). needs.* here spans every check-results dependency (broader than the old
       # consumer-only gate) — strictly safer: a failure anywhere keeps the objects for a rerun.
       # Orphaned objects on abandoned runs are reaped by the bucket TTL (Infra-owned).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2315,20 +2315,27 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   tasklist-ci:
-    if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
+    if: >-
+      always() &&
+      needs.build-distball.result == 'success' &&
+      (needs.build-camunda-docker-test-image.result == 'success' ||
+       needs.build-camunda-docker-test-image.result == 'skipped') &&
+      (needs.detect-changes.outputs.java-code-changes == 'true' ||
+       needs.detect-changes.outputs.frontend-changes == 'true')
     name: "Tasklist"
-    needs: [ detect-changes, build-distball ]
+    needs: [ detect-changes, build-distball, build-camunda-docker-test-image ]
     uses: ./.github/workflows/ci-tasklist.yml
     secrets: inherit
     permissions:
       contents: read
-      id-token: write  # granted through to the reusable back-end UT's WIF GCS auth
+      id-token: write  # granted through to the reusable back-end UT and Docker IT WIF GCS auth
     with:
       runFeTests: ${{ needs.detect-changes.outputs.tasklist-frontend-changes  == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
       # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
       # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
       use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
+      use-shared-docker-test-image: ${{ github.event.pull_request.head.repo.fork != true && needs.build-camunda-docker-test-image.result == 'success' }}
 
   operate-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,7 @@ jobs:
         uses: ./.github/actions/print-metadata
         with:
           test_product: "Camunda Docker"
+          test_type: Build
       - uses: ./.github/actions/setup-build
         if: steps.is-fork.outputs.is-fork != 'true'
         with:


### PR DESCRIPTION
## Description

Draft POC for sharing the Camunda Docker image across `ci.yml` integration-test shards.

Today each integration-test shard that needs a Docker image packages the shared distball into `camunda/camunda:current-test` and pushes it to its job-local registry. This POC moves that image build into a single producer job, uploads the saved image to the existing run-scoped GCS build cache, and has non-fork integration shards load, retag, and push the same image to their local registry.

This is intentionally limited to integration tests so we can measure the real trade-off before broadening the design. It does not yet solve the larger "publish what we test" goal, since snapshot publishing still rebuilds separately. Related context: #52693, #54352, and the earlier closed POC #56507.

Measurement criteria for this draft:

- Producer job duration and failure modes.
- Per-shard download, `docker load`, retag, and local-registry push duration.
- Total self-hosted runner minutes versus current repeated per-shard packaging.
- Whether centralizing the image build reduces flaky exposure or instead moves failure risk to GCS transfer and image load/push steps.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to #52693
Related to #54352

## Measurement result

Measured on PR run https://github.com/camunda/camunda/actions/runs/32502738049 and compared with five recent successful `main` `ci.yml` runs.

Integration-test image packaging only:

- Baseline: 9 per-shard `build-platform-docker` steps total 10.60 to 10.67 self-hosted runner-minutes, average 1.18 minutes per shard.
- POC: producer job 2.75 minutes, plus 9 consumer load/tag/push steps total 2.13 runner-minutes, average 0.24 minutes per shard.
- Net: about 4.88 image-related runner-minutes instead of about 10.63, saving about 5.7 self-hosted runner-minutes per full integration matrix.
- Latency trade-off: old shard-local builds run in parallel and cost about 1.2 minutes on the critical path; the POC adds the 2.75-minute producer before the integration matrix plus about 0.3 minutes load time per Docker-consuming shard. Expect roughly 1.8 minutes worse integration critical-path latency unless another dependency hides the producer time.

Verdict for this narrow POC: worthwhile only if the priority is self-hosted runner cost and single-image provenance. It is not a clear merge-velocity win by itself. The stronger design is still a registry/digest flow that builds the tested multi-arch image once and promotes the same digest for publishing.

Follow-up migration candidates:

- Easier: Tasklist Docker IT still builds the same `camunda.Dockerfile` image under a local `localhost:5000/camunda/tasklist` tag. It could likely load the shared Camunda image and retag it, with the existing fork fallback. Expected additional saving is about 1.1 to 1.3 runner-minutes.
- Moderate: Zeebe smoke tests build linux/amd64 and linux/arm64 images in `ci-zeebe.yml`. Reuse would need workflow-call inputs and either per-arch artifacts or a registry digest, so the current single-arch tar is not enough.
- Not easy with the tar POC: Docker checks and snapshot deploy jobs need multi-arch images, verification metadata, and published tags. These should use a registry-backed digest/promotion design, not GCS image tar reuse.

Tasklist Docker IT follow-up:

- PR run: https://github.com/camunda/camunda/actions/runs/32734804647/job/97457877841
- Result: `Tasklist / Integration / Docker ITs` passed.
- The job authenticated to GCS, restored shared Maven SNAPSHOTs, loaded the shared Camunda Docker image, skipped local `build-zeebe`, skipped local `build-platform-docker`, and ran Docker tests successfully.
- Baseline across five recent successful `main` runs: Tasklist Docker IT took 8.88 to 11.88 minutes. The local `build-zeebe` plus `build-platform-docker` prep accounted for 5.85 to 7.70 minutes.
- POC run: Tasklist Docker IT took 4.10 minutes. Shared-image overhead was 0.57 minutes total: GCS auth 0.13, shared m2 restore 0.10, image load/tag/push 0.33.
- Net: this follow-up saves roughly 5 to 7 self-hosted runner-minutes for Tasklist Docker IT and shortens that job's wall-clock time by roughly 5 to 8 minutes.

## Validation

- `./mvnw spotless:apply -T1C`
- `conftest test --rego-version v0 -o github --policy .github .github/workflows/*.yml`
- `git diff --check`
- `actionlint .github/workflows/ci.yml` compared against `origin/main`: both report 44 local findings from existing repository patterns, so this branch did not increase the local finding count.

## Act testing

Tier 3. The changed behavior depends on Vault-backed GCS auth, self-hosted runners, Docker Buildx, GCS object transfer, the shared distball artifact, and the CI job-local Docker registry. A local act harness would mock the parts that matter most, so the useful validation is a real draft PR run.


