### PR TITLE
fix: fall back to latest release candidate when previous minor has no GA release

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
@@ -19,7 +19,6 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -98,10 +97,6 @@ class ElasticsearchExporterMigrationIT {
     }
   }
 
-  @Disabled(
-      "No 8.10 release images are published yet after bumping the development version to "
-          + "8.11.0-SNAPSHOT, so there is no previous-minor patch to migrate from. Re-enable once "
-          + "8.10 has a released patch on Docker Hub.")
   @ParameterizedTest(name = "Migrate from {0} to current version")
   @MethodSource(
       "io.camunda.it.schema.ExporterMigrationTestHelper#fetchLatestPatchFromPreviousMinor")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -554,11 +554,22 @@ public class ExporterMigrationTestHelper {
   public static Optional<String> findLatestReleaseCandidate(
       final List<DockerHubTag> allTags, final String previousMinorVersion) {
     return allTags.stream()
-        .filter(t -> t.name().startsWith(previousMinorVersion))
+        .filter(t -> hasMinorPrefix(t.name(), previousMinorVersion))
         .filter(t -> RC_SUFFIX_PATTERN.matcher(t.name()).matches())
         .filter(t -> t.lastPushed() != null)
         .max(Comparator.comparing(t -> Instant.parse(t.lastPushed())))
         .map(DockerHubTag::name);
+  }
+
+  /**
+   * A plain {@code startsWith} would also match a different minor sharing the same digits, e.g.
+   * "8.80.0-rc1" starts with "8.8". The character right after the prefix must not continue the
+   * minor number itself.
+   */
+  private static boolean hasMinorPrefix(final String tagName, final String minorVersion) {
+    return tagName.startsWith(minorVersion)
+        && (tagName.length() == minorVersion.length()
+            || !Character.isDigit(tagName.charAt(minorVersion.length())));
   }
 
   /**
@@ -632,7 +643,7 @@ public class ExporterMigrationTestHelper {
 
     final List<String> allVersions = new ArrayList<>();
     for (final DockerHubTag tag : allTags) {
-      if (!tag.name().startsWith(PREVIOUS_MINOR_VERSION)) {
+      if (!hasMinorPrefix(tag.name(), PREVIOUS_MINOR_VERSION)) {
         continue;
       }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -34,11 +34,15 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.awaitility.Awaitility;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
@@ -53,6 +57,7 @@ import tools.jackson.databind.ObjectMapper;
 public class ExporterMigrationTestHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExporterMigrationTestHelper.class);
+  private static final Pattern RC_SUFFIX_PATTERN = Pattern.compile(".*-rc\\d+$");
 
   private static final String CONTAINER_DATA_PATH = "/usr/local/camunda/data";
   private static final String HTTP_PREFIX = "http://";
@@ -546,6 +551,16 @@ public class ExporterMigrationTestHelper {
     return List.of(allVersions.get(latestReleaseIndex));
   }
 
+  public static Optional<String> findLatestReleaseCandidate(
+      final List<DockerHubTag> allTags, final String previousMinorVersion) {
+    return allTags.stream()
+        .filter(t -> t.name().startsWith(previousMinorVersion))
+        .filter(t -> RC_SUFFIX_PATTERN.matcher(t.name()).matches())
+        .filter(t -> t.lastPushed() != null)
+        .max(Comparator.comparing(t -> Instant.parse(t.lastPushed())))
+        .map(DockerHubTag::name);
+  }
+
   /**
    * Docker Hub is an external dependency, and this runs while JUnit provides the arguments for the
    * migration ITs. An argument-provider failure is a container-level failure, which Failsafe's
@@ -571,7 +586,7 @@ public class ExporterMigrationTestHelper {
       throws IOException, InterruptedException {
     final ObjectMapper mapper = new ObjectMapper();
 
-    final List<String> allTags = new ArrayList<>();
+    final List<DockerHubTag> allTags = new ArrayList<>();
     String url = API_URL;
 
     try (final HttpClient client =
@@ -596,7 +611,10 @@ public class ExporterMigrationTestHelper {
         final JsonNode root = mapper.readTree(response.body());
 
         for (final JsonNode tag : root.get("results")) {
-          allTags.add(tag.get("name").asString());
+          final JsonNode lastPushedNode = tag.get("tag_last_pushed");
+          final String lastPushed =
+              lastPushedNode == null || lastPushedNode.isNull() ? null : lastPushedNode.asString();
+          allTags.add(new DockerHubTag(tag.get("name").asString(), lastPushed));
         }
 
         // pagination
@@ -613,12 +631,12 @@ public class ExporterMigrationTestHelper {
     }
 
     final List<String> allVersions = new ArrayList<>();
-    for (final String tag : allTags) {
-      if (!tag.startsWith(PREVIOUS_MINOR_VERSION)) {
+    for (final DockerHubTag tag : allTags) {
+      if (!tag.name().startsWith(PREVIOUS_MINOR_VERSION)) {
         continue;
       }
 
-      final String[] components = tag.split("\\.");
+      final String[] components = tag.name().split("\\.");
       if (components.length != 3) {
         continue;
       }
@@ -629,17 +647,26 @@ public class ExporterMigrationTestHelper {
         continue;
       }
 
-      allVersions.add(tag);
+      allVersions.add(tag.name());
     }
 
     if (allVersions.isEmpty()) {
-      throw new NoSuchElementException("No release images found for " + PREVIOUS_MINOR_VERSION);
+      final Optional<String> latestRc = findLatestReleaseCandidate(allTags, PREVIOUS_MINOR_VERSION);
+      if (latestRc.isEmpty()) {
+        throw new NoSuchElementException("No release images found for " + PREVIOUS_MINOR_VERSION);
+      }
+      LOG.warn(
+          "No stable release found for previous minor {}, falling back to latest release"
+              + " candidate {}",
+          PREVIOUS_MINOR_VERSION,
+          latestRc.get());
+      allVersions.add(latestRc.get());
+    } else {
+      allVersions.sort(ExporterMigrationTestHelper::comparePatches);
     }
 
-    allVersions.sort(ExporterMigrationTestHelper::comparePatches);
-
     final String snapshotVersion = PREVIOUS_MINOR_VERSION + "-SNAPSHOT";
-    if (allTags.contains(snapshotVersion)) {
+    if (allTags.stream().anyMatch(t -> t.name().equals(snapshotVersion))) {
       allVersions.add(snapshotVersion);
     }
 
@@ -670,4 +697,6 @@ public class ExporterMigrationTestHelper {
 
     return String.format("%s.%s", components[0], String.valueOf(minor - 1));
   }
+
+  record DockerHubTag(String name, String lastPushed) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -57,7 +57,17 @@ import tools.jackson.databind.ObjectMapper;
 public class ExporterMigrationTestHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExporterMigrationTestHelper.class);
-  private static final Pattern RC_SUFFIX_PATTERN = Pattern.compile(".*-rc\\d+$");
+
+  /**
+   * Matches Docker Hub's actual pre-release tag shapes for camunda/camunda: plain alpha ({@code
+   * 8.10.0-alpha4}, optionally with a sub-patch suffix like {@code -alpha4.1}), alpha plus rc
+   * ({@code 8.10.0-alpha4-rc2}), or a final rc with no alpha stage ({@code 8.10.0-rc1}).
+   * Deliberately a positive allow-list rather than "not GA and not snapshot" — Docker Hub tags are
+   * external data, and a variant/build tag we don't know about yet must not be picked up as if it
+   * were a genuine pre-release stage.
+   */
+  private static final Pattern PRE_RELEASE_PATTERN =
+      Pattern.compile("^\\d+\\.\\d+\\.\\d+-(alpha\\d+(\\.\\d+)?(-rc\\d+)?|rc\\d+)$");
 
   private static final String CONTAINER_DATA_PATH = "/usr/local/camunda/data";
   private static final String HTTP_PREFIX = "http://";
@@ -551,11 +561,17 @@ public class ExporterMigrationTestHelper {
     return List.of(allVersions.get(latestReleaseIndex));
   }
 
-  public static Optional<String> findLatestReleaseCandidate(
+  /**
+   * Picks the most recently pushed pre-release (alpha and/or rc) tag for the minor. Alpha/rc stages
+   * are strictly sequential within one target release (alpha1 -> alpha1-rcN -> alpha2 -> ... -> rc1
+   * -> ... -> GA), so the most recently pushed tag is always the most mature one — no separate
+   * "prefer final rc over alpha" tiering is needed on top of the timestamp.
+   */
+  public static Optional<String> findLatestPreRelease(
       final List<DockerHubTag> allTags, final String previousMinorVersion) {
     return allTags.stream()
         .filter(t -> hasMinorPrefix(t.name(), previousMinorVersion))
-        .filter(t -> RC_SUFFIX_PATTERN.matcher(t.name()).matches())
+        .filter(t -> PRE_RELEASE_PATTERN.matcher(t.name()).matches())
         .filter(t -> t.lastPushed() != null)
         .max(Comparator.comparing(t -> Instant.parse(t.lastPushed())))
         .map(DockerHubTag::name);
@@ -570,6 +586,19 @@ public class ExporterMigrationTestHelper {
     return tagName.startsWith(minorVersion)
         && (tagName.length() == minorVersion.length()
             || !Character.isDigit(tagName.charAt(minorVersion.length())));
+  }
+
+  private static boolean isGaVersionTag(final String tagName) {
+    final String[] components = tagName.split("\\.");
+    if (components.length != 3) {
+      return false;
+    }
+    try {
+      Integer.parseInt(components[2]);
+      return true;
+    } catch (final NumberFormatException ignored) {
+      return false;
+    }
   }
 
   /**
@@ -643,18 +672,7 @@ public class ExporterMigrationTestHelper {
 
     final List<String> allVersions = new ArrayList<>();
     for (final DockerHubTag tag : allTags) {
-      if (!hasMinorPrefix(tag.name(), PREVIOUS_MINOR_VERSION)) {
-        continue;
-      }
-
-      final String[] components = tag.name().split("\\.");
-      if (components.length != 3) {
-        continue;
-      }
-
-      try {
-        Integer.parseInt(components[2]);
-      } catch (final NumberFormatException ignored) {
+      if (!hasMinorPrefix(tag.name(), PREVIOUS_MINOR_VERSION) || !isGaVersionTag(tag.name())) {
         continue;
       }
 
@@ -662,16 +680,16 @@ public class ExporterMigrationTestHelper {
     }
 
     if (allVersions.isEmpty()) {
-      final Optional<String> latestRc = findLatestReleaseCandidate(allTags, PREVIOUS_MINOR_VERSION);
-      if (latestRc.isEmpty()) {
+      final Optional<String> latestPreRelease =
+          findLatestPreRelease(allTags, PREVIOUS_MINOR_VERSION);
+      if (latestPreRelease.isEmpty()) {
         throw new NoSuchElementException("No release images found for " + PREVIOUS_MINOR_VERSION);
       }
       LOG.warn(
-          "No stable release found for previous minor {}, falling back to latest release"
-              + " candidate {}",
+          "No stable release found for previous minor {}, falling back to latest pre-release {}",
           PREVIOUS_MINOR_VERSION,
-          latestRc.get());
-      allVersions.add(latestRc.get());
+          latestPreRelease.get());
+      allVersions.add(latestPreRelease.get());
     } else {
       allVersions.sort(ExporterMigrationTestHelper::comparePatches);
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelperTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelperTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.schema.ExporterMigrationTestHelper.DockerHubTag;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ExporterMigrationTestHelperTest {
+
+  @Test
+  void shouldReturnEmptyWhenNoRcTagsPresent() {
+    // given
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0", "2026-01-01T00:00:00Z"),
+            new DockerHubTag("8.8-SNAPSHOT", "2026-01-02T00:00:00Z"),
+            new DockerHubTag("8.8.0-alpha8", "2026-01-03T00:00:00Z"));
+
+    // when
+    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+
+    // then
+    assertThat(latestRc).isEmpty();
+  }
+
+  @Test
+  void shouldPickMostRecentlyPushedRcRegardlessOfAlphaStage() {
+    // given
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0-rc1", "2026-04-02T12:53:39Z"),
+            new DockerHubTag("8.8.0-alpha5-rc4", "2026-03-05T12:57:48Z"));
+
+    // when
+    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+
+    // then
+    assertThat(latestRc).contains("8.8.0-rc1");
+  }
+
+  @Test
+  void shouldPickTagWithLatestPushTimestampNotHighestNameOrRcNumber() {
+    // given
+    // "8.8.0-rc9" sorts after "8.8.0-rc10" both lexicographically and by parsed rc-number, but was
+    // pushed earlier — only a timestamp-based comparison picks the actually latest tag.
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0-rc9", "2026-01-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-rc10", "2026-04-01T00:00:00Z"));
+
+    // when
+    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+
+    // then
+    assertThat(latestRc).contains("8.8.0-rc10");
+  }
+
+  @Test
+  void shouldIgnoreTagsFromDifferentMinor() {
+    // given
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.7.0-rc1", "2026-05-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-rc1", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+
+    // then
+    assertThat(latestRc).contains("8.8.0-rc1");
+  }
+
+  @Test
+  void shouldIgnoreTagsWithMissingPushTimestamp() {
+    // given
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0-rc1", null),
+            new DockerHubTag("8.8.0-rc2", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+
+    // then
+    assertThat(latestRc).contains("8.8.0-rc2");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelperTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelperTest.java
@@ -16,23 +16,99 @@ import org.junit.jupiter.api.Test;
 class ExporterMigrationTestHelperTest {
 
   @Test
-  void shouldReturnEmptyWhenNoRcTagsPresent() {
+  void shouldReturnEmptyWhenOnlyGaAndSnapshotTagsPresent() {
     // given
     final List<DockerHubTag> tags =
         List.of(
             new DockerHubTag("8.8.0", "2026-01-01T00:00:00Z"),
-            new DockerHubTag("8.8-SNAPSHOT", "2026-01-02T00:00:00Z"),
-            new DockerHubTag("8.8.0-alpha8", "2026-01-03T00:00:00Z"));
+            new DockerHubTag("8.8-SNAPSHOT", "2026-01-02T00:00:00Z"));
 
     // when
-    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
 
     // then
-    assertThat(latestRc).isEmpty();
+    assertThat(latestPreRelease).isEmpty();
   }
 
   @Test
-  void shouldPickMostRecentlyPushedRcRegardlessOfAlphaStage() {
+  void shouldExcludeGaTagsEvenIfMoreRecentlyPushed() {
+    // given
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0", "2026-05-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-alpha1", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
+
+    // then
+    assertThat(latestPreRelease).contains("8.8.0-alpha1");
+  }
+
+  @Test
+  void shouldPickLatestPlainAlphaTagWhenNoRcExistsYet() {
+    // given
+    // a brand-new alpha stage may not have an rc build yet.
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0-alpha1", "2026-01-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-alpha2", "2026-02-01T00:00:00Z"));
+
+    // when
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
+
+    // then
+    assertThat(latestPreRelease).contains("8.8.0-alpha2");
+  }
+
+  @Test
+  void shouldIgnoreNonPreReleaseVariantTagsEvenIfMoreRecentlyPushed() {
+    // given
+    // a hypothetical variant/build tag sharing the minor prefix that is neither GA, snapshot, nor
+    // a real alpha/rc stage must never be picked over a genuine pre-release tag.
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8.0-ubi", "2026-06-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-alpha1", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
+
+    // then
+    assertThat(latestPreRelease).contains("8.8.0-alpha1");
+  }
+
+  @Test
+  void shouldIgnoreBareFloatingMinorTag() {
+    // given
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.8", "2026-06-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-alpha1", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
+
+    // then
+    assertThat(latestPreRelease).contains("8.8.0-alpha1");
+  }
+
+  @Test
+  void shouldMatchAlphaTagWithSubPatchSuffix() {
+    // given
+    // Docker Hub publishes sub-patch alpha rebuilds like "8.8.0-alpha4.1".
+    final List<DockerHubTag> tags =
+        List.of(new DockerHubTag("8.8.0-alpha4.1", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
+
+    // then
+    assertThat(latestPreRelease).contains("8.8.0-alpha4.1");
+  }
+
+  @Test
+  void shouldPickMostRecentlyPushedPreReleaseRegardlessOfAlphaStage() {
     // given
     final List<DockerHubTag> tags =
         List.of(
@@ -40,10 +116,10 @@ class ExporterMigrationTestHelperTest {
             new DockerHubTag("8.8.0-alpha5-rc4", "2026-03-05T12:57:48Z"));
 
     // when
-    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
 
     // then
-    assertThat(latestRc).contains("8.8.0-rc1");
+    assertThat(latestPreRelease).contains("8.8.0-rc1");
   }
 
   @Test
@@ -57,10 +133,10 @@ class ExporterMigrationTestHelperTest {
             new DockerHubTag("8.8.0-rc9", "2026-04-01T00:00:00Z"));
 
     // when
-    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
 
     // then
-    assertThat(latestRc).contains("8.8.0-rc9");
+    assertThat(latestPreRelease).contains("8.8.0-rc9");
   }
 
   @Test
@@ -72,10 +148,10 @@ class ExporterMigrationTestHelperTest {
             new DockerHubTag("8.8.0-rc1", "2026-01-01T00:00:00Z"));
 
     // when
-    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
 
     // then
-    assertThat(latestRc).contains("8.8.0-rc1");
+    assertThat(latestPreRelease).contains("8.8.0-rc1");
   }
 
   @Test
@@ -88,10 +164,10 @@ class ExporterMigrationTestHelperTest {
             new DockerHubTag("8.8.0-rc1", "2026-01-01T00:00:00Z"));
 
     // when
-    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
 
     // then
-    assertThat(latestRc).contains("8.8.0-rc1");
+    assertThat(latestPreRelease).contains("8.8.0-rc1");
   }
 
   @Test
@@ -103,9 +179,9 @@ class ExporterMigrationTestHelperTest {
             new DockerHubTag("8.8.0-rc2", "2026-01-01T00:00:00Z"));
 
     // when
-    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+    final var latestPreRelease = ExporterMigrationTestHelper.findLatestPreRelease(tags, "8.8");
 
     // then
-    assertThat(latestRc).contains("8.8.0-rc2");
+    assertThat(latestPreRelease).contains("8.8.0-rc2");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelperTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelperTest.java
@@ -47,20 +47,20 @@ class ExporterMigrationTestHelperTest {
   }
 
   @Test
-  void shouldPickTagWithLatestPushTimestampNotHighestNameOrRcNumber() {
+  void shouldPickTagWithLatestPushTimestampNotHighestRcNumber() {
     // given
-    // "8.8.0-rc9" sorts after "8.8.0-rc10" both lexicographically and by parsed rc-number, but was
-    // pushed earlier — only a timestamp-based comparison picks the actually latest tag.
+    // "8.8.0-rc10" has the higher rc number, but "8.8.0-rc9" was pushed later — only a
+    // timestamp-based comparison picks the actually latest tag.
     final List<DockerHubTag> tags =
         List.of(
-            new DockerHubTag("8.8.0-rc9", "2026-01-01T00:00:00Z"),
-            new DockerHubTag("8.8.0-rc10", "2026-04-01T00:00:00Z"));
+            new DockerHubTag("8.8.0-rc10", "2026-01-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-rc9", "2026-04-01T00:00:00Z"));
 
     // when
     final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
 
     // then
-    assertThat(latestRc).contains("8.8.0-rc10");
+    assertThat(latestRc).contains("8.8.0-rc9");
   }
 
   @Test
@@ -69,6 +69,22 @@ class ExporterMigrationTestHelperTest {
     final List<DockerHubTag> tags =
         List.of(
             new DockerHubTag("8.7.0-rc1", "2026-05-01T00:00:00Z"),
+            new DockerHubTag("8.8.0-rc1", "2026-01-01T00:00:00Z"));
+
+    // when
+    final var latestRc = ExporterMigrationTestHelper.findLatestReleaseCandidate(tags, "8.8");
+
+    // then
+    assertThat(latestRc).contains("8.8.0-rc1");
+  }
+
+  @Test
+  void shouldIgnoreTagsSharingOnlyANumericPrefixWithTheMinor() {
+    // given
+    // "8.80.0-rc1" starts with "8.8" but belongs to a different minor entirely.
+    final List<DockerHubTag> tags =
+        List.of(
+            new DockerHubTag("8.80.0-rc1", "2026-05-01T00:00:00Z"),
             new DockerHubTag("8.8.0-rc1", "2026-01-01T00:00:00Z"));
 
     // when

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/OpensearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/OpensearchExporterMigrationIT.java
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.core5.http.HttpHost;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -98,10 +97,6 @@ public class OpensearchExporterMigrationIT {
     }
   }
 
-  @Disabled(
-      "No 8.10 release images are published yet after bumping the development version to "
-          + "8.11.0-SNAPSHOT, so there is no previous-minor patch to migrate from. Re-enable once "
-          + "8.10 has a released patch on Docker Hub.")
   @ParameterizedTest(name = "Migrate from {0} to current version")
   @MethodSource(
       "io.camunda.it.schema.ExporterMigrationTestHelper#fetchLatestPatchFromPreviousMinor")


### PR DESCRIPTION
fetchAllPatchesFromPreviousMinor() threw when the previous minor had no GA release yet (the window right after a new minor branches, before its first alpha/rc/GA is published). Falls back to the latest pre-release tag instead — covering plain alpha, alpha+rc, and final rc tags uniformly, since a brand-new alpha stage may not have an rc build yet. Candidates are matched against the actual pre-release tag shapes (not just "not GA") and picked by Docker Hub's push timestamp rather than version-number parsing, since rc numbers reset across alpha stages and sort incorrectly on their own.