### PR TITLE
feat: report per-physical-tenant RDBMS health status

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.health.contributor.CompositeHealthContributor;
 import org.springframework.boot.health.contributor.HealthContributor;
 import org.springframework.boot.jdbc.health.DataSourceHealthIndicator;
 import org.springframework.context.annotation.Bean;
@@ -194,11 +195,14 @@ public class RdbmsConfiguration {
 
   @Bean
   HealthContributor rdbmsStatusHealthIndicator(final RdbmsDataSources rdbmsDataSources) {
-    // Equivalent to what Boot would normally wire for "db"
-    // TODO: make this a CompositeHealthContributor over all physical tenants (one
-    // DataSourceHealthIndicator per pool) instead of default-tenant only.
-    return new DataSourceHealthIndicator(
-        rdbmsDataSources.dataSourceFor(DEFAULT_PHYSICAL_TENANT_ID));
+    // Equivalent to what Boot would normally wire for "db". A single physical tenant keeps the
+    // original flat shape for backward compatibility; more than one is reported as a composite,
+    // keyed by physical tenant id, with one DataSourceHealthIndicator per pool.
+    final var dataSources = rdbmsDataSources.dataSources();
+    if (dataSources.size() == 1) {
+      return new DataSourceHealthIndicator(dataSources.values().iterator().next());
+    }
+    return CompositeHealthContributor.fromMap(dataSources, DataSourceHealthIndicator::new);
   }
 
   private static RdbmsTenantReaders defaultReaders(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsStatusHealthIndicatorIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsStatusHealthIndicatorIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code rdbmsStatus} entry of {@code /actuator/health}: a single physical tenant
+ * keeps the original flat {@link org.springframework.boot.jdbc.health.DataSourceHealthIndicator}
+ * shape, while more than one is reported as a composite, keyed by physical tenant id, with one
+ * indicator per pool.
+ */
+@Tag("rdbms")
+class RdbmsStatusHealthIndicatorIT {
+
+  private static final String TENANT_B = "tenantb";
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private CamundaRdbmsTestApplication app;
+
+  @AfterEach
+  void tearDown() {
+    if (app != null) {
+      app.close();
+    }
+  }
+
+  @Test
+  void shouldExposePlainDataSourceHealthForSingleTenant() throws Exception {
+    // given - a single, default physical tenant, exactly as before physical tenants existed
+    app =
+        new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
+            .withUnauthenticatedAccess()
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.url",
+                "jdbc:h2:mem:rdbms-health-single;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+            .withProperty("camunda.data.secondary-storage.rdbms.username", "sa")
+            .withProperty("camunda.data.secondary-storage.rdbms.password", "")
+            .withProperty("management.endpoint.health.show-details", "always");
+    app.start();
+
+    // when
+    final JsonNode rdbmsStatus = fetchRdbmsStatus(app);
+
+    // then - the original flat shape is preserved: a plain DataSourceHealthIndicator, not a
+    // composite
+    assertThat(rdbmsStatus.path("status").asText()).isEqualTo("UP");
+    assertThat(rdbmsStatus.path("details").path("database").asText()).isEqualTo("H2");
+    assertThat(rdbmsStatus.has("components")).isFalse();
+  }
+
+  @Test
+  void shouldExposeCompositeHealthPerPhysicalTenantForMultipleTenants() throws Exception {
+    // given - the default tenant plus one more, each on its own H2 database
+    app =
+        new CamundaRdbmsTestApplication(RdbmsTestConfiguration.class)
+            .withUnauthenticatedAccess()
+            .withProperty(
+                "camunda.data.secondary-storage.rdbms.url",
+                "jdbc:h2:mem:rdbms-health-multi-default;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+            .withProperty("camunda.data.secondary-storage.rdbms.username", "sa")
+            .withProperty("camunda.data.secondary-storage.rdbms.password", "")
+            .withProperty(
+                "camunda.physical-tenants." + TENANT_B + ".data.secondary-storage.rdbms.url",
+                "jdbc:h2:mem:rdbms-health-multi-tenantb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+            .withProperty(
+                "camunda.physical-tenants." + TENANT_B + ".data.secondary-storage.rdbms.username",
+                "sa")
+            .withProperty(
+                "camunda.physical-tenants." + TENANT_B + ".data.secondary-storage.rdbms.password",
+                "")
+            // explicitly-configured tenants must provide their own initialization block
+            .withProperty(
+                "camunda.physical-tenants."
+                    + TENANT_B
+                    + ".security.initialization.default-roles.admin.users[0]",
+                TENANT_B + "-admin")
+            .withProperty("management.endpoint.health.show-details", "always");
+    app.start();
+
+    // when
+    final JsonNode rdbmsStatus = fetchRdbmsStatus(app);
+
+    // then - a composite over both physical tenants, each reported under its own tenant id, and
+    // the default tenant is no longer special-cased into the flat shape
+    assertThat(rdbmsStatus.path("status").asText()).isEqualTo("UP");
+    assertThat(rdbmsStatus.has("details")).isFalse();
+    assertThat(
+            rdbmsStatus.path("components").path(DEFAULT_PHYSICAL_TENANT_ID).path("status").asText())
+        .isEqualTo("UP");
+    assertThat(rdbmsStatus.path("components").path(TENANT_B).path("status").asText())
+        .isEqualTo("UP");
+  }
+
+  private static JsonNode fetchRdbmsStatus(final CamundaRdbmsTestApplication app)
+      throws IOException, InterruptedException {
+    final var request =
+        HttpRequest.newBuilder(
+                URI.create(
+                    "http://localhost:"
+                        + app.mappedPort(TestZeebePort.MONITORING)
+                        + "/actuator/health"))
+            .GET()
+            .build();
+    final HttpResponse<String> response = HTTP.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return OBJECT_MAPPER.readTree(response.body()).path("components").path("rdbmsStatus");
+  }
+}


### PR DESCRIPTION
## Summary
- `rdbmsStatusHealthIndicator` reported only the default physical tenant's `DataSourceHealthIndicator`, no matter how many physical tenants were configured, so a multi-tenant RDBMS node's `/actuator/health` gave no visibility into non-default tenants' database health.
- A single physical tenant now keeps the original flat `DataSourceHealthIndicator` shape (no change for existing single-tenant deployments); more than one tenant is reported as a `CompositeHealthContributor`, keyed by physical tenant id, with one indicator per pool.