### PR TITLE
revert: log in to Harbor with a robot account

### DIFF
--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,22 +35,22 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-|          Input           |                             Description                             | Required |  Default  |
-|--------------------------|---------------------------------------------------------------------|----------|-----------|
-| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |
-| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)        | false    | `"false"` |
-| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits    | false    | `"false"` |
-| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs) | false    | `"false"` |
-| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)          | false    | `"false"` |
-| java-distribution        | Java distribution to install                                        | false    | `temurin` |
-| java-version             | JDK version to install                                              | false    | `"21"`    |
-| maven-cache-key-modifier | Modifier for the Maven cache key                                    | false    | `shared`  |
-| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)    | false    | `'[]'`    |
-| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)    | false    | `'[]'`    |
-| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)  | false    |           |
-| vault-address            | Vault URL to retrieve secrets from                                  | false    |           |
-| vault-role-id            | Vault AppRole role id                                               | false    |           |
-| vault-secret-id          | Vault AppRole secret id                                             | false    |           |
+|          Input           |                            Description                             | Required |  Default  |
+|--------------------------|--------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)        | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)       | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits   | false    | `"false"` |
+| harbor                   | Log into Harbor with a CI account (disabled for fork PRs)          | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)         | false    | `"false"` |
+| java-distribution        | Java distribution to install                                       | false    | `temurin` |
+| java-version             | JDK version to install                                             | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                   | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)   | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)   | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only) | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                 | false    |           |
+| vault-role-id            | Vault AppRole role id                                              | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                            | false    |           |
 
 ### Outputs
 

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: "false"
   harbor:
     description: |
-      If enabled, logs into Harbor with a Harbor robot account.
+      If enabled, logs into Harbor with a CI account.
       Harbor login is automatically disabled for fork PRs.
     required: false
     default: "false"
@@ -152,23 +152,6 @@ runs:
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
         secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
-  # Kept separate from "Import Secrets" so that jobs which do not ask for Harbor
-  # never depend on this path resolving.
-  - name: Import Harbor Secrets
-    if: >-
-      steps.is-fork.outputs.is-fork != 'true' &&
-      inputs.harbor == 'true'
-    id: harbor-secrets
-    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-    with:
-      url: ${{ inputs.vault-address }}
-      method: approle
-      roleId: ${{ inputs.vault-role-id }}
-      secretId: ${{ inputs.vault-secret-id }}
-      exportEnv: false
-      secrets: |
-        secret/data/products/camunda/ci/harbor username | harbor-username;
-        secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
     uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
     with:
@@ -297,8 +280,8 @@ runs:
       inputs.harbor == 'true'
     uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     env:
-      DOCKER_USERNAME: ${{ steps.harbor-secrets.outputs.harbor-username }}
-      DOCKER_PASSWORD: ${{ steps.harbor-secrets.outputs.harbor-password }}
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.ci-account-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.ci-account-password }}
     with:
       max_attempts: 3
       retry_wait_seconds: 10


### PR DESCRIPTION
The Harbor robot account introduced in #60844 lacks push permission on the team-scoped Harbor projects that stable/8.8's legacy Operate and Tasklist build workflows still push to (team-operate/camunda-operate, team-hto/tasklist). Login succeeds, but every subsequent image push fails with a 401 Unauthorized on the registry, breaking Operate and Tasklist CI on every push to this branch.

main and stable/8.9 are unaffected because they no longer contain the legacy per-team Docker build workflows this branch still runs, so this revert is scoped to stable/8.8 only. Restoring the prior ci-account credentials unblocks CI while the robot account's permissions are widened upstream (camunda/infra-core#13907).

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
