### PR TITLE
fix: allow retention job to be registered without the checkpoint scheduler

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulingService.java
@@ -120,20 +120,19 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   @Override
   protected void onActorCloseRequested() {
     membershipService.removeListener(this);
-    if (isSchedulerActive()) {
-      final List<ActorFuture<Void>> shutdownFutures = new ArrayList<>();
-      shutdownFutures.add(checkpointScheduler.closeAsync());
-      if (backupRetentionJob != null) {
-        shutdownFutures.add(backupRetentionJob.closeAsync());
+    final List<ActorFuture<Void>> shutdownFutures = new ArrayList<>();
+    for (final var schedulerActor : schedulerActors()) {
+      if (!schedulerActor.isActorClosed()) {
+        shutdownFutures.add(schedulerActor.closeAsync());
       }
-      actor.runOnCompletion(
-          shutdownFutures,
-          (error) -> {
-            if (error != null) {
-              LOG.error("Failed to close checkpoint creator actor", error);
-            }
-          });
     }
+    actor.runOnCompletion(
+        shutdownFutures,
+        (error) -> {
+          if (error != null) {
+            LOG.error("Failed to close checkpoint scheduling actors", error);
+          }
+        });
   }
 
   @Override
@@ -154,29 +153,36 @@ public class CheckpointSchedulingService extends Actor implements ClusterMembers
   }
 
   private void checkedStopScheduler() {
-    if (shouldStopSchedulers() && isSchedulerActive()) {
-      checkpointScheduler.close();
-      if (backupRetentionJob != null) {
-        backupRetentionJob.close();
+    if (!shouldStopSchedulers()) {
+      return;
+    }
+    for (final var schedulerActor : schedulerActors()) {
+      if (!schedulerActor.isActorClosed()) {
+        schedulerActor.close();
       }
     }
   }
 
   private void checkedStartScheduler() {
-    if (shouldStartSchedulers() && isSchedulerInactive()) {
-      actorScheduler.submitActor(checkpointScheduler, SchedulingHints.ioBound());
-      if (backupRetentionJob != null) {
-        actorScheduler.submitActor(backupRetentionJob, SchedulingHints.ioBound());
+    if (!shouldStartSchedulers()) {
+      return;
+    }
+    for (final var schedulerActor : schedulerActors()) {
+      if (schedulerActor.isActorClosed()) {
+        actorScheduler.submitActor(schedulerActor, SchedulingHints.ioBound());
       }
     }
   }
 
-  private boolean isSchedulerActive() {
-    return checkpointScheduler != null && !checkpointScheduler.isActorClosed();
-  }
-
-  private boolean isSchedulerInactive() {
-    return checkpointScheduler != null && checkpointScheduler.isActorClosed();
+  private List<Actor> schedulerActors() {
+    final List<Actor> actors = new ArrayList<>(2);
+    if (checkpointScheduler != null) {
+      actors.add(checkpointScheduler);
+    }
+    if (backupRetentionJob != null) {
+      actors.add(backupRetentionJob);
+    }
+    return actors;
   }
 
   private boolean shouldStartSchedulers() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/CheckpointSchedulerServiceTest.java
@@ -392,6 +392,58 @@ public class CheckpointSchedulerServiceTest {
     verify(scheduler, never()).submitActor(argThat(BackupRetention.class::isInstance), any());
   }
 
+  @Test
+  void shouldStartRetentionJobWithoutCheckpointOrBackupSchedule() {
+    // given — an ES/OS style setup: retention only, no checkpoint interval and no backup schedule
+    brokerConfig.getData().getBackup().setContinuous(false);
+    brokerConfig.getData().getBackup().setSchedule(null);
+    brokerConfig.getData().getBackup().setCheckpointInterval(null);
+    doReturn(Set.of(member1)).when(membershipService).getMembers();
+    doReturn(member1).when(membershipService).getLocalMember();
+
+    // when
+    schedulingService.onActorStarting();
+    schedulingService.onActorStarted();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                verify(scheduler, times(1))
+                    .submitActor(
+                        argThat(BackupRetention.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
+    verify(scheduler, never()).submitActor(argThat(CheckpointScheduler.class::isInstance), any());
+  }
+
+  @Test
+  void shouldRelocateStandaloneRetentionJobOnMembershipChange()
+      throws NoSuchFieldException, IllegalAccessException {
+    // given — retention only, and this broker is not the lowest member
+    brokerConfig.getData().getBackup().setContinuous(false);
+    brokerConfig.getData().getBackup().setSchedule(null);
+    brokerConfig.getData().getBackup().setCheckpointInterval(null);
+    doReturn(member2).when(membershipService).getLocalMember();
+    doReturn(Set.of(member2, member3)).when(membershipService).getMembers();
+    schedulingService.onActorStarting();
+    schedulingService.onActorStarted();
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                verify(scheduler, times(1))
+                    .submitActor(
+                        argThat(BackupRetention.class::isInstance),
+                        argThat(arg -> arg.equals(SchedulingHints.IO_BOUND))));
+    final var retentionJobSpy = getRetentionJob(schedulingService);
+
+    // when — a lower member joins
+    doReturn(Set.of(member1, member2, member3)).when(membershipService).getMembers();
+    schedulingService.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, member1));
+
+    // then
+    assertThat(retentionJobSpy.isActorClosed()).isTrue();
+  }
+
   private CheckpointScheduler getCheckpointCreator(
       final CheckpointSchedulingService schedulingService)
       throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Allow the primary storage backup retention actor to be registered independently.

Previously, the actor was bound to startup on the existence of a checkpoint/backup schedule configured.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #60615
