### PR TITLE
fix: normalize RDBMS table prefix to upper case

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -10,6 +10,7 @@ package io.camunda.configuration;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.exporter.rdbms.ExporterConfiguration;
 import java.time.Duration;
+import java.util.Locale;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
@@ -20,7 +21,10 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   /** If true, the database schema is automatically created and updated on application startup. */
   private boolean autoDdl = DEFAULT_AUTO_DDL;
 
-  /** The prefix to use for all database artifacts like tables, indexes etc. */
+  /**
+   * The prefix to use for all database artifacts like tables, indexes etc. Normalized to upper
+   * case, because the generated table names it is prepended to are upper case.
+   */
   private String prefix;
 
   /** The interval at which the exporters execution queue is flushed. */
@@ -115,7 +119,7 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   }
 
   public void setPrefix(final String prefix) {
-    this.prefix = prefix;
+    this.prefix = prefix == null ? null : prefix.toUpperCase(Locale.ROOT);
   }
 
   public Duration getFlushInterval() {

--- a/configuration/src/test/java/io/camunda/configuration/RdbmsPrefixNormalizationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RdbmsPrefixNormalizationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class RdbmsPrefixNormalizationTest {
+
+  @ParameterizedTest
+  @CsvSource({"ta_, TA_", "Ta_, TA_", "TA_, TA_", "c8, C8", "my_prefix_, MY_PREFIX_"})
+  void shouldUpperCasePrefix(final String configured, final String expected) {
+    // given
+    final Rdbms rdbms = new Rdbms();
+
+    // when
+    rdbms.setPrefix(configured);
+
+    // then
+    assertThat(rdbms.getPrefix()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldKeepNullPrefix() {
+    // given
+    final Rdbms rdbms = new Rdbms();
+
+    // when
+    rdbms.setPrefix(null);
+
+    // then
+    assertThat(rdbms.getPrefix()).isNull();
+  }
+
+  /**
+   * {@code ti_} upper-cases differently under {@code tr-TR}, where the dotless {@code i} becomes
+   * {@code İ} and yields a prefix that no longer matches the created tables. Asserting against both
+   * results pins the normalization to {@link Locale#ROOT} without mutating the JVM-wide default
+   * locale, which would leak into unrelated tests.
+   */
+  @Test
+  void shouldUpperCaseIndependentlyOfDefaultLocale() {
+    // given
+    final Rdbms rdbms = new Rdbms();
+
+    // when
+    rdbms.setPrefix("ti_");
+
+    // then
+    assertThat(rdbms.getPrefix())
+        .isEqualTo("ti_".toUpperCase(Locale.ROOT))
+        .isNotEqualTo("ti_".toUpperCase(Locale.forLanguageTag("tr-TR")));
+  }
+}

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -893,7 +893,8 @@ camunda: # Type: io.camunda.configuration.Camunda
 
         # Password for the database configured as secondary storage.
         password: "" # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
-        # The prefix to use for all database artifacts like tables, indexes etc.
+        # The prefix to use for all database artifacts like tables, indexes etc. Normalized to upper case,
+        # because the generated table names it is prepended to are upper case.
         prefix: null # Type: String, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PREFIX
         # Process definition cache configuration. Defines the size of the process definition cache.
         process-cache: null # Type: io.camunda.configuration.RdbmsCache, Env: CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_PROCESSCACHE


### PR DESCRIPTION
## Description

Every table name in the schema is upper case (`${prefix}PROCESS_INSTANCE`), but the configured `prefix` was used exactly as typed — so a lower-case prefix landed in the schema as-is, across ~640 identifier sites in the Liquibase changesets and MyBatis mappers.

`Rdbms.setPrefix` now upper-cases the value. That setter is the only write path — Spring binds through it, and the one programmatic caller (`CamundaMultiDBExtension`) sets the same object — so the root prefix and every per-physical-tenant override are covered by this single change. `Locale.ROOT` keeps a Turkish-locale JVM from turning `i` into `İ`.

### Notes for the reviewer

- Normalizing rather than rejecting (the approach in the superseded #59295) keeps deployments already running a lower-case prefix booting.
- Side effect: the isolation identity in `StorageIdentity` becomes case-insensitive, so tenants configured with `ta_` and `TA_` are now correctly flagged as sharing storage.
- Prefixes invalid for other reasons (hyphens, spaces, leading digits) are still accepted and fail at migration time, as before.

## Related issues

closes #56093
supersedes #59295
