### PR TITLE
feat: create schema for every physical tenant and fail if any tenant fails

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/LegacyExporterPhysicalTenantFallbackTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/LegacyExporterPhysicalTenantFallbackTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class LegacyExporterPhysicalTenantFallbackTest {
+
+  private static final String ES_CLASS = "io.camunda.zeebe.exporter.ElasticsearchExporter";
+  private static final String LEGACY_ONLY_ID = "legacyes";
+
+  private static Map<String, ExporterCfg> resolveThroughResolverAlone(
+      final Environment environment, final Camunda rootCamunda, final String tenantId) {
+    final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, rootCamunda);
+    return BrokerBasedPropertiesOverride.convert(resolver.forPhysicalTenant(tenantId))
+        .getExporters();
+  }
+
+  @Nested
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    BrokerBasedPropertiesOverride.class,
+    UnifiedConfigurationHelper.class
+  })
+  @ActiveProfiles("broker")
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.exporters." + LEGACY_ONLY_ID + ".class-name=" + ES_CLASS,
+        "zeebe.broker.exporters." + LEGACY_ONLY_ID + ".args.url=http://legacy:9200"
+      })
+  class LegacyOnlyExporter {
+
+    @Autowired private BrokerBasedProperties rootBrokerProperties;
+    @Autowired private Camunda rootCamunda;
+    @Autowired private Environment environment;
+
+    @Test
+    void shouldSupportALegacyOnlyExporterOnTheRootBean() {
+      // then
+      assertThat(rootBrokerProperties.getExporters()).containsKey(LEGACY_ONLY_ID);
+      assertThat(rootBrokerProperties.getExporters().get(LEGACY_ONLY_ID).getArgs())
+          .containsEntry("url", "http://legacy:9200");
+    }
+
+    @Test
+    void shouldRecordWhetherTheLegacyNamespaceSurvivesTheResolver() {
+      // when
+      final var resolved =
+          resolveThroughResolverAlone(
+              environment, rootCamunda, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+
+      // then
+      assertThat(resolved).doesNotContainKey(LEGACY_ONLY_ID);
+    }
+
+    @Test
+    void shouldRestoreTheLegacyExporterByFillingGapsFromTheLegacyProperties() {
+      // given
+      final var resolved =
+          new LinkedHashMap<>(
+              resolveThroughResolverAlone(
+                  environment, rootCamunda, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
+
+      // when
+      rootBrokerProperties.getExporters().forEach(resolved::putIfAbsent);
+
+      // then
+      assertThat(resolved).containsKey(LEGACY_ONLY_ID);
+      assertThat(resolved.get(LEGACY_ONLY_ID).getArgs()).containsEntry("url", "http://legacy:9200");
+    }
+  }
+
+  @Nested
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    BrokerBasedPropertiesOverride.class,
+    UnifiedConfigurationHelper.class
+  })
+  @ActiveProfiles("broker")
+  @TestPropertySource(
+      properties = {
+        "camunda.data.exporters.rootes.class-name=" + ES_CLASS,
+        "camunda.data.exporters.rootes.args.url=http://root:9200",
+        "camunda.physical-tenants.default.data.exporters-assigned=",
+        "camunda.physical-tenants.tenanta.security.authorizations.enabled=false",
+        "camunda.physical-tenants.tenanta.data.exporters-assigned[0]=rootes",
+        "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix=tenanta"
+      })
+  class DeassignedRootExporter {
+
+    @Autowired private Camunda rootCamunda;
+    @Autowired private Environment environment;
+
+    @Test
+    void shouldNarrowARootExporterAwayFromTheDefaultTenantThatDeassignedIt() {
+      // when
+      final var forDefault =
+          resolveThroughResolverAlone(
+              environment, rootCamunda, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+
+      // then
+      assertThat(forDefault).doesNotContainKey("rootes");
+    }
+
+    @Test
+    void shouldKeepARootExporterForTheTenantThatAssignedIt() {
+      // when
+      final var forTenantA = resolveThroughResolverAlone(environment, rootCamunda, "tenanta");
+
+      // then
+      assertThat(forTenantA).containsKey("rootes");
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -10,10 +10,17 @@ package io.camunda.application;
 import static io.camunda.zeebe.protocol.impl.record.RecordMetadata.CURRENT_BROKER_VERSION;
 
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
+import io.camunda.application.commons.search.PhysicalTenantSearchEngineConfigurations;
 import io.camunda.application.initializers.StandaloneSchemaManagerInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.LegacyBrokerBasedProperties;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.search.schema.SchemaManager;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
@@ -23,45 +30,56 @@ import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterSchemaManager;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Import;
 
 /**
- * Soley create or update Schema for ElasticSearch by running this standalone application.
+ * Solely creates or updates the secondary storage schema by running this standalone application.
  *
- * <p>Configure with {@link ConnectConfiguration} properties, prefixed by `camunda.database`, for
- * example:
+ * <p>Configure with the unified configuration properties under {@code
+ * camunda.data.secondary-storage}, for example:
  *
  * <pre>
- * camunda.database.type=elasticsearch
- * camunda.database.url=
- * camunda.database.security.self-signed=
- * camunda.database.security.enabled=
- * camunda.database.security.certificate-path=
- * camunda.database.username=
- * camunda.database.password=
- * camunda.database.index-prefix=
+ * camunda.data.secondary-storage.type=elasticsearch
+ * camunda.data.secondary-storage.elasticsearch.url=
+ * camunda.data.secondary-storage.elasticsearch.username=
+ * camunda.data.secondary-storage.elasticsearch.password=
+ * camunda.data.secondary-storage.elasticsearch.index-prefix=
  * </pre>
  *
- * All of those porperties can also be handed over via environment variables, e.g.
- * `CAMUNDA_DATABASE_URL`
+ * <p>All of those properties can also be handed over via environment variables, e.g. {@code
+ * CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_URL}. Every property can be overridden per physical
+ * tenant under {@code camunda.physical-tenants.<id>.}, in which case each tenant's schema is
+ * created against its own storage.
  */
 @SpringBootConfiguration(proxyBeanMethods = false)
 public class StandaloneSchemaManager implements CommandLineRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(StandaloneSchemaManager.class);
-  private final LegacyBrokerBasedProperties brokerProperties;
 
-  public StandaloneSchemaManager(final LegacyBrokerBasedProperties brokerProperties) {
+  private final PhysicalTenantResolver physicalTenantResolver;
+  private final LegacyBrokerBasedProperties brokerProperties;
+  private final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant;
+
+  public StandaloneSchemaManager(
+      final PhysicalTenantResolver physicalTenantResolver,
+      final LegacyBrokerBasedProperties brokerProperties,
+      @Qualifier("searchEngineConfigurationsByTenant")
+          final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant) {
+    this.physicalTenantResolver = physicalTenantResolver;
     this.brokerProperties = brokerProperties;
+    this.searchEngineConfigurationsByTenant = searchEngineConfigurationsByTenant;
   }
 
   public static void main(final String[] args) throws IOException {
@@ -98,21 +116,79 @@ public class StandaloneSchemaManager implements CommandLineRunner {
 
   @Override
   public void run(final String... args) throws Exception {
-    try {
-      getSchemaCreators()
-          .forEach(
-              schemaCreator -> {
-                schemaCreator.createSchema(CURRENT_BROKER_VERSION.toString());
-              });
-    } catch (final Exception e) {
-      LOG.error("Failed to create/update schema", e);
-      throw e;
+    final var tenantIds = searchEngineConfigurationsByTenant.keySet();
+
+    LOG.info("Creating/updating schema for {} physical tenant(s): {}", tenantIds.size(), tenantIds);
+
+    final Map<String, Exception> failures = new LinkedHashMap<>();
+    for (final String tenantId : tenantIds) {
+      try {
+        createWebappIndices(tenantId);
+        createZeebeIndices(tenantId);
+        LOG.info("Created/updated schema for physical tenant '{}'.", tenantId);
+      } catch (final Exception e) {
+        LOG.error("Failed to create/update schema for physical tenant '{}'.", tenantId, e);
+        failures.put(tenantId, e);
+      }
+    }
+
+    if (!failures.isEmpty()) {
+      final var succeeded = new ArrayList<>(tenantIds);
+      succeeded.removeAll(failures.keySet());
+      throw new SchemaCreationFailedException(failures, succeeded);
     }
   }
 
-  private List<SchemaCreator> getSchemaCreators() {
+  private void createWebappIndices(final String tenantId) throws IOException {
+    final SearchEngineConfiguration configuration =
+        searchEngineConfigurationsByTenant.get(tenantId);
+    final IndexDescriptors indexDescriptors = indexDescriptorsFor(configuration);
+
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(configuration.connect());
+        final SchemaManager schemaManager =
+            new SchemaManager(
+                clientAdapter.getSearchEngineClient(),
+                indexDescriptors.indices(),
+                indexDescriptors.templates(),
+                configuration,
+                clientAdapter.objectMapper())) {
+      schemaManager.startupOnce();
+    }
+  }
+
+  private void createZeebeIndices(final String tenantId) {
+    final Map<String, ExporterCfg> exporters = exportersOf(tenantId);
+    LOG.info(
+        "Creating/updating Zeebe record schema for physical tenant '{}' from exporter(s) {}.",
+        tenantId,
+        exporters.keySet());
+    for (final SchemaCreator schemaCreator : zeebeSchemaCreators(exporters)) {
+      schemaCreator.createSchema(CURRENT_BROKER_VERSION.toString());
+    }
+  }
+
+  private static IndexDescriptors indexDescriptorsFor(
+      final SearchEngineConfiguration configuration) {
+    final var connect = configuration.connect();
+    return new IndexDescriptors(connect.getIndexPrefix(), connect.getTypeEnum().isElasticSearch());
+  }
+
+  private Map<String, ExporterCfg> exportersOf(final String tenantId) {
+    final Map<String, ExporterCfg> exporters =
+        new LinkedHashMap<>(
+            BrokerBasedPropertiesOverride.convert(
+                    physicalTenantResolver.forPhysicalTenant(tenantId))
+                .getExporters());
+    if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
+      // 'zeebe.broker.exporters.*' has no per-tenant equivalent, so it never reaches the resolver
+      brokerProperties.getExporters().forEach(exporters::putIfAbsent);
+    }
+    return exporters;
+  }
+
+  private List<SchemaCreator> zeebeSchemaCreators(final Map<String, ExporterCfg> exporters) {
     final SchemaManagerFactory schemaManagerFactory = getSchemaManagerFactory();
-    return brokerProperties.getExporters().entrySet().stream()
+    return exporters.entrySet().stream()
         .map(entry -> schemaManagerFactory.create(entry.getKey(), entry.getValue()))
         .toList();
   }
@@ -138,12 +214,24 @@ public class StandaloneSchemaManager implements CommandLineRunner {
   }
 
   @EnableAutoConfiguration
-  // TODO: Use unified configuration when it is available
   @EnableConfigurationProperties(LegacyBrokerBasedProperties.class)
-  @ComponentScan(
-      basePackages = "io.camunda.application.commons.search",
-      nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+  @Import(PhysicalTenantSearchEngineConfigurations.class)
   public static class StandaloneSchemaManagerConfiguration {}
+
+  private static final class SchemaCreationFailedException extends RuntimeException {
+    private SchemaCreationFailedException(
+        final Map<String, Exception> failures, final List<String> succeeded) {
+      super(
+          "Failed to create/update the schema for %d of %d physical tenant(s): %s. Succeeded: %s. "
+                  .formatted(
+                      failures.size(),
+                      failures.size() + succeeded.size(),
+                      failures.keySet(),
+                      succeeded.isEmpty() ? "none" : succeeded)
+              + "Schema creation is idempotent, so re-run once the reported tenants are fixed.");
+      failures.values().forEach(this::addSuppressed);
+    }
+  }
 
   /*
    * Since we don't have a common SchemaManager interface that we can put in a common project for

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/PhysicalTenantStandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/PhysicalTenantStandaloneSchemaManagerIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.it.schema.strategy.ElasticsearchBackendStrategy;
+import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class PhysicalTenantStandaloneSchemaManagerIT {
+
+  private static final String TENANT_ID = "tenanta";
+  private static final String DEFAULT_INDEX_PREFIX = "default-tenant";
+  private static final String TENANT_INDEX_PREFIX = "tenant-a-prefix";
+
+  private static final String DEFAULT_EXPORTER_PREFIX = "zeebe-record";
+
+  private static final String ROOT_EXPORTER_ID = "rootrecords";
+
+  private static final String ROOT_EXPORTER_PREFIX = "root-records";
+  private static final String TENANT_ROOT_EXPORTER_PREFIX = "tenant-a-records";
+
+  @AutoClose
+  private final ElasticsearchBackendStrategy strategy = new ElasticsearchBackendStrategy();
+
+  @TestZeebe(autoStart = false)
+  private final TestStandaloneSchemaManager schemaManager = new TestStandaloneSchemaManager();
+
+  @Test
+  void shouldCreateSchemaForEveryPhysicalTenantInOneRun() throws Exception {
+    // given
+    strategy.startContainer();
+    strategy.createAdminClient();
+    configureDefaultTenant();
+    configureTenant(url());
+
+    // when
+    schemaManager.start();
+
+    // then
+    assertThat(strategy.indicesExist(DEFAULT_INDEX_PREFIX + "-*")).isTrue();
+    assertThat(strategy.indicesExist(TENANT_INDEX_PREFIX + "-*")).isTrue();
+
+    assertThat(strategy.countTemplates(TENANT_INDEX_PREFIX + "_process_*")).isGreaterThan(0);
+    assertThat(strategy.countTemplates(DEFAULT_EXPORTER_PREFIX + "_process_*")).isGreaterThan(0);
+  }
+
+  @Test
+  void shouldFailAndNameTheTenantWhenOneTenantCannotBeReached() throws Exception {
+    // given - the tenant points at a port nothing is listening on
+    strategy.startContainer();
+    strategy.createAdminClient();
+    configureDefaultTenant();
+    configureTenant("http://localhost:1");
+
+    // when / then
+    assertThatThrownBy(schemaManager::start)
+        .hasMessageContaining("Failed to create/update the schema")
+        .hasMessageContaining(TENANT_ID);
+
+    // and - the healthy tenant was still attempted
+    assertThat(strategy.indicesExist(DEFAULT_INDEX_PREFIX + "-*")).isTrue();
+  }
+
+  @Test
+  void shouldNotCreateSchemaOfARootExporterTheDefaultTenantDidNotAssign() throws Exception {
+    // given - a root-declared exporter only tenant A is assigned
+    strategy.startContainer();
+    strategy.createAdminClient();
+    configureDefaultTenant();
+    strategy.configureExporter(
+        schemaManager,
+        ElasticsearchBackendStrategy.ROOT_SCOPE,
+        ROOT_EXPORTER_ID,
+        url(),
+        ROOT_EXPORTER_PREFIX);
+    schemaManager.withProperty("camunda.physical-tenants.default.data.exporters-assigned", "");
+    configureTenant(url());
+    strategy.configureExporter(
+        schemaManager,
+        ElasticsearchBackendStrategy.tenantScope(TENANT_ID),
+        ROOT_EXPORTER_ID,
+        url(),
+        TENANT_ROOT_EXPORTER_PREFIX);
+    strategy.assignExporters(
+        schemaManager,
+        TENANT_ID,
+        ElasticsearchBackendStrategy.TENANT_EXPORTER_ID,
+        ROOT_EXPORTER_ID);
+
+    // when
+    schemaManager.start();
+
+    // then - the assigned tenant got the exporter's templates
+    assertThat(strategy.countTemplates(TENANT_ROOT_EXPORTER_PREFIX + "_process_*"))
+        .isGreaterThan(0);
+
+    // and - the default tenant did not, but its legacy exporter still ran
+    assertThat(strategy.countTemplates(ROOT_EXPORTER_PREFIX + "_*")).isZero();
+
+    assertThat(strategy.countTemplates(DEFAULT_EXPORTER_PREFIX + "_process_*")).isGreaterThan(0);
+  }
+
+  private String url() {
+    return "http://localhost:" + strategy.getContainer().getMappedPort(9200);
+  }
+
+  private void configureDefaultTenant() {
+    strategy.configureStandaloneSchemaManager(schemaManager);
+    schemaManager.withProperty("zeebe.broker.exporters.elasticsearch.args.index.process", "true");
+    schemaManager.withUnifiedConfig(
+        cfg ->
+            cfg.getData()
+                .getSecondaryStorage()
+                .getElasticsearch()
+                .setIndexPrefix(DEFAULT_INDEX_PREFIX));
+  }
+
+  private void configureTenant(final String tenantUrl) {
+    strategy.configurePhysicalTenant(schemaManager, TENANT_ID, tenantUrl, TENANT_INDEX_PREFIX);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
@@ -45,6 +45,8 @@ public final class ElasticsearchBackendStrategy implements SearchBackendStrategy
               - names: ['zeebe-*', 'operate-*', 'tasklist-*', 'camunda-*']
                 privileges: ['manage', 'read', 'write']
           """;
+  public static final String ROOT_SCOPE = "camunda.";
+  public static final String TENANT_EXPORTER_ID = "elasticsearch";
   private static final String ADMIN_USER = "camunda-admin";
   private static final String ADMIN_PASSWORD = "admin123";
   private static final String ADMIN_ROLE = "superuser";
@@ -128,6 +130,56 @@ public final class ElasticsearchBackendStrategy implements SearchBackendStrategy
             "zeebe.broker.exporters.elasticsearch.args.authentication.username", ADMIN_USER)
         .withProperty(
             "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD);
+  }
+
+  public void configurePhysicalTenant(
+      final TestStandaloneSchemaManager schemaManager,
+      final String tenantId,
+      final String tenantUrl,
+      final String indexPrefix) {
+    final String tenant = tenantScope(tenantId);
+    schemaManager
+        .withProperty(tenant + "data.secondary-storage.type", "elasticsearch")
+        .withProperty(tenant + "data.secondary-storage.elasticsearch.url", tenantUrl)
+        .withProperty(tenant + "data.secondary-storage.elasticsearch.username", ADMIN_USER)
+        .withProperty(tenant + "data.secondary-storage.elasticsearch.password", ADMIN_PASSWORD)
+        .withProperty(tenant + "data.secondary-storage.elasticsearch.index-prefix", indexPrefix)
+        // A physical tenant must either declare its own security initialization or opt out of
+        // authorization; the schema manager creates indices and has no use for either.
+        .withProperty(tenant + "security.authorizations.enabled", "false");
+    configureExporter(schemaManager, tenant, TENANT_EXPORTER_ID, tenantUrl, indexPrefix);
+    assignExporters(schemaManager, tenantId, TENANT_EXPORTER_ID);
+  }
+
+  public void configureExporter(
+      final TestStandaloneSchemaManager schemaManager,
+      final String scope,
+      final String exporterId,
+      final String exporterUrl,
+      final String indexPrefix) {
+    final String exporter = scope + "data.exporters." + exporterId + ".";
+    schemaManager
+        .withProperty(exporter + "class-name", ElasticsearchExporter.class.getName())
+        .withProperty(exporter + "args.url", exporterUrl)
+        .withProperty(exporter + "args.authentication.username", ADMIN_USER)
+        .withProperty(exporter + "args.authentication.password", ADMIN_PASSWORD)
+        .withProperty(exporter + "args.index.prefix", indexPrefix)
+        .withProperty(exporter + "args.index.process", "true");
+  }
+
+  /** The tenant's complete assignment manifest: declaring a generic exporter obliges it to. */
+  public void assignExporters(
+      final TestStandaloneSchemaManager schemaManager,
+      final String tenantId,
+      final String... exporterIds) {
+    final String tenant = tenantScope(tenantId);
+    for (int i = 0; i < exporterIds.length; i++) {
+      schemaManager.withProperty(tenant + "data.exporters-assigned[" + i + "]", exporterIds[i]);
+    }
+  }
+
+  public static String tenantScope(final String tenantId) {
+    return "camunda.physical-tenants." + tenantId + ".";
   }
 
   @Override


### PR DESCRIPTION
## Description

The schema manager CLI now creates the secondary storage schema for every physical tenant, driven imperatively from `run()`, one tenant at a time.

For each tenant it creates the webapp indices and templates, then the index templates owned by that tenant's Elasticsearch or OpenSearch exporter. Exporters resolve per tenant through `PhysicalTenantResolver` — the default tenant included — so a tenant only gets the schema of the exporters actually assigned to it: a root-declared exporter left out of `data.exporters-assigned` does not have its indices created. The default tenant then gap-fills from `LegacyBrokerBasedProperties`, because `zeebe.broker.exporters.*` predates physical tenants, is not part of the unified configuration the resolver reads, and would otherwise be dropped entirely. Filling gaps rather than replacing keeps the resolver authoritative for any id it already resolved.

Every tenant is attempted even if an earlier one fails. Failures are collected and reported together, naming both the failed and the succeeded tenants, and the CLI exits non-zero. A tenant that already succeeded keeps its schema — schema creation is idempotent, so re-running once the reported tenants are fixed is the repair.

Schema creation is no longer a side effect of autowiring `SearchEngineSchemaInitializer`. That component is built for a long-running node — indefinite background retries and a startup gate — whereas the CLI needs exactly one attempt per tenant and a reported outcome. Only `PhysicalTenantSearchEngineConfigurations` is imported, not `SearchEngineDatabaseConfiguration`, so no initializer bean exists to start work in the background.

`LegacyExporterPhysicalTenantFallbackTest` pins down the legacy-namespace behaviour against the real configuration beans, as the guard on the resolve-then-gap-fill ordering.

## Related issues

closes #57843