### PR TITLE
Defer agent instance configuration application until history commit

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.agenthistory;
 
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -24,12 +25,15 @@ import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
 
 // COMMIT is always a follow-up command emitted internally by the engine and is never issued
 // through the public API, so there is no user to authorize against.
 @ExcludeAuthorizationCheck
 public final class AgentHistoryCommitProcessor
     implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
+
+  private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
 
   private final StateWriter stateWriter;
   private final AgentInstanceState agentInstanceState;
@@ -86,6 +90,11 @@ public final class AgentHistoryCommitProcessor
       // Safety net, should never happen: a CONFIGURATION item's job is always tied to exactly one
       // still-existing agent instance. Guards against an NPE below if that ever stops holding.
       if (agentInstance.get() == null) {
+        LOG.error(
+            "Expected agent instance '{}' to exist while committing agent history item '{}', but"
+                + " it was not found",
+            item.getAgentInstanceKey(),
+            item.getAgentHistoryKey());
         return;
       }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -83,6 +83,12 @@ public final class AgentHistoryCommitProcessor
         agentInstance.set(agentInstanceState.getRecord(item.getAgentInstanceKey()));
       }
 
+      // Safety net, should never happen: a CONFIGURATION item's job is always tied to exactly one
+      // still-existing agent instance. Guards against an NPE below if that ever stops holding.
+      if (agentInstance.get() == null) {
+        return;
+      }
+
       // Apply configuration changes and emit UPDATED event
       final var changedAttributes =
           AgentHistoryBatchBehavior.applyConfigurationChanges(agentInstance.get(), item);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -70,8 +70,9 @@ public final class AgentHistoryCommitProcessor
 
   private void commitHistoryItem(
       final AgentHistoryRecord item, final AtomicReference<AgentInstanceRecord> agentInstance) {
-    // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
-    // so the COMMITTED/DISCARDED events emitted here carry that same trimmed shape for free.
+    // Items in state are already trimmed down by AgentHistoryCreatedApplier (identity fields
+    // only, plus the CONFIGURATION-specific fields below for that role), so the
+    // COMMITTED/DISCARDED events emitted here carry that same trimmed shape for free.
     stateWriter.appendFollowUpEvent(item.getAgentHistoryKey(), AgentHistoryIntent.COMMITTED, item);
 
     // When committing a CONFIGURATION item, the Agent Instance itself is updated with the new

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -8,16 +8,22 @@
 package io.camunda.zeebe.engine.processing.agenthistory;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.concurrent.atomic.AtomicReference;
 
 // COMMIT is always a follow-up command emitted internally by the engine and is never issued
 // through the public API, so there is no user to authorize against.
@@ -26,10 +32,12 @@ public final class AgentHistoryCommitProcessor
     implements TypedRecordProcessor<AgentHistoryRecord>, SuspensionAware<AgentHistoryRecord> {
 
   private final StateWriter stateWriter;
+  private final AgentInstanceState agentInstanceState;
   private final AgentHistoryState agentHistoryState;
 
   public AgentHistoryCommitProcessor(final Writers writers, final ProcessingState processingState) {
     stateWriter = writers.state();
+    agentInstanceState = processingState.getAgentInstanceState();
     agentHistoryState = processingState.getAgentHistoryState();
   }
 
@@ -37,16 +45,16 @@ public final class AgentHistoryCommitProcessor
   public void processRecord(final TypedRecord<AgentHistoryRecord> command) {
     final long jobKey = command.getValue().getJobKey();
     final String jobLease = command.getValue().getJobLease();
-    // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
-    // so the COMMITTED/DISCARDED events emitted here carry that same trimmed shape for free.
-    final AgentHistoryState.AgentHistoryVisitor visitor =
-        item ->
-            stateWriter.appendFollowUpEvent(
-                item.getAgentHistoryKey(), AgentHistoryIntent.COMMITTED, item);
+
+    // The agent instance record is only needed if a CONFIGURATION item is committed, so we lazily
+    // load it only if needed.
+    final AtomicReference<AgentInstanceRecord> agentInstance = new AtomicReference<>();
+
     if (jobLease.isEmpty()) {
-      agentHistoryState.visitByJobKey(jobKey, visitor);
+      agentHistoryState.visitByJobKey(jobKey, item -> commitHistoryItem(item, agentInstance));
     } else {
-      agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
+      agentHistoryState.visitByJobLease(
+          jobKey, jobLease, item -> commitHistoryItem(item, agentInstance));
       // Discard items from superseded activations (different lease, same job)
       agentHistoryState.visitByJobKey(
           jobKey,
@@ -58,6 +66,31 @@ public final class AgentHistoryCommitProcessor
           });
     }
     // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+
+  private void commitHistoryItem(
+      final AgentHistoryRecord item, final AtomicReference<AgentInstanceRecord> agentInstance) {
+    // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
+    // so the COMMITTED/DISCARDED events emitted here carry that same trimmed shape for free.
+    stateWriter.appendFollowUpEvent(item.getAgentHistoryKey(), AgentHistoryIntent.COMMITTED, item);
+
+    // When committing a CONFIGURATION item, the Agent Instance itself is updated with the new
+    // configuration
+    if (item.getRole() == AgentHistoryRole.CONFIGURATION) {
+      // Lazily load agent instance record
+      if (agentInstance.get() == null) {
+        agentInstance.set(agentInstanceState.getRecord(item.getAgentInstanceKey()));
+      }
+
+      // Apply configuration changes and emit UPDATED event
+      final var changedAttributes =
+          AgentHistoryBatchBehavior.applyConfigurationChanges(agentInstance.get(), item);
+      agentInstance.get().setChangedAttributes(changedAttributes.stream().sorted().toList());
+      stateWriter.appendFollowUpEvent(
+          agentInstance.get().getAgentInstanceKey(),
+          AgentInstanceIntent.UPDATED,
+          agentInstance.get());
+    }
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -67,6 +67,10 @@ public final class AgentHistoryBatchBehavior {
   private static final String ERROR_MSG_UNKNOWN_ATTRIBUTES =
       "Expected to update agent instance configuration with history item '%s',"
           + " but changedAttributes contained unknown attribute(s) %s. Allowed attributes are: %s.";
+  private static final String ERROR_MSG_CHANGED_ATTRIBUTES_EMPTY =
+      "Expected to update agent instance configuration with history item '%s',"
+          + " but changedAttributes was empty. A CONFIGURATION item must name at least one"
+          + " attribute it changes.";
 
   private final KeyGenerator keyGenerator;
   private final ProcessingState processingState;
@@ -169,6 +173,13 @@ public final class AgentHistoryBatchBehavior {
       }
 
       if (item.getRole() == AgentHistoryRole.CONFIGURATION) {
+        if (item.getChangedAttributes().isEmpty()) {
+          return Either.left(
+              new Rejection(
+                  RejectionType.INVALID_ARGUMENT,
+                  ERROR_MSG_CHANGED_ATTRIBUTES_EMPTY.formatted(historyItemId)));
+        }
+
         final var unknown =
             item.getChangedAttributes().stream()
                 .filter(Predicate.not(ALLOWED_CONFIGURATION_ATTRIBUTES::contains))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -190,14 +190,20 @@ public final class AgentHistoryBatchBehavior {
   /**
    * Applies an already-validated batch onto {@code target}, in array order: builds one {@code
    * AGENT_HISTORY} event per item (a full copy of the item, with its record-context fields
-   * overwritten to match {@code target}/{@code jobKey}/{@code jobLease}), accumulates metrics
-   * immediately, and — for {@link AgentHistoryRole#CONFIGURATION} items only — applies whichever of
-   * model/provider/systemPrompt/tools/limits the item names in its own {@code changedAttributes}.
+   * overwritten to match {@code target}/{@code jobKey}/{@code jobLease}) and accumulates metrics
+   * immediately. Whichever of model/provider/systemPrompt/tools/limits a {@link
+   * AgentHistoryRole#CONFIGURATION} item names in its own {@code changedAttributes} is only applied
+   * immediately if {@code applyConfigurationChanges} is {@code true} — CREATE passes {@code true}
+   * so a newly created instance always has a valid definition, while UPDATE passes {@code false}
+   * and instead defers that application to when the item is committed (see {@code
+   * AgentHistoryCommitProcessor}).
    *
    * <p><strong>Mutates {@code target} in place</strong> (metrics, definition, tools, limits,
    * history) and does not itself emit any event — the caller is responsible for turning {@code
    * target.getHistory()} into {@code AGENT_HISTORY:CREATED} follow-up events.
    *
+   * @param applyConfigurationChanges whether a CONFIGURATION item's changes should be applied onto
+   *     {@code target} immediately, rather than deferred until the item is committed
    * @return the {@code AgentInstanceRecord} attribute names that actually changed as a result
    */
   Set<String> applyInstanceChangesFromHistory(
@@ -205,7 +211,8 @@ public final class AgentHistoryBatchBehavior {
       final long jobKey,
       final String jobLease,
       final long elementInstanceKey,
-      final List<? extends AgentHistoryRecordValue> history) {
+      final List<? extends AgentHistoryRecordValue> history,
+      final boolean applyConfigurationChanges) {
     final var changedAttributes = new HashSet<String>();
     final var items = new ArrayList<AgentHistoryRecord>(history.size());
 
@@ -232,7 +239,9 @@ public final class AgentHistoryBatchBehavior {
       if (applyMetrics(target.getMetrics(), item)) {
         changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
       }
-      changedAttributes.addAll(applyConfigurationChanges(target, item));
+      if (applyConfigurationChanges) {
+        changedAttributes.addAll(applyConfigurationChanges(target, item));
+      }
 
       items.add(event);
     }
@@ -249,7 +258,7 @@ public final class AgentHistoryBatchBehavior {
    *
    * @return the {@code AgentInstanceRecord} attribute names that actually changed
    */
-  private Set<String> applyConfigurationChanges(
+  public static Set<String> applyConfigurationChanges(
       final AgentInstanceRecord target, final AgentHistoryRecordValue item) {
     if (item.getRole() != AgentHistoryRole.CONFIGURATION) {
       return Set.of();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -225,7 +225,8 @@ public final class AgentInstanceCreateProcessor
           commandValue.getJobKey(),
           commandValue.getJobLease(),
           commandValue.getElementInstanceKey(),
-          commandValue.getHistory());
+          commandValue.getHistory(),
+          false);
     }
 
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.CREATED, event);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -226,7 +226,7 @@ public final class AgentInstanceCreateProcessor
           commandValue.getJobLease(),
           commandValue.getElementInstanceKey(),
           commandValue.getHistory(),
-          false);
+          true);
     }
 
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.CREATED, event);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -238,7 +238,8 @@ public final class AgentInstanceUpdateProcessor
               commandValue.getJobKey(),
               commandValue.getJobLease(),
               commandValue.getElementInstanceKey(),
-              commandValue.getHistory());
+              commandValue.getHistory(),
+              false);
 
       current
           .getHistory()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 
 public final class AgentHistoryCreatedApplier
     implements TypedEventApplier<AgentHistoryIntent, AgentHistoryRecord> {
@@ -31,14 +33,18 @@ public final class AgentHistoryCreatedApplier
     // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
     // stripping needed at those emit sites.
     //
+    // CONFIGURATION items are the exception: whichever of model/provider/systemPrompt/tools/limits
+    // the item's own changedAttributes names must survive until COMMIT, since that's when
+    // AgentHistoryCommitProcessor applies them onto the AgentInstance — so those fields (plus
+    // changedAttributes itself) are also kept, but only for that role.
+    //
     // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
     // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
     // someone has to deliberately add it here for it to be persisted past CREATED. Keeping the
     // selection inline rather than in a shared helper also means any future change to which fields
     // are stored requires a new applier version with its own golden file, preventing silent
-    // behavior
-    // changes to already-released appliers.
-    final var identityRecord =
+    // behavior changes to already-released appliers.
+    final var storedRecord =
         new AgentHistoryRecord()
             .setAgentHistoryKey(value.getAgentHistoryKey())
             .setAgentInstanceKey(value.getAgentInstanceKey())
@@ -52,6 +58,32 @@ public final class AgentHistoryCreatedApplier
             .setJobLease(value.getJobLease())
             .setLoopIteration(value.getLoopIteration())
             .setRole(value.getRole());
-    agentHistoryState.insert(key, identityRecord);
+    if (value.getRole() == AgentHistoryRole.CONFIGURATION) {
+      final var changedAttributes = value.getChangedAttributes();
+      storedRecord.setChangedAttributes(changedAttributes);
+
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MODEL)) {
+        storedRecord.setModel(value.getModel());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_PROVIDER)) {
+        storedRecord.setProvider(value.getProvider());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_SYSTEM_PROMPT)) {
+        storedRecord.setSystemPrompt(value.getSystemPrompt());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_TOOLS)) {
+        storedRecord.setTools(value.getTools());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MAX_TOKENS)) {
+        storedRecord.getLimits().setMaxTokens(value.getLimits().getMaxTokens());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MAX_MODEL_CALLS)) {
+        storedRecord.getLimits().setMaxModelCalls(value.getLimits().getMaxModelCalls());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MAX_TOOL_CALLS)) {
+        storedRecord.getLimits().setMaxToolCalls(value.getLimits().getMaxToolCalls());
+      }
+    }
+    agentHistoryState.insert(key, storedRecord);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTo
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
@@ -948,7 +949,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
-  public void shouldApplyInstanceFieldsFromConfigurationItemOnUpdate() {
+  public void shouldApplyInstanceFieldsFromConfigurationItemOnlyOnCommit() {
     // given
     ENGINE
         .deployment()
@@ -988,11 +989,11 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .setHistoryItemId("item-config")
             .setRole(AgentHistoryRole.CONFIGURATION)
             .setLoopIteration(1);
-    configItem.setModel("gpt-4o-mini").setProvider("openai");
+    configItem.setModel("gpt-4o-mini").setProvider("azure-openai");
     configItem.addSystemPrompt(
         new AgentHistoryMessageContent()
             .setContentType(AgentHistoryContentType.TEXT)
-            .setText("You are a helpful agent."));
+            .setText("You are a specialized agent."));
     configItem.setTools(List.of(new AgentInstanceTool().setName("calc").setElementId("calc-task")));
     configItem.getLimits().setMaxTokens(5000L).setMaxModelCalls(8).setMaxToolCalls(16);
     configItem.setChangedAttributes(
@@ -1015,22 +1016,50 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withHistory(List.of(configItem))
             .update();
 
-    // then — applied immediately onto the live fields, driven by the item's own changedAttributes.
-    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    // then — the item is only queued, not yet applied: the live fields still reflect the
+    // instance's definition at creation, so the instance always has a valid definition even
+    // while this CONFIGURATION item is pending.
+    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o");
     assertThat(updated.getValue().getDefinition().getProvider()).isEqualTo("openai");
     assertThat(updated.getValue().getDefinition().getSystemPrompt())
         .hasSize(1)
         .first()
-        .satisfies(
-            block -> {
-              assertThat(block.getContentType()).isEqualTo(AgentHistoryContentType.TEXT);
-              assertThat(block.getText()).isEqualTo("You are a helpful agent.");
-            });
-    assertThat(updated.getValue().getTools()).extracting("name").containsExactly("calc");
-    assertThat(updated.getValue().getLimits().getMaxTokens()).isEqualTo(5000L);
-    assertThat(updated.getValue().getLimits().getMaxModelCalls()).isEqualTo(8);
-    assertThat(updated.getValue().getLimits().getMaxToolCalls()).isEqualTo(16);
-    assertThat(updated.getValue().getChangedAttributes())
+        .satisfies(block -> assertThat(block.getText()).isEqualTo("You are a helpful agent."));
+    assertThat(updated.getValue().getTools()).isEmpty();
+    assertThat(updated.getValue().getChangedAttributes()).isEmpty();
+
+    // the persisted AGENT_HISTORY event is still a full copy of the item, including these fields.
+    final var historyItem =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(agentInstanceKey)
+            .getFirst();
+    assertThat(historyItem.getValue().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(historyItem.getValue().getProvider()).isEqualTo("azure-openai");
+
+    // when — the item is committed
+    final var committed =
+        ENGINE.agentHistories().withAgentInstanceKey(agentInstanceKey).withJobKey(jobKey).commit();
+    assertThat(committed.getIntent()).isEqualTo(AgentHistoryIntent.COMMITTED);
+
+    // then — only now are the live fields driven by the item's own changedAttributes. Skip the
+    // UPDATED event from the update command itself (queuing the item, no config applied yet) to
+    // reach the one commit() causes.
+    final var instanceUpdated =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
+            .withAgentInstanceKey(agentInstanceKey)
+            .skip(1)
+            .getFirst();
+    assertThat(instanceUpdated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(instanceUpdated.getValue().getDefinition().getProvider()).isEqualTo("azure-openai");
+    assertThat(instanceUpdated.getValue().getDefinition().getSystemPrompt())
+        .hasSize(1)
+        .first()
+        .satisfies(block -> assertThat(block.getText()).isEqualTo("You are a specialized agent."));
+    assertThat(instanceUpdated.getValue().getTools()).extracting("name").containsExactly("calc");
+    assertThat(instanceUpdated.getValue().getLimits().getMaxTokens()).isEqualTo(5000L);
+    assertThat(instanceUpdated.getValue().getLimits().getMaxModelCalls()).isEqualTo(8);
+    assertThat(instanceUpdated.getValue().getLimits().getMaxToolCalls()).isEqualTo(16);
+    assertThat(instanceUpdated.getValue().getChangedAttributes())
         .containsExactlyInAnyOrder(
             "systemPrompt",
             "model",
@@ -1039,22 +1068,14 @@ public class AgentInstanceHistoryBatchProcessingTest {
             "maxTokens",
             "maxModelCalls",
             "maxToolCalls");
-
-    // the persisted AGENT_HISTORY event is a full copy of the item, including these fields.
-    final var historyEvent =
-        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
-            .withAgentInstanceKey(agentInstanceKey)
-            .getFirst();
-    assertThat(historyEvent.getValue().getModel()).isEqualTo("gpt-4o-mini");
-    assertThat(historyEvent.getValue().getProvider()).isEqualTo("openai");
   }
 
   @Test
-  public void shouldOnlyApplyAttributesNamedInConfigurationItemChangedAttributes() {
+  public void shouldOnlyApplyAttributesNamedInConfigurationItemChangedAttributesOnCommit() {
     // given — the agent instance is created with model="gpt-4o"/provider="openai" below. The item
     // carries a different value for both, but only names "model" in its own changedAttributes:
-    // provider must be left at its original value, since presence alone no longer drives
-    // application (that's what tells apart "left as-is" from "deliberately cleared").
+    // provider must be left at its original value once committed, since presence alone no longer
+    // drives application (that's what tells apart "left as-is" from "deliberately cleared").
     ENGINE
         .deployment()
         .withXmlResource(
@@ -1106,10 +1127,24 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withHistory(List.of(configItem))
             .update();
 
-    // then
-    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    // then — nothing is applied yet, the item is only queued
+    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o");
     assertThat(updated.getValue().getDefinition().getProvider()).isEqualTo("openai");
-    assertThat(updated.getValue().getChangedAttributes()).containsExactly("model");
+    assertThat(updated.getValue().getChangedAttributes()).isEmpty();
+
+    // when — the item is committed
+    ENGINE.agentHistories().withAgentInstanceKey(agentInstanceKey).withJobKey(jobKey).commit();
+
+    // then — only "model" lands, "provider" is left at its original value. Skip the UPDATED
+    // event from the update command itself (queuing the item, no config applied yet).
+    final var instanceUpdated =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.UPDATED)
+            .withAgentInstanceKey(agentInstanceKey)
+            .skip(1)
+            .getFirst();
+    assertThat(instanceUpdated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(instanceUpdated.getValue().getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(instanceUpdated.getValue().getChangedAttributes()).containsExactly("model");
   }
 
   @Test
@@ -1371,6 +1406,77 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(historyEvent.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
     // changedAttributes stays empty on CREATED, unaffected by the history batch.
     assertThat(created.getValue().getChangedAttributes()).isEmpty();
+  }
+
+  @Test
+  public void shouldApplyInstanceFieldsFromConfigurationItemImmediatelyOnCreate() {
+    // given — unlike UPDATE (where a CONFIGURATION item stays pending until it is committed),
+    // CREATE applies it right away, so the instance is guaranteed to start with a valid
+    // definition instead of the placeholder one on its CREATE command.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
+    configItem.setModel("gpt-4o-mini").setProvider("azure-openai");
+    configItem.setTools(List.of(new AgentInstanceTool().setName("calc").setElementId("calc-task")));
+    configItem.getLimits().setMaxTokens(5000L).setMaxModelCalls(8).setMaxToolCalls(16);
+    configItem.setChangedAttributes(
+        List.of("model", "provider", "tools", "maxTokens", "maxModelCalls", "maxToolCalls"));
+
+    // when — the initial definition below ("gpt-4o"/"openai") is a placeholder immediately
+    // overridden by the CONFIGURATION item in the same CREATE command
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(configItem))
+            .create();
+
+    // then
+    assertThat(created.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(created.getValue().getDefinition().getProvider()).isEqualTo("azure-openai");
+    assertThat(created.getValue().getTools()).extracting("name").containsExactly("calc");
+    assertThat(created.getValue().getLimits().getMaxTokens()).isEqualTo(5000L);
+    assertThat(created.getValue().getLimits().getMaxModelCalls()).isEqualTo(8);
+    assertThat(created.getValue().getLimits().getMaxToolCalls()).isEqualTo(16);
+    // CREATED has no prior state to diff against, so changedAttributes stays empty regardless
+    // (same as for a non-CONFIGURATION item, see shouldEmitHistoryEventsOnCreate above).
+    assertThat(created.getValue().getChangedAttributes()).isEmpty();
+
+    final var historyEvent =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(created.getKey())
+            .getFirst();
+    assertThat(historyEvent.getValue().getModel()).isEqualTo("gpt-4o-mini");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -352,6 +352,69 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectWholeBatchWhenConfigurationItemHasEmptyChangedAttributes() {
+    // given — a CONFIGURATION item that names no attribute at all, which would otherwise be
+    // accepted as a no-op
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var invalidItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(List.of(invalidItem))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance configuration with history item 'item-config', but "
+                + "changedAttributes was empty. A CONFIGURATION item must name at least one "
+                + "attribute it changes.");
+  }
+
+  @Test
   public void shouldRejectWhenJobNotActive() {
     // given
     ENGINE

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
@@ -11,7 +11,9 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 
 public final class AgentHistoryCreatedApplier
     implements TypedEventApplier<AgentHistoryIntent, AgentHistoryRecord> {
@@ -31,14 +33,18 @@ public final class AgentHistoryCreatedApplier
     // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
     // stripping needed at those emit sites.
     //
+    // CONFIGURATION items are the exception: whichever of model/provider/systemPrompt/tools/limits
+    // the item's own changedAttributes names must survive until COMMIT, since that's when
+    // AgentHistoryCommitProcessor applies them onto the AgentInstance — so those fields (plus
+    // changedAttributes itself) are also kept, but only for that role.
+    //
     // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
     // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
     // someone has to deliberately add it here for it to be persisted past CREATED. Keeping the
     // selection inline rather than in a shared helper also means any future change to which fields
     // are stored requires a new applier version with its own golden file, preventing silent
-    // behavior
-    // changes to already-released appliers.
-    final var identityRecord =
+    // behavior changes to already-released appliers.
+    final var storedRecord =
         new AgentHistoryRecord()
             .setAgentHistoryKey(value.getAgentHistoryKey())
             .setAgentInstanceKey(value.getAgentInstanceKey())
@@ -52,6 +58,32 @@ public final class AgentHistoryCreatedApplier
             .setJobLease(value.getJobLease())
             .setLoopIteration(value.getLoopIteration())
             .setRole(value.getRole());
-    agentHistoryState.insert(key, identityRecord);
+    if (value.getRole() == AgentHistoryRole.CONFIGURATION) {
+      final var changedAttributes = value.getChangedAttributes();
+      storedRecord.setChangedAttributes(changedAttributes);
+
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MODEL)) {
+        storedRecord.setModel(value.getModel());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_PROVIDER)) {
+        storedRecord.setProvider(value.getProvider());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_SYSTEM_PROMPT)) {
+        storedRecord.setSystemPrompt(value.getSystemPrompt());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_TOOLS)) {
+        storedRecord.setTools(value.getTools());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MAX_TOKENS)) {
+        storedRecord.getLimits().setMaxTokens(value.getLimits().getMaxTokens());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MAX_MODEL_CALLS)) {
+        storedRecord.getLimits().setMaxModelCalls(value.getLimits().getMaxModelCalls());
+      }
+      if (changedAttributes.contains(AgentInstanceRecord.ATTR_MAX_TOOL_CALLS)) {
+        storedRecord.getLimits().setMaxToolCalls(value.getLimits().getMaxToolCalls());
+      }
+    }
+    agentHistoryState.insert(key, storedRecord);
   }
 }


### PR DESCRIPTION
## Description

**Summary:** A CONFIGURATION-role AgentHistory item's changes (model/provider/systemPrompt/tools/limits) now only land on the AgentInstance's live definition when the item is committed, instead of immediately when it's queued through `AGENT_INSTANCE:UPDATE` — except at `AGENT_INSTANCE:CREATE`, which keeps applying immediately so a newly created instance is never left with an invalid definition.

**Reasoning:** Applying a CONFIGURATION item's changes as part of the same `UPDATE` command that queued it gave real-time visibility into an in-flight configuration change, but it also meant the live definition could reflect a change whose owning job activation later got rolled back and discarded. Deferring application to `AGENT_HISTORY:COMMIT` trades away that real-time visibility for correctness: the definition only ever reflects configuration that actually committed. `CREATE` is the deliberate exception to this — an instance needs a valid, usable definition from the moment it exists, so its own embedded CONFIGURATION item is still applied immediately rather than deferred.

Making `COMMIT`-time application work surfaced a second, pre-existing gap: `AgentHistoryCreatedApplier` persists `AGENT_HISTORY:CREATED` items into primary storage (RocksDB) as an explicit allow-list of identity fields only, on the assumption that nothing needs to read anything else back out of primary storage once an item is created. That's no longer true for CONFIGURATION items, whose model/provider/systemPrompt/tools/limits/changedAttributes now need to survive until `COMMIT` reads them back — the allow-list was silently dropping exactly those fields, so nothing was actually being applied. This is fixed alongside the deferral itself.

**Details:**
- `AgentHistoryCommitProcessor` now applies a CONFIGURATION item's changes and emits `AgentInstance:UPDATED` only when the item is committed, reusing `AgentHistoryBatchBehavior#applyConfigurationChanges` for the same per-attribute logic already used by `CREATE`/`UPDATE`.
- `AgentHistoryCreatedApplier`'s allow-list is extended to also keep model/provider/systemPrompt/tools/limits/changedAttributes for CONFIGURATION-role items; its golden-file snapshot (`AgentHistory_CREATED_v1.golden`) is refreshed to match, since that file exists specifically to catch any unintended behavior change to an already-released applier.
- `AgentInstanceHistoryBatchProcessingTest` covers the new lifecycle: a CONFIGURATION item queued via `UPDATE` leaves the live definition untouched until committed, only the attributes it names in its own `changedAttributes` land at that point, and `CREATE` still applies immediately.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #58797