### PR TITLE
feat: suppress import writes for process definitions with delete job records

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/db/reader/JobRegistryReaderIT.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.service.security.util.LocalDateUtil;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -247,6 +248,54 @@ public class JobRegistryReaderIT extends AbstractBrokerlessZeebeCCSMIT {
     final Optional<JobRegistryEntryDto> found =
         jobRegistryReader.findLastByJobTypeAndEntityId(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, "does-not-exist");
+
+    // then
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  void shouldFindEntityIdsWithJobAmongCandidates() {
+    // given
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
+    // "3" has no job registry entry at all
+
+    // when
+    final Set<String> found =
+        jobRegistryReader.findEntityIdsWithJob(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, List.of("1", "2", "3"));
+
+    // then
+    assertThat(found).containsExactlyInAnyOrder("1", "2");
+  }
+
+  @Test
+  void shouldFindAllRequestedEntityIdsWhenOneHasDuplicateRegistryEntries() {
+    // given
+    final JobRegistryEntryDto failedEntry =
+        jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.updateJobStatus(failedEntry.getId(), JobStatus.FAILED, "boom");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "2");
+
+    // when
+    final Set<String> found =
+        jobRegistryReader.findEntityIdsWithJob(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, List.of("1", "2"));
+
+    // then
+    assertThat(found).containsExactlyInAnyOrder("1", "2");
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenNoneOfTheCandidatesHaveAJobEntry() {
+    // given
+    jobRegistryWriter.createJobEntry(JobType.DELETE, EntityType.PROCESS_DEFINITION, "1");
+
+    // when
+    final Set<String> found =
+        jobRegistryReader.findEntityIdsWithJob(
+            JobType.DELETE, EntityType.PROCESS_DEFINITION, List.of("does-not-exist"));
 
     // then
     assertThat(found).isEmpty();

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -66,9 +66,13 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.optimize.AbstractCCSMIT;
 import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
 import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
 import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceRecordDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -87,6 +91,8 @@ import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
@@ -1097,5 +1103,85 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
       final String processDefinitionKey, final int nestedDocLimit) {
     databaseIntegrationTestExtension.updateProcessInstanceNestedDocLimit(
         processDefinitionKey, nestedDocLimit, embeddedOptimizeExtension.getConfigurationService());
+  }
+
+  @Test
+  public void shouldImportProcessInstance_whenNoDeletionJobEntryExists() {
+    // given
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("noDeletionJobProcess"));
+
+    // when
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            savedInstance ->
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(deployedInstance.getProcessInstanceKey())));
+  }
+
+  @ParameterizedTest
+  @EnumSource(JobStatus.class)
+  public void shouldSuppressImport_whenDeletionJobEntryExistsForDefinition(
+      final JobStatus jobStatus) {
+    // given a deletion job entry for this exact process definition version, in any status --
+    // including QUEUED, simulating a batch racing a delete that hasn't been picked up yet
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("suppressedProcess"));
+    final JobRegistryWriter jobRegistryWriter =
+        embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+    final var jobEntry =
+        jobRegistryWriter.createJobEntry(
+            JobType.DELETE,
+            EntityType.PROCESS_DEFINITION,
+            String.valueOf(deployedInstance.getProcessDefinitionKey()));
+    if (jobStatus != JobStatus.QUEUED) {
+      jobRegistryWriter.updateJobStatus(jobEntry.getId(), jobStatus, null);
+    }
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // when
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances()).isEmpty();
+  }
+
+  @Test
+  public void shouldOnlySuppressMatchingDefinition_inMixedBatch() {
+    // given two distinct process definitions in flight, only one has a deletion job entry
+    final ProcessInstanceEvent suppressedInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("mixedBatchSuppressedProcess"));
+    final ProcessInstanceEvent keptInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("mixedBatchKeptProcess"));
+    final JobRegistryWriter jobRegistryWriter =
+        embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+    jobRegistryWriter.createJobEntry(
+        JobType.DELETE,
+        EntityType.PROCESS_DEFINITION,
+        String.valueOf(suppressedInstance.getProcessDefinitionKey()));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // when
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, suppressedInstance.getProcessInstanceKey());
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, keptInstance.getProcessInstanceKey());
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            savedInstance ->
+                assertThat(savedInstance.getProcessInstanceId())
+                    .isEqualTo(String.valueOf(keptInstance.getProcessInstanceKey())));
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
@@ -38,6 +38,10 @@ import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobStatus;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.optimize.util.ZeebeBpmnModels;
@@ -50,6 +54,8 @@ import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
 
@@ -367,6 +373,82 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
         .extracting(ProcessDefinitionOptimizeDto::getTenantId)
         .singleElement()
         .isEqualTo(expectedTenantId);
+  }
+
+  @Test
+  public void shouldImportProcessDefinition_whenNoDeletionJobEntryExists() {
+    // given
+    final Process deployedProcess =
+        deployProcessAndStartInstance(createStartEndProcess("noDeletionJobDefinitionProcess"));
+    waitUntilNumberOfDefinitionsExported(1);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+        .singleElement()
+        .satisfies(
+            importedDef ->
+                assertThat(importedDef.getId())
+                    .isEqualTo(String.valueOf(deployedProcess.getProcessDefinitionKey())));
+  }
+
+  @ParameterizedTest
+  @EnumSource(JobStatus.class)
+  public void shouldSuppressImport_whenDeletionJobEntryExistsForDefinition(
+      final JobStatus jobStatus) {
+    // given a deletion job entry for this exact process definition version, in any status --
+    // including QUEUED, simulating a batch racing a delete that hasn't been picked up yet
+    final Process deployedProcess =
+        deployProcessAndStartInstance(createStartEndProcess("suppressedDefinitionProcess"));
+    final JobRegistryWriter jobRegistryWriter =
+        embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+    final var jobEntry =
+        jobRegistryWriter.createJobEntry(
+            JobType.DELETE,
+            EntityType.PROCESS_DEFINITION,
+            String.valueOf(deployedProcess.getProcessDefinitionKey()));
+    if (jobStatus != JobStatus.QUEUED) {
+      jobRegistryWriter.updateJobStatus(jobEntry.getId(), jobStatus, null);
+    }
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    waitUntilNumberOfDefinitionsExported(1);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions()).isEmpty();
+  }
+
+  @Test
+  public void shouldOnlySuppressMatchingDefinition_inMixedBatch() {
+    // given two distinct process definitions in flight, only one has a deletion job entry
+    final Process suppressedProcess =
+        deployProcessAndStartInstance(
+            createStartEndProcess("mixedBatchSuppressedDefinitionProcess"));
+    final Process keptProcess =
+        deployProcessAndStartInstance(createStartEndProcess("mixedBatchKeptDefinitionProcess"));
+    final JobRegistryWriter jobRegistryWriter =
+        embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
+    jobRegistryWriter.createJobEntry(
+        JobType.DELETE,
+        EntityType.PROCESS_DEFINITION,
+        String.valueOf(suppressedProcess.getProcessDefinitionKey()));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    waitUntilNumberOfDefinitionsExported(2);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+        .singleElement()
+        .satisfies(
+            importedDef ->
+                assertThat(importedDef.getId())
+                    .isEqualTo(String.valueOf(keptProcess.getProcessDefinitionKey())));
   }
 
   private Process deployProcessAndStartInstance(final BpmnModelInstance simpleProcess) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -165,6 +165,7 @@ public class JobRegistryReaderES implements JobRegistryReader {
                 s.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
                     .query(query)
                     .source(src -> src.filter(f -> f.includes(JobRegistryIndex.ENTITY_ID)))
+                    .collapse(c -> c.field(JobRegistryIndex.ENTITY_ID))
                     .size(entityIds.size()));
 
     try {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/JobRegistryReaderES.java
@@ -9,7 +9,9 @@ package io.camunda.optimize.service.db.es.reader;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.JOB_REGISTRY_INDEX_NAME;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -25,9 +27,12 @@ import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -91,24 +96,9 @@ public class JobRegistryReaderES implements JobRegistryReader {
         Query.of(
             q ->
                 q.bool(
-                    b ->
-                        b.must(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(JobRegistryIndex.JOB_TYPE)
-                                                .value(jobType.name())))
-                            .must(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(JobRegistryIndex.ENTITY_TYPE)
-                                                .value(entityType.name())))
-                            .must(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(JobRegistryIndex.ENTITY_ID).value(entityId)))));
+                    jobTypeAndEntityTypeQuery(jobType, entityType)
+                        .must(m -> m.term(t -> t.field(JobRegistryIndex.ENTITY_ID).value(entityId)))
+                        .build()));
 
     final SearchRequest searchRequest =
         OptimizeSearchRequestBuilderES.of(
@@ -128,7 +118,7 @@ public class JobRegistryReaderES implements JobRegistryReader {
       if (searchResponse.hits().hits().isEmpty()) {
         return Optional.empty();
       }
-      return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+      return Optional.ofNullable(searchResponse.hits().hits().getFirst().source());
     } catch (final IOException e) {
       final String message =
           String.format(
@@ -137,5 +127,68 @@ public class JobRegistryReaderES implements JobRegistryReader {
       LOG.error(message, e);
       throw new OptimizeRuntimeException(message, e);
     }
+  }
+
+  @Override
+  public Set<String> findEntityIdsWithJob(
+      final JobType jobType, final EntityType entityType, final Collection<String> entityIds) {
+    if (entityIds.isEmpty()) {
+      return Set.of();
+    }
+    LOG.debug(
+        "Fetching entity IDs with [{}] job entries for entity type [{}] among [{}] candidates.",
+        jobType,
+        entityType,
+        entityIds.size());
+
+    final Query query =
+        Query.of(
+            q ->
+                q.bool(
+                    jobTypeAndEntityTypeQuery(jobType, entityType)
+                        .must(
+                            m ->
+                                m.terms(
+                                    t ->
+                                        t.field(JobRegistryIndex.ENTITY_ID)
+                                            .terms(
+                                                tt ->
+                                                    tt.value(
+                                                        entityIds.stream()
+                                                            .map(FieldValue::of)
+                                                            .toList()))))
+                        .build()));
+
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            s ->
+                s.optimizeIndex(esClient, JOB_REGISTRY_INDEX_NAME)
+                    .query(query)
+                    .source(src -> src.filter(f -> f.includes(JobRegistryIndex.ENTITY_ID)))
+                    .size(entityIds.size()));
+
+    try {
+      final SearchResponse<JobRegistryEntryDto> searchResponse =
+          esClient.search(searchRequest, JobRegistryEntryDto.class);
+      return searchResponse.hits().hits().stream()
+          .map(Hit::source)
+          .filter(Objects::nonNull)
+          .map(JobRegistryEntryDto::getEntityId)
+          .collect(Collectors.toSet());
+    } catch (final IOException e) {
+      final String message =
+          String.format(
+              "Was not able to fetch entity IDs with [%s] job entries for entity type [%s].",
+              jobType, entityType);
+      LOG.error(message, e);
+      throw new OptimizeRuntimeException(message, e);
+    }
+  }
+
+  private BoolQuery.Builder jobTypeAndEntityTypeQuery(
+      final JobType jobType, final EntityType entityType) {
+    return new BoolQuery.Builder()
+        .must(m -> m.term(t -> t.field(JobRegistryIndex.JOB_TYPE).value(jobType.name())))
+        .must(m -> m.term(t -> t.field(JobRegistryIndex.ENTITY_TYPE).value(entityType.name())));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -27,6 +27,7 @@ import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.es.builders.OptimizeDeleteRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES;
 import io.camunda.optimize.service.db.repository.es.TaskRepositoryES;
+import io.camunda.optimize.service.db.writer.DeletedProcessDefinitionFilter;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -54,20 +55,26 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
       org.slf4j.LoggerFactory.getLogger(ProcessDefinitionWriterES.class);
 
   private final ConfigurationService configurationService;
+  private final DeletedProcessDefinitionFilter deletedProcessDefinitionFilter;
 
   public ProcessDefinitionWriterES(
       final OptimizeElasticsearchClient esClient,
       final ObjectMapper objectMapper,
       final ConfigurationService configurationService,
-      final TaskRepositoryES taskRepositoryES) {
+      final TaskRepositoryES taskRepositoryES,
+      final DeletedProcessDefinitionFilter deletedProcessDefinitionFilter) {
     super(objectMapper, esClient, taskRepositoryES);
     this.configurationService = configurationService;
+    this.deletedProcessDefinitionFilter = deletedProcessDefinitionFilter;
   }
 
   @Override
   public void importProcessDefinitions(final List<ProcessDefinitionOptimizeDto> procDefs) {
-    LOG.debug("Writing [{}] process definitions to elasticsearch", procDefs.size());
-    writeProcessDefinitionInformation(procDefs);
+    final List<ProcessDefinitionOptimizeDto> filteredProcDefs =
+        deletedProcessDefinitionFilter.filterOutSuppressed(
+            procDefs, ProcessDefinitionOptimizeDto::getId);
+    LOG.debug("Writing [{}] process definitions to elasticsearch", filteredProcDefs.size());
+    writeProcessDefinitionInformation(filteredProcDefs);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -110,7 +110,7 @@ public class JobRegistryReaderOS implements JobRegistryReader {
     if (searchResponse.hits().hits().isEmpty()) {
       return Optional.empty();
     }
-    return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+    return Optional.ofNullable(searchResponse.hits().hits().getFirst().source());
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -135,6 +135,7 @@ public class JobRegistryReaderOS implements JobRegistryReader {
             .index(JOB_REGISTRY_INDEX_NAME)
             .size(entityIds.size())
             .query(boolQuery.toQuery())
+            .collapse(c -> c.field(JobRegistryIndex.ENTITY_ID))
             .source(QueryDSL.sourceInclude(List.of(JobRegistryIndex.ENTITY_ID)));
 
     final String errorMessage =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/JobRegistryReaderOS.java
@@ -18,9 +18,12 @@ import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
 import io.camunda.optimize.service.db.schema.index.JobRegistryIndex;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -83,9 +86,7 @@ public class JobRegistryReaderOS implements JobRegistryReader {
         entityType,
         entityId);
     final BoolQuery boolQuery =
-        new BoolQuery.Builder()
-            .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
-            .must(QueryDSL.term(JobRegistryIndex.ENTITY_TYPE, entityType.name()))
+        jobTypeAndEntityTypeQuery(jobType, entityType)
             .must(QueryDSL.term(JobRegistryIndex.ENTITY_ID, entityId))
             .build();
 
@@ -110,5 +111,50 @@ public class JobRegistryReaderOS implements JobRegistryReader {
       return Optional.empty();
     }
     return Optional.ofNullable(searchResponse.hits().hits().get(0).source());
+  }
+
+  @Override
+  public Set<String> findEntityIdsWithJob(
+      final JobType jobType, final EntityType entityType, final Collection<String> entityIds) {
+    if (entityIds.isEmpty()) {
+      return Set.of();
+    }
+    LOG.debug(
+        "Fetching entity IDs with [{}] job entries for entity type [{}] among [{}] candidates.",
+        jobType,
+        entityType,
+        entityIds.size());
+
+    final BoolQuery boolQuery =
+        jobTypeAndEntityTypeQuery(jobType, entityType)
+            .must(QueryDSL.stringTerms(JobRegistryIndex.ENTITY_ID, entityIds))
+            .build();
+
+    final SearchRequest.Builder searchReqBuilder =
+        new SearchRequest.Builder()
+            .index(JOB_REGISTRY_INDEX_NAME)
+            .size(entityIds.size())
+            .query(boolQuery.toQuery())
+            .source(QueryDSL.sourceInclude(List.of(JobRegistryIndex.ENTITY_ID)));
+
+    final String errorMessage =
+        String.format(
+            "Was not able to fetch entity IDs with [%s] job entries for entity type [%s].",
+            jobType, entityType);
+    final SearchResponse<JobRegistryEntryDto> searchResponse =
+        osClient.search(searchReqBuilder, JobRegistryEntryDto.class, errorMessage);
+
+    return searchResponse.hits().hits().stream()
+        .map(Hit::source)
+        .filter(Objects::nonNull)
+        .map(JobRegistryEntryDto::getEntityId)
+        .collect(Collectors.toSet());
+  }
+
+  private BoolQuery.Builder jobTypeAndEntityTypeQuery(
+      final JobType jobType, final EntityType entityType) {
+    return new BoolQuery.Builder()
+        .must(QueryDSL.term(JobRegistryIndex.JOB_TYPE, jobType.name()))
+        .must(QueryDSL.term(JobRegistryIndex.ENTITY_TYPE, entityType.name()));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
 import io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex;
+import io.camunda.optimize.service.db.writer.DeletedProcessDefinitionFilter;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
@@ -50,19 +51,25 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
       org.slf4j.LoggerFactory.getLogger(ProcessDefinitionWriterOS.class);
 
   private final ConfigurationService configurationService;
+  private final DeletedProcessDefinitionFilter deletedProcessDefinitionFilter;
 
   public ProcessDefinitionWriterOS(
       final OptimizeOpenSearchClient osClient,
       final ObjectMapper objectMapper,
-      final ConfigurationService configurationService) {
+      final ConfigurationService configurationService,
+      final DeletedProcessDefinitionFilter deletedProcessDefinitionFilter) {
     super(objectMapper, osClient);
     this.configurationService = configurationService;
+    this.deletedProcessDefinitionFilter = deletedProcessDefinitionFilter;
   }
 
   @Override
   public void importProcessDefinitions(final List<ProcessDefinitionOptimizeDto> procDefs) {
-    LOG.debug("Writing [{}] process definitions to opensearch", procDefs.size());
-    writeProcessDefinitionInformation(procDefs);
+    final List<ProcessDefinitionOptimizeDto> filteredProcDefs =
+        deletedProcessDefinitionFilter.filterOutSuppressed(
+            procDefs, ProcessDefinitionOptimizeDto::getId);
+    LOG.debug("Writing [{}] process definitions to opensearch", filteredProcDefs.size());
+    writeProcessDefinitionInformation(filteredProcDefs);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/JobRegistryReader.java
@@ -10,8 +10,10 @@ package io.camunda.optimize.service.db.reader;
 import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface JobRegistryReader {
 
@@ -27,4 +29,11 @@ public interface JobRegistryReader {
    */
   Optional<JobRegistryEntryDto> findLastByJobTypeAndEntityId(
       JobType jobType, EntityType entityType, String entityId);
+
+  /**
+   * Returns the subset of {@code entityIds} that have at least one job registry entry (in any
+   * status) matching the given jobType and entityType.
+   */
+  Set<String> findEntityIdsWithJob(
+      JobType jobType, EntityType entityType, Collection<String> entityIds);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeletedProcessDefinitionFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeletedProcessDefinitionFilter.class);
+
+  private final JobRegistryReader jobRegistryReader;
+
+  public DeletedProcessDefinitionFilter(final JobRegistryReader jobRegistryReader) {
+    this.jobRegistryReader = jobRegistryReader;
+  }
+
+  /**
+   * Returns the subset of {@code processDefinitionIds} that have a job registry entry (in any
+   * status) for a DELETE job on PROCESS_DEFINITION.
+   */
+  public Set<String> suppressedDefinitionIds(final Collection<String> processDefinitionIds) {
+    if (processDefinitionIds.isEmpty()) {
+      return Set.of();
+    }
+    return jobRegistryReader.findEntityIdsWithJob(
+        JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionIds);
+  }
+
+  /**
+   * Filters out entries whose process definition (identified via {@code
+   * processDefinitionIdExtractor}) has a pending or completed deletion job in the job registry.
+   */
+  public <T> List<T> filterOutSuppressed(
+      final List<T> entries, final Function<T, String> processDefinitionIdExtractor) {
+    if (entries.isEmpty()) {
+      return entries;
+    }
+    final Set<String> candidateIds =
+        entries.stream().map(processDefinitionIdExtractor).collect(Collectors.toSet());
+    final Set<String> suppressedIds = suppressedDefinitionIds(candidateIds);
+    if (suppressedIds.isEmpty()) {
+      return entries;
+    }
+    final long suppressedCount =
+        entries.stream()
+            .filter(entry -> suppressedIds.contains(processDefinitionIdExtractor.apply(entry)))
+            .count();
+    LOG.info(
+        "Suppressing import of {} entries for process definition ids {} with a deletion job.",
+        suppressedCount,
+        suppressedIds);
+    return entries.stream()
+        .filter(entry -> !suppressedIds.contains(processDefinitionIdExtractor.apply(entry)))
+        .toList();
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
@@ -57,16 +57,14 @@ public class DeletedProcessDefinitionFilter {
     if (suppressedIds.isEmpty()) {
       return entries;
     }
-    final long suppressedCount =
+    final List<T> filteredEntries =
         entries.stream()
-            .filter(entry -> suppressedIds.contains(processDefinitionIdExtractor.apply(entry)))
-            .count();
+            .filter(entry -> !suppressedIds.contains(processDefinitionIdExtractor.apply(entry)))
+            .toList();
     LOG.info(
         "Suppressing import of {} entries for process definition ids {} with a deletion job.",
-        suppressedCount,
+        entries.size() - filteredEntries.size(),
         suppressedIds);
-    return entries.stream()
-        .filter(entry -> !suppressedIds.contains(processDefinitionIdExtractor.apply(entry)))
-        .toList();
+    return filteredEntries;
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessInstanceWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessInstanceWriter.java
@@ -51,16 +51,19 @@ public class ProcessInstanceWriter {
   private final ObjectMapper objectMapper;
   private final ImportRequestDtoFactory importRequestDtoFactory;
   private final ProcessInstanceRepository processInstanceRepository;
+  private final DeletedProcessDefinitionFilter deletedProcessDefinitionFilter;
 
   public ProcessInstanceWriter(
       final IndexRepository indexRepository,
       final ObjectMapper objectMapper,
       final ImportRequestDtoFactory importRequestDtoFactory,
-      final ProcessInstanceRepository processInstanceRepository) {
+      final ProcessInstanceRepository processInstanceRepository,
+      final DeletedProcessDefinitionFilter deletedProcessDefinitionFilter) {
     this.indexRepository = indexRepository;
     this.objectMapper = objectMapper;
     this.importRequestDtoFactory = importRequestDtoFactory;
     this.processInstanceRepository = processInstanceRepository;
+    this.deletedProcessDefinitionFilter = deletedProcessDefinitionFilter;
   }
 
   public void deleteInstancesByDefinitionId(final String bpmnProcessId, final String definitionId) {
@@ -69,16 +72,13 @@ public class ProcessInstanceWriter {
 
   public List<ImportRequestDto> generateProcessInstanceImports(
       final List<ProcessInstanceDto> processInstances, final String sourceExportIndex) {
+    final List<ProcessInstanceDto> filteredInstances =
+        filterOutInstancesOfDeletedDefinitions(processInstances);
+    ensureProcessInstanceIndicesExist(filteredInstances);
     final String importItemName = "zeebe process instances";
-    LOG.debug("Creating imports for {} [{}].", processInstances.size(), importItemName);
-    indexRepository.createMissingIndices(
-        PROCESS_INSTANCE_INDEX,
-        Set.of(PROCESS_INSTANCE_MULTI_ALIAS),
-        processInstances.stream()
-            .map(ProcessInstanceDto::getProcessDefinitionKey)
-            .collect(Collectors.toSet()));
+    LOG.debug("Creating imports for {} [{}].", filteredInstances.size(), importItemName);
 
-    return processInstances.stream()
+    return filteredInstances.stream()
         .map(
             procInst -> {
               final Map<String, Object> params = new HashMap<>();
@@ -110,16 +110,13 @@ public class ProcessInstanceWriter {
 
   public List<ImportRequestDto> generateRunningProcessInstanceImports(
       final List<ProcessInstanceDto> processInstances) {
+    final List<ProcessInstanceDto> filteredInstances =
+        filterOutInstancesOfDeletedDefinitions(processInstances);
+    ensureProcessInstanceIndicesExist(filteredInstances);
     final String importItemName = "running process instances";
-    LOG.debug("Creating imports for {} [{}].", processInstances.size(), importItemName);
-    indexRepository.createMissingIndices(
-        PROCESS_INSTANCE_INDEX,
-        Set.of(PROCESS_INSTANCE_MULTI_ALIAS),
-        processInstances.stream()
-            .map(ProcessInstanceDto::getProcessDefinitionKey)
-            .collect(Collectors.toSet()));
+    LOG.debug("Creating imports for {} [{}].", filteredInstances.size(), importItemName);
 
-    return processInstances.stream()
+    return filteredInstances.stream()
         .map(
             instance ->
                 importRequestDtoFactory.createImportRequestForProcessInstance(
@@ -139,15 +136,12 @@ public class ProcessInstanceWriter {
 
   public List<ImportRequestDto> generateCompletedProcessInstanceImports(
       final List<ProcessInstanceDto> processInstances) {
+    final List<ProcessInstanceDto> filteredInstances =
+        filterOutInstancesOfDeletedDefinitions(processInstances);
+    ensureProcessInstanceIndicesExist(filteredInstances);
     final String importItemName = "completed process instances";
-    LOG.debug("Creating imports for {} [{}].", processInstances.size(), importItemName);
-    indexRepository.createMissingIndices(
-        PROCESS_INSTANCE_INDEX,
-        Set.of(PROCESS_INSTANCE_MULTI_ALIAS),
-        processInstances.stream()
-            .map(ProcessInstanceDto::getProcessDefinitionKey)
-            .collect(Collectors.toSet()));
-    return processInstances.stream()
+    LOG.debug("Creating imports for {} [{}].", filteredInstances.size(), importItemName);
+    return filteredInstances.stream()
         .map(
             processInstanceDto ->
                 importRequestDtoFactory.createImportRequestForProcessInstance(
@@ -165,5 +159,20 @@ public class ProcessInstanceWriter {
                         TENANT_ID),
                     importItemName))
         .toList();
+  }
+
+  private List<ProcessInstanceDto> filterOutInstancesOfDeletedDefinitions(
+      final List<ProcessInstanceDto> processInstances) {
+    return deletedProcessDefinitionFilter.filterOutSuppressed(
+        processInstances, ProcessInstanceDto::getProcessDefinitionId);
+  }
+
+  private void ensureProcessInstanceIndicesExist(final List<ProcessInstanceDto> processInstances) {
+    indexRepository.createMissingIndices(
+        PROCESS_INSTANCE_INDEX,
+        Set.of(PROCESS_INSTANCE_MULTI_ALIAS),
+        processInstances.stream()
+            .map(ProcessInstanceDto::getProcessDefinitionKey)
+            .collect(Collectors.toSet()));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterESTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.repository.es.TaskRepositoryES;
+import io.camunda.optimize.service.db.writer.DeletedProcessDefinitionFilter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProcessDefinitionWriterESTest {
+
+  private OptimizeElasticsearchClient esClient;
+  private ConfigurationService configurationService;
+  private TaskRepositoryES taskRepositoryES;
+  private JobRegistryReader jobRegistryReader;
+  private ProcessDefinitionWriterES writer;
+
+  @BeforeEach
+  void setUp() {
+    esClient = mock(OptimizeElasticsearchClient.class);
+    configurationService = mock(ConfigurationService.class);
+    taskRepositoryES = mock(TaskRepositoryES.class);
+    jobRegistryReader = mock(JobRegistryReader.class);
+    writer =
+        new ProcessDefinitionWriterES(
+            esClient,
+            new ObjectMapper(),
+            configurationService,
+            taskRepositoryES,
+            new DeletedProcessDefinitionFilter(jobRegistryReader));
+  }
+
+  @Test
+  void shouldImportAllDefinitionsWhenNoDeletionJobEntryExists() {
+    // given
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of());
+    final ProcessDefinitionOptimizeDto definitionA = definition("1");
+    final ProcessDefinitionOptimizeDto definitionB = definition("2");
+
+    // when
+    writer.importProcessDefinitions(List.of(definitionA, definitionB));
+
+    // then
+    final ArgumentCaptor<List<ProcessDefinitionOptimizeDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(esClient)
+        .doImportBulkRequestWithList(anyString(), captor.capture(), any(), anyBoolean());
+    assertThat(captor.getValue()).containsExactlyInAnyOrder(definitionA, definitionB);
+  }
+
+  @Test
+  void shouldSuppressOnlyMatchingDefinition() {
+    // given
+    final ProcessDefinitionOptimizeDto suppressed = definition("deletedDefinitionId");
+    final ProcessDefinitionOptimizeDto kept = definition("keptDefinitionId");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("deletedDefinitionId"));
+
+    // when
+    writer.importProcessDefinitions(List.of(suppressed, kept));
+
+    // then
+    final ArgumentCaptor<List<ProcessDefinitionOptimizeDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(esClient)
+        .doImportBulkRequestWithList(anyString(), captor.capture(), any(), anyBoolean());
+    assertThat(captor.getValue()).containsExactly(kept);
+  }
+
+  @Test
+  void shouldWriteNothingWhenAllDefinitionsAreDeleted() {
+    // given
+    final ProcessDefinitionOptimizeDto definitionA = definition("1");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("1"));
+
+    // when
+    writer.importProcessDefinitions(List.of(definitionA));
+
+    // then
+    final ArgumentCaptor<List<ProcessDefinitionOptimizeDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(esClient)
+        .doImportBulkRequestWithList(anyString(), captor.capture(), any(), anyBoolean());
+    assertThat(captor.getValue()).isEmpty();
+  }
+
+  private ProcessDefinitionOptimizeDto definition(final String id) {
+    final ProcessDefinitionOptimizeDto dto = new ProcessDefinitionOptimizeDto();
+    dto.setId(id);
+    dto.setKey("someKey");
+    return dto;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOSTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.writer.DeletedProcessDefinitionFilter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProcessDefinitionWriterOSTest {
+
+  private OptimizeOpenSearchClient osClient;
+  private ConfigurationService configurationService;
+  private JobRegistryReader jobRegistryReader;
+  private ProcessDefinitionWriterOS writer;
+
+  @BeforeEach
+  void setUp() {
+    osClient = mock(OptimizeOpenSearchClient.class);
+    configurationService = mock(ConfigurationService.class);
+    jobRegistryReader = mock(JobRegistryReader.class);
+    writer =
+        new ProcessDefinitionWriterOS(
+            osClient,
+            new ObjectMapper(),
+            configurationService,
+            new DeletedProcessDefinitionFilter(jobRegistryReader));
+  }
+
+  @Test
+  void shouldImportAllDefinitionsWhenNoDeletionJobEntryExists() {
+    // given
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of());
+    final ProcessDefinitionOptimizeDto definitionA = definition("1");
+    final ProcessDefinitionOptimizeDto definitionB = definition("2");
+
+    // when
+    writer.importProcessDefinitions(List.of(definitionA, definitionB));
+
+    // then
+    final ArgumentCaptor<List<ProcessDefinitionOptimizeDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(osClient)
+        .doImportBulkRequestWithList(
+            anyString(), captor.capture(), any(), anyBoolean(), anyString());
+    assertThat(captor.getValue()).containsExactlyInAnyOrder(definitionA, definitionB);
+  }
+
+  @Test
+  void shouldSuppressOnlyMatchingDefinition() {
+    // given
+    final ProcessDefinitionOptimizeDto suppressed = definition("deletedDefinitionId");
+    final ProcessDefinitionOptimizeDto kept = definition("keptDefinitionId");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("deletedDefinitionId"));
+
+    // when
+    writer.importProcessDefinitions(List.of(suppressed, kept));
+
+    // then
+    final ArgumentCaptor<List<ProcessDefinitionOptimizeDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(osClient)
+        .doImportBulkRequestWithList(
+            anyString(), captor.capture(), any(), anyBoolean(), anyString());
+    assertThat(captor.getValue()).containsExactly(kept);
+  }
+
+  @Test
+  void shouldWriteNothingWhenAllDefinitionsAreDeleted() {
+    // given
+    final ProcessDefinitionOptimizeDto definitionA = definition("1");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("1"));
+
+    // when
+    writer.importProcessDefinitions(List.of(definitionA));
+
+    // then
+    final ArgumentCaptor<List<ProcessDefinitionOptimizeDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(osClient)
+        .doImportBulkRequestWithList(
+            anyString(), captor.capture(), any(), anyBoolean(), anyString());
+    assertThat(captor.getValue()).isEmpty();
+  }
+
+  private ProcessDefinitionOptimizeDto definition(final String id) {
+    final ProcessDefinitionOptimizeDto dto = new ProcessDefinitionOptimizeDto();
+    dto.setId(id);
+    dto.setKey("someKey");
+    return dto;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilterTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.job.EntityType;
+import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeletedProcessDefinitionFilterTest {
+
+  private JobRegistryReader jobRegistryReader;
+  private DeletedProcessDefinitionFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    jobRegistryReader = mock(JobRegistryReader.class);
+    filter = new DeletedProcessDefinitionFilter(jobRegistryReader);
+  }
+
+  @Test
+  void shouldReturnEmptySetForEmptyInputWithoutQueryingReader() {
+    // when
+    final Set<String> result = filter.suppressedDefinitionIds(List.of());
+
+    // then
+    assertThat(result).isEmpty();
+    verifyNoInteractions(jobRegistryReader);
+  }
+
+  @Test
+  void shouldDelegateToReaderAndReturnItsResult() {
+    // given
+    final List<String> candidateIds = List.of("1", "2", "3");
+    when(jobRegistryReader.findEntityIdsWithJob(
+            any(JobType.class), any(EntityType.class), anyCollection()))
+        .thenReturn(Set.of("2"));
+
+    // when
+    final Set<String> result = filter.suppressedDefinitionIds(candidateIds);
+
+    // then
+    assertThat(result).containsExactly("2");
+    verify(jobRegistryReader)
+        .findEntityIdsWithJob(JobType.DELETE, EntityType.PROCESS_DEFINITION, candidateIds);
+  }
+
+  @Test
+  void shouldReturnSameListForEmptyInputWithoutQueryingReader() {
+    // given
+    final List<String> entries = List.of();
+
+    // when
+    final List<String> result = filter.filterOutSuppressed(entries, Function.identity());
+
+    // then
+    assertThat(result).isSameAs(entries);
+    verifyNoInteractions(jobRegistryReader);
+  }
+
+  @Test
+  void shouldReturnAllEntriesWhenNoneAreSuppressed() {
+    // given
+    when(jobRegistryReader.findEntityIdsWithJob(
+            any(JobType.class), any(EntityType.class), anyCollection()))
+        .thenReturn(Set.of());
+    final List<String> entries = List.of("1", "2");
+
+    // when
+    final List<String> result = filter.filterOutSuppressed(entries, Function.identity());
+
+    // then
+    assertThat(result).containsExactlyInAnyOrder("1", "2");
+  }
+
+  @Test
+  void shouldFilterOutOnlySuppressedEntries() {
+    // given
+    when(jobRegistryReader.findEntityIdsWithJob(
+            any(JobType.class), any(EntityType.class), anyCollection()))
+        .thenReturn(Set.of("2"));
+    final List<String> entries = List.of("1", "2", "3");
+
+    // when
+    final List<String> result = filter.filterOutSuppressed(entries, Function.identity());
+
+    // then
+    assertThat(result).containsExactlyInAnyOrder("1", "3");
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAllEntriesAreSuppressed() {
+    // given
+    when(jobRegistryReader.findEntityIdsWithJob(
+            any(JobType.class), any(EntityType.class), anyCollection()))
+        .thenReturn(Set.of("1"));
+    final List<String> entries = List.of("1");
+
+    // when
+    final List<String> result = filter.filterOutSuppressed(entries, Function.identity());
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/ProcessInstanceWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/ProcessInstanceWriterTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.ImportRequestDto;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.service.db.helper.ImportRequestDtoFactory;
+import io.camunda.optimize.service.db.reader.JobRegistryReader;
+import io.camunda.optimize.service.db.repository.IndexRepository;
+import io.camunda.optimize.service.db.repository.ProcessInstanceRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProcessInstanceWriterTest {
+
+  private IndexRepository indexRepository;
+  private ImportRequestDtoFactory importRequestDtoFactory;
+  private ProcessInstanceRepository processInstanceRepository;
+  private JobRegistryReader jobRegistryReader;
+  private ProcessInstanceWriter writer;
+
+  @BeforeEach
+  void setUp() {
+    indexRepository = mock(IndexRepository.class);
+    importRequestDtoFactory = mock(ImportRequestDtoFactory.class);
+    processInstanceRepository = mock(ProcessInstanceRepository.class);
+    jobRegistryReader = mock(JobRegistryReader.class);
+    writer =
+        new ProcessInstanceWriter(
+            indexRepository,
+            new ObjectMapper(),
+            importRequestDtoFactory,
+            processInstanceRepository,
+            new DeletedProcessDefinitionFilter(jobRegistryReader));
+    when(importRequestDtoFactory.createImportRequestForProcessInstance(
+            any(ProcessInstanceDto.class), anySet(), any(String.class)))
+        .thenAnswer(
+            invocation ->
+                ImportRequestDto.builder()
+                    .id(((ProcessInstanceDto) invocation.getArgument(0)).getProcessInstanceId())
+                    .build());
+  }
+
+  @Test
+  void shouldImportNormallyWhenNoDeletionJobEntryExists() {
+    // given
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of());
+    final ProcessInstanceDto instanceA = instance("definitionKeyA", "definitionIdA", "instance-1");
+    final ProcessInstanceDto instanceB = instance("definitionKeyB", "definitionIdB", "instance-2");
+
+    // when
+    final List<ImportRequestDto> requests =
+        writer.generateProcessInstanceImports(List.of(instanceA, instanceB), "source-index");
+
+    // then
+    assertThat(requests).hasSize(2);
+    final ArgumentCaptor<Set<String>> keysCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(indexRepository, times(1)).createMissingIndices(any(), anySet(), keysCaptor.capture());
+    assertThat(keysCaptor.getValue()).containsExactlyInAnyOrder("definitionKeyA", "definitionKeyB");
+  }
+
+  @Test
+  void shouldSuppressOnlyMatchingDefinitionInMixedBatch() {
+    // given
+    final ProcessInstanceDto suppressed =
+        instance("sharedKey", "deletedDefinitionId", "instance-1");
+    final ProcessInstanceDto kept = instance("sharedKey", "keptDefinitionId", "instance-2");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("deletedDefinitionId"));
+
+    // when
+    final List<ImportRequestDto> requests =
+        writer.generateProcessInstanceImports(List.of(suppressed, kept), "source-index");
+
+    // then
+    assertThat(requests)
+        .singleElement()
+        .satisfies(request -> assertThat(request.getId()).isEqualTo("instance-2"));
+  }
+
+  @Test
+  void shouldSuppressEntireBatchWhenAllDefinitionsAreDeleted() {
+    // given
+    final ProcessInstanceDto instanceA = instance("definitionKeyA", "definitionIdA", "instance-1");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("definitionIdA"));
+
+    // when
+    final List<ImportRequestDto> requests =
+        writer.generateProcessInstanceImports(List.of(instanceA), "source-index");
+
+    // then
+    assertThat(requests).isEmpty();
+    verify(indexRepository).createMissingIndices(any(), anySet(), eq(Set.of()));
+  }
+
+  @Test
+  void shouldSuppressOnlyMatchingDefinitionForRunningProcessInstanceImports() {
+    // given
+    final ProcessInstanceDto suppressed =
+        instance("sharedKey", "deletedDefinitionId", "instance-1");
+    final ProcessInstanceDto kept = instance("sharedKey", "keptDefinitionId", "instance-2");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("deletedDefinitionId"));
+
+    // when
+    final List<ImportRequestDto> requests =
+        writer.generateRunningProcessInstanceImports(new ArrayList<>(List.of(suppressed, kept)));
+
+    // then
+    assertThat(requests)
+        .singleElement()
+        .satisfies(request -> assertThat(request.getId()).isEqualTo("instance-2"));
+  }
+
+  @Test
+  void shouldSuppressOnlyMatchingDefinitionForCompletedProcessInstanceImports() {
+    // given
+    final ProcessInstanceDto suppressed =
+        instance("sharedKey", "deletedDefinitionId", "instance-1");
+    final ProcessInstanceDto kept = instance("sharedKey", "keptDefinitionId", "instance-2");
+    when(jobRegistryReader.findEntityIdsWithJob(any(), any(), anyCollection()))
+        .thenReturn(Set.of("deletedDefinitionId"));
+
+    // when
+    final List<ImportRequestDto> requests =
+        writer.generateCompletedProcessInstanceImports(new ArrayList<>(List.of(suppressed, kept)));
+
+    // then
+    assertThat(requests)
+        .singleElement()
+        .satisfies(request -> assertThat(request.getId()).isEqualTo("instance-2"));
+  }
+
+  @Test
+  void shouldNeverFilterDeleteByIds() {
+    // when
+    writer.deleteByIds("someDefinitionKey", List.of("instance-1"));
+
+    // then
+    verifyNoInteractions(jobRegistryReader);
+  }
+
+  private ProcessInstanceDto instance(
+      final String processDefinitionKey,
+      final String processDefinitionId,
+      final String instanceId) {
+    final ProcessInstanceDto dto = new ProcessInstanceDto();
+    dto.setProcessDefinitionKey(processDefinitionKey);
+    dto.setProcessDefinitionId(processDefinitionId);
+    dto.setProcessInstanceId(instanceId);
+    return dto;
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -588,6 +588,9 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
       final String bulkRequestName,
       final List<ImportRequestDto> importRequestDtos,
       final Boolean retryFailedRequestsOnNestedDocLimit) {
+    if (importRequestDtos.isEmpty()) {
+      return;
+    }
     final BulkRequest bulkRequest =
         BulkRequest.of(
             b -> {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The delete process definition data API records a deletion job in the job registry, but the Zeebe importer runs independently of that state. Without a check, the next import batch could still write fresh process-instance data for a version whose erasure was requested.

Changes:

- `JobRegistryReader.findEntityIdsWithJob`: batch lookup of entity ids with a matching job registry entry (ES/OS
  implementations).
- `DeletedProcessDefinitionFilter`: filters a list against the registry, keyed on `processDefinitionId`.
- Wired into `ProcessInstanceWriter` and both `ProcessDefinitionWriter` implementations.
- Fixed a related bug found via the integration test: `OptimizeElasticsearchClient.executeImportRequestsAsBulk` had
  no guard for an empty request list (unlike its OpenSearch counterpart) — once a batch could legitimately filter
  down to zero, it threw and retried forever.

Performance impact:

This adds one extra Elasticsearch/OpenSearch query per import batch — a cheap bool filter against the job-registry index, restricted to just the `entityId` field, with a result size bounded by the batch's distinct process-definition count (≤ `maxImportPageSize`, 200 by default). Since each of the 5 process-instance-scoped import types (instance, incident, variable, user task, agent instance) runs its own mediator per Zeebe partition, and there's no cache in front of this lookup, the query fires on essentially every batch during active import — up to partitions × 5 extra round trips per import cycle. Individually negligible against a typically near-empty registry index, but it's a permanent addition to the hottest part of the importer, so worth watching under sustained high-throughput load.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
