### PR TITLE
fix: retry demo data creation when the process count fails

### DIFF
--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -158,8 +158,8 @@ public abstract class AbstractDataGenerator implements DataGenerator {
       try {
         exists = processStore.count() > 0;
       } catch (final IOException e) {
-        LOGGER.warn("Error occurred when counting processes.", e);
-        return false;
+        // a failed count says nothing about whether data exists, so let createZeebeDataAsync retry
+        throw new OperateRuntimeException("Error occurred when counting processes.", e);
       }
       if (exists) {
         // data already exists

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -78,11 +78,11 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   @Autowired CamundaAuthenticationProvider authenticationProvider;
 
+  @Autowired(required = false)
+  ProcessStore processStore;
+
   @Autowired private SecurityConfiguration securityConfiguration;
   private boolean shutdown = false;
-
-  @Autowired(required = false)
-  private ProcessStore processStore;
 
   @PostConstruct
   private void startDataGenerator() {

--- a/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
+++ b/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.store.ProcessStore;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.service.ProcessInstanceServices;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -132,6 +134,32 @@ class AbstractDataGeneratorTest {
 
     // then
     assertThat(processDefinitionKey).isNull();
+  }
+
+  @Test
+  void shouldPropagateProcessCountFailureInsteadOfReportingDataExists() throws IOException {
+    // given
+    final ProcessStore processStore = mock(ProcessStore.class);
+    generator.processStore = processStore;
+    final IOException searchFailure = new IOException("no_shard_available_action_exception");
+    when(processStore.count()).thenThrow(searchFailure);
+
+    // when / then
+    assertThatThrownBy(() -> generator.shouldCreateData(false))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasCause(searchFailure);
+  }
+
+  @Test
+  void shouldRecogniseAWrappedCountFailureAsSchemaNotReady() {
+    // given
+    final OperateRuntimeException wrapped =
+        new OperateRuntimeException(
+            "Error occurred when counting processes.",
+            new IOException("no_shard_available_action_exception"));
+
+    // when / then
+    assertThat(generator.isSchemaNotReady(wrapped)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Why

The `dev-data` generator checks whether data already exists before creating any. That check routinely fails at startup — the `operate-process` index has just been created and has not allocated its shards yet:

```
WARN io.camunda.operate.data.AbstractDataGenerator - Error occurred when counting processes.
ResponseException: POST /operate-process-8.3.0_alias/_count → 503 Service Unavailable
  {"type":"no_shard_available_action_exception"}
    at AbstractDataGenerator.shouldCreateData(AbstractDataGenerator.java:159)
    at UserTestDataGenerator.createZeebeData(UserTestDataGenerator.java:52)
```

`shouldCreateData` caught it and returned `false`, which the caller reads as *"data already exists"*. And `false` is a non-null `Boolean`, so `createZeebeDataAsync`'s `while (zeebeDataCreated == null && !shutdown)` loop **exits**. A single transient error ends the generator permanently, having created nothing.

The retry for this already exists. The loop's handler lists the error by name:

```java
private static final List<String> SCHEMA_NOT_READY_MARKERS =
    List.of("index_not_found_exception", "no_shard_available_action_exception");
```

but the `catch` consumed the exception before `isSchemaNotReady` could classify it, making that path unreachable. Throwing instead of answering lets the handler do what it was written for.

## What changed

```diff
-        LOGGER.warn("Error occurred when counting processes.", e);
-        return false;
+        // a failed count says nothing about whether data exists, so let createZeebeDataAsync retry
+        throw new OperateRuntimeException("Error occurred when counting processes.", e);
```

`OperateRuntimeException` is already imported and used twice elsewhere in the file.

## Impact

Visible in Optimize's E2E jobs. Operate's generator contributes nothing, Tasklist's still runs, and the stack settles at **17** process definitions instead of 60. Nothing recovers it, so `Wait for import to complete` waits for a count that will never arrive until the job is cancelled or times out — twice in four days on this branch: [run 32398394769](https://github.com/camunda/camunda/actions/runs/32398394769) and [run 32518911045](https://github.com/camunda/camunda/actions/runs/32518911045), both with the same `null → 0 → 17, then flat` signature.

Only the `dev-data` profile is affected, so the blast radius is development and CI stacks; no released deployment runs this generator.

## Branches

- **main** is unaffected — it has no `catch` there, so the exception already reaches the retry loop. That is why main's E2E reliably reaches 60.
- **stable/8.8** carries the identical code and has the same latent flake. Happy to open the same fix there; not included here since this cannot be backported from main (main's version of this method was rewritten around `searchClientsProxy`).

## Verification

Not compiled locally: `./mvnw -pl operate/data-generator -am compile` fails in this environment on an unrelated `401` fetching `org.camunda.bpm:camunda-license-check` from Artifactory, and the module is skipped before it builds. CI compiles it.

The behavioural claim is not directly testable in CI either — it needs the ES shard-allocation race to lose, which is what makes it rare. What the change guarantees structurally is that the generator can no longer treat a failed count as evidence, and the existing retry loop keeps running until the count actually succeeds.
