### PR TITLE
Add idempotency support for embedded history items

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistoryDedupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistoryDedupIT.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryItem;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers idempotency of the embedded {@code history[]} batch on {@code UpdateAgentInstance} across
+ * job activations (window 3): an item committed by an earlier job, then resent by a later,
+ * different job for the same agent instance, must still be recognized as a duplicate — over the
+ * real REST API, not just at the engine level.
+ *
+ * <p>Kept as its own class rather than added to {@link AgentInstanceHistorySearchIT}: that class's
+ * fixture is a single shared {@code @BeforeAll} agent instance reused by every {@code @Test} method
+ * for search-filter assertions. This scenario needs its own multi-instance process and asserts on
+ * the synchronous command response, not on search results, so sharing that fixture would only add
+ * coupling.
+ */
+@MultiDbTest
+@CompatibilityTest
+public class AgentInstanceHistoryDedupIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentDedupElement";
+  private static final String PROCESS_ID = "agentHistoryDedupProcess";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldFlagResentHistoryItemAsDuplicateAcrossJobActivations() {
+    // given — a sequential multi-instance AI-agent service task: job1 pushes "item-x" and
+    // completes (which commits the item via AGENT_HISTORY:COMMIT), then job2 — a brand-new job on
+    // a brand-new element instance, for the same agent instance — resends "item-x".
+    final var processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                AGENT_ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeAiAgentTaskDefinition()
+                        .multiInstance(
+                            m ->
+                                m.sequential()
+                                    .zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "agent-history-dedup.bpmn");
+
+    final var processInstanceKey =
+        camundaClient
+            .newCreateInstanceCommand()
+            .processDefinitionKey(process.getProcessDefinitionKey())
+            .variables(Map.of("items", List.of("a", "b")))
+            .execute()
+            .getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.elementId(AGENT_ELEMENT_ID)
+                .type(ElementInstanceType.SERVICE_TASK)
+                .processInstanceKey(processInstanceKey),
+        1);
+    final var ei1 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(AGENT_ELEMENT_ID)
+                        .type(ElementInstanceType.SERVICE_TASK)
+                        .processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    final var agentInstanceKey =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei1)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+
+    final var job1 =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+
+    // when — job1 pushes "item-x", then completes: AgentHistoryCommitProcessor commits it.
+    final var firstResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(ei1)
+            .jobKey(job1.getKey())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId("item-x")
+                        .role(AgentInstanceHistoryRole.USER)
+                        .loopIteration(1)
+                        .content(List.of(AgentInstanceHistoryContent.text("hi")))
+                        .producedAt(OffsetDateTime.now())))
+            .send()
+            .join();
+    final var originalKey = firstResponse.getCreatedHistory().getFirst().getHistoryItemKey();
+
+    camundaClient.newCompleteCommand(job1.getKey()).send().join();
+
+    // given — the multi-instance body advances: a second, brand-new element instance activates.
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.elementId(AGENT_ELEMENT_ID)
+                .type(ElementInstanceType.SERVICE_TASK)
+                .processInstanceKey(processInstanceKey),
+        2);
+    final var ei2 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(AGENT_ELEMENT_ID)
+                        .type(ElementInstanceType.SERVICE_TASK)
+                        .processInstanceKey(processInstanceKey))
+            .sort(s -> s.elementInstanceKey().asc())
+            .execute()
+            .items()
+            .get(1)
+            .getElementInstanceKey();
+
+    final var job2 =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+
+    // when — job2 (a brand-new job, on a brand-new element instance) resends "item-x", with
+    // different content (dedup keys on historyItemId alone, not content).
+    final var secondResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(ei2)
+            .jobKey(job2.getKey())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId("item-x")
+                        .role(AgentInstanceHistoryRole.USER)
+                        .loopIteration(1)
+                        .content(List.of(AgentInstanceHistoryContent.text("hi again")))
+                        .producedAt(OffsetDateTime.now())))
+            .send()
+            .join();
+
+    // then — the resent item is echoed back flagged as a duplicate of the original, carrying the
+    // original's key, not a newly minted one — over the real REST API.
+    final var echoed = secondResponse.getCreatedHistory();
+    assertThat(echoed).hasSize(1);
+    assertThat(echoed.getFirst().isDuplicate()).isTrue();
+    assertThat(echoed.getFirst().getHistoryItemKey()).isEqualTo(originalKey);
+
+    // supporting check — confirms job2 really was activated on the second element instance, as
+    // the test setup intended.
+    assertThat(job2.getElementInstanceKey())
+        .as("job2 must be the job activated for the second element instance")
+        .isEqualTo(ei2);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -266,11 +266,15 @@ public final class AgentHistoryBatchBehavior {
       final List<? extends AgentHistoryRecordValue> history) {
     final var changedAttributes = new HashSet<String>();
     final var items = new ArrayList<AgentHistoryRecord>(history.size());
+    final var agentHistoryState = processingState.getAgentHistoryState();
     final var pendingByHistoryItemId = collectPendingByHistoryItemId(jobKey, jobLease);
 
     for (final var item : history) {
       final var historyItemId = item.getHistoryItemId();
-      final var matchedKey = pendingByHistoryItemId.get(historyItemId);
+      final var committedKey =
+          agentHistoryState.getCommittedHistoryItemKey(target.getAgentInstanceKey(), historyItemId);
+      final var matchedKey =
+          committedKey != null ? committedKey : pendingByHistoryItemId.get(historyItemId);
       final var isDuplicate = matchedKey != null;
       final var historyKey = isDuplicate ? matchedKey : keyGenerator.nextKey();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -67,9 +67,6 @@ public final class AgentHistoryBatchBehavior {
   static final String ERROR_MSG_JOB_REQUIRED_FOR_HISTORY =
       "Expected a job to be provided for the embedded history batch, but no jobKey was set."
           + " A history batch must be attributed to the active job that produced it.";
-  private static final String ERROR_MSG_UNKNOWN_ATTRIBUTES =
-      "Expected to update agent instance configuration with history item '%s',"
-          + " but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
   static final String ERROR_MSG_DUPLICATE_HISTORY_ITEM_ID_IN_REQUEST =
       "Expected to update agent instance, but historyItemId '%s' is used by more than one history "
           + "item. Each history item must have a unique historyItemId.";
@@ -78,6 +75,9 @@ public final class AgentHistoryBatchBehavior {
           + "pending history items associated with a lease and this request carries none. Once a "
           + "job's pending history is scoped to a lease, every later request for that job must "
           + "supply one too.";
+  private static final String ERROR_MSG_UNKNOWN_ATTRIBUTES =
+      "Expected to update agent instance configuration with history item '%s',"
+          + " but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
 
   private final KeyGenerator keyGenerator;
   private final ProcessingState processingState;
@@ -161,9 +161,6 @@ public final class AgentHistoryBatchBehavior {
 
     return Either.right(job);
   }
-
-  /** One pending scan for a job, gathering both facts the unleased-request check needs. */
-  private record PendingScanResult(boolean anyLeased, Map<String, Long> byHistoryItemId) {}
 
   private PendingScanResult scanPendingByJobKey(final long jobKey) {
     final var byHistoryItemId = new HashMap<String, Long>();
@@ -434,4 +431,7 @@ public final class AgentHistoryBatchBehavior {
     }
     return changed;
   }
+
+  /** One pending scan for a job, gathering both facts the unleased-request check needs. */
+  private record PendingScanResult(boolean anyLeased, Map<String, Long> byHistoryItemId) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.agentinstance;
 
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
@@ -20,8 +21,10 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -67,6 +70,14 @@ public final class AgentHistoryBatchBehavior {
   private static final String ERROR_MSG_UNKNOWN_ATTRIBUTES =
       "Expected to update agent instance configuration with history item '%s',"
           + " but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
+  static final String ERROR_MSG_DUPLICATE_HISTORY_ITEM_ID_IN_REQUEST =
+      "Expected to update agent instance, but historyItemId '%s' is used by more than one history "
+          + "item. Each history item must have a unique historyItemId.";
+  static final String ERROR_MSG_UNLEASED_REQUEST_WITH_LEASED_PENDING_ITEMS =
+      "Expected to update agent instance related to job with key '%d', but the job already has "
+          + "pending history items associated with a lease and this request carries none. Once a "
+          + "job's pending history is scoped to a lease, every later request for that job must "
+          + "supply one too.";
 
   private final KeyGenerator keyGenerator;
   private final ProcessingState processingState;
@@ -124,7 +135,46 @@ public final class AgentHistoryBatchBehavior {
                   jobKey, jobElementInstanceKey, elementInstanceKey)));
     }
 
+    // Leases separate attempts: pending items pushed with a lease survive only if their lease
+    // wins. A request with no lease can't say which attempt it belongs to, so once the job has
+    // any leased pending items, an unleased request that would introduce a genuinely new pending
+    // item is refused outright — that new item would carry no lease of its own and could be
+    // silently discarded once a real lease commits. An unleased request that resends ids already
+    // pending is not a risk: it creates nothing new, so it is left to the ordinary dedup check
+    // below instead of being rejected here.
+    if (jobLease.isEmpty() && history != null && !history.isEmpty()) {
+      final var pendingScan = scanPendingByJobKey(jobKey);
+      if (pendingScan.anyLeased()
+          && history.stream()
+              .anyMatch(
+                  item -> !pendingScan.byHistoryItemId().containsKey(item.getHistoryItemId()))) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                ERROR_MSG_UNLEASED_REQUEST_WITH_LEASED_PENDING_ITEMS.formatted(jobKey)));
+      }
+    }
+
     return Either.right(job);
+  }
+
+  /** One pending scan for a job, gathering both facts the unleased-request check needs. */
+  private record PendingScanResult(boolean anyLeased, Map<String, Long> byHistoryItemId) {}
+
+  private PendingScanResult scanPendingByJobKey(final long jobKey) {
+    final var byHistoryItemId = new HashMap<String, Long>();
+    final var anyLeased = new boolean[1];
+    processingState
+        .getAgentHistoryState()
+        .visitByJobKey(
+            jobKey,
+            item -> {
+              byHistoryItemId.putIfAbsent(item.getHistoryItemId(), item.getAgentHistoryKey());
+              if (!item.getJobLease().isEmpty()) {
+                anyLeased[0] = true;
+              }
+            });
+    return new PendingScanResult(anyLeased[0], byHistoryItemId);
   }
 
   /**
@@ -143,6 +193,7 @@ public final class AgentHistoryBatchBehavior {
       return Either.rightVoid();
     }
 
+    final var seenHistoryItemIds = new HashSet<String>();
     for (int i = 0; i < history.size(); i++) {
       final var item = history.get(i);
       final var historyItemId = item.getHistoryItemId();
@@ -151,6 +202,13 @@ public final class AgentHistoryBatchBehavior {
         return Either.left(
             new Rejection(
                 RejectionType.INVALID_ARGUMENT, ERROR_MSG_HISTORY_ITEM_ID_MISSING.formatted(i)));
+      }
+
+      if (!seenHistoryItemIds.add(historyItemId)) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                ERROR_MSG_DUPLICATE_HISTORY_ITEM_ID_IN_REQUEST.formatted(historyItemId)));
       }
 
       if (item.getRole() == AgentHistoryRole.UNSPECIFIED) {
@@ -208,9 +266,13 @@ public final class AgentHistoryBatchBehavior {
       final List<? extends AgentHistoryRecordValue> history) {
     final var changedAttributes = new HashSet<String>();
     final var items = new ArrayList<AgentHistoryRecord>(history.size());
+    final var pendingByHistoryItemId = collectPendingByHistoryItemId(jobKey, jobLease);
 
     for (final var item : history) {
-      final var historyKey = keyGenerator.nextKey();
+      final var historyItemId = item.getHistoryItemId();
+      final var matchedKey = pendingByHistoryItemId.get(historyItemId);
+      final var isDuplicate = matchedKey != null;
+      final var historyKey = isDuplicate ? matchedKey : keyGenerator.nextKey();
 
       final var event = new AgentHistoryRecord();
       // `item` is always a concrete AgentHistoryRecord at runtime (the only implementation of
@@ -227,18 +289,48 @@ public final class AgentHistoryBatchBehavior {
           .setProcessDefinitionKey(target.getProcessDefinitionKey())
           .setTenantId(target.getTenantId())
           .setJobKey(jobKey)
-          .setJobLease(jobLease);
+          .setJobLease(jobLease)
+          .setDuplicate(isDuplicate);
 
-      if (applyMetrics(target.getMetrics(), item)) {
-        changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
+      // A duplicate is skipped entirely: no metrics accumulation, no CONFIGURATION attributes
+      // applied — re-applying values the instance already reflects would be unobservable, so the
+      // durable signal that it was skipped is the isDuplicate flag on the echoed item alone.
+      if (!isDuplicate) {
+        if (applyMetrics(target.getMetrics(), item)) {
+          changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
+        }
+        changedAttributes.addAll(applyConfigurationChanges(target, item));
       }
-      changedAttributes.addAll(applyConfigurationChanges(target, item));
 
       items.add(event);
     }
 
     target.setHistory(items);
     return changedAttributes;
+  }
+
+  /**
+   * Collects, by {@code historyItemId}, the {@code agentHistoryKey} of every history item already
+   * pending for this activation: lease-scoped when {@code jobLease} is given (another lease's
+   * pending items are never duplicates — they belong to an attempt that may be about to lose), or
+   * scoped to the whole job when it is not (pending items live only until the job's committing
+   * lease clears them, so "all pending for this job" is exactly the set that will be committed
+   * together).
+   */
+  private Map<String, Long> collectPendingByHistoryItemId(
+      final long jobKey, final String jobLease) {
+    final var pendingByHistoryItemId = new HashMap<String, Long>();
+    final AgentHistoryState.AgentHistoryVisitor collect =
+        pending ->
+            pendingByHistoryItemId.putIfAbsent(
+                pending.getHistoryItemId(), pending.getAgentHistoryKey());
+    final var agentHistoryState = processingState.getAgentHistoryState();
+    if (jobLease.isEmpty()) {
+      agentHistoryState.visitByJobKey(jobKey, collect);
+    } else {
+      agentHistoryState.visitByJobLease(jobKey, jobLease, collect);
+    }
+    return pendingByHistoryItemId;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -141,13 +141,17 @@ public final class AgentHistoryBatchBehavior {
     // item is refused outright — that new item would carry no lease of its own and could be
     // silently discarded once a real lease commits. An unleased request that resends ids already
     // pending is not a risk: it creates nothing new, so it is left to the ordinary dedup check
-    // below instead of being rejected here.
+    // below instead of being rejected here. Items with no historyItemId are excluded from this
+    // check too — they belong to validateHistory's rejection instead, which runs after this and
+    // names the actual defect.
     if (jobLease.isEmpty() && history != null && !history.isEmpty()) {
       final var pendingScan = scanPendingByJobKey(jobKey);
       if (pendingScan.anyLeased()
           && history.stream()
               .anyMatch(
-                  item -> !pendingScan.byHistoryItemId().containsKey(item.getHistoryItemId()))) {
+                  item ->
+                      !item.getHistoryItemId().isEmpty()
+                          && !pendingScan.byHistoryItemId().containsKey(item.getHistoryItemId()))) {
         return Either.left(
             new Rejection(
                 RejectionType.INVALID_ARGUMENT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -233,9 +233,14 @@ public final class AgentInstanceCreateProcessor
     event
         .getHistory()
         .forEach(
-            item ->
+            item -> {
+              // A duplicate is skipped entirely: it was already created by an earlier request, so
+              // no second AGENT_HISTORY:CREATED event is appended for it.
+              if (!item.isDuplicate()) {
                 stateWriter.appendFollowUpEvent(
-                    item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item));
+                    item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item);
+              }
+            });
 
     responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.CREATED, event, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -70,6 +70,11 @@ public final class AgentInstanceUpdateProcessor
       "Expected to update agent instance with key '%d' for element instance with key '%d', but the process instance key '%d' does not match the agent instance's process instance key '%d'.";
   private static final String ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS =
       "Expected to associate element instance with key '%d' with an agent instance, but it is already associated with agent instance with key '%d'.";
+  private static final String ERROR_MSG_SECOND_ACTIVE_WRITER =
+      "Expected to update agent instance with key '%d' for element instance with key '%d', but "
+          + "element instance with key '%d' is still the active writer for this agent instance "
+          + "and has not completed. Only one element instance may write to a given agent instance "
+          + "at a time.";
   private static final long METRIC_NOT_PROVIDED = -1L;
   private static final Set<AgentInstanceStatus> ACTIVE_STATUSES =
       EnumSet.of(
@@ -198,6 +203,23 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
+    // An agent instance has one active writer at a time. It can span several element instances
+    // (e.g. sequential re-entry), but only one of them may add history at any moment — read as
+    // live state (is the previous writer still active?), not a latch, so sequential re-entry is
+    // accepted once that previous element instance has completed.
+    final var currentWriterElementInstanceKey = current.getElementInstanceKey();
+    if (currentWriterElementInstanceKey != newElementInstanceKey) {
+      final var currentWriter = elementInstanceState.getInstance(currentWriterElementInstanceKey);
+      if (currentWriter != null && currentWriter.isActive()) {
+        writeRejection(
+            command,
+            RejectionType.INVALID_STATE,
+            ERROR_MSG_SECOND_ACTIVE_WRITER.formatted(
+                agentInstanceKey, newElementInstanceKey, currentWriterElementInstanceKey));
+        return;
+      }
+    }
+
     final var validJob =
         historyBatchHelper.validateJobContext(
             commandValue.getJobKey(),
@@ -243,9 +265,14 @@ public final class AgentInstanceUpdateProcessor
       current
           .getHistory()
           .forEach(
-              item ->
+              item -> {
+                // A duplicate is skipped entirely: it was already created by an earlier request,
+                // so no second AGENT_HISTORY:CREATED event is appended for it.
+                if (!item.isDuplicate()) {
                   stateWriter.appendFollowUpEvent(
-                      item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item));
+                      item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item);
+                }
+              });
 
       changedAttributes.addAll(historyChanges);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceMetrics;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
@@ -89,6 +90,7 @@ public final class AgentInstanceUpdateProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final AgentInstanceState agentInstanceState;
   private final ElementInstanceState elementInstanceState;
+  private final JobState jobState;
   private final CslAuthorizationCheck cslCheck;
   private final AgentHistoryBatchBehavior historyBatchHelper;
 
@@ -102,6 +104,7 @@ public final class AgentInstanceUpdateProcessor
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
     elementInstanceState = processingState.getElementInstanceState();
+    jobState = processingState.getJobState();
     this.cslCheck = cslCheck;
     historyBatchHelper = new AgentHistoryBatchBehavior(keyGenerator, processingState);
   }
@@ -203,20 +206,24 @@ public final class AgentInstanceUpdateProcessor
       return;
     }
 
-    // An agent instance has one active writer at a time. It can span several element instances
-    // (e.g. sequential re-entry), but only one of them may add history at any moment — read as
-    // live state (is the previous writer still active?), not a latch, so sequential re-entry is
-    // accepted once that previous element instance has completed.
-    final var currentWriterElementInstanceKey = current.getElementInstanceKey();
-    if (currentWriterElementInstanceKey != newElementInstanceKey) {
-      final var currentWriter = elementInstanceState.getInstance(currentWriterElementInstanceKey);
-      if (currentWriter != null && currentWriter.isActive()) {
-        writeRejection(
-            command,
-            RejectionType.INVALID_STATE,
-            ERROR_MSG_SECOND_ACTIVE_WRITER.formatted(
-                agentInstanceKey, newElementInstanceKey, currentWriterElementInstanceKey));
-        return;
+    // Only matters when history is being pushed; a plain status update can't collide with
+    // another writer. The old writer counts as active only while its job is ACTIVATED, not
+    // while its element instance is active: history resolves in the same step as the job, but
+    // the element instance can stay active longer for unrelated reasons.
+    if (!commandValue.getHistory().isEmpty()) {
+      final var currentWriterElementInstanceKey = current.getElementInstanceKey();
+      if (currentWriterElementInstanceKey != newElementInstanceKey) {
+        final var currentWriter = elementInstanceState.getInstance(currentWriterElementInstanceKey);
+        final var currentWriterJobKey = currentWriter == null ? -1L : currentWriter.getJobKey();
+        if (currentWriterJobKey != -1L
+            && jobState.getState(currentWriterJobKey) == JobState.State.ACTIVATED) {
+          writeRejection(
+              command,
+              RejectionType.INVALID_STATE,
+              ERROR_MSG_SECOND_ACTIVE_WRITER.formatted(
+                  agentInstanceKey, newElementInstanceKey, currentWriterElementInstanceKey));
+          return;
+        }
       }
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import java.util.ArrayList;
+import java.util.function.Consumer;
 
 public final class DbAgentHistoryState implements MutableAgentHistoryState {
 
@@ -36,6 +38,17 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
   private final ColumnFamily<DbCompositeKey<DbCompositeKey<DbLong, DbString>, DbLong>, DbNil>
       byJobKeyColumnFamily;
 
+  // Committed ids: (agentInstanceKey, historyItemId) -> agentHistoryKey
+  // Supports prefix search by agentInstanceKey alone, for the one-shot delete on instance
+  // completion.
+  private final DbLong committedAgentInstanceKey = new DbLong();
+  private final DbString committedHistoryItemId = new DbString();
+  private final DbCompositeKey<DbLong, DbString> committedKey =
+      new DbCompositeKey<>(committedAgentInstanceKey, committedHistoryItemId);
+  private final DbLong committedAgentHistoryKey = new DbLong();
+  private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbLong>
+      committedHistoryItemIdsColumnFamily;
+
   public DbAgentHistoryState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     agentHistoryColumnFamily =
@@ -47,6 +60,12 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
             transactionContext,
             jobKeyLeaseAndHistoryItemKey,
             DbNil.INSTANCE);
+    committedHistoryItemIdsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AGENT_HISTORY_COMMITTED_IDS,
+            transactionContext,
+            committedKey,
+            committedAgentHistoryKey);
   }
 
   @Override
@@ -110,5 +129,39 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
     jobLease.wrapString(record.getJobLease());
     agentHistoryColumnFamily.deleteIfExists(historyItemKey);
     byJobKeyColumnFamily.deleteIfExists(jobKeyLeaseAndHistoryItemKey);
+  }
+
+  @Override
+  public Long getCommittedHistoryItemKey(final long agentInstanceKey, final String historyItemId) {
+    committedAgentInstanceKey.wrapLong(agentInstanceKey);
+    committedHistoryItemId.wrapString(historyItemId);
+    final var stored = committedHistoryItemIdsColumnFamily.get(committedKey);
+    return stored == null ? null : stored.getValue();
+  }
+
+  @Override
+  public void putCommittedHistoryItemKey(
+      final long agentInstanceKey, final String historyItemId, final long agentHistoryKeyValue) {
+    committedAgentInstanceKey.wrapLong(agentInstanceKey);
+    committedHistoryItemId.wrapString(historyItemId);
+    committedAgentHistoryKey.wrapLong(agentHistoryKeyValue);
+    committedHistoryItemIdsColumnFamily.upsert(committedKey, committedAgentHistoryKey);
+  }
+
+  @Override
+  public void deleteCommittedHistoryItemKeys(final long agentInstanceKey) {
+    committedAgentInstanceKey.wrapLong(agentInstanceKey);
+    // Collect the ids in one pass, then delete in a second: mutating the column family while its
+    // own iterator is still open is unsafe (RocksDB explicitly warns against it), so this must not
+    // call deleteExisting from inside the whileEqualPrefix visitor below.
+    final var historyItemIds = new ArrayList<String>();
+    final Consumer<DbCompositeKey<DbLong, DbString>> collectHistoryItemId =
+        key -> historyItemIds.add(key.second().toString());
+    committedHistoryItemIdsColumnFamily.whileEqualPrefix(
+        committedAgentInstanceKey, collectHistoryItemId);
+    for (final var historyItemId : historyItemIds) {
+      committedHistoryItemId.wrapString(historyItemId);
+      committedHistoryItemIdsColumnFamily.deleteExisting(committedKey);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -24,6 +24,11 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    // Recorded before the delete below removes the pending entry this id would otherwise still
+    // be found through: a later job resending this id has only this map left to check against
+    // once the committing job's own pending item is gone.
+    agentHistoryState.putCommittedHistoryItemKey(
+        value.getAgentInstanceKey(), value.getHistoryItemId(), key);
     agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
@@ -27,9 +27,10 @@ public final class AgentHistoryCreatedApplier
     // Store only the identity fields in primary storage (RocksDB). content/toolCalls/metrics/
     // producedAt have already reached secondary storage via the CREATED event itself; nothing reads
     // them back out of primary storage — matching a COMMIT/DISCARD only needs jobKey/jobLease, and
-    // deleting the item needs the same two fields. Storing the trimmed copy also means the
-    // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
-    // stripping needed at those emit sites.
+    // deleting the item needs the same two fields. historyItemId is kept too: dedup matches on it
+    // once an item is pending or committed, so it must survive here as well. Storing the trimmed
+    // copy also means the COMMITTED/DISCARDED events re-emitted from state carry only identity
+    // fields, with no extra stripping needed at those emit sites.
     //
     // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
     // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
@@ -50,6 +51,7 @@ public final class AgentHistoryCreatedApplier
             .setTenantId(value.getTenantId())
             .setJobKey(value.getJobKey())
             .setJobLease(value.getJobLease())
+            .setHistoryItemId(value.getHistoryItemId())
             .setLoopIteration(value.getLoopIteration())
             .setRole(value.getRole());
     agentHistoryState.insert(key, identityRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -16,13 +17,21 @@ public final class AgentInstanceCompletedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
 
   private final MutableAgentInstanceState agentInstanceState;
+  private final MutableAgentHistoryState agentHistoryState;
 
-  public AgentInstanceCompletedApplier(final MutableAgentInstanceState agentInstanceState) {
+  public AgentInstanceCompletedApplier(
+      final MutableAgentInstanceState agentInstanceState,
+      final MutableAgentHistoryState agentHistoryState) {
     this.agentInstanceState = agentInstanceState;
+    this.agentHistoryState = agentHistoryState;
   }
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    // The committed-ids map is retained for exactly the agent instance's lifetime; this is the
+    // one point where that lifetime ends, and the only path that removes an agent instance at
+    // all, so this is the single place cleanup needs to happen.
+    agentHistoryState.deleteCommittedHistoryItemKeys(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -223,7 +223,8 @@ public final class EventAppliers implements EventApplier {
             state.getAgentInstanceState(), state.getElementInstanceState()));
     register(
         AgentInstanceIntent.COMPLETED,
-        new AgentInstanceCompletedApplier(state.getAgentInstanceState()));
+        new AgentInstanceCompletedApplier(
+            state.getAgentInstanceState(), state.getAgentHistoryState()));
     register(
         AgentInstanceIntent.MIGRATED,
         new AgentInstanceMigratedApplier(state.getAgentInstanceState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
@@ -34,6 +34,12 @@ public interface AgentHistoryState {
    */
   void visitByJobLease(long jobKey, String jobLease, AgentHistoryVisitor visitor);
 
+  /**
+   * @return the {@code agentHistoryKey} of the history item that was committed under this {@code
+   *     historyItemId} for this agent instance, or {@code null} if none was
+   */
+  Long getCommittedHistoryItemKey(long agentInstanceKey, String historyItemId);
+
   @FunctionalInterface
   interface AgentHistoryVisitor {
     void visit(AgentHistoryRecord record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
@@ -36,7 +36,7 @@ public interface AgentHistoryState {
 
   /**
    * @return the {@code agentHistoryKey} of the history item that was committed under this {@code
-   *     historyItemId} for this agent instance, or {@code null} if none was
+   *     historyItemId} for this agent instance, or {@code null} if none was committed
    */
   Long getCommittedHistoryItemKey(long agentInstanceKey, String historyItemId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
@@ -25,4 +25,18 @@ public interface MutableAgentHistoryState extends AgentHistoryState {
    * to locate the secondary index entry, avoiding an extra state lookup.
    */
   void delete(long historyItemKey, AgentHistoryRecord record);
+
+  /**
+   * Records that {@code historyItemId} was committed under {@code agentHistoryKey} for {@code
+   * agentInstanceKey}, so a later job resending this id can still be recognized as a duplicate once
+   * the pending item itself is gone.
+   */
+  void putCommittedHistoryItemKey(
+      long agentInstanceKey, String historyItemId, long agentHistoryKey);
+
+  /**
+   * Deletes every committed-id entry recorded for {@code agentInstanceKey}. Called once, when the
+   * agent instance completes.
+   */
+  void deleteCommittedHistoryItemKeys(long agentInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Pins down that a history item's {@code historyItemId} survives the batch/update path: an item
+ * pushed through {@code AGENT_INSTANCE:UPDATE}'s embedded {@code history[]} and applied by {@code
+ * AgentHistoryBatchBehavior} is read back from state when its lease is committed or superseded, and
+ * the {@code COMMITTED}/{@code DISCARDED} events re-emitted at that point must still carry the
+ * item's original {@code historyItemId}.
+ */
+public class AgentHistoryItemIdPersistenceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCarryHistoryItemIdOnCommittedAndDiscardedEvents() {
+    // given — two activations of the same job, each pushing one history item under its own
+    // lease via the batch/update path. Committing one lease commits its item and discards the
+    // other lease's now-superseded pending item.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+
+    final var committedUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-committed")
+            .withHistory(List.of(historyItem("history-item-committed")))
+            .update();
+    final long committedItemKey =
+        committedUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    final var discardedUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-discarded")
+            .withHistory(List.of(historyItem("history-item-discarded")))
+            .update();
+    final long discardedItemKey =
+        discardedUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when
+    ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-committed").commit();
+
+    // then
+    assertThat(
+            RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+                .withRecordKey(committedItemKey)
+                .getFirst()
+                .getValue()
+                .getHistoryItemId())
+        .describedAs("the COMMITTED event re-emitted from state must carry the original id")
+        .isEqualTo("history-item-committed");
+    assertThat(
+            RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+                .withRecordKey(discardedItemKey)
+                .getFirst()
+                .getValue()
+                .getHistoryItemId())
+        .describedAs("the DISCARDED event re-emitted from state must carry the original id")
+        .isEqualTo("history-item-discarded");
+  }
+
+  private static AgentHistoryRecord historyItem(final String historyItemId) {
+    return new AgentHistoryRecord()
+        .setHistoryItemId(historyItemId)
+        .setRole(AgentHistoryRole.USER)
+        .setLoopIteration(1)
+        .addContent(
+            new AgentHistoryMessageContent()
+                .setContentType(AgentHistoryContentType.TEXT)
+                .setText("hi"));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteTest.java
@@ -9,10 +9,12 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -20,6 +22,8 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +59,56 @@ public class AgentInstanceCompleteTest {
             .withRecordKey(fixture.agentInstanceKey())
             .getFirst();
     assertThat(completed.getValue().getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED);
+  }
+
+  @Test
+  public void shouldRemoveCommittedHistoryItemIdsAtScaleOnCompletion() {
+    // given — an agent instance that accumulated more than 1,000 committed history-item ids,
+    // seeded directly against state rather than by driving 1,500 real commands, since only the
+    // cleanup on completion is under test here
+    final var fixture = deployAndCreateAgentInstance();
+    final int committedIdCount = 1500;
+    Awaitility.await("engine is idle before writing directly to state")
+        .until(ENGINE::hasReachedEnd);
+    final var agentHistoryState =
+        ((MutableProcessingState) ENGINE.getProcessingState()).getAgentHistoryState();
+    IntStream.range(0, committedIdCount)
+        .forEach(
+            i ->
+                agentHistoryState.putCommittedHistoryItemKey(
+                    fixture.agentInstanceKey(), "history-item-" + i, i));
+
+    // when
+    ENGINE.agentInstances().withProcessInstanceKey(fixture.processInstanceKey()).complete();
+
+    // then — the agent instance still completes normally
+    final var completed =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+            .withRecordKey(fixture.agentInstanceKey())
+            .getFirst();
+    assertThat(completed.getValue().getStatus()).isEqualTo(AgentInstanceStatus.COMPLETED);
+
+    // and — every committed id seeded for this agent instance is gone from state
+    Awaitility.await("engine is idle before reading directly from state")
+        .until(ENGINE::hasReachedEnd);
+    IntStream.range(0, committedIdCount)
+        .forEach(
+            i ->
+                assertThat(
+                        agentHistoryState.getCommittedHistoryItemKey(
+                            fixture.agentInstanceKey(), "history-item-" + i))
+                    .describedAs("committed id history-item-%d should be removed on completion", i)
+                    .isNull());
+
+    // and — cleanup did not write any AGENT_HISTORY records; it only touched the committed-ids
+    // column family directly, so this pins "no drain loop" without pinning a record count on the
+    // AGENT_INSTANCE value type, which legitimately carries the re-chain command and the closing
+    // NOT_FOUND rejection in addition to COMPLETED
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records -> records.withValueType(ValueType.AGENT_HISTORY).exists()))
+        .describedAs("completion must not write any AGENT_HISTORY records")
+        .isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2250,4 +2250,94 @@ public class AgentInstanceHistoryBatchProcessingTest {
             supply one too."""
                 .formatted(jobKey));
   }
+
+  @Test
+  public void shouldRejectPushFromSecondActiveElementInstanceLinkedToSameAgentInstance() {
+    // given — a parallel multi-instance AI-agent service task produces two element instances,
+    // EI1 and EI2, active at the same time, sharing the same elementId and process instance.
+    final var multiInstanceProcessId = "dedup-parallel-multi-instance";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(helper.getJobType())
+                            .zeebeAiAgentTaskDefinition()
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var children =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList();
+    final var ei1 = children.get(0).getKey();
+    final var ei2 = children.get(1).getKey();
+
+    // the agent instance is created on EI1; EI1 remains active (parallel multi-instance).
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).activate();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2)
+            .getFirst()
+            .getKey();
+
+    // when — EI2, a second, still-active element instance, attempts to push a history batch to
+    // the same agent instance while EI1 (the current writer) has not completed.
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2)
+            .withJobKey(job2Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-from-ei2")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .expectRejection()
+            .update();
+
+    // then — only one element instance may write to a given agent instance at a time.
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains(
+            """
+            Expected to update agent instance with key '%d' for element instance with key '%d', \
+            but element instance with key '%d' is still the active writer for this agent instance \
+            and has not completed. Only one element instance may write to a given agent instance \
+            at a time."""
+                .formatted(agentInstanceKey, ei2, ei1));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
@@ -2418,6 +2419,102 @@ public class AgentInstanceHistoryBatchProcessingTest {
             and has not completed. Only one element instance may write to a given agent instance \
             at a time."""
                 .formatted(agentInstanceKey, ei2, ei1));
+  }
+
+  @Test
+  public void shouldAcceptPushFromSecondElementInstanceWhenFirstWritersJobHasFailed() {
+    // given — same setup as the rejection case above: a parallel multi-instance AI-agent service
+    // task produces two element instances, EI1 and EI2, both still active.
+    final var multiInstanceProcessId = "dedup-parallel-multi-instance-failed-writer";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(helper.getJobType())
+                            .zeebeAiAgentTaskDefinition()
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var children =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList();
+    final var ei1 = children.get(0).getKey();
+    final var ei2 = children.get(1).getKey();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).withMaxJobsToActivate(2).activate();
+    final var activatedJobs =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .limit(2)
+            .toList();
+    final var job1Key =
+        activatedJobs.stream()
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1)
+            .findFirst()
+            .orElseThrow()
+            .getKey();
+    final var job2Key =
+        activatedJobs.stream()
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2)
+            .findFirst()
+            .orElseThrow()
+            .getKey();
+
+    // EI1's job fails with no retries left, raising an incident. EI1 itself stays active — job
+    // failure and element-instance completion are independent, so the element instance does not
+    // reflect that its writer is done.
+    ENGINE.job().withKey(job1Key).withRetries(0).fail();
+
+    // when — EI2 pushes a history batch to the same agent instance. EI1 is still active, but its
+    // job is no longer ACTIVATED, so EI1 can no longer be mid-write.
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2)
+            .withJobKey(job2Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-from-ei2")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+
+    // then — accepted: a failed job cannot still be mid-write, regardless of its element
+    // instance's activity.
+    assertThat(updated.getIntent()).isEqualTo(AgentInstanceIntent.UPDATED);
   }
 
   // --- regression guards: these pin CURRENTLY-CORRECT behavior. Each one is the accept/no-op

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2251,6 +2251,85 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectMissingHistoryItemIdWithItsOwnMessageEvenWhenUnleasedAndJobHasLeasedPending() {
+    // given — job activated WITHOUT a lease; a first request pushes an item under an explicit
+    // request-level lease, so the job now has leased pending items.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease("push-lease-c")
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-r")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hi"))))
+        .update();
+
+    // when — a later, unleased request for the same job carries a new item with no
+    // historyItemId. Two problems overlap here: the item is malformed, and the job already has
+    // leased pending items. The malformed-item rejection must win, since it names the actual
+    // defect in the request rather than a side effect of it.
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(new AgentHistoryRecord().setRole(AgentHistoryRole.USER)))
+            .expectRejection()
+            .update();
+
+    // then — rejected for the missing historyItemId, not for mixing leased/unleased requests.
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to add history item at index 0 to agent instance, but historyItemId is "
+                + "missing (got empty string). Each history item must have a non-empty "
+                + "historyItemId.");
+  }
+
+  @Test
   public void shouldRejectPushFromSecondActiveElementInstanceLinkedToSameAgentInstance() {
     // given — a parallel multi-instance AI-agent service task produces two element instances,
     // EI1 and EI2, active at the same time, sharing the same elementId and process instance.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -1984,4 +1984,93 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(((AgentHistoryRecordValue) newCreatedEvents.get(0).getValue()).getHistoryItemId())
         .isEqualTo("item-c");
   }
+
+  @Test
+  public void shouldRejectWholeBatchWhenTwoItemsShareHistoryItemIdWithinSameRequest() {
+    // given — a single request carries two items with the same historyItemId. This is a
+    // malformed request, distinct from a cross-request retry: nothing may be created at all.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var firstItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("dup-id")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("first"));
+    final var secondItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("dup-id")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("second"));
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(firstItem, secondItem))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .contains(
+            """
+            Expected to update agent instance, but historyItemId 'dup-id' is used by more than one \
+            history item. Each history item must have a unique historyItemId.""");
+
+    // nothing was created at all — bounded via a clock reset sentinel.
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var createdEvents =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(
+                r -> ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("dup-id"))
+            .toList();
+    assertThat(createdEvents).isEmpty();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2340,4 +2340,281 @@ public class AgentInstanceHistoryBatchProcessingTest {
             at a time."""
                 .formatted(agentInstanceKey, ei2, ei1));
   }
+
+  // --- regression guards: these pin CURRENTLY-CORRECT behavior. Each one is the accept/no-op
+  // counter-case to a rejection or dedup rule pinned as RED above (in a separate commit). They
+  // pass today because the restrictive logic they guard against does not exist yet; once
+  // window-1 dedup, lease scoping, and the one-active-writer check land, these must keep passing
+  // unchanged — a regression in any of them means the new logic overreached.
+
+  @Test
+  public void shouldNotTreatItemPendingUnderDifferentLeaseAsDuplicate() {
+    // given — a lease marks one activation attempt. Only the committing lease's pending items
+    // may ever survive, so matching an item pending under a DIFFERENT lease as a duplicate would
+    // falsely erase an item that is about to be legitimately recreated under the winning lease.
+    // Activation 1 (superseded): push an item under lease1, then fail to trigger re-activation.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    final var batch1 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
+    final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
+
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease(lease1)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-cross-lease")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hi"))))
+        .update();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(lease1)
+        .withRetries(1)
+        .fail();
+
+    // Activation 2 (winning): re-activate under a new lease, then resend the same historyItemId.
+    final var batch2 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex2 = batch2.getValue().getJobKeys().indexOf(jobKey);
+    final var lease2 = batch2.getValue().getJobs().get(jobIndex2).getLeaseToken();
+
+    // when
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease2)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-cross-lease")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+
+    // then — the item pending under lease1 must not be treated as a duplicate of this one.
+    assertThat(secondUpdate.getValue().getHistory().get(0).isDuplicate()).isFalse();
+    assertThat(lease2).as("re-activation must advance the lease token").isNotEqualTo(lease1);
+  }
+
+  @Test
+  public void shouldAcceptLeasedRequestWhenJobHasUnleasedPendingItems() {
+    // given — job activated WITHOUT a lease, so the request's own jobLease is free-form; an
+    // unleased request pushes a pending item first.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-r")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hi"))))
+        .update();
+
+    // when — a later request for the same job DOES carry a lease. Reverse order from the
+    // rejected case (leased-then-unleased): mixing is only a problem when a leased pending item
+    // could be silently orphaned by an unleased request, not the other way around.
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("push-lease-2")
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-s")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+
+    // then — accepted, not rejected.
+    assertThat(secondUpdate.getValue().getHistory()).hasSize(1);
+  }
+
+  @Test
+  public void shouldAcceptPushFromSecondElementInstanceAfterFirstCompletes() {
+    // given — a sequential multi-instance AI-agent service task: EI1 activates, completes, then
+    // EI2 activates. This is the counter-case to the second-active-writer rejection above: it
+    // proves the check is about "still active", not "ever used" for this agent instance.
+    final var multiInstanceProcessId = "dedup-sequential-multi-instance";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(helper.getJobType())
+                            .zeebeAiAgentTaskDefinition()
+                            .multiInstance(
+                                m ->
+                                    m.sequential()
+                                        .zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var ei1 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+
+    final var ei2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList()
+            .get(1)
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2)
+            .getFirst()
+            .getKey();
+
+    // when
+    final var updated =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2)
+            .withJobKey(job2Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-from-ei2")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+
+    // then — accepted, not rejected: EI1 already completed, so it no longer holds the write lock.
+    assertThat(updated.getValue().getHistory()).hasSize(1);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2073,4 +2073,181 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .toList();
     assertThat(createdEvents).isEmpty();
   }
+
+  @Test
+  public void shouldDedupAgainstAllPendingItemsWhenRequestCarriesNoLease() {
+    // given — job activated WITHOUT a lease, so the request's own jobLease is free-form and the
+    // pre-existing job/lease mismatch check in validateJobContext never triggers.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — first request pushes the item under an explicit (request-level) lease
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("push-lease-a")
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-x")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when — a second request for the same historyItemId carries NO lease at all
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-x")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again"))))
+            .update();
+
+    // then — an unleased request dedups against all pending items for the job, regardless of
+    // which lease they were pushed under.
+    final var echoed = secondUpdate.getValue().getHistory();
+    assertThat(echoed).hasSize(1);
+    assertThat(echoed.get(0).isDuplicate()).isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(originalKey);
+  }
+
+  @Test
+  public void shouldRejectUnleasedRequestWhenJobHasLeasedPendingItems() {
+    // given — job activated WITHOUT a lease (so the pre-existing job/lease mismatch check never
+    // triggers); a first request pushes an item under an explicit request-level lease.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease("push-lease-b")
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-p")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hi"))))
+        .update();
+
+    // when — a later request for the same job carries no lease at all, even though the job
+    // already has pending items pushed with a lease. This must not be silently processed: mixing
+    // leased and unleased requests for the same job is the one remaining path to the silent-loss
+    // scenario the lease scoping otherwise prevents.
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-q")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .contains(
+            """
+            Expected to update agent instance related to job with key '%d', but the job already \
+            has pending history items associated with a lease and this request carries none. Once \
+            a job's pending history is scoped to a lease, every later request for that job must \
+            supply one too."""
+                .formatted(jobKey));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2251,7 +2251,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
-  public void shouldRejectMissingHistoryItemIdWithItsOwnMessageEvenWhenUnleasedAndJobHasLeasedPending() {
+  public void
+      shouldRejectMissingHistoryItemIdWithItsOwnMessageEvenWhenUnleasedAndJobHasLeasedPending() {
     // given — job activated WITHOUT a lease; a first request pushes an item under an explicit
     // request-level lease, so the job now has leased pending items.
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbe
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -2616,5 +2615,427 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
     // then — accepted, not rejected: EI1 already completed, so it no longer holds the write lock.
     assertThat(updated.getValue().getHistory()).hasSize(1);
+  }
+
+  @Test
+  public void shouldMarkResentItemAsDuplicateAcrossJobActivations() {
+    // given — a sequential multi-instance AI-agent service task: job1 pushes "item-x" and
+    // completes (which commits the item), then job2 — a brand-new job on a brand-new element
+    // instance, for the same agent instance — resends "item-x". By the time job2 exists, the
+    // pending-item state that Part B's within-job dedup relies on is already gone: commit deletes
+    // it. Only a durable, cross-job committed-ids lookup can still recognize this as a duplicate.
+    final var multiInstanceProcessId = "cross-job-dedup-sequential-multi-instance";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(helper.getJobType())
+                            .zeebeAiAgentTaskDefinition()
+                            .multiInstance(
+                                m ->
+                                    m.sequential()
+                                        .zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var ei1 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — job1 pushes "item-x", then completes: AgentHistoryCommitProcessor commits it,
+    // deleting it from pending state.
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-x")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+        .withJobKey(job1Key)
+        .getFirst();
+
+    final var ei2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList()
+            .get(1)
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2)
+            .getFirst()
+            .getKey();
+
+    // when — job2 (a brand-new job, on a brand-new element instance) resends "item-x", with
+    // different content (dedup keys on historyItemId alone, not content).
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2)
+            .withJobKey(job2Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-x")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again"))))
+            .update();
+
+    // then — the resent item is echoed back flagged as a duplicate of the original, not minted as
+    // a new entry, even though job1's pending item was deleted from state the moment it committed.
+    final var echoed = secondUpdate.getValue().getHistory();
+    assertThat(echoed).hasSize(1);
+    assertThat(echoed.get(0).isDuplicate()).isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(originalKey);
+
+    // no second AGENT_HISTORY:CREATED event was appended for "item-x" — bounded via a clock reset
+    // sentinel so the check cannot hang waiting for a record that must never arrive.
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var createdForItem =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(
+                r -> ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("item-x"))
+            .toList();
+    assertThat(createdForItem).hasSize(1);
+  }
+
+  @Test
+  public void shouldScopeDuplicateDetectionPerAgentInstance() {
+    // given — agent instance A: an item is committed via an explicit COMMIT command (the job
+    // itself stays ACTIVATED throughout — dedup keys on "was this id ever committed", not on
+    // whether the job that committed it is still around).
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKeyA = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKeyA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyA)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKeyA =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobAKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKeyA)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyA)
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-shared")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+    ENGINE.agentHistories().withJobKey(jobAKey).commit();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+        .withJobKey(jobAKey)
+        .getFirst();
+
+    // when — the same historyItemId is resent to agent instance A itself, on the same
+    // still-activated job.
+    final var resendToA =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyA)
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-shared")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again"))))
+            .update();
+
+    // then — flagged a duplicate of the original, within A.
+    assertThat(resendToA.getValue().getHistory().get(0).isDuplicate()).isTrue();
+    assertThat(resendToA.getValue().getHistory().get(0).getAgentHistoryKey())
+        .isEqualTo(originalKey);
+
+    // given — a second, unrelated agent instance B: its own process instance, element instance,
+    // and job.
+    final var processInstanceKeyB = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKeyB =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyB)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKeyB =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKeyB)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — the SAME historyItemId ("item-shared") is sent under agent instance B for the first
+    // time.
+    final var sentToB =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyB)
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withJobKey(jobBKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-shared")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+
+    // then — not a duplicate: the committed-ids scope is per agent instance, not global. A
+    // brand-new item is created under B, with its own key.
+    assertThat(sentToB.getValue().getHistory().get(0).isDuplicate()).isFalse();
+    assertThat(sentToB.getValue().getHistory().get(0).getAgentHistoryKey())
+        .isNotEqualTo(originalKey);
+  }
+
+  @Test
+  public void shouldNotTreatDiscardedItemAsDuplicateWhenResent() {
+    // given — one job pushes two items under two different (request-level) leases: "item-a"
+    // under lease-1, "item-b" under lease-2.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-1")
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-committed")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var committedOriginalKey =
+        firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease("lease-2")
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-discarded")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hey"))))
+        .update();
+
+    // when — COMMIT with lease-1: "item-committed" is committed; "item-discarded" (lease-2, a
+    // superseded activation relative to lease-1) is discarded — mirrors
+    // AgentHistoryCommitProcessor's superseded-lease cleanup pass.
+    ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-1").commit();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+        .withJobKey(jobKey)
+        .getFirst();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+        .withJobKey(jobKey)
+        .getFirst();
+
+    // when — a later request resends both historyItemIds, under the same still-activated job.
+    final var resend =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-committed")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-discarded")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hey again"))))
+            .update();
+
+    // then — the committed item is flagged a duplicate of the original...
+    final var echoed = resend.getValue().getHistory();
+    assertThat(echoed).hasSize(2);
+    assertThat(echoed.get(0).isDuplicate()).isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(committedOriginalKey);
+
+    // ...but the discarded item left no trace in the committed-ids map: it is treated as brand
+    // new, not a duplicate.
+    assertThat(echoed.get(1).isDuplicate()).isFalse();
+
+    // two AGENT_HISTORY:CREATED events exist for "item-discarded" in total: one from the first
+    // push (before the commit/discard) and one from this resend, since the discard left no trace
+    // for it to match against — bounded via a clock reset sentinel so the check cannot hang.
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var createdForDiscardedItem =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(
+                r ->
+                    ((AgentHistoryRecordValue) r.getValue())
+                        .getHistoryItemId()
+                        .equals("item-discarded"))
+            .toList();
+    assertThat(createdForDiscardedItem).hasSize(2);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -16,8 +16,10 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbe
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -30,6 +32,7 @@ import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
+import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1441,5 +1444,544 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // before ever storing a record — if they didn't, the first update's batch would still be
     // sitting in state and would leak back out here.
     assertThat(secondUpdate.getValue().getHistory()).isEmpty();
+  }
+
+  @Test
+  public void shouldMarkResentItemAsDuplicateWithinSameJobActivation() {
+    // given — an item is created once, then the same historyItemId is resent on a second UPDATE
+    // to the same still-activated job (e.g. an HTTP client retry).
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — first submission creates the item
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-user")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when — the same historyItemId is resent, with different content, on a second UPDATE to the
+    // same job (content differs on purpose: dedup keys on historyItemId alone, not on content).
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-user")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again"))))
+            .update();
+
+    // then — the batch is still accepted, but the resent item is echoed back flagged as a
+    // duplicate of the original, not as a new entry.
+    final var echoed = secondUpdate.getValue().getHistory();
+    assertThat(echoed).hasSize(1);
+    assertThat(echoed.get(0).isDuplicate()).isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(originalKey);
+
+    // no second AGENT_HISTORY:CREATED event was appended for "item-user" — bounded via a clock
+    // reset as a sentinel so the check cannot hang waiting for a record that must never arrive.
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var createdForItem =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(
+                r ->
+                    ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("item-user"))
+            .toList();
+    assertThat(createdForItem).hasSize(1);
+  }
+
+  @Test
+  public void shouldNotReaccumulateMetricsForDuplicateAssistantItem() {
+    // given — an ASSISTANT item with token metrics and a tool call is applied once.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var assistantItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Sure, here is the summary."));
+    assistantItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
+    assistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
+
+    // when — first submission applies the metrics
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(assistantItem))
+            .update();
+    assertThat(firstUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(firstUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(firstUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+
+    // when — the exact same item is resent on a second UPDATE to the same job
+    final var resentAssistantItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("Sure, here is the summary."));
+    resentAssistantItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
+    resentAssistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(resentAssistantItem))
+            .update();
+
+    // then — the duplicate must not be counted a second time: metrics stay exactly as after the
+    // first submission.
+    assertThat(secondUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens()).isEqualTo(40L);
+    assertThat(secondUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(secondUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotReapplyChangedAttributesForDuplicateConfigurationItem() {
+    // given — a CONFIGURATION item changes the model once.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+
+    // when — first submission applies the model change
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(configItem))
+            .update();
+    assertThat(firstUpdate.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(firstUpdate.getValue().getChangedAttributes()).contains("model");
+
+    // when — the exact same item is resent on a second UPDATE to the same job
+    final var resentConfigItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(resentConfigItem))
+            .update();
+
+    // then — re-applying the same values would be unobservable on the field itself, so the
+    // durable signal is that "model" is absent from changedAttributes on the resend, and the
+    // echoed item is flagged as a duplicate.
+    assertThat(secondUpdate.getValue().getChangedAttributes()).doesNotContain("model");
+    assertThat(secondUpdate.getValue().getHistory().get(0).isDuplicate()).isTrue();
+  }
+
+  @Test
+  public void shouldDedupUniformlyAcrossAllRoles() {
+    // given — one item per role (USER, ASSISTANT, TOOL_RESULT, CONFIGURATION) is created.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    final var assistantItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-assistant")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hello back"));
+    final var toolResultItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-tool-result")
+            .setRole(AgentHistoryRole.TOOL_RESULT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("lookup result"));
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+
+    // when — first submission creates all four items
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(userItem, assistantItem, toolResultItem, configItem))
+            .update();
+    final var originalKeys =
+        firstUpdate.getValue().getHistory().stream()
+            .map(AgentHistoryRecordValue::getAgentHistoryKey)
+            .toList();
+
+    // when — the same four historyItemIds are resent, in the same order, on a second UPDATE
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-user")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-assistant")
+                        .setRole(AgentHistoryRole.ASSISTANT)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hello back")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-tool-result")
+                        .setRole(AgentHistoryRole.TOOL_RESULT)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("lookup result")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-config")
+                        .setRole(AgentHistoryRole.CONFIGURATION)
+                        .setLoopIteration(1)
+                        .setModel("gpt-4o-mini")
+                        .setChangedAttributes(List.of("model"))))
+            .update();
+
+    // then — every role dedups the same way: all four echoed entries are flagged duplicates of
+    // their respective originals, regardless of role.
+    final var echoed = secondUpdate.getValue().getHistory();
+    assertThat(echoed).hasSize(4);
+    assertThat(echoed)
+        .extracting(AgentHistoryRecordValue::isDuplicate)
+        .containsExactly(true, true, true, true);
+    assertThat(echoed)
+        .extracting(AgentHistoryRecordValue::getAgentHistoryKey)
+        .containsExactlyElementsOf(originalKeys);
+  }
+
+  @Test
+  public void shouldFlagOnlyAlreadySeenItemsInMixedBatchPreservingOrder() {
+    // given — two items ("item-a", "item-b") are created on a first UPDATE.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var itemA =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-a")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("first"));
+    final var itemB =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-b")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("second"));
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(itemA, itemB))
+            .update();
+    final var keyA = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+    final var keyB = firstUpdate.getValue().getHistory().get(1).getAgentHistoryKey();
+
+    // when — a second UPDATE mixes the two already-seen items with one brand-new item
+    // ("item-c"), deliberately out of creation order: [b, c, a].
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-b")
+                        .setRole(AgentHistoryRole.ASSISTANT)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("second")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-c")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("third")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-a")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("first"))))
+            .update();
+
+    // then — exactly one entry per submitted item, in request order: [b (dup), c (new), a (dup)].
+    final var echoed = secondUpdate.getValue().getHistory();
+    assertThat(echoed).hasSize(3);
+    assertThat(echoed)
+        .extracting(AgentHistoryRecordValue::getHistoryItemId)
+        .containsExactly("item-b", "item-c", "item-a");
+    assertThat(echoed.get(0).isDuplicate()).isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(keyB);
+    assertThat(echoed.get(1).isDuplicate()).isFalse();
+    assertThat(echoed.get(2).isDuplicate()).isTrue();
+    assertThat(echoed.get(2).getAgentHistoryKey()).isEqualTo(keyA);
+
+    // exactly one new AGENT_HISTORY:CREATED event was appended by the second UPDATE, for
+    // "item-c" only.
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var newCreatedEvents =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(r -> r.getSourceRecordPosition() == secondUpdate.getSourceRecordPosition())
+            .toList();
+    assertThat(newCreatedEvents).hasSize(1);
+    assertThat(((AgentHistoryRecordValue) newCreatedEvents.get(0).getValue()).getHistoryItemId())
+        .isEqualTo("item-c");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -26,16 +27,18 @@ public class AgentInstanceCompletedApplierTest {
   private MutableProcessingState processingState;
 
   private MutableAgentInstanceState agentInstanceState;
+  private MutableAgentHistoryState agentHistoryState;
   private AgentInstanceCreatedApplier createdApplier;
   private AgentInstanceCompletedApplier completedApplier;
 
   @BeforeEach
   public void setup() {
     agentInstanceState = processingState.getAgentInstanceState();
+    agentHistoryState = processingState.getAgentHistoryState();
     final MutableElementInstanceState elementInstanceState =
         processingState.getElementInstanceState();
     createdApplier = new AgentInstanceCreatedApplier(agentInstanceState, elementInstanceState);
-    completedApplier = new AgentInstanceCompletedApplier(agentInstanceState);
+    completedApplier = new AgentInstanceCompletedApplier(agentInstanceState, agentHistoryState);
   }
 
   @Test
@@ -96,5 +99,63 @@ public class AgentInstanceCompletedApplierTest {
     assertThat(agentInstanceState.getRecord(secondAgentInstanceKey)).isNotNull();
     assertThat(agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(processInstanceKey))
         .containsExactly(secondAgentInstanceKey);
+  }
+
+  @Test
+  void shouldDeleteCommittedHistoryItemIdsOnCompletion() {
+    // given — a completed agent instance with committed history item ids recorded against it.
+    final long agentInstanceKey = 21L;
+    final long processInstanceKey = 5L;
+    createdApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentHistoryState.putCommittedHistoryItemKey(agentInstanceKey, "history-item-1", 101L);
+    agentHistoryState.putCommittedHistoryItemKey(agentInstanceKey, "history-item-2", 102L);
+
+    // when — the agent instance completes.
+    completedApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — every committed id recorded for this agent instance is gone.
+    assertThat(agentHistoryState.getCommittedHistoryItemKey(agentInstanceKey, "history-item-1"))
+        .isNull();
+    assertThat(agentHistoryState.getCommittedHistoryItemKey(agentInstanceKey, "history-item-2"))
+        .isNull();
+  }
+
+  @Test
+  void shouldNotAffectCommittedHistoryItemIdsOfOtherAgentInstances() {
+    // given — committed ids for two different agent instances.
+    final long processInstanceKey = 5L;
+    final long firstAgentInstanceKey = 22L;
+    final long secondAgentInstanceKey = 23L;
+    createdApplier.applyState(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentHistoryState.putCommittedHistoryItemKey(firstAgentInstanceKey, "history-item-1", 101L);
+    agentHistoryState.putCommittedHistoryItemKey(secondAgentInstanceKey, "history-item-1", 201L);
+
+    // when — only the first agent instance completes.
+    completedApplier.applyState(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — the second agent instance's committed id is untouched.
+    assertThat(
+            agentHistoryState.getCommittedHistoryItemKey(secondAgentInstanceKey, "history-item-1"))
+        .isEqualTo(201L);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -74,6 +74,11 @@ public final class AgentHistoryClient {
     return this;
   }
 
+  public AgentHistoryClient withHistoryItemId(final String historyItemId) {
+    record.setHistoryItemId(historyItemId);
+    return this;
+  }
+
   public AgentHistoryClient withElementInstanceKey(final long elementInstanceKey) {
     record.setElementInstanceKey(elementInstanceKey);
     return this;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -24,6 +24,11 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    // Recorded before the delete below removes the pending entry this id would otherwise still
+    // be found through: a later job resending this id has only this map left to check against
+    // once the committing job's own pending item is gone.
+    agentHistoryState.putCommittedHistoryItemKey(
+        value.getAgentInstanceKey(), value.getHistoryItemId(), key);
     agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
@@ -27,9 +27,10 @@ public final class AgentHistoryCreatedApplier
     // Store only the identity fields in primary storage (RocksDB). content/toolCalls/metrics/
     // producedAt have already reached secondary storage via the CREATED event itself; nothing reads
     // them back out of primary storage — matching a COMMIT/DISCARD only needs jobKey/jobLease, and
-    // deleting the item needs the same two fields. Storing the trimmed copy also means the
-    // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
-    // stripping needed at those emit sites.
+    // deleting the item needs the same two fields. historyItemId is kept too: dedup matches on it
+    // once an item is pending or committed, so it must survive here as well. Storing the trimmed
+    // copy also means the COMMITTED/DISCARDED events re-emitted from state carry only identity
+    // fields, with no extra stripping needed at those emit sites.
     //
     // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
     // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
@@ -50,6 +51,7 @@ public final class AgentHistoryCreatedApplier
             .setTenantId(value.getTenantId())
             .setJobKey(value.getJobKey())
             .setJobLease(value.getJobLease())
+            .setHistoryItemId(value.getHistoryItemId())
             .setLoopIteration(value.getLoopIteration())
             .setRole(value.getRole());
     agentHistoryState.insert(key, identityRecord);

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -16,13 +17,21 @@ public final class AgentInstanceCompletedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
 
   private final MutableAgentInstanceState agentInstanceState;
+  private final MutableAgentHistoryState agentHistoryState;
 
-  public AgentInstanceCompletedApplier(final MutableAgentInstanceState agentInstanceState) {
+  public AgentInstanceCompletedApplier(
+      final MutableAgentInstanceState agentInstanceState,
+      final MutableAgentHistoryState agentHistoryState) {
     this.agentInstanceState = agentInstanceState;
+    this.agentHistoryState = agentHistoryState;
   }
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    // The committed-ids map is retained for exactly the agent instance's lifetime; this is the
+    // one point where that lifetime ends, and the only path that removes an agent instance at
+    // all, so this is the single place cleanup needs to happen.
+    agentHistoryState.deleteCommittedHistoryItemKeys(key);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -798,7 +798,10 @@ components:
             Used for ownership/equality validation against the stored agent instance
             and, when the supplied key differs from the previous association (re-entry
             of an ad-hoc sub-process or AI Agent task), appended to elementInstanceKeys
-            with the reverse link updated on the supplied element instance.
+            with the reverse link updated on the supplied element instance. Only one
+            element instance may push history to an agent instance at a time: a request
+            carrying history is rejected while the previous element instance's job is
+            still active.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
         status:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -372,7 +372,15 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // AGENT_DEFINITION_KEY_BY_PROCESS_DEFINITION_KEY_AND_ELEMENT_ID at deploy time, so the record can
   // be fully retrieved, without re-deriving it from the parsed BPMN model. GLOBAL for the same
   // reason as the sibling CF above.
-  AGENT_DEFINITION_BY_KEY(162, GLOBAL);
+  AGENT_DEFINITION_BY_KEY(162, GLOBAL),
+
+  // (agentInstanceKey, historyItemId) -> agentHistoryKey. Records every history item ever
+  // committed for an agent instance, so a later job resending an id that an earlier, already-
+  // completed job committed can still be recognized as a duplicate — pending state alone can't do
+  // this, since a committed item is deleted from it. Retained for the agent instance's whole
+  // lifetime and deleted in one pass when the instance completes (see
+  // AgentInstanceCompletedApplier).
+  AGENT_HISTORY_COMMITTED_IDS(163, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

This PR adds duplicate detection for embedded agent history items (`historyItemId`). If a batch request is retried, or an earlier job's items get resent, we don't create a second history item for the same id.

The change has three parts. We kept them as separate commits, in this order, so each one is easy to review on its own:

- **Keep the id when we store a pending item.** Before this change, the code that stores pending history items dropped `historyItemId`. Now it keeps it, so later steps have something to compare against.
- **Detect duplicates within one job.** This fixes a case where the connector's HTTP retry logic sends the same batch twice. If an id repeats within one job activation, we skip it and mark it `isDuplicate: true`, returning the original key. If an id repeats within a single request, we reject the whole batch — the client built that list itself, so a repeat there can't be a retry.
- **Detect duplicates across jobs.** If a later job resends an id that an earlier, already-committed job already pushed, we skip it the same way. We keep committed ids for the whole life of the agent instance, and delete them all at once when the instance completes.

## Cleanup cost at scale

We keep every committed id for an agent instance's whole lifetime. When the instance completes, we delete each id one by one — there's no limit on how many, and we don't split the deletes into batches. The risk: if one instance holds a lot of ids, deleting them all at once could block the stream processor for a processing cycle.

We measured this with a one-off test (not committed). Many agent instances complete at the same time, each holding some number of committed ids:

| agent instances | ids per instance | total deletes | completion time |
|---|---|---|---|
| 1,000 | 100 | 100,000 | 381ms |
| 100 | 10,000 | 1,000,000 | 2,616ms |
| 1,000 | 10,000 | 10,000,000 | 28,514ms |

Cost per id stays flat, around 3µs, no matter the shape. Normal cases will complete well within acceptable bounds. Even the most extreme case we tested — 10,000 ids on one instance — completes in under 30ms, which is still acceptable but will be felt in cases with low latency constraints.

This isn't a theoretical worst case: a parallel multi-instance where each child element has its own agent instance can produce hundreds or thousands of agent instances completing together in one process-instance completion. However, agent instances are completed asynchronous in separate commands, each command blocking the stream processor but only for as long as needed to clear the ids of that agent instance. Generally, we only batch 100 commands together. So, other commands will have a chance to get in between.

Based on these numbers, we're keeping the simple, uncapped delete. No follow-up needed.

## Out of scope

Not in scope: undoing an agent instance's status when a lease's history gets discarded. That's a separate PR, planned after this one.

## Related issues

closes #58792
