### PR TITLE
fix: stop deriving an OIDC user-info-uri for Optimize

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -281,7 +281,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
           "Optimize left '{}' unused: its OIDC endpoint paths are only known for Keycloak, so CSL"
               + " resolves the endpoints from the issuer by discovery. Set the"
               + " 'camunda.security.authentication.oidc.authorization-uri', 'token-uri',"
-              + " 'jwk-set-uri', 'user-info-uri' and 'end-session-endpoint-uri' explicitly to have"
+              + " 'jwk-set-uri' and 'end-session-endpoint-uri' explicitly to have"
               + " Optimize reach the provider on that URL.",
           IDENTITY_ISSUER_BACKEND_URL);
       return;
@@ -305,9 +305,11 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         OIDC_PREFIX + "end-session-endpoint-uri", front + "/protocol/openid-connect/logout");
     // Back channel: Optimize calls these itself.
     derived.putIfAbsent(OIDC_PREFIX + "token-uri", back + "/protocol/openid-connect/token");
-    // CSL requests UserInfo during login by default, and Spring skips the call when the endpoint is
-    // unknown, dropping the claims it contributes.
-    derived.putIfAbsent(OIDC_PREFIX + "user-info-uri", back + "/protocol/openid-connect/userinfo");
+    // Deliberately no 'user-info-uri'. CSL builds the registration without a userNameAttributeName,
+    // which Spring's DefaultOAuth2UserService requires as soon as the UserInfo endpoint is known,
+    // so deriving it fails every login with 'missing_user_name_attribute'. Nothing consumes it:
+    // CSL resolves its claims from the ID token, and UserInfo augmentation is off by default and
+    // keys on an issuer-uri this bridge deliberately never derives.
     // The public API's own JWK set URI wins: it belongs to the IdP that signs the API tokens, which
     // need not be the Identity instance behind issuerBackendUrl.
     final String publicApiJwks =
@@ -396,8 +398,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
       LOG.warn(
           "Optimize config '{}' is deprecated; migrate to the explicit"
               + " 'camunda.security.authentication.oidc.authorization-uri', 'token-uri',"
-              + " 'jwk-set-uri', 'user-info-uri' and 'end-session-endpoint-uri' — the last two are"
-              + " needed for the UserInfo claims and for RP-initiated logout. Prefer those over"
+              + " 'jwk-set-uri' and 'end-session-endpoint-uri' — the last one is"
+              + " needed for RP-initiated logout. Prefer those over"
               + " 'camunda.security.authentication.oidc.issuer-uri', which makes CSL dial this URL"
               + " for OIDC discovery at startup. Support for the legacy key will be removed in {}.",
           legacyKey,

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -641,10 +641,10 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
         .isEqualTo(backend + "/protocol/openid-connect/token");
     assertThat(env.getProperty(OIDC + "jwk-set-uri"))
         .isEqualTo(backend + "/protocol/openid-connect/certs");
-    // CSL requests UserInfo during login by default; without the endpoint the call is skipped
-    // and the claims it contributes are lost.
-    assertThat(env.getProperty(OIDC + "user-info-uri"))
-        .isEqualTo(backend + "/protocol/openid-connect/userinfo");
+    // Never derive a UserInfo endpoint: CSL builds the registration without a
+    // userNameAttributeName, so as soon as Spring knows the endpoint every login fails with
+    // 'missing_user_name_attribute'. Deriving it here regressed SM 8.10 Optimize login (#60834).
+    assertThat(env.getProperty(OIDC + "user-info-uri")).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes the Optimize OIDC login 401 on Self-Managed 8.10 reported in #60834.

The legacy-config bridge derived `camunda.security.authentication.oidc.user-info-uri` from `camunda.identity.issuerBackendUrl`. That property makes **every** OIDC login fail, because of an asymmetry between Spring's two `ClientRegistration` construction paths:

- `ClientRegistrations.fromIssuerLocation` (discovery) sets `.userNameAttributeName(IdTokenClaimNames.SUB)` for you — `ClientRegistrations.java:331`.
- CSL's manual-endpoint path, `ScopedClientRegistrationFactory.clientRegistrationBuilder`, sets `userInfoUri` but **never** sets `userNameAttributeName`.

`DefaultOAuth2UserService.getUserNameAttributeName` throws as soon as the UserInfo endpoint is known, so the callback returns a bare 401 **before any request reaches the identity provider**:

```
TRACE OAuth2LoginAuthenticationFilter : Failed to process authentication request
org.springframework.security.oauth2.core.OAuth2AuthenticationException:
  [missing_user_name_attribute] Missing required "user name" attribute name in
  UserInfoEndpoint for Client Registration: oidc
	at DefaultOAuth2UserService.getUserNameAttributeName(DefaultOAuth2UserService.java:187)
	at OidcUserService.loadUser(OidcUserService.java:101)
	at OidcAuthorizationCodeAuthenticationProvider.authenticate(...:162)
```

Since the bridge never sets `issuer-uri` (by design — see `shouldNotDeriveIssuerUriWhenTheHostConfiguredTheOidcEndpoints`), Optimize always takes the manual path and always hit this.

### Nothing consumed the derived endpoint

Both potential consumers were already inert, so removing it is not a functional loss:

- **Login-path claims.** CSL resolves username/groups from the ID token via `usernameClaim` / `groupsClaim`, not from Spring's `OidcUser` name attribute.
- **UserInfo augmentation.** `OidcUserInfoAugmentationConfiguration.enabled` defaults to `false`, and `ScopedOidcClaimsProviderFactory.buildUserInfoUriByIssuer` only keeps registrations that have **both** `issuerUri` and `userInfoUri`. With no `issuer-uri` the map is empty and the factory throws — so augmentation could never have used it.

This is why orchestration is unaffected: its config carries no `user-info-uri`, so `shouldRetrieveUserInfo` returns `false` and the path is skipped entirely.

Also drops `user-info-uri` from the two operator-guidance log messages, which recommended explicitly setting the one property that breaks login.

## Related

- Regressed by #60708 (`cf7cffc2ba2`), which added the derivation. `end-session-endpoint-uri` from that same commit is logout-only and is kept.
- Reported in #60834.
- Follow-up in CSL: camunda/camunda-security-library#621.
- Nightly: `SM Nightly 8.10 Upgrade Minor` › `migration-path-user-flows.spec.ts` › `Basic Navigation`, failing 2026-08-22 through 2026-08-24.

## Verification

- Root cause confirmed against a live 8.10 nightly cluster with `LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_SECURITY=TRACE`; the 401 was reproduced by hand in a browser.
- Mechanism confirmed by reading CSL `0.1.0-alpha67` and `spring-security-oauth2-client` sources.
- Confirmed on the same live cluster that setting `CAMUNDA_SECURITY_AUTHENTICATION_OIDC_USER_INFO_ENABLED=false` makes login work again. That flag drives CSL's `builder.userInfoUri(null)` branch, so the client registration ends up in the same state this PR produces by never deriving the URI — the fix and the working workaround are behaviourally equivalent.
- `OptimizeSecurityConfigCompatibilityPostProcessorTest` — 62 tests, all green. The front/back-channel split test now asserts `user-info-uri` is `null` and carries the regression rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
