### PR TITLE
[WIP] fix: update surefire plugin version to 3.6.0-M1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -249,7 +249,7 @@
     <plugin.version.shade>3.6.2</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.8.3</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.2</plugin.version.surefire>
+    <plugin.version.surefire>3.6.0-M1</plugin.version.surefire>
     <plugin.version.versions>2.21.0</plugin.version.versions>
     <plugin.version.frontend-maven>2.0.2</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.4.0</plugin.version.maven-source>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
TODO: 

- [ ] ArchUnit tests
- [ ] Nested test class failures to not trigger retries properly, making CI appear green despite real failures
- [ ] output of nested test classes

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
related to inc-7122 ([slack](https://camunda.slack.com/archives/C0BPHV7U9NF))