### PR TITLE
fix: stop WARNing when there are not actual duplicate flow nodes

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -512,9 +512,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentDocument incident,
       final IncidentState newState,
       final String fniId,
-      final List<String> flowNodeIndices,
+      final Collection<String> flowNodeIndices,
       final IncidentBulkUpdate updates,
-      final List<String> listViewIndices) {
+      final Collection<String> listViewIndices) {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;
     if (hasIncident) {
@@ -599,7 +599,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentState newState,
       final String piId,
       final IncidentBulkUpdate updates,
-      final List<String> indexes) {
+      final Collection<String> indexes) {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;
     if (hasIncident) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
@@ -8,10 +8,8 @@
 package io.camunda.exporter.tasks.incident;
 
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,11 +19,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public record IncidentsState(
     Collection<IncidentDocument> incidentDocuments,
     Set<String> incidentIdsToSkip,
-    Map<String, List<String>> flowNodeInstanceIndices,
-    Map<String, List<String>> flowNodeInstanceInListViewIndices,
+    Map<String, Set<String>> flowNodeInstanceIndices,
+    Map<String, Set<String>> flowNodeInstanceInListViewIndices,
     Map<Long, String> processInstanceTreePaths,
     Map<String, String> incidentTreePaths,
-    Map<String, List<String>> processInstanceIndices,
+    Map<String, Set<String>> processInstanceIndices,
     Map<String, Set<String>> piIdsWithIncidentIds,
     Map<String, Set<String>> fniIdsWithIncidentIds) {
   public IncidentsState() {
@@ -72,15 +70,17 @@ public record IncidentsState(
   }
 
   public void addProcessInstance(final String id, final String index) {
-    processInstanceIndices.computeIfAbsent(id, k -> new ArrayList<>()).add(index);
+    processInstanceIndices.computeIfAbsent(id, k -> ConcurrentHashMap.newKeySet()).add(index);
   }
 
   public void addFlowNodeInstanceInListView(final String id, final String index) {
-    flowNodeInstanceInListViewIndices.computeIfAbsent(id, k -> new ArrayList<>()).add(index);
+    flowNodeInstanceInListViewIndices
+        .computeIfAbsent(id, k -> ConcurrentHashMap.newKeySet())
+        .add(index);
   }
 
   public void addFlowNodeInstance(final String id, final String index) {
-    flowNodeInstanceIndices.computeIfAbsent(id, k -> new ArrayList<>()).add(index);
+    flowNodeInstanceIndices.computeIfAbsent(id, k -> ConcurrentHashMap.newKeySet()).add(index);
   }
 
   private boolean addIncidentIdByInstanceId(


### PR DESCRIPTION
change things to use Set instead of List, as otherwise incidents from sub-processes (via call activity) can lead us to having the same index collected more than once.  By using a Set we dedupe that, which is correct as we only want to WARN when we see the same ID in _different_ indexes.

