### PR TITLE
ci: remove separate Harbor secrets import step

### DIFF
--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,22 +35,22 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-|          Input           |                            Description                             | Required |  Default  |
-|--------------------------|--------------------------------------------------------------------|----------|-----------|
-| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)        | false    | `"true"`  |
-| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)       | false    | `"false"` |
-| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits   | false    | `"false"` |
-| harbor                   | Log into Harbor with a CI account (disabled for fork PRs)          | false    | `"false"` |
-| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)         | false    | `"false"` |
-| java-distribution        | Java distribution to install                                       | false    | `temurin` |
-| java-version             | JDK version to install                                             | false    | `"21"`    |
-| maven-cache-key-modifier | Modifier for the Maven cache key                                   | false    | `shared`  |
-| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)   | false    | `'[]'`    |
-| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)   | false    | `'[]'`    |
-| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only) | false    |           |
-| vault-address            | Vault URL to retrieve secrets from                                 | false    |           |
-| vault-role-id            | Vault AppRole role id                                              | false    |           |
-| vault-secret-id          | Vault AppRole secret id                                            | false    |           |
+|          Input           |                            Description                              | Required |  Default  |
+|--------------------------|---------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)        | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits    | false    | `"false"` |
+| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs) | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)          | false    | `"false"` |
+| java-distribution        | Java distribution to install                                        | false    | `temurin` |
+| java-version             | JDK version to install                                              | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                    | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)    | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)    | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)  | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                  | false    |           |
+| vault-role-id            | Vault AppRole role id                                               | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                             | false    |           |
 
 ### Outputs
 

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,7 +35,7 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-|          Input           |                            Description                              | Required |  Default  |
+|          Input           |                             Description                             | Required |  Default  |
 |--------------------------|---------------------------------------------------------------------|----------|-----------|
 | camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |
 | dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)        | false    | `"false"` |

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -151,22 +151,7 @@ runs:
         secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
-        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
-  # Kept separate from "Import Secrets" so that jobs which do not ask for Harbor
-  # never depend on this path resolving.
-  - name: Import Harbor Secrets
-    if: >-
-      steps.is-fork.outputs.is-fork != 'true' &&
-      inputs.harbor == 'true'
-    id: harbor-secrets
-    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-    with:
-      url: ${{ inputs.vault-address }}
-      method: approle
-      roleId: ${{ inputs.vault-role-id }}
-      secretId: ${{ inputs.vault-secret-id }}
-      exportEnv: false
-      secrets: |
+        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
@@ -297,8 +282,8 @@ runs:
       inputs.harbor == 'true'
     uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     env:
-      DOCKER_USERNAME: ${{ steps.harbor-secrets.outputs.harbor-username }}
-      DOCKER_PASSWORD: ${{ steps.harbor-secrets.outputs.harbor-password }}
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.harbor-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.harbor-password }}
     with:
       max_attempts: 3
       retry_wait_seconds: 10

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -165,6 +165,7 @@ runs:
       method: approle
       roleId: ${{ inputs.vault-role-id }}
       secretId: ${{ inputs.vault-secret-id }}
+      exportEnv: false
       secrets: |
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->
Follow up of https://github.com/camunda/camunda/pull/60169

Changes:

* remove separate Harbor secrets import step
* update readme.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to INC-7155
