### PR TITLE
fix: add required timeout_minutes to nick-fields/retry in urgency cron

### DIFF
--- a/.github/workflows/assign-urgency-to-issues-cron.yml
+++ b/.github/workflows/assign-urgency-to-issues-cron.yml
@@ -54,6 +54,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           retry_wait_seconds: 10
+          timeout_minutes: 15
           command: |
             bash .github/workflows/assign-urgency-to-issues.sh \
               --project 187 \


### PR DESCRIPTION
## Description

[#60400](https://github.com/camunda/camunda/pull/60400) introduced
`nick-fields/retry` in the hourly urgency-assign cron but did not include
`timeout_minutes` or `timeout_seconds`. The action requires one of them, so
every scheduled run on main has been failing with:

```
Must specify either timeout_minutes or timeout_seconds inputs
```

This adds the missing `timeout_minutes: 15` (matching the job's own
`timeout-minutes`) to satisfy the required input. Setting it equal to the job
ceiling means the action never independently fires its process-kill path.

Fixes incident INC-7292.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
