### PR TITLE
fix: keep exporting paused across partition role transitions

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -33,24 +33,6 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
   }
 
   @Override
-  public ActorFuture<Void> pauseExporting() {
-    logCall();
-    return CompletableActorFuture.completed(null);
-  }
-
-  @Override
-  public ActorFuture<Void> softPauseExporting() {
-    logCall();
-    return CompletableActorFuture.completed(null);
-  }
-
-  @Override
-  public ActorFuture<Void> resumeExporting() {
-    logCall();
-    return CompletableActorFuture.completed(null);
-  }
-
-  @Override
   public ActorFuture<Void> pauseProcessing() {
     logCall();
     return CompletableActorFuture.completed(null);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -8,35 +8,15 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
-import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControlLimits;
 import io.camunda.zeebe.protocol.impl.encoding.PartitionMigrationStatus;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Optional;
 
 public interface PartitionAdminAccess {
   Optional<PartitionAdminAccess> forPartition(int partitionId);
 
   ActorFuture<Void> takeSnapshot();
-
-  default ActorFuture<Void> setExportingState(final ExportingState exportingState) {
-    return switch (exportingState) {
-      case PAUSED -> pauseExporting();
-      case EXPORTING -> resumeExporting();
-      case SOFT_PAUSED -> softPauseExporting();
-      case UNKNOWN ->
-          CompletableActorFuture.completedExceptionally(
-              new IllegalArgumentException(
-                  "Expected exporting state to be a valid value, but was " + exportingState));
-    };
-  }
-
-  ActorFuture<Void> pauseExporting();
-
-  ActorFuture<Void> softPauseExporting();
-
-  ActorFuture<Void> resumeExporting();
 
   ActorFuture<Void> pauseProcessing();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -595,7 +595,7 @@ public final class PartitionManagerImpl
                   .formatted(partitionId)));
     }
     LOGGER.trace("Setting exporting state {} on partition {}", exportingState, partitionId);
-    return partition.zeebePartition().getAdminAccess().setExportingState(exportingState);
+    return partition.zeebePartition().setExportingState(exportingState);
   }
 
   private void disableExporter(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
@@ -19,8 +18,6 @@ public interface PartitionAdminControl {
   ZeebeDb getZeebeDb();
 
   LogStream getLogStream();
-
-  ExporterDirector getExporterDirector();
 
   void triggerSnapshot();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -19,7 +18,6 @@ import java.util.function.Supplier;
 public class PartitionAdminControlImpl implements PartitionAdminControl {
 
   private final Supplier<StreamProcessor> streamProcessorSupplier;
-  private final Supplier<ExporterDirector> exporterDirectorSupplier;
   private final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier;
   private final Supplier<PartitionProcessingState> partitionProcessingStateSupplier;
   private final Supplier<ZeebeDb> zeebeDbSupplier;
@@ -28,14 +26,12 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
 
   public PartitionAdminControlImpl(
       final Supplier<StreamProcessor> streamProcessorSupplier,
-      final Supplier<ExporterDirector> exporterDirectorSupplier,
       final Supplier<AsyncSnapshotDirector> snapshotDirectorSupplier,
       final Supplier<PartitionProcessingState> partitionProcessingStateSupplier,
       final Supplier<ZeebeDb> zeebeDbSupplier,
       final Supplier<LogStream> logStreamSupplier,
       final Supplier<Boolean> migrationSnapshotTakenSupplier) {
     this.streamProcessorSupplier = streamProcessorSupplier;
-    this.exporterDirectorSupplier = exporterDirectorSupplier;
     this.snapshotDirectorSupplier = snapshotDirectorSupplier;
     this.partitionProcessingStateSupplier = partitionProcessingStateSupplier;
     this.zeebeDbSupplier = zeebeDbSupplier;
@@ -56,11 +52,6 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   @Override
   public LogStream getLogStream() {
     return logStreamSupplier.get();
-  }
-
-  @Override
-  public ExporterDirector getExporterDirector() {
-    return exporterDirectorSupplier.get();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -179,7 +179,6 @@ public class PartitionStartupAndTransitionContextImpl
   public PartitionAdminControl getPartitionAdminControl() {
     return new PartitionAdminControlImpl(
         () -> getPartitionContext().getStreamProcessor(),
-        () -> getPartitionContext().getExporterDirector(),
         () -> snapshotDirector,
         () -> partitionProcessingState,
         () -> zeebeDb,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
 import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.rebalance.ClusterConfigurationCoordinatorCheck;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
@@ -745,6 +746,13 @@ public final class ZeebePartition extends Actor
             partitionConfigurationManager
                 .enableExporter(exporterId, metadataVersion, initializeFrom)
                 .onComplete(future));
+    return future;
+  }
+
+  public ActorFuture<Void> setExportingState(final ExportingState exportingState) {
+    final var future = new CompletableActorFuture<Void>();
+    actor.run(
+        () -> partitionConfigurationManager.setExportingState(exportingState).onComplete(future));
     return future;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.system.partitions;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -40,7 +39,6 @@ import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Inc
 import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.function.Function;
 import org.slf4j.Logger;
 
 class ZeebePartitionAdminAccess implements PartitionAdminAccess {
@@ -91,43 +89,6 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
           }
         });
 
-    return completed;
-  }
-
-  @Override
-  public ActorFuture<Void> pauseExporting() {
-    return applyToDirector(ExporterDirector::pauseExporting);
-  }
-
-  @Override
-  public ActorFuture<Void> softPauseExporting() {
-    return applyToDirector(ExporterDirector::softPauseExporting);
-  }
-
-  @Override
-  public ActorFuture<Void> resumeExporting() {
-    return applyToDirector(ExporterDirector::resumeExporting);
-  }
-
-  /**
-   * Applies an exporting-state change to the live director, if one is currently open on this
-   * replica. Dynamic cluster configuration is the durable record of the target state; there is
-   * nothing else to persist locally, so a replica with no live director simply has nothing to do
-   * here — it will open with the correct phase once it does start (see {@code
-   * ExporterDirectorPartitionTransitionStep}).
-   */
-  private ActorFuture<Void> applyToDirector(
-      final Function<ExporterDirector, ActorFuture<Void>> operation) {
-    final ActorFuture<Void> completed = concurrencyControl.createFuture();
-    concurrencyControl.run(
-        () -> {
-          final var director = adminControl.getExporterDirector();
-          if (director != null) {
-            operation.apply(director).onComplete(completed);
-          } else {
-            completed.complete(null);
-          }
-        });
     return completed;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExportingPauseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExportingPauseIT.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.exporter;
+
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Covers pausing exporting across a leader change, which the restart-based tests in {@code
+ * ExportingEndpointIT} cannot: a restart re-reads the exporting state during partition bootstrap,
+ * whereas a leader change reuses the already-running partition and only closes and reopens the
+ * exporter director. A pause that only reached the live director, and not the state the director
+ * reopens from, resumes exporting here while the API still reports the cluster as paused.
+ */
+@Timeout(2 * 60) // 2 minutes
+@ZeebeIntegration
+final class ExportingPauseIT {
+  private static final int PARTITIONS_COUNT = 2;
+  private static final int MAX_CREATION_ATTEMPTS = 10 * PARTITIONS_COUNT;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          .withBrokersCount(3)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(3)
+          .withEmbeddedGateway(false)
+          // We have to stop a broker in the test. So use a standalone gateway to avoid potentially
+          // accessing an unavailable broker
+          .withGatewaysCount(1)
+          .build();
+
+  @AutoClose private CamundaClient client;
+  private ExportingActuator actuator;
+
+  @BeforeEach
+  void setup() {
+    client = cluster.newClientBuilder().build();
+    actuator = ExportingActuator.of(cluster.availableGateway());
+
+    final var deploymentKey =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess("processId").startEvent().endEvent().done(),
+                "process.bpmn")
+            .send()
+            .join();
+
+    new ZeebeResourcesHelper(client).waitUntilDeploymentIsDone(deploymentKey.getKey());
+  }
+
+  @Test
+  void exportingStaysPausedAfterLeaderChange() {
+    // given
+    generateEventsOnAllPartitions();
+
+    actuator.pause();
+
+    final var recordsBeforeLeaderChange =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // when
+    shutdownLeaderOfPartition2();
+    generateEventsOnAllPartitions();
+
+    // then
+    final var recordsAfterLeaderChange =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    assertThat(recordsAfterLeaderChange)
+        .describedAs("No new records are exported after pausing exporting and a leader change.")
+        .isEqualTo(recordsBeforeLeaderChange);
+  }
+
+  private void shutdownLeaderOfPartition2() {
+    final TestStandaloneBroker brokerToStop = cluster.leaderForPartition(2);
+    brokerToStop.stop();
+
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                    .doesNotContainBroker(Integer.parseInt(brokerToStop.nodeId().id())));
+
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                    .hasLeaderForEachPartition(PARTITIONS_COUNT));
+  }
+
+  private void generateEventsOnAllPartitions() {
+    // The gateway round-robins requests across partitions, but nothing guarantees that
+    // PARTITIONS_COUNT requests land one per partition. Since the assertion compares record counts
+    // before and after a leader change, a partition that never saw a record would let a resumed
+    // exporter go unnoticed. So keep creating instances, deriving the partition from the returned
+    // key, until every partition has produced at least one record.
+    final Set<Integer> coveredPartitions = new HashSet<>();
+    for (int attempt = 0; attempt < MAX_CREATION_ATTEMPTS; attempt++) {
+      final var processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("processId")
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+      coveredPartitions.add(Protocol.decodePartitionId(processInstanceKey));
+
+      if (coveredPartitions.size() == PARTITIONS_COUNT) {
+        return;
+      }
+    }
+
+    throw new AssertionError(
+        "Expected to create a process instance on each of the %d partitions within %d attempts, but only reached %s"
+            .formatted(PARTITIONS_COUNT, MAX_CREATION_ATTEMPTS, coveredPartitions));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExportingPauseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExportingPauseIT.java
@@ -14,11 +14,11 @@ import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
-import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.restapi.ExportingRestClient;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.Timeout;
 final class ExportingPauseIT {
   private static final int PARTITIONS_COUNT = 2;
   private static final int MAX_CREATION_ATTEMPTS = 10 * PARTITIONS_COUNT;
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
 
   @TestZeebe
   private final TestCluster cluster =
@@ -54,15 +56,24 @@ final class ExportingPauseIT {
           // We have to stop a broker in the test. So use a standalone gateway to avoid potentially
           // accessing an unavailable broker
           .withGatewaysCount(1)
+          .withNodeConfig(
+              node ->
+                  node.withProperty(
+                          "camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+                      .withProperty(
+                          "camunda.security.cluster-admin.basic.users[0].password",
+                          CLUSTER_ADMIN_PASSWORD))
           .build();
 
   @AutoClose private CamundaClient client;
-  private ExportingActuator actuator;
+  private ExportingRestClient exportingClient;
 
   @BeforeEach
   void setup() {
     client = cluster.newClientBuilder().build();
-    actuator = ExportingActuator.of(cluster.availableGateway());
+    exportingClient =
+        ExportingRestClient.of(
+            cluster.availableGateway(), CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD);
 
     final var deploymentKey =
         client
@@ -81,7 +92,7 @@ final class ExportingPauseIT {
     // given
     generateEventsOnAllPartitions();
 
-    actuator.pause();
+    exportingClient.pause();
 
     final var recordsBeforeLeaderChange =
         Awaitility.await()

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ExportingRestClient.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ExportingRestClient.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.restapi;
+
+import feign.Feign;
+import feign.Headers;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.auth.BasicAuthRequestInterceptor;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+
+/**
+ * Wraps the v2 REST API's exporting endpoints: the cluster-wide ones ({@code
+ * /cluster/v2/exporting/*}), served by the cluster-admin security chain and thus requiring its
+ * Basic Auth credentials, and, given a physical tenant id, their per-tenant counterparts ({@code
+ * /physical-tenants/{physicalTenantId}/v2/exporting/*}).
+ */
+public interface ExportingRestClient {
+  static ExportingRestClient of(
+      final TestGateway<?> node, final String clusterAdminUser, final String clusterAdminPassword) {
+    final var endpoint = node.restAddress().resolve("/cluster/v2/exporting").toString();
+    return of(endpoint, new BasicAuthRequestInterceptor(clusterAdminUser, clusterAdminPassword));
+  }
+
+  static ExportingRestClient of(final TestGateway<?> node, final String physicalTenantId) {
+    final var path = "/physical-tenants/%s/v2/exporting".formatted(physicalTenantId);
+    return of(node.restAddress().resolve(path).toString(), request -> {});
+  }
+
+  private static ExportingRestClient of(
+      final String endpoint, final feign.RequestInterceptor requestInterceptor) {
+    final var target = new HardCodedTarget<>(ExportingRestClient.class, endpoint);
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .requestInterceptor(requestInterceptor)
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  /**
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /pause")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void pause();
+
+  /**
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /pause?soft=true")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void softPause();
+
+  /**
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /resume")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void resume();
+}


### PR DESCRIPTION
## Summary

Follow-up to #60737. Pausing exporting did not survive a partition role
change: after a leader change, exporting silently resumed while
`/v2/exporting` and `/cluster/v2/exporting` kept reporting `PAUSED`.
Backup tooling trusting that response could snapshot a cluster that is
actively exporting.

## Root cause

Writer and reader pointed at different stores.

The reader takes the exporting state from the partition's in-memory
config copy, which is seeded once during partition bootstrap:

https://github.com/camunda/camunda/blob/079fd948da153159555d2976ea787140223a5157/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java#L181

The writer routed the change through `PartitionAdminAccess`, which only
touched the live `ExporterDirector`. Any role transition closes and
reopens the director, which then reopens from the stale bootstrap value.
`PartitionConfigurationManager.setExportingState` already updated both
the context and the director, and was already unit-tested, but had no
production caller.

This was latent until #60737 removed the legacy `.exporterPaused` file
and its `UNKNOWN` fallback, which left the stale bootstrap value as the
only source.

## Change

Route the change through `PartitionConfigurationManager` via a new
`ZeebePartition.setExportingState` delegate, mirroring how
`enableExporter`, `disableExporter` and `deleteExporter` are already
wired rather than adding a second mechanism.

The second commit is a pure deletion and can be dropped independently:
it removes `PartitionAdminAccess.setExportingState` and the
`pauseExporting` / `softPauseExporting` / `resumeExporting` primitives,
which are unreachable once the writer moves, plus
`PartitionAdminControl.getExporterDirector`, whose only caller they were.

## Testing

`ExportingPauseIT` drives a leader change rather than a restart. A
restart re-runs partition bootstrap and re-seeds the context from
persisted configuration, which is why the existing restart-based
coverage in `ExportingEndpointIT` passes either way; the equivalent
leader-change test existed only for exporter disable.

Verified the test has teeth: with the context update disabled it fails
with `expected: 59 but was: 263`.

## Alternative considered

Removing the per-partition context copy entirely and reading the
gossiped cluster configuration directly. That deletes the duplicated
state instead of maintaining it, and a synchronous accessor already
exists, but the appliers persist the config only *after*
`PartitionChangeExecutor` completes, so a transition landing in that
window would still read a stale value. Left as a follow-up since it
touches all four exporter operations and their appliers.
