### PR TITLE
Retain historyItemId in pending agent history state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
@@ -27,9 +27,10 @@ public final class AgentHistoryCreatedApplier
     // Store only the identity fields in primary storage (RocksDB). content/toolCalls/metrics/
     // producedAt have already reached secondary storage via the CREATED event itself; nothing reads
     // them back out of primary storage — matching a COMMIT/DISCARD only needs jobKey/jobLease, and
-    // deleting the item needs the same two fields. Storing the trimmed copy also means the
-    // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
-    // stripping needed at those emit sites.
+    // deleting the item needs the same two fields. historyItemId is kept too: dedup matches on it
+    // once an item is pending or committed, so it must survive here as well. Storing the trimmed
+    // copy also means the COMMITTED/DISCARDED events re-emitted from state carry only identity
+    // fields, with no extra stripping needed at those emit sites.
     //
     // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
     // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
@@ -50,6 +51,7 @@ public final class AgentHistoryCreatedApplier
             .setTenantId(value.getTenantId())
             .setJobKey(value.getJobKey())
             .setJobLease(value.getJobLease())
+            .setHistoryItemId(value.getHistoryItemId())
             .setLoopIteration(value.getLoopIteration())
             .setRole(value.getRole());
     agentHistoryState.insert(key, identityRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Pins down that a history item's {@code historyItemId} survives the batch/update path: an item
+ * pushed through {@code AGENT_INSTANCE:UPDATE}'s embedded {@code history[]} and applied by {@code
+ * AgentHistoryBatchBehavior} is read back from state when its lease is committed or superseded, and
+ * the {@code COMMITTED}/{@code DISCARDED} events re-emitted at that point must still carry the
+ * item's original {@code historyItemId}.
+ */
+public class AgentHistoryItemIdPersistenceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCarryHistoryItemIdOnCommittedAndDiscardedEvents() {
+    // given — two activations of the same job, each pushing one history item under its own
+    // lease via the batch/update path. Committing one lease commits its item and discards the
+    // other lease's now-superseded pending item.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+
+    final var committedUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-committed")
+            .withHistory(List.of(historyItem("history-item-committed")))
+            .update();
+    final long committedItemKey =
+        committedUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    final var discardedUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-discarded")
+            .withHistory(List.of(historyItem("history-item-discarded")))
+            .update();
+    final long discardedItemKey =
+        discardedUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // when
+    ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-committed").commit();
+
+    // then
+    assertThat(
+            RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+                .withRecordKey(committedItemKey)
+                .getFirst()
+                .getValue()
+                .getHistoryItemId())
+        .describedAs("the COMMITTED event re-emitted from state must carry the original id")
+        .isEqualTo("history-item-committed");
+    assertThat(
+            RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+                .withRecordKey(discardedItemKey)
+                .getFirst()
+                .getValue()
+                .getHistoryItemId())
+        .describedAs("the DISCARDED event re-emitted from state must carry the original id")
+        .isEqualTo("history-item-discarded");
+  }
+
+  private static AgentHistoryRecord historyItem(final String historyItemId) {
+    return new AgentHistoryRecord()
+        .setHistoryItemId(historyItemId)
+        .setRole(AgentHistoryRole.USER)
+        .setLoopIteration(1)
+        .addContent(
+            new AgentHistoryMessageContent()
+                .setContentType(AgentHistoryContentType.TEXT)
+                .setText("hi"));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -74,6 +74,11 @@ public final class AgentHistoryClient {
     return this;
   }
 
+  public AgentHistoryClient withHistoryItemId(final String historyItemId) {
+    record.setHistoryItemId(historyItemId);
+    return this;
+  }
+
   public AgentHistoryClient withElementInstanceKey(final long elementInstanceKey) {
     record.setElementInstanceKey(elementInstanceKey);
     return this;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
@@ -27,9 +27,10 @@ public final class AgentHistoryCreatedApplier
     // Store only the identity fields in primary storage (RocksDB). content/toolCalls/metrics/
     // producedAt have already reached secondary storage via the CREATED event itself; nothing reads
     // them back out of primary storage — matching a COMMIT/DISCARD only needs jobKey/jobLease, and
-    // deleting the item needs the same two fields. Storing the trimmed copy also means the
-    // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
-    // stripping needed at those emit sites.
+    // deleting the item needs the same two fields. historyItemId is kept too: dedup matches on it
+    // once an item is pending or committed, so it must survive here as well. Storing the trimmed
+    // copy also means the COMMITTED/DISCARDED events re-emitted from state carry only identity
+    // fields, with no extra stripping needed at those emit sites.
     //
     // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
     // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
@@ -50,6 +51,7 @@ public final class AgentHistoryCreatedApplier
             .setTenantId(value.getTenantId())
             .setJobKey(value.getJobKey())
             .setJobLease(value.getJobLease())
+            .setHistoryItemId(value.getHistoryItemId())
             .setLoopIteration(value.getLoopIteration())
             .setRole(value.getRole());
     agentHistoryState.insert(key, identityRecord);


### PR DESCRIPTION
## Description

First of three stacked PRs adding duplicate detection for embedded agent history items (`historyItemId`). This PR is the prerequisite: it keeps the id when a pending history item is stored.

Before this change, the applier that stores pending history items dropped `historyItemId`. So when the same id came back later, there was nothing to compare it against. This PR retains it, so the next two PRs (dedup within one job activation, dedup across jobs) have something to check against.

The applier is edited in place, and its golden file is updated to match, rather than adding a new applier version. Agent history is unreleased, so there's no committed event log with the old shape that a version bump would need to stay compatible with.

No observable API behavior changes here, and no replay-compatibility consequence either.

## Out of scope

Not in scope here: the actual dedup logic (follow-up PRs), and reverting an agent instance's status when a lease's history gets discarded (planned after all three dedup PRs ship).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Part of #58792
