### PR TITLE
test: fix failing RDBMS ITs in future 8.11 version

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseMultiTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/LiquibaseMultiTenantIT.java
@@ -28,6 +28,8 @@ class LiquibaseMultiTenantIT {
   private static final String TENANT_A = "tenanta";
   private static final String TENANT_B = "tenantb";
 
+  private static final String URL_DEFAULT =
+      "jdbc:h2:mem:lb-mt-default;DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
   private static final String URL_A = "jdbc:h2:mem:lb-mt-a;DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
   private static final String URL_B = "jdbc:h2:mem:lb-mt-b;DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
   private static final String PREFIX_A = "TA_";
@@ -48,6 +50,8 @@ class LiquibaseMultiTenantIT {
     app =
         new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
             .withH2()
+            .withUnifiedConfig(
+                c -> c.getData().getSecondaryStorage().getRdbms().setUrl(URL_DEFAULT))
             .withProperty(
                 "camunda.physical-tenants." + TENANT_A + ".data.secondary-storage.rdbms.url", URL_A)
             .withProperty(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
@@ -44,6 +44,8 @@ import org.springframework.context.annotation.Configuration;
 @Tag("rdbms")
 class PhysicalTenantWebSessionIsolationIT {
 
+  private static final String URL_DEFAULT =
+      "jdbc:h2:mem:ws-isol-default;DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
   private static final String URL_TENANTA =
       "jdbc:h2:mem:ws-isol-tenanta;DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
   private static final String TENANT_A = "tenanta";
@@ -75,6 +77,7 @@ class PhysicalTenantWebSessionIsolationIT {
     return new CamundaRdbmsTestApplication(
             RdbmsTestConfiguration.class, SessionStoreConfiguration.class)
         .withH2()
+        .withUnifiedConfig(c -> c.getData().getSecondaryStorage().getRdbms().setUrl(URL_DEFAULT))
         .withProperty(
             "camunda.physical-tenants." + TENANT_A + ".data.secondary-storage.rdbms.url",
             URL_TENANTA)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
LiquibaseMultiTenantIT and PhysicalTenantWebSessionIsolationIT 
Both test classes call `.withH2()`, which points their `default` physical tenant at a hardcoded H2 in-memory database name `(jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1)`.
When one of these tests observes that shared database in a state, created by a concurrent test, where the legacy `EXPORTER_POSITION` table exists but `RDBMS_SCHEMA_VERSION` hasn't been populated yet, it assumes 8.9.0 (see https://github.com/camunda/camunda/blob/46b9d7d91caeb95c3d5f33114502050d5375f272/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java#L39) . This was not failing in `main` because 8.9.0to 8.10.0 was classified as a compatible minor upgrade. Bumping the dev version to 8.11.0-SNAPSHOT in https://github.com/camunda/camunda/pull/60380 turned it into a jump of a minir version 8.9 to 8.11

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
