### PR TITLE
fix: correct type and source for deprecated cluster-variables properties

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -275,16 +275,16 @@
     },
     {
       "name": "camunda.client.cluster-variables.global",
-      "type": "java.util.Map",
-      "description": "Deprecated globally-scoped cluster variables to set at startup as key-value pairs.",
+      "type": "java.util.Map<java.lang.String,java.lang.Object>",
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
       "deprecation": {
         "replacement": "camunda.client.cluster-variables.variables"
       }
     },
     {
       "name": "camunda.client.cluster-variables.tenant",
-      "type": "java.util.Map",
-      "description": "Deprecated tenant-scoped cluster variables to set at startup, keyed by tenant ID.",
+      "type": "java.util.Map<java.lang.String,java.lang.Object>",
+      "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
       "deprecation": {
         "replacement": "camunda.client.cluster-variables.variables"
       }

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -278,7 +278,8 @@
       "type": "java.util.Map<java.lang.String,java.lang.Object>",
       "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
       "deprecation": {
-        "replacement": "camunda.client.cluster-variables.variables"
+        "replacement": "camunda.client.cluster-variables.variables",
+        "reason": "Cluster variables are now set in a single list instead of separate maps for global and tenant variables."
       }
     },
     {
@@ -286,7 +287,8 @@
       "type": "java.util.Map<java.lang.String,java.lang.Object>",
       "sourceType": "io.camunda.client.spring.properties.CamundaClientClusterVariablesProperties",
       "deprecation": {
-        "replacement": "camunda.client.cluster-variables.variables"
+        "replacement": "camunda.client.cluster-variables.variables",
+        "reason": "Cluster variables are now set in a single list instead of separate maps for global and tenant variables."
       }
     },
     {


### PR DESCRIPTION
## Summary
- Fix `additional-spring-configuration-metadata.json` entries for the deprecated `camunda.client.cluster-variables.global` and `.tenant` properties: they declared a raw `java.util.Map` type and no `sourceType`, so IDE tooling couldn't resolve them correctly against their declaring class.
- Add generic parameters (`java.util.Map<java.lang.String,java.lang.Object>`) and `sourceType` (`CamundaClientClusterVariablesProperties`), matching the replacement property's metadata.

## Test plan
- [ ] Verify IDE (IntelliJ/Eclipse) property autocompletion shows correct deprecation warning and type for `camunda.client.cluster-variables.global`/`.tenant`