### PR TITLE
fix: reject standalone restore of clusters with multiple physical tenants

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -106,7 +106,15 @@ public class RestoreApp implements ApplicationRunner {
       // set up already especially when using dynamic node ids.
       final DataDirectoryProvider dataDirectoryProvider,
       final PostRestoreAction postRestoreAction,
-      final PreRestoreAction preRestoreAction) {
+      final PreRestoreAction preRestoreAction,
+      final PhysicalTenantIds physicalTenantIds) {
+    if (physicalTenantIds.known().size() > 1) {
+      throw new IllegalStateException(
+          "Restoring a cluster with multiple physical tenants configured is not supported by "
+              + "RestoreApp. Please use the v2 REST APIs "
+              + "(/physical-tenants/<physical-tenant-id>/v2/restore/ or /cluster/v2/restore) "
+              + "to restore such a cluster instead.");
+    }
     this.camunda = camunda;
     this.configuration = configuration;
     this.backupStore = backupStore;

--- a/dist/src/test/java/io/camunda/zeebe/restore/RestoreAppMultiplePhysicalTenantsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/restore/RestoreAppMultiplePhysicalTenantsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.beans.RestoreProperties;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryProvider;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class RestoreAppMultiplePhysicalTenantsTest {
+
+  @Test
+  void shouldRejectRestoreWhenMultiplePhysicalTenantsAreConfigured() {
+    // given
+    final PhysicalTenantIds physicalTenantIds = () -> Set.of("default", "tenantA");
+
+    // when / then
+    assertThatThrownBy(() -> newRestoreApp(physicalTenantIds))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not supported by RestoreApp")
+        .hasMessageContaining("/cluster/v2/restore");
+  }
+
+  private RestoreApp newRestoreApp(final PhysicalTenantIds physicalTenantIds) {
+    return new RestoreApp(
+        new Camunda(),
+        new BrokerBasedProperties(),
+        Mockito.mock(BackupStore.class),
+        null,
+        new RestoreProperties(false, List.of()),
+        new SimpleMeterRegistry(),
+        NodeIdProvider.staticProvider(1),
+        Mockito.mock(DataDirectoryProvider.class),
+        context -> {},
+        (restoreId, nodeId) -> new RestoreApp.PreRestoreActionResult(false, ""),
+        physicalTenantIds);
+  }
+}


### PR DESCRIPTION
## Problem
- `RestoreApp`/`RestoreManager` hardcode the default physical tenant when performing a standalone restore, with no guard against multi-tenant clusters.
- On a multi-physical-tenant cluster, standalone restore would restore only the default tenant's data. `PhysicalTenantProvisioningInitializer` then re-provisions the other tenants as empty partition groups on boot, so the cluster reports a complete, healthy topology while the other tenants' data is silently gone.

## Fix
- We do not support restoring multi-physical-tenant clusters via the standalone restore app, so `RestoreApp` now rejects the restore outright (before acquiring a node id or setting up the data directory) when more than one physical tenant is configured, and points operators at the v2 Cluster Configuration Management API instead.
- Restoring a single-tenant cluster using the default physical tenant is unaffected.

related to #57007 