### PR TITLE
feat: Replace CPT data deletion toggle with mode

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -24,6 +24,8 @@ import io.camunda.process.test.api.similarity.SemanticSimilarityConfig;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.util.InstantProbeAwaitBehavior;
+import io.camunda.process.test.impl.cleanup.CleanupStrategy;
+import io.camunda.process.test.impl.cleanup.CleanupStrategyFactory;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.coverage.CoverageCollector;
 import io.camunda.process.test.impl.coverage.CoverageCollectorBuilder;
@@ -128,7 +130,8 @@ public class CamundaProcessTestExtension
   private CamundaManagementClient camundaManagementClient;
   private CamundaDataSource dataSource;
   private boolean clockResetEnabled = CamundaProcessTestRuntimeDefaults.CLOCK_RESET_ENABLED;
-  private boolean dataDeletionEnabled = CamundaProcessTestRuntimeDefaults.DATA_DELETION_ENABLED;
+  private DataDeletionMode dataDeletionMode = CamundaProcessTestRuntimeDefaults.DATA_DELETION_MODE;
+  private Instant testCaseStartTime;
 
   private CamundaProcessTestContext camundaProcessTestContext;
   private final ConditionalBehaviorEngine conditionalBehaviorEngine =
@@ -317,7 +320,7 @@ public class CamundaProcessTestExtension
     }
 
     // initialize assertions
-    final Instant testCaseStartTime = readCurrentRuntimeTime();
+    testCaseStartTime = readCurrentRuntimeTime();
     dataSource = new CamundaDataSource(camundaProcessTestContext.createClient(), testCaseStartTime);
     CamundaAssert.initialize(dataSource);
 
@@ -398,19 +401,14 @@ public class CamundaProcessTestExtension
     CamundaAssert.reset();
     closeCreatedClients();
     // final steps: reset the time and delete data
-    // It's important that the runtime clock is reset before the purge is started, as doing it
+    // It's important that the runtime clock is reset before the cleanup is started, as doing it
     // the other way around leads to race conditions and inconsistencies in the tests
     if (clockResetEnabled) {
       resetRuntimeClock();
     } else {
       LOG.info("Runtime clock reset is disabled. Skipping.");
     }
-
-    if (dataDeletionEnabled) {
-      deleteRuntimeData();
-    } else {
-      LOG.info("Runtime data deletion is disabled. Skipping.");
-    }
+    deleteRuntimeData();
   }
 
   private String getCoverageTestName(final ExtensionContext context) {
@@ -446,14 +444,15 @@ public class CamundaProcessTestExtension
   }
 
   private void deleteRuntimeData() {
-    try {
-      LOG.debug("Deleting the runtime data");
-      final Instant startTime = Instant.now();
+    final CleanupStrategyFactory cleanupStrategyFactory =
+        runtimeBuilder.getCleanupStrategyFactory();
+    final CleanupStrategy cleanupStrategy = cleanupStrategyFactory.create(dataDeletionMode);
 
-      camundaManagementClient.purgeCluster();
-      final Instant endTime = Instant.now();
-      final Duration duration = Duration.between(startTime, endTime);
-      LOG.debug("Runtime data deleted in {}", duration);
+    try {
+      cleanupStrategy.cleanup(
+          camundaManagementClient,
+          () -> runtime.getCamundaClientBuilderFactory().get().build(),
+          testCaseStartTime);
 
     } catch (final Throwable t) {
       LOG.warn(
@@ -788,13 +787,13 @@ public class CamundaProcessTestExtension
   }
 
   /**
-   * Enable or disable runtime data deletion after each test. By default, data deletion is enabled.
+   * Configure runtime data deletion mode after each test.
    *
-   * @param enabled set {@code true} to enable runtime data deletion
+   * @param mode the runtime data deletion mode
    * @return the extension builder
    */
-  public CamundaProcessTestExtension withDataDeletionEnabled(final boolean enabled) {
-    dataDeletionEnabled = enabled;
+  public CamundaProcessTestExtension withDataDeletionMode(final DataDeletionMode mode) {
+    dataDeletionMode = mode;
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/DataDeletionMode.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/DataDeletionMode.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.api;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/DataDeletionMode.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/DataDeletionMode.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.api;
+
+/** Defines how Camunda Process Test cleans up runtime and deployment data after each test. */
+public enum DataDeletionMode {
+  /** Purges the full cluster state after each test (default). */
+  CLUSTER_PURGE,
+
+  /** Skips runtime data deletion after each test. */
+  NONE
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategy.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.impl.client.CamundaManagementClient;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+/** Internal strategy contract for test cleanup behavior based on the configured deletion mode. */
+public interface CleanupStrategy {
+
+  /**
+   * Executes test cleanup for data created since the provided test case start time.
+   *
+   * @param managementClient management API client
+   * @param clientSupplier supplier to create a Camunda API client
+   * @param testCaseStartTime start time of the current test case
+   */
+  void cleanup(
+      CamundaManagementClient managementClient,
+      Supplier<CamundaClient> clientSupplier,
+      Instant testCaseStartTime);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategyFactory.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategyFactory.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategyFactory.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/CleanupStrategyFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import io.camunda.process.test.api.DataDeletionMode;
+
+/**
+ * Factory interface for creating {@link CleanupStrategy} instances based on the provided {@link
+ * DataDeletionMode}.
+ */
+public interface CleanupStrategyFactory {
+
+  /**
+   * Creates a {@link CleanupStrategy} instance based on the provided {@link DataDeletionMode}.
+   *
+   * @param deletionMode the mode of data deletion
+   * @return a {@link CleanupStrategy} instance
+   */
+  CleanupStrategy create(final DataDeletionMode deletionMode);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategy.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.impl.client.CamundaManagementClient;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ClusterPurgeCleanupStrategy implements CleanupStrategy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterPurgeCleanupStrategy.class);
+
+  @Override
+  public void cleanup(
+      final CamundaManagementClient managementClient,
+      final Supplier<CamundaClient> clientSupplier,
+      final Instant testCaseStartTime) {
+    LOG.debug("Purging cluster runtime data");
+    final Instant startTime = Instant.now();
+
+    managementClient.purgeCluster();
+
+    final Duration duration = Duration.between(startTime, Instant.now());
+    LOG.debug("Cluster runtime data purged in {}", duration);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactory.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactory.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactory.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactory.java
@@ -13,13 +13,17 @@ public final class DefaultCleanupStrategyFactory implements CleanupStrategyFacto
 
   @Override
   public CleanupStrategy create(final DataDeletionMode dataDeletionMode) {
+    if (dataDeletionMode == null) {
+      return new NoneCleanupStrategy();
+    }
+
     switch (dataDeletionMode) {
       case CLUSTER_PURGE:
         return new ClusterPurgeCleanupStrategy();
       case NONE:
-        return new NoOpCleanupStrategy();
+        return new NoneCleanupStrategy();
       default:
-        return new NoOpCleanupStrategy();
+        return new NoneCleanupStrategy();
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactory.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import io.camunda.process.test.api.DataDeletionMode;
+
+public final class DefaultCleanupStrategyFactory implements CleanupStrategyFactory {
+
+  @Override
+  public CleanupStrategy create(final DataDeletionMode dataDeletionMode) {
+    switch (dataDeletionMode) {
+      case CLUSTER_PURGE:
+        return new ClusterPurgeCleanupStrategy();
+      case NONE:
+        return new NoOpCleanupStrategy();
+      default:
+        return new NoOpCleanupStrategy();
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/NoOpCleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/NoOpCleanupStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.process.test.impl.client.CamundaManagementClient;
+import java.time.Instant;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class NoOpCleanupStrategy implements CleanupStrategy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NoOpCleanupStrategy.class);
+
+  @Override
+  public void cleanup(
+      final CamundaManagementClient managementClient,
+      final Supplier<CamundaClient> clientSupplier,
+      final Instant testCaseStartTime) {
+
+    LOG.debug("Runtime data deletion mode is NONE. Skipping.");
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/NoneCleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/NoneCleanupStrategy.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/NoneCleanupStrategy.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/cleanup/NoneCleanupStrategy.java
@@ -14,9 +14,9 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class NoOpCleanupStrategy implements CleanupStrategy {
+public final class NoneCleanupStrategy implements CleanupStrategy {
 
-  private static final Logger LOG = LoggerFactory.getLogger(NoOpCleanupStrategy.class);
+  private static final Logger LOG = LoggerFactory.getLogger(NoneCleanupStrategy.class);
 
   @Override
   public void cleanup(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -20,6 +20,8 @@ import io.camunda.client.CredentialsProvider;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
+import io.camunda.process.test.impl.cleanup.CleanupStrategyFactory;
+import io.camunda.process.test.impl.cleanup.DefaultCleanupStrategyFactory;
 import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConfiguration;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
@@ -40,6 +42,8 @@ public class CamundaProcessTestRuntimeBuilder {
       LoggerFactory.getLogger(CamundaProcessTestRuntimeBuilder.class);
 
   private ContainerFactory containerFactory = new ContainerFactory();
+
+  private CleanupStrategyFactory cleanupStrategyFactory = new DefaultCleanupStrategyFactory();
 
   private String camundaDockerImageName =
       CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME;
@@ -113,8 +117,15 @@ public class CamundaProcessTestRuntimeBuilder {
 
   // ============ For testing =================
 
-  CamundaProcessTestRuntimeBuilder withContainerFactory(final ContainerFactory containerFactory) {
+  public CamundaProcessTestRuntimeBuilder withContainerFactory(
+      final ContainerFactory containerFactory) {
     this.containerFactory = containerFactory;
+    return this;
+  }
+
+  public CamundaProcessTestRuntimeBuilder withCleanupStrategyFactory(
+      final CleanupStrategyFactory cleanupStrategyFactory) {
+    this.cleanupStrategyFactory = cleanupStrategyFactory;
     return this;
   }
 
@@ -480,5 +491,9 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public Optional<Duration> getAssertionInterval() {
     return assertionInterval;
+  }
+
+  public CleanupStrategyFactory getCleanupStrategyFactory() {
+    return cleanupStrategyFactory;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.runtime;
 
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.api.DataDeletionMode;
 import io.camunda.process.test.impl.runtime.properties.AssertionProperties;
 import io.camunda.process.test.impl.runtime.properties.JudgeProperties;
 import io.camunda.process.test.impl.runtime.properties.SemanticSimilarityProperties;
@@ -91,7 +92,7 @@ public class CamundaProcessTestRuntimeDefaults {
 
   public static final boolean MULTI_TENANCY_ENABLED = PROPERTIES_UTIL.isMultiTenancyEnabled();
   public static final boolean CLOCK_RESET_ENABLED = PROPERTIES_UTIL.isClockResetEnabled();
-  public static final boolean DATA_DELETION_ENABLED = PROPERTIES_UTIL.isDataDeletionEnabled();
+  public static final DataDeletionMode DATA_DELETION_MODE = PROPERTIES_UTIL.getDataDeletionMode();
 
   public static final String COVERAGE_REPORT_DIRECTORY =
       PROPERTIES_UTIL.getCoverageReportProperties().getCoverageReportDirectory();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -19,6 +19,7 @@ import static io.camunda.process.test.impl.runtime.util.PropertiesUtil.getProper
 
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.api.DataDeletionMode;
 import io.camunda.process.test.impl.runtime.properties.AssertionProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaContainerRuntimeProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaProcessTestClientProperties;
@@ -50,7 +51,7 @@ public final class ContainerRuntimePropertiesUtil {
   public static final String PROPERTY_NAME_ELASTICSEARCH_VERSION = "elasticsearch.version";
   public static final String PROPERTY_NAME_MULTI_TENANCY_ENABLED = "multiTenancyEnabled";
   public static final String PROPERTY_NAME_CLOCK_RESET_ENABLED = "clockResetEnabled";
-  public static final String PROPERTY_NAME_DATA_DELETION_ENABLED = "dataDeletionEnabled";
+  public static final String PROPERTY_NAME_DATA_DELETION_MODE = "dataDeletionMode";
 
   private static final String BASE_DIR = "/";
 
@@ -66,7 +67,7 @@ public final class ContainerRuntimePropertiesUtil {
   private final CamundaProcessTestRuntimeMode runtimeMode;
   private final boolean multiTenancyEnabled;
   private final boolean clockResetEnabled;
-  private final boolean dataDeletionEnabled;
+  private final DataDeletionMode dataDeletionMode;
 
   private final String elasticsearchVersion;
 
@@ -108,10 +109,12 @@ public final class ContainerRuntimePropertiesUtil {
             .trim()
             .equalsIgnoreCase("true");
 
-    dataDeletionEnabled =
-        getPropertyOrDefault(properties, PROPERTY_NAME_DATA_DELETION_ENABLED, "true")
-            .trim()
-            .equalsIgnoreCase("true");
+    dataDeletionMode =
+        getPropertyOrDefault(
+            properties,
+            PROPERTY_NAME_DATA_DELETION_MODE,
+            value -> parseDataDeletionModeOrDefault(value, DataDeletionMode.CLUSTER_PURGE),
+            DataDeletionMode.CLUSTER_PURGE);
   }
 
   public static ContainerRuntimePropertiesUtil readProperties() {
@@ -159,6 +162,15 @@ public final class ContainerRuntimePropertiesUtil {
 
     try {
       return CamundaProcessTestRuntimeMode.valueOf(value.trim().toUpperCase());
+    } catch (final IllegalArgumentException e) {
+      return defaultValue;
+    }
+  }
+
+  private static DataDeletionMode parseDataDeletionModeOrDefault(
+      final String value, final DataDeletionMode defaultValue) {
+    try {
+      return DataDeletionMode.valueOf(value.trim().toUpperCase());
     } catch (final IllegalArgumentException e) {
       return defaultValue;
     }
@@ -254,8 +266,8 @@ public final class ContainerRuntimePropertiesUtil {
     return clockResetEnabled;
   }
 
-  public boolean isDataDeletionEnabled() {
-    return dataDeletionEnabled;
+  public DataDeletionMode getDataDeletionMode() {
+    return dataDeletionMode;
   }
 
   public CoverageReportProperties getCoverageReportProperties() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -31,6 +31,8 @@ import io.camunda.process.test.api.judge.JudgeConfig;
 import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.api.similarity.SemanticSimilarityConfig;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
+import io.camunda.process.test.impl.cleanup.CleanupStrategy;
+import io.camunda.process.test.impl.cleanup.CleanupStrategyFactory;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.coverage.CoverageCollector;
 import io.camunda.process.test.impl.coverage.CoverageCollectorBuilder;
@@ -80,6 +82,8 @@ public class JunitExtensionTest {
   @Mock private CamundaManagementClient camundaManagementClient;
   @Mock private CamundaProcessTestResultCollector camundaProcessTestResultCollector;
   @Mock private CamundaProcessTestContainerProvider containerProvider;
+  @Mock private CleanupStrategyFactory cleanupStrategyFactory;
+  @Mock private CleanupStrategy cleanupStrategy;
 
   @Mock private ExtensionContext extensionContext;
   @Mock private TestInstances testInstances;
@@ -394,6 +398,12 @@ public class JunitExtensionTest {
   @Nested
   class AfterEachTests {
 
+    @BeforeEach
+    void configureMocks() {
+      when(camundaRuntimeBuilder.getCleanupStrategyFactory()).thenReturn(cleanupStrategyFactory);
+      when(cleanupStrategyFactory.create(any())).thenReturn(cleanupStrategy);
+    }
+
     @Test
     void shouldPrintResultIfTestFailed() throws Exception {
       // given
@@ -446,7 +456,7 @@ public class JunitExtensionTest {
     }
 
     @Test
-    void shouldPurgeCluster() throws Exception {
+    void shouldCleanupData() throws Exception {
       // given
       final CamundaProcessTestExtension extension =
           new CamundaProcessTestExtension(camundaRuntimeBuilder, processCoverageBuilder, NOOP);
@@ -460,7 +470,7 @@ public class JunitExtensionTest {
       extension.afterEach(extensionContext);
 
       // then
-      verify(camundaManagementClient).purgeCluster();
+      verify(cleanupStrategy).cleanup(any(), any(), any());
     }
 
     @Test
@@ -498,25 +508,6 @@ public class JunitExtensionTest {
 
       // then
       verify(camundaManagementClient, never()).resetTime();
-    }
-
-    @Test
-    void shouldSkipDataDeletionIfDisabled() throws Exception {
-      // given
-      final CamundaProcessTestExtension extension =
-          new CamundaProcessTestExtension(camundaRuntimeBuilder, processCoverageBuilder, NOOP)
-              .withDataDeletionEnabled(false);
-
-      // when
-      extension.beforeAll(extensionContext);
-      extension.beforeEach(extensionContext);
-
-      setManagementClientDummy(extension);
-
-      extension.afterEach(extensionContext);
-
-      // then
-      verify(camundaManagementClient, never()).purgeCluster();
     }
 
     private void setManagementClientDummy(final CamundaProcessTestExtension extension) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategyTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategyTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategyTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/ClusterPurgeCleanupStrategyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import static org.mockito.Mockito.verify;
+
+import io.camunda.process.test.impl.client.CamundaManagementClient;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterPurgeCleanupStrategyTest {
+
+  @Mock private CamundaManagementClient managementClient;
+
+  @Test
+  void shouldPurgeCluster() {
+    // given
+    final ClusterPurgeCleanupStrategy strategy = new ClusterPurgeCleanupStrategy();
+
+    // when
+    strategy.cleanup(managementClient, () -> null, Instant.now());
+
+    // then
+    verify(managementClient).purgeCluster();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactoryTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactoryTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.cleanup;
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactoryTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactoryTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.process.test.api.DataDeletionMode;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,9 +34,20 @@ class DefaultCleanupStrategyFactoryTest {
     assertThat(strategy).isInstanceOf(expectedType);
   }
 
+  @Test
+  void shouldCreateNoneCleanupStrategyIfDeletionModeIsNull() {
+    // given
+
+    // when
+    final CleanupStrategy strategy = factory.create(null);
+
+    // then
+    assertThat(strategy).isInstanceOf(NoneCleanupStrategy.class);
+  }
+
   private static Stream<Arguments> dataDeletionModes() {
     return Stream.of(
         Arguments.of(DataDeletionMode.CLUSTER_PURGE, ClusterPurgeCleanupStrategy.class),
-        Arguments.of(DataDeletionMode.NONE, NoOpCleanupStrategy.class));
+        Arguments.of(DataDeletionMode.NONE, NoneCleanupStrategy.class));
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactoryTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/cleanup/DefaultCleanupStrategyFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.cleanup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.api.DataDeletionMode;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DefaultCleanupStrategyFactoryTest {
+
+  private final DefaultCleanupStrategyFactory factory = new DefaultCleanupStrategyFactory();
+
+  @ParameterizedTest
+  @MethodSource("dataDeletionModes")
+  void shouldCreateCleanupStrategyForDataDeletionMode(
+      final DataDeletionMode dataDeletionMode,
+      final Class<? extends CleanupStrategy> expectedType) {
+    // given
+
+    // when
+    final CleanupStrategy strategy = factory.create(dataDeletionMode);
+
+    // then
+    assertThat(strategy).isInstanceOf(expectedType);
+  }
+
+  private static Stream<Arguments> dataDeletionModes() {
+    return Stream.of(
+        Arguments.of(DataDeletionMode.CLUSTER_PURGE, ClusterPurgeCleanupStrategy.class),
+        Arguments.of(DataDeletionMode.NONE, NoOpCleanupStrategy.class));
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.api.DataDeletionMode;
 import io.camunda.process.test.impl.runtime.properties.AssertionProperties;
 import io.camunda.process.test.impl.runtime.properties.CamundaContainerRuntimeProperties;
 import io.camunda.process.test.impl.runtime.properties.ConnectorsContainerRuntimeProperties;
@@ -61,7 +62,7 @@ public class ContainerRuntimePropertiesUtilTest {
 
     assertThat(propertiesUtil.getRemoteRuntimeConnectionTimeout()).isEqualTo(Duration.ofMinutes(1));
     assertThat(propertiesUtil.isClockResetEnabled()).isTrue();
-    assertThat(propertiesUtil.isDataDeletionEnabled()).isTrue();
+    assertThat(propertiesUtil.getDataDeletionMode()).isEqualTo(DataDeletionMode.CLUSTER_PURGE);
   }
 
   @Test
@@ -374,7 +375,7 @@ public class ContainerRuntimePropertiesUtilTest {
 
       assertThat(propertiesUtil.isMultiTenancyEnabled()).isTrue();
       assertThat(propertiesUtil.isClockResetEnabled()).isFalse();
-      assertThat(propertiesUtil.isDataDeletionEnabled()).isFalse();
+      assertThat(propertiesUtil.getDataDeletionMode()).isEqualTo(DataDeletionMode.NONE);
 
       final CoverageReportProperties coverageReportProperties =
           propertiesUtil.getCoverageReportProperties();

--- a/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/test/resources/containerRuntimePropertiesUtil/camunda-container-runtime.properties
@@ -32,7 +32,7 @@ connectorsExposedPorts[2]=9088
 
 multiTenancyEnabled=true
 clockResetEnabled=false
-dataDeletionEnabled=false
+dataDeletionMode=NONE
 
 coverage.reportDirectory=custom/coverage-report
 coverage.excludedProcesses[0]=process1

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -22,6 +22,7 @@ import io.camunda.client.spring.event.CamundaClientCreatedSpringEvent;
 import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.assertions.util.InstantProbeAwaitBehavior;
+import io.camunda.process.test.impl.cleanup.CleanupStrategy;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.configuration.AssertionConfiguration;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
@@ -55,6 +56,7 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.DisplayName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
@@ -101,7 +103,7 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
   private CamundaManagementClient camundaManagementClient;
   private CamundaDataSource dataSource;
   private boolean clockResetEnabled = true;
-  private boolean dataDeletionEnabled = true;
+  private Instant testCaseStartTime;
 
   private CamundaClient client;
   private final ConditionalBehaviorEngine conditionalBehaviorEngine =
@@ -127,7 +129,6 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
         testContext.getApplicationContext().getBean(CamundaProcessTestRuntimeConfiguration.class);
     clockResetEnabled = runtimeConfiguration.isClockResetEnabled();
-    dataDeletionEnabled = runtimeConfiguration.isDataDeletionEnabled();
 
     final JsonMapper jsonMapper = testContext.getApplicationContext().getBean(JsonMapper.class);
 
@@ -185,7 +186,7 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
         .publishEvent(new CamundaClientCreatedSpringEvent(this, client));
 
     // initialize assertions
-    final Instant testCaseStartTime = readCurrentRuntimeTime();
+    testCaseStartTime = readCurrentRuntimeTime();
     dataSource = new CamundaDataSource(client, testCaseStartTime);
     CamundaAssert.initialize(dataSource);
 
@@ -208,6 +209,8 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
 
   @Override
   public void afterTestMethod(final TestContext testContext) throws Exception {
+    final ApplicationContext applicationContext = testContext.getApplicationContext();
+
     if (runtime == null) {
       // Skip if the runtime is not created.
       return;
@@ -232,22 +235,17 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     // reset assertions
     CamundaAssert.reset();
     // close Zeebe clients
-    testContext
-        .getApplicationContext()
-        .publishEvent(new CamundaClientClosingSpringEvent(this, client));
+    applicationContext.publishEvent(new CamundaClientClosingSpringEvent(this, client));
 
     closeCreatedClients();
 
     // clean up proxies
-    testContext.getApplicationContext().getBean(CamundaClientProxy.class).removeDelegate();
-    testContext
-        .getApplicationContext()
-        .getBean(CamundaProcessTestContextProxy.class)
-        .removeDelegate();
-    testContext.getApplicationContext().getBean(TestCaseRunnerProxy.class).removeDelegate();
+    applicationContext.getBean(CamundaClientProxy.class).removeDelegate();
+    applicationContext.getBean(CamundaProcessTestContextProxy.class).removeDelegate();
+    applicationContext.getBean(TestCaseRunnerProxy.class).removeDelegate();
 
     // final steps: reset the time and delete data
-    // It's important that the runtime clock is reset before the purge is started, as doing it
+    // It's important that the runtime clock is reset before the cleanup is started, as doing it
     // the other way around leads to race conditions and inconsistencies in the tests
     if (clockResetEnabled) {
       resetRuntimeClock();
@@ -255,11 +253,7 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
       LOG.info("Runtime clock reset is disabled. Skipping.");
     }
 
-    if (dataDeletionEnabled) {
-      deleteRuntimeData();
-    } else {
-      LOG.info("Runtime data deletion is disabled. Skipping.");
-    }
+    deleteRuntimeData(applicationContext);
   }
 
   @Override
@@ -323,15 +317,14 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     }
   }
 
-  private void deleteRuntimeData() {
-    try {
-      LOG.debug("Deleting the runtime data");
-      final Instant startTime = Instant.now();
+  private void deleteRuntimeData(final ApplicationContext applicationContext) {
+    final CleanupStrategy cleanupStrategy = applicationContext.getBean(CleanupStrategy.class);
 
-      camundaManagementClient.purgeCluster();
-      final Instant endTime = Instant.now();
-      final Duration duration = Duration.between(startTime, endTime);
-      LOG.debug("Runtime data deleted in {}", duration);
+    try {
+      cleanupStrategy.cleanup(
+          camundaManagementClient,
+          () -> runtime.getCamundaClientBuilderFactory().get().build(),
+          testCaseStartTime);
 
     } catch (final Throwable t) {
       LOG.warn(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Bean;
   CamundaProcessTestDefaultConfiguration.class,
   LegacyCamundaProcessTestRuntimeConfiguration.class,
   CamundaProcessTestRuntimeConfiguration.class,
+  CamundaProcessTestCleanupConfiguration.class,
   CamundaAutoConfiguration.class,
 })
 @AutoConfigureBefore(CamundaAutoConfiguration.class)

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestCleanupConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestCleanupConfiguration.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.process.test.impl.configuration;
 

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestCleanupConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestCleanupConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import io.camunda.process.test.api.DataDeletionMode;
+import io.camunda.process.test.impl.cleanup.CleanupStrategy;
+import io.camunda.process.test.impl.cleanup.DefaultCleanupStrategyFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CamundaProcessTestCleanupConfiguration {
+
+  @Bean
+  public CleanupStrategy cleanupStrategy(
+      final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
+    final DataDeletionMode dataDeletionMode = runtimeConfiguration.getDataDeletionMode();
+    return new DefaultCleanupStrategyFactory().create(dataDeletionMode);
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.configuration;
 
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.api.DataDeletionMode;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.util.Collections;
 import java.util.List;
@@ -53,7 +54,9 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   private boolean multiTenancyEnabled = false;
   private boolean clockResetEnabled = true;
-  private boolean dataDeletionEnabled = true;
+
+  /** Cleanup mode after each test. */
+  private DataDeletionMode dataDeletionMode = DataDeletionMode.CLUSTER_PURGE;
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
 
@@ -244,12 +247,17 @@ public class CamundaProcessTestRuntimeConfiguration {
     this.clockResetEnabled = clockResetEnabled;
   }
 
-  public boolean isDataDeletionEnabled() {
-    return dataDeletionEnabled;
+  public DataDeletionMode getDataDeletionMode() {
+    return dataDeletionMode;
   }
 
-  public void setDataDeletionEnabled(final boolean dataDeletionEnabled) {
-    this.dataDeletionEnabled = dataDeletionEnabled;
+  /**
+   * Sets the data deletion mode for cleanup between tests.
+   *
+   * @param dataDeletionMode the cleanup mode to apply after each test
+   */
+  public void setDataDeletionMode(final DataDeletionMode dataDeletionMode) {
+    this.dataDeletionMode = dataDeletionMode;
   }
 
   public CoverageReportConfiguration getCoverage() {

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -36,6 +36,7 @@ import io.camunda.process.test.api.judge.ChatModelAdapter;
 import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.api.similarity.EmbeddingModelAdapter;
 import io.camunda.process.test.api.testCases.TestCaseRunner;
+import io.camunda.process.test.impl.cleanup.CleanupStrategy;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
 import io.camunda.process.test.impl.coverage.CoverageCollector;
@@ -91,6 +92,7 @@ public class ExecutionListenerTest {
   @Mock private CamundaProcessTestResultCollector camundaProcessTestResultCollector;
   @Mock private CamundaClientBuilderFactory camundaClientBuilderFactory;
   @Mock private CamundaClientProperties camundaClientProperties;
+  @Mock private CleanupStrategy cleanupStrategy;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private CamundaClientBuilder camundaClientBuilder;
@@ -159,6 +161,7 @@ public class ExecutionListenerTest {
     lenient()
         .when(applicationContext.getBeansOfType(EmbeddingModelAdapter.class))
         .thenReturn(Map.of());
+    lenient().when(applicationContext.getBean(CleanupStrategy.class)).thenReturn(cleanupStrategy);
   }
 
   @Test
@@ -364,7 +367,7 @@ public class ExecutionListenerTest {
   }
 
   @Test
-  void shouldPurgeTheClusterInBetweenTests() throws Exception {
+  void shouldCleanupDataInBetweenTests() throws Exception {
     // given
     final CamundaProcessTestExecutionListener listener =
         new CamundaProcessTestExecutionListener(
@@ -374,13 +377,10 @@ public class ExecutionListenerTest {
     listener.beforeTestClass(testContext);
     listener.beforeTestMethod(testContext);
 
-    // CamundaManagementClient will attempt to call purgeCluster() and we need to prevent
-    // it from trying to execute real code (the HTTP call will fail).
-    setManagementClientDummy(listener);
     listener.afterTestMethod(testContext);
 
     // then
-    verify(camundaManagementClient).purgeCluster();
+    verify(cleanupStrategy).cleanup(any(), any(), any());
   }
 
   @Test
@@ -432,7 +432,7 @@ public class ExecutionListenerTest {
     // given
     final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
         new CamundaProcessTestRuntimeConfiguration();
-    runtimeConfiguration.setDataDeletionEnabled(false);
+    runtimeConfiguration.setDataDeletionMode(DataDeletionMode.NONE);
     when(applicationContext.getBean(CamundaProcessTestRuntimeConfiguration.class))
         .thenReturn(runtimeConfiguration);
 

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/CamundaProcessTestDefaultConfigurationTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/CamundaProcessTestDefaultConfigurationTest.java
@@ -31,6 +31,7 @@ import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.impl.util.Environment;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import io.camunda.process.test.api.DataDeletionMode;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestAutoConfiguration;
 import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
 import java.net.URI;
@@ -68,6 +69,70 @@ public class CamundaProcessTestDefaultConfigurationTest {
           CamundaClient.newClientBuilder()
               .restAddress(URI.create("http://custom-factory-host:9999"))
               .grpcAddress(URI.create("http://custom-factory-host:26500"));
+    }
+  }
+
+  @Configuration
+  static class CustomJsonMapperConfig {
+    @Bean
+    JsonMapper jsonMapper() {
+      final ObjectMapper objectMapper =
+          new ObjectMapper()
+              .configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
+              .registerModule(new JavaTimeModule());
+      return new CamundaObjectMapper(objectMapper);
+    }
+  }
+
+  private static class BlueprintTest {
+    private Long id;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private String businessKey;
+
+    BlueprintTest() {}
+
+    BlueprintTest(
+        final Long id,
+        final LocalDateTime createdDate,
+        final LocalDateTime modifiedDate,
+        final String businessKey) {
+      this.id = id;
+      this.createdDate = createdDate;
+      this.modifiedDate = modifiedDate;
+      this.businessKey = businessKey;
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public void setId(final Long id) {
+      this.id = id;
+    }
+
+    public LocalDateTime getCreatedDate() {
+      return createdDate;
+    }
+
+    public void setCreatedDate(final LocalDateTime createdDate) {
+      this.createdDate = createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+      return modifiedDate;
+    }
+
+    public void setModifiedDate(final LocalDateTime modifiedDate) {
+      this.modifiedDate = modifiedDate;
+    }
+
+    public String getBusinessKey() {
+      return businessKey;
+    }
+
+    public void setBusinessKey(final String businessKey) {
+      this.businessKey = businessKey;
     }
   }
 
@@ -232,7 +297,7 @@ public class CamundaProcessTestDefaultConfigurationTest {
       properties = {
         "camunda.process-test.connectors-enabled=true",
         "camunda.process-test.clock-reset-enabled=false",
-        "camunda.process-test.data-deletion-enabled=false",
+        "camunda.process-test.data-deletion-mode=none",
         "camunda.process-test.camunda-docker-image-version=8.8.0-new",
         "camunda.process-test.camunda-docker-image-name=camunda/camunda-new",
         "io.camunda.process.test.camunda-docker-image-name=camunda/camunda-legacy",
@@ -245,7 +310,7 @@ public class CamundaProcessTestDefaultConfigurationTest {
     void shouldReadConfigurationWithNewPrefix() {
       assertThat(configuration.isConnectorsEnabled()).isTrue();
       assertThat(configuration.isClockResetEnabled()).isFalse();
-      assertThat(configuration.isDataDeletionEnabled()).isFalse();
+      assertThat(configuration.getDataDeletionMode()).isEqualTo(DataDeletionMode.NONE);
       assertThat(configuration.getCamundaDockerImageVersion()).isEqualTo("8.8.0-new");
       assertThat(configuration.getCamundaDockerImageName()).isEqualTo("camunda/camunda-new");
     }
@@ -266,7 +331,7 @@ public class CamundaProcessTestDefaultConfigurationTest {
     void shouldUseLegacyConfiguration() {
       assertThat(configuration.isConnectorsEnabled()).isTrue();
       assertThat(configuration.isClockResetEnabled()).isTrue();
-      assertThat(configuration.isDataDeletionEnabled()).isTrue();
+      assertThat(configuration.getDataDeletionMode()).isEqualTo(DataDeletionMode.CLUSTER_PURGE);
       assertThat(configuration.getCamundaDockerImageVersion()).isEqualTo("8.8.0-legacy");
       assertThat(configuration.getCamundaDockerImageName()).isEqualTo("camunda/camunda-legacy");
     }
@@ -325,70 +390,6 @@ public class CamundaProcessTestDefaultConfigurationTest {
 
     private CamundaClientConfiguration buildConfiguration() {
       return CamundaProcessTestDefaultConfigurationTest.buildConfiguration(clientBuilderFactory);
-    }
-  }
-
-  @Configuration
-  static class CustomJsonMapperConfig {
-    @Bean
-    JsonMapper jsonMapper() {
-      final ObjectMapper objectMapper =
-          new ObjectMapper()
-              .configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
-              .registerModule(new JavaTimeModule());
-      return new CamundaObjectMapper(objectMapper);
-    }
-  }
-
-  private static class BlueprintTest {
-    private Long id;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-    private String businessKey;
-
-    BlueprintTest() {}
-
-    BlueprintTest(
-        final Long id,
-        final LocalDateTime createdDate,
-        final LocalDateTime modifiedDate,
-        final String businessKey) {
-      this.id = id;
-      this.createdDate = createdDate;
-      this.modifiedDate = modifiedDate;
-      this.businessKey = businessKey;
-    }
-
-    public Long getId() {
-      return id;
-    }
-
-    public void setId(final Long id) {
-      this.id = id;
-    }
-
-    public LocalDateTime getCreatedDate() {
-      return createdDate;
-    }
-
-    public void setCreatedDate(final LocalDateTime createdDate) {
-      this.createdDate = createdDate;
-    }
-
-    public LocalDateTime getModifiedDate() {
-      return modifiedDate;
-    }
-
-    public void setModifiedDate(final LocalDateTime modifiedDate) {
-      this.modifiedDate = modifiedDate;
-    }
-
-    public String getBusinessKey() {
-      return businessKey;
-    }
-
-    public void setBusinessKey(final String businessKey) {
-      this.businessKey = businessKey;
     }
   }
 }


### PR DESCRIPTION
## Description

Replace the data deletion enable/disable configuration option with a deletion mode. The abstraction of the deletion mode enables further cleanup strategies, for example, https://github.com/camunda/camunda/issues/57919. 

Extracted the refactoring from https://github.com/camunda/camunda/pull/57971. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Contributes to https://github.com/camunda/camunda/issues/57919. 
