### PR TITLE
docs: link hasAgenticPrefix's removal condition to its tracking issue

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -724,7 +724,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
    *     attribution (jobs deployed on 8.9 with this job type and no resolved agent definition still
    *     need attribution). Every other agentic decision uses whether the job's element has a
    *     resolved agent definition instead. Remove once no supported version relies on this prefix
-   *     rule anymore, and affected processes have been redeployed with changed content.
+   *     rule anymore, and affected processes have been redeployed with changed content. Tracked in
+   *     https://github.com/camunda/camunda/issues/60860.
    */
   @Deprecated
   @JsonIgnore


### PR DESCRIPTION
## Description

Small follow-up to #60620: it deprecated `hasAgenticPrefix` and wrote out the condition for removing it directly in the javadoc, since that condition is easy to lose otherwise. The follow-up issue tracking that removal (#60860) didn't exist yet when #60620 merged. This links the javadoc to it, so the two stay in sync.

No behavior change.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to #60860
