### PR TITLE
fix: override state and parent key filters in batch suspend and resume

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSuspendResumeProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSuspendResumeProcessInstanceIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.Strings;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class BatchOperationSuspendResumeProcessInstanceIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldSuspendRootInstanceWhenStateAndParentKeyFiltersAreIgnored() {
+    // given
+    final long processInstanceKey = startActiveRootInstance();
+
+    // when - both filters would match nothing if they were applied
+    final var batchOperationKey =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceSuspend()
+            .filter(
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .state(ProcessInstanceState.COMPLETED)
+                        .parentProcessInstanceKey(k -> k.exists(true)))
+            .send()
+            .join()
+            .getBatchOperationKey();
+
+    // then
+    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 1);
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 1, 0);
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+  }
+
+  @Test
+  void shouldResumeRootInstanceWhenStateAndParentKeyFiltersAreIgnored() {
+    // given
+    final long processInstanceKey = startActiveRootInstance();
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when - both filters would match nothing if they were applied
+    final var batchOperationKey =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceResume()
+            .filter(
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .state(ProcessInstanceState.ACTIVE)
+                        .parentProcessInstanceKey(k -> k.exists(true)))
+            .send()
+            .join()
+            .getBatchOperationKey();
+
+    // then
+    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 1);
+    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 1, 0);
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceKey),
+        instances ->
+            assertThat(instances)
+                .singleElement()
+                .extracting(ProcessInstance::getState)
+                .isEqualTo(ProcessInstanceState.ACTIVE));
+  }
+
+  private static long startActiveRootInstance() {
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobType = Strings.newRandomValidBpmnId();
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(camundaClient, process, processId + ".bpmn");
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    return processInstanceKey;
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -212,14 +212,31 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder replaceParentProcessInstanceKeyOperations(
+        final List<Operation<Long>> operations) {
+      parentProcessInstanceKeyOperations = new ArrayList<>(operations);
+      return this;
+    }
+
     public Builder parentProcessInstanceKeys(final Long value, final Long... values) {
       return parentProcessInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceParentProcessInstanceKeys(final Long value, final Long... values) {
+      return replaceParentProcessInstanceKeyOperations(
+          FilterUtil.mapDefaultToOperation(value, values));
     }
 
     @SafeVarargs
     public final Builder parentProcessInstanceKeyOperations(
         final Operation<Long> operation, final Operation<Long>... operations) {
       return parentProcessInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    @SafeVarargs
+    public final Builder replaceParentProcessInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return replaceParentProcessInstanceKeyOperations(collectValues(operation, operations));
     }
 
     public Builder parentFlowNodeInstanceKeyOperations(final List<Operation<Long>> operations) {
@@ -265,14 +282,29 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder replaceStateOperations(final List<Operation<String>> operations) {
+      stateOperations = new ArrayList<>(operations);
+      return this;
+    }
+
     public Builder states(final String value, final String... values) {
       return stateOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceStates(final String value, final String... values) {
+      return replaceStateOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     @SafeVarargs
     public final Builder stateOperations(
         final Operation<String> operation, final Operation<String>... operations) {
       return stateOperations(collectValues(operation, operations));
+    }
+
+    @SafeVarargs
+    public final Builder replaceStateOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return replaceStateOperations(collectValues(operation, operations));
     }
 
     public Builder hasIncident(final Boolean value) {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -222,11 +222,6 @@ public record ProcessInstanceFilter(
       return parentProcessInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder replaceParentProcessInstanceKeys(final Long value, final Long... values) {
-      return replaceParentProcessInstanceKeyOperations(
-          FilterUtil.mapDefaultToOperation(value, values));
-    }
-
     @SafeVarargs
     public final Builder parentProcessInstanceKeyOperations(
         final Operation<Long> operation, final Operation<Long>... operations) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactory.java
@@ -138,8 +138,8 @@ public class ItemProviderFactory {
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)
-            .states(ProcessInstanceState.ACTIVE.name())
-            .parentProcessInstanceKeyOperations(Operation.exists(false))
+            .replaceStates(ProcessInstanceState.ACTIVE.name())
+            .replaceParentProcessInstanceKeyOperations(Operation.exists(false))
             .build(),
         authentication);
   }
@@ -151,8 +151,8 @@ public class ItemProviderFactory {
         metrics,
         filter.toBuilder()
             .partitionId(partitionId)
-            .states(ProcessInstanceState.SUSPENDED.name())
-            .parentProcessInstanceKeyOperations(Operation.exists(false))
+            .replaceStates(ProcessInstanceState.SUSPENDED.name())
+            .replaceParentProcessInstanceKeyOperations(Operation.exists(false))
             .build(),
         authentication);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
@@ -31,17 +31,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForCancelProcessInstance() {
-    // Arrange
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -53,17 +53,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForSuspendProcessInstance() {
-    // Arrange
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.SUSPEND_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -76,7 +76,7 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldOverrideFiltersForSuspendProcessInstance() {
-    // Arrange
+    // given
     final var filter =
         new ProcessInstanceFilter.Builder()
             .states("COMPLETED")
@@ -88,10 +88,10 @@ class ItemProviderFactoryTest {
         .thenReturn(BatchOperationType.SUSPEND_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -105,17 +105,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForResumeProcessInstance() {
-    // Arrange
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.RESUME_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -128,7 +128,7 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldOverrideFiltersForResumeProcessInstance() {
-    // Arrange
+    // given
     final var filter =
         new ProcessInstanceFilter.Builder()
             .states("ACTIVE")
@@ -140,10 +140,10 @@ class ItemProviderFactoryTest {
         .thenReturn(BatchOperationType.RESUME_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -157,16 +157,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForMigrateProcessInstance() {
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -178,16 +179,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForModifyProcessInstance() {
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.MODIFY_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -199,15 +201,16 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForResolveIncident() {
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType()).thenReturn(BatchOperationType.RESOLVE_INCIDENT);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(IncidentItemProvider.class);
 
@@ -219,16 +222,16 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForUpdateJob() {
-    // Arrange
+    // given
     final var filter = new JobFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType()).thenReturn(BatchOperationType.UPDATE_JOB);
     when(batchOperation.getEntityFilter(JobFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(JobItemProvider.class);
 
@@ -250,17 +253,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForDeleteProcessInstance() {
-    // Arrange
+    // given
     final var filter = new ProcessInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.DELETE_PROCESS_INSTANCE);
     when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
@@ -270,17 +273,17 @@ class ItemProviderFactoryTest {
 
   @Test
   void shouldSetFiltersForDeleteDecisionInstance() {
-    // Arrange
+    // given
     final var filter = new DecisionInstanceFilter.Builder().build();
     final var batchOperation = mock(PersistedBatchOperation.class);
     when(batchOperation.getBatchOperationType())
         .thenReturn(BatchOperationType.DELETE_DECISION_INSTANCE);
     when(batchOperation.getEntityFilter(DecisionInstanceFilter.class)).thenReturn(filter);
 
-    // Act
+    // when
     final var itemProvider = factory.fromBatchOperation(batchOperation);
 
-    // Assert
+    // then
     assertThat(itemProvider).isNotNull();
     assertThat(itemProvider).isInstanceOf(DecisionInstanceItemProvider.class);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/itemprovider/ItemProviderFactoryTest.java
@@ -68,8 +68,38 @@ class ItemProviderFactoryTest {
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
     final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
-    assertThat(usedFilter.parentProcessInstanceKeyOperations()).contains(Operation.exists(false));
-    assertThat(usedFilter.stateOperations()).contains(Operation.eq("ACTIVE"));
+    assertThat(usedFilter.parentProcessInstanceKeyOperations())
+        .containsExactly(Operation.exists(false));
+    assertThat(usedFilter.stateOperations()).containsExactly(Operation.eq("ACTIVE"));
+    assertThat(usedFilter.partitionId()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldOverrideFiltersForSuspendProcessInstance() {
+    // Arrange
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .states("COMPLETED")
+            .parentProcessInstanceKeys(12345L)
+            .processInstanceKeys(67890L)
+            .build();
+    final var batchOperation = mock(PersistedBatchOperation.class);
+    when(batchOperation.getBatchOperationType())
+        .thenReturn(BatchOperationType.SUSPEND_PROCESS_INSTANCE);
+    when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
+
+    // Act
+    final var itemProvider = factory.fromBatchOperation(batchOperation);
+
+    // Assert
+    assertThat(itemProvider).isNotNull();
+    assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
+
+    final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
+    assertThat(usedFilter.parentProcessInstanceKeyOperations())
+        .containsExactly(Operation.exists(false));
+    assertThat(usedFilter.stateOperations()).containsExactly(Operation.eq("ACTIVE"));
+    assertThat(usedFilter.processInstanceKeyOperations()).containsExactly(Operation.eq(67890L));
     assertThat(usedFilter.partitionId()).isEqualTo(1);
   }
 
@@ -90,8 +120,38 @@ class ItemProviderFactoryTest {
     assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
 
     final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
-    assertThat(usedFilter.parentProcessInstanceKeyOperations()).contains(Operation.exists(false));
-    assertThat(usedFilter.stateOperations()).contains(Operation.eq("SUSPENDED"));
+    assertThat(usedFilter.parentProcessInstanceKeyOperations())
+        .containsExactly(Operation.exists(false));
+    assertThat(usedFilter.stateOperations()).containsExactly(Operation.eq("SUSPENDED"));
+    assertThat(usedFilter.partitionId()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldOverrideFiltersForResumeProcessInstance() {
+    // Arrange
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .states("ACTIVE")
+            .parentProcessInstanceKeys(12345L)
+            .processInstanceKeys(67890L)
+            .build();
+    final var batchOperation = mock(PersistedBatchOperation.class);
+    when(batchOperation.getBatchOperationType())
+        .thenReturn(BatchOperationType.RESUME_PROCESS_INSTANCE);
+    when(batchOperation.getEntityFilter(ProcessInstanceFilter.class)).thenReturn(filter);
+
+    // Act
+    final var itemProvider = factory.fromBatchOperation(batchOperation);
+
+    // Assert
+    assertThat(itemProvider).isNotNull();
+    assertThat(itemProvider).isInstanceOf(ProcessInstanceItemProvider.class);
+
+    final var usedFilter = ((ProcessInstanceItemProvider) itemProvider).getFilter();
+    assertThat(usedFilter.parentProcessInstanceKeyOperations())
+        .containsExactly(Operation.exists(false));
+    assertThat(usedFilter.stateOperations()).containsExactly(Operation.eq("SUSPENDED"));
+    assertThat(usedFilter.processInstanceKeyOperations()).containsExactly(Operation.eq(67890L));
     assertThat(usedFilter.partitionId()).isEqualTo(1);
   }
 


### PR DESCRIPTION
## Description

`POST /v2/process-instances/suspension` and `POST /v2/process-instances/resumption` document that caller `state` and `parentProcessInstanceKey` filters are ignored. The engine appended those operations instead of replacing them. A request with a non-matching filter completed as an empty batch.

This change replaces those filter operations for suspend and resume batch operations. MultiDb tests send both conflicting filters and assert that the targeted root instance is still suspended or resumed.

## Related issues

Closes #60684