### PR TITLE
fix: validate OpenSearch minimum age configuration

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -21,10 +21,23 @@ import io.camunda.zeebe.util.SemanticVersion;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OpensearchExporter implements Exporter {
+
+  /**
+   * Supported pattern for the ISM {@code min_index_age} property. Retention periods smaller than a
+   * second are not useful here, so only days, hours, minutes, and seconds are supported.
+   *
+   * <p>See https://docs.opensearch.org/latest/api-reference/units/
+   */
+  private static final String PATTERN_MIN_AGE_FORMAT = "^[0-9]+[dhms]$";
+
+  private static final Predicate<String> CHECKER_MIN_AGE =
+      Pattern.compile(PATTERN_MIN_AGE_FORMAT).asPredicate();
 
   // by default, the bulk request may not be bigger than 100MB
   private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
@@ -195,6 +208,14 @@ public class OpensearchExporter implements Exporter {
     if (priority < 0) {
       throw new ExporterException(
           "Opensearch index template priority must be >= 0. Current value: %d".formatted(priority));
+    }
+
+    final String minimumAge = configuration.retention.getMinimumAge();
+    if (minimumAge != null && !CHECKER_MIN_AGE.test(minimumAge)) {
+      throw new ExporterException(
+          String.format(
+              "Opensearch minimumAge '%s' must match pattern '%s', but didn't.",
+              minimumAge, PATTERN_MIN_AGE_FORMAT));
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -576,6 +576,29 @@ final class OpensearchExporterTest {
       assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
     }
 
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"1", "-1", "1ms"})
+    void shouldNotAllowInvalidMinimumAge(final String invalidMinimumAge) {
+      // given
+      config.retention.setMinimumAge(invalidMinimumAge);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context))
+          .isInstanceOf(ExporterException.class)
+          .hasMessageContaining("must match pattern '^[0-9]+[dhms]$'")
+          .hasMessageContaining("minimumAge '" + invalidMinimumAge + "'");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"1s", "5m", "2h", "30d"})
+    void shouldAllowValidMinimumAge(final String validMinimumAge) {
+      // given
+      config.retention.setMinimumAge(validMinimumAge);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context)).doesNotThrowAnyException();
+    }
+
     @Test
     void shouldForbidNegativeNumberOfReplicas() {
       // given


### PR DESCRIPTION
## Description

The OpenSearch exporter accepted unsupported retention `minimumAge` values during configuration. These values failed later when OpenSearch applied the ISM policy, causing the exporter to enter a repeating failure loop.

This change validates `minimumAge` during exporter configuration. It accepts whole values using days, hours, minutes, or seconds (`d`, `h`, `m`, `s`), matching the Elasticsearch exporter. Tests cover both valid and invalid values.

## Testing

- `./mvnw verify -pl zeebe/exporters/opensearch-exporter -Dquickly -DskipTests=false -T1C`
- `./mvnw install -Dquickly -T1C`

## Checklist

- [x] Enable backports when necessary. Backports are requested for stable 8.7, 8.8, and 8.9.

## Related issues

Closes #15987