### PR TITLE
test: target Operate's Design System header in E2E page objects

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -23,7 +23,7 @@ class OperateHomePage {
   readonly variableValueEditor: Locator;
   readonly saveVariableButton: Locator;
   readonly editVariableSpinner: Locator;
-  readonly settingsButton: Locator;
+  readonly userMenuButton: Locator;
   readonly logoutButton: Locator;
   readonly openButton: Locator;
   readonly closeButton: Locator;
@@ -32,13 +32,13 @@ class OperateHomePage {
 
   constructor(page: Page) {
     this.page = page;
-    this.operateBanner = page.getByRole('link', {name: 'Camunda logo Operate'});
+    this.operateBanner = page.getByRole('link', {name: 'Camunda Operate'});
     this.dashboardLink = page.getByRole('link', {name: 'Dashboard'});
     this.processesTab = page.getByRole('link', {name: 'Processes'}).first();
     this.decisionsTab = page.getByRole('link', {name: 'Decisions'});
-    this.operationsMenuButton = page
-      .locator('.cds--header__menu-title')
-      .filter({hasText: /^Operations$/});
+    this.operationsMenuButton = page.getByRole('button', {
+      name: 'Toggle Operations',
+    });
     this.batchOperationsNavItem = page.getByRole('link', {
       name: 'Batch operations',
     });
@@ -56,8 +56,8 @@ class OperateHomePage {
       .getByTestId('variable-operation-spinner')
       .locator('circle')
       .nth(1);
-    this.settingsButton = page.getByRole('button', {name: 'Open Settings'});
-    this.logoutButton = page.getByRole('button', {name: 'Log out'});
+    this.userMenuButton = page.getByRole('button', {name: /^User menu/});
+    this.logoutButton = page.getByRole('menuitem', {name: /log out/i});
     this.openButton = page
       .getByTestId('variable-testVariable')
       .getByLabel('Open');
@@ -112,7 +112,7 @@ class OperateHomePage {
   }
 
   async logout(): Promise<void> {
-    await this.settingsButton.click();
+    await this.userMenuButton.click();
     await this.logoutButton.click();
   }
 


### PR DESCRIPTION
## Description

The nightly [C8 Orchestration Cluster E2E run on `main`](https://github.com/camunda/camunda/actions/runs/32612344551)
has been failing **143 tests per night since 2026-08-21**, every one of them on the same assertion:

```
Locator: getByRole('link', { name: 'Camunda logo Operate' })
Error: element(s) not found
```

Operate switched from the legacy Carbon header to the Design System header in ae7adef59 (#60570),
which defaults `camunda.operate.nav-v2-enabled` to `true`. That PR refreshed Operate's own visual
baselines but left this suite untouched, so `OperateHomePage` still described the legacy header.
Because nearly every Operate spec gates its `beforeEach` on the banner locator, one stale selector
took out 33 spec files.

Four header surfaces were renamed or relocated. All four names were read off the running app, not
inferred:

| Field | Legacy header | Design System header |
|---|---|---|
| `operateBanner` | `link "Camunda logo Operate"` | `link "Camunda Operate"` (`aria-label` on the logo link) |
| `settingsButton` → `userMenuButton` | `button "Open Settings"` | `button "User menu, <displayName>"` |
| `logoutButton` | top-level `button "Log out"` | `menuitem "Log out"` inside the user menu |
| `operationsMenuButton` | `.cds--header__menu-title` | `button "Toggle Operations"` (sidebar group) |

Updating the page object was sufficient — **no spec needed changing**, including the two tests that
exercise the logout flow and the Operations menu directly. `settingsButton` is renamed to
`userMenuButton` so the field still describes what it points at; it is only referenced by `logout()`
in the same class.

Tasklist and Identity keep the legacy header (`tasklist/client/src/modules/featureFlags.tsx` hardcodes
`IS_NAV_V2_ENABLED = false`), so their `"Camunda logo Tasklist"` locators are deliberately left alone.
Only `main` is affected — `stable/8.9` and `stable/8.8` nightlies are green.

### Local verification

Run against `camunda/camunda:SNAPSHOT` + Elasticsearch from `config/docker-compose.yml`:

- **Reproduce gate before editing:** same two tests, same locator as the nightly.
- **`tests/operate` + `tests/common-flows`: 155 passed / 6 failed / 2 flaky / 5 skipped** (was: 143 failing).
- `login.spec.ts` 4/4 including "Log out"; `batchOperations.spec.ts` 14 passed including
  "Navigate to Batch Operations list via the Operations header menu".
- **`tests/tasklist` + `tests/identity`: 102 passed / 0 failed / 1 flaky** (the flaky one is an
  `embedded-form` render wait, unrelated to the header; it passed on retry). A page snapshot in that
  run confirms Tasklist still renders `link "Camunda logo Tasklist"` and `button "Open Settings"`,
  i.e. the legacy header — so scoping this change to Operate is correct and Tasklist/Identity are
  provably unaffected.
- `prettier --check`, `eslint`, `tsc --noEmit` clean.

## On-demand E2E run

[Run 32709055657](https://github.com/camunda/camunda/actions/runs/32709055657) on this branch. All 4
API-test jobs pass. **Zero header-locator failures** — the 143 nightly failures are cleared.

| Job | Passed | Hard failures |
|---|---|---|
| E2E (Mode profiles, Tasklist v2) | 260 | `processInstanceIncidents:386`, `optimize-startup` |
| E2E (Mode all-in-one, Tasklist v2) | 259 | `processInstanceIncidents:386`, `processInstancesFilters:339`, `optimize-startup` |

### Remaining failures are not regressions from this PR

These specs had not actually executed since 2026-08-20, because the stale banner locator killed them
in `beforeEach` — so they are newly *visible*, not newly *broken*.

- **`processInstanceIncidents.spec.ts:386` › Click Call Activity and verify the error type** — fails in
  both jobs. Pre-existing: this is the single failing test in the
  [2026-08-19 nightly](https://github.com/camunda/camunda/actions/runs/32207625501), i.e. *before* the
  Design System navigation rollout.
- **`processInstancesFilters.spec.ts:339` › Filter by variable and batch operation key** — hard failure
  in all-in-one, flaky in profiles. Pre-existing; unrelated to the header.
- **`optimize-startup.spec.ts`** — separate, already-diagnosed root cause: Optimize now redirects via
  Spring Security's `/oauth2/authorization/oidc`, which `CslChainIntegrationTest.java:302` asserts as
  intended behaviour, so the test's expectation of a direct Keycloak hop is out of date. Introduced by
  the CSL security rollout (`6e81b439d`), not by this PR. Follow-up PR.

Additionally these failed once and passed on retry (pre-existing flakiness, not introduced here):
`processes:86`, `processInstancesFilters:169`, `processInstanceWaitStates:114` and `:140`,
`operations:76`, `tasklist/task-history:71`.

Note the nightly was already red from 2026-08-14 — before either root cause — with a small, varying
failure set. `processInstanceIncidents:386` belongs to that pre-existing backlog and deserves its own
triage pass.

<sub>One observation from local debugging, recorded only so it is not lost: in a constrained local
environment the new-variable row's JSON value editor expands to the full row width while focused,
pushing the Save button out of the visible area until the editor is blurred. This did **not** reproduce
in CI and is not a test blocker there, so it is noted as a possible narrow-viewport UX nit rather than
a defect.</sub>

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

Backports are not required — the Design System navigation rollout targets `main` only.

## Related issues

Related to #60124
Related to #60570
