### PR TITLE
fix: remove message subscriptions on suspend, reopen on resume

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MessageSubscriptionMapper.java
@@ -18,6 +18,8 @@ public interface MessageSubscriptionMapper
 
   void insert(MessageSubscriptionDbModel messageSubscription);
 
+  void createIfNotExists(MessageSubscriptionDbModel messageSubscription);
+
   void update(MessageSubscriptionDbModel messageSubscription);
 
   Long count(MessageSubscriptionDbQuery filter);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -31,13 +31,8 @@ public enum ContextType {
   JOB(false),
   JOB_METRICS_BATCH(false),
   MAPPING_RULE(false),
-  // the suspend/resume restore re-emits CREATED (createIfNotExists, an INSERT-typed upsert) on a
-  // row that may already be CORRELATED (an UPDATE). The default INSERT-before-UPDATE sort would run
-  // the restore-CREATED upsert before an earlier-queued CORRELATED update in the same flush,
-  // leaving
-  // the row stale as CORRELATED. Preserve insertion order so the later engine event wins; the
-  // normal
-  // create-before-update order is insertion order too, so it stays correct.
+  // suspend/resume can queue a CORRELATED update then a restore-CREATED upsert for the same row in
+  // one flush; the default sort would run CREATED first and leave the row stale as CORRELATED
   MESSAGE_SUBSCRIPTION(true),
   // draining-deletion issues markDraining and markDeleted as two UPDATEs on the same row, their
   // order must be preserved so the state is updated correctly

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -31,7 +31,14 @@ public enum ContextType {
   JOB(false),
   JOB_METRICS_BATCH(false),
   MAPPING_RULE(false),
-  MESSAGE_SUBSCRIPTION(false),
+  // the suspend/resume restore re-emits CREATED (createIfNotExists, an INSERT-typed upsert) on a
+  // row that may already be CORRELATED (an UPDATE). The default INSERT-before-UPDATE sort would run
+  // the restore-CREATED upsert before an earlier-queued CORRELATED update in the same flush,
+  // leaving
+  // the row stale as CORRELATED. Preserve insertion order so the later engine event wins; the
+  // normal
+  // create-before-update order is insertion order too, so it stays correct.
+  MESSAGE_SUBSCRIPTION(true),
   // draining-deletion issues markDraining and markDeleted as two UPDATEs on the same row, their
   // order must be preserved so the state is updated correctly
   PROCESS_DEFINITION(true),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -46,6 +46,30 @@ public class MessageSubscriptionWriter extends ProcessInstanceDependant implemen
             truncated));
   }
 
+  /**
+   * Idempotent upsert for the CREATED intent. A process message subscription can receive CREATED
+   * more than once — the suspend/resume flow reuses the same key and re-emits CREATED when the
+   * resume manifest is restored and when the subscription is reopened. A plain {@link #create}
+   * would violate the primary key on the second CREATED. This variant inserts the row when absent
+   * and, when a row with the same key already exists, refreshes all columns to the incoming CREATED
+   * projection. The refresh is required, not cosmetic: a reusable non-interrupting subscription may
+   * already be stored as CORRELATED, and the suspend-close ack re-emits CREATED to restore it to
+   * OPENED — a no-op-on-conflict would leave the stale CORRELATED state behind.
+   */
+  public void createIfNotExists(final MessageSubscriptionDbModel messageSubscription) {
+    final var truncated =
+        messageSubscription.truncateToolFields(
+            vendorDatabaseProperties.userCharColumnSize(),
+            vendorDatabaseProperties.charColumnMaxBytes());
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.MESSAGE_SUBSCRIPTION,
+            WriteStatementType.INSERT,
+            truncated.messageSubscriptionKey(),
+            "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.createIfNotExists",
+            truncated));
+  }
+
   public void update(final MessageSubscriptionDbModel messageSubscription) {
     final var truncated =
         messageSubscription.truncateToolFields(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -47,14 +47,11 @@ public class MessageSubscriptionWriter extends ProcessInstanceDependant implemen
   }
 
   /**
-   * Idempotent upsert for the CREATED intent. A process message subscription can receive CREATED
-   * more than once — the suspend/resume flow reuses the same key and re-emits CREATED when the
-   * resume manifest is restored and when the subscription is reopened. A plain {@link #create}
-   * would violate the primary key on the second CREATED. This variant inserts the row when absent
-   * and, when a row with the same key already exists, refreshes all columns to the incoming CREATED
-   * projection. The refresh is required, not cosmetic: a reusable non-interrupting subscription may
-   * already be stored as CORRELATED, and the suspend-close ack re-emits CREATED to restore it to
-   * OPENED — a no-op-on-conflict would leave the stale CORRELATED state behind.
+   * Idempotent upsert for the CREATED intent: the suspend/resume flow re-emits CREATED for the same
+   * key (manifest restore, reopen), and a plain {@link #create} would violate the primary key on
+   * the second call. Refreshes all columns on conflict rather than a no-op — a reusable
+   * non-interrupting subscription can already be CORRELATED when the suspend-close ack re-emits
+   * CREATED to restore OPENED, and a no-op would leave that stale.
    */
   public void createIfNotExists(final MessageSubscriptionDbModel messageSubscription) {
     final var truncated =

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -255,6 +255,424 @@
     )
   </insert>
 
+  <!--
+    Upsert used for the CREATED intent. A process message subscription row can receive CREATED more
+    than once: the suspend/resume flow re-emits CREATED when the delete ack for the suspend-driven
+    close arrives (manifest restore) and again when the CREATE acknowledgement for a buffered REOPEN
+    completes re-subscription during resume. A plain INSERT would then violate the primary key. On
+    conflict, all columns are updated so that a prior stale state (e.g. CORRELATED for a
+    non-interrupting subscription that was correlated before suspension) is correctly reset to
+    CREATED.
+  -->
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel"
+    databaseId="postgresql">
+    INSERT INTO ${prefix}MESSAGE_SUBSCRIPTION (
+                                               MESSAGE_SUBSCRIPTION_KEY,
+                                               PROCESS_DEFINITION_ID,
+                                               PROCESS_DEFINITION_KEY,
+                                               PROCESS_INSTANCE_KEY,
+                                               ROOT_PROCESS_INSTANCE_KEY,
+                                               FLOW_NODE_ID,
+                                               FLOW_NODE_INSTANCE_KEY,
+                                               MESSAGE_SUBSCRIPTION_STATE,
+                                               MESSAGE_SUBSCRIPTION_TYPE,
+                                               DATE_TIME,
+                                               MESSAGE_NAME,
+                                               CORRELATION_KEY,
+                                               TENANT_ID,
+                                               PARTITION_ID,
+                                               PROCESS_DEFINITION_NAME,
+                                               PROCESS_DEFINITION_VERSION,
+                                               TOOL_PROPERTIES,
+                                               TOOL_NAME,
+                                               INBOUND_CONNECTOR_TYPE,
+                                               BUSINESS_ID
+    )
+    VALUES (
+            #{messageSubscriptionKey},
+            #{processDefinitionId},
+            #{processDefinitionKey},
+            #{processInstanceKey},
+            #{rootProcessInstanceKey},
+            #{flowNodeId},
+            #{flowNodeInstanceKey},
+            #{messageSubscriptionState},
+            #{messageSubscriptionType},
+            #{dateTime, jdbcType=TIMESTAMP},
+            #{messageName},
+            #{correlationKey},
+            #{tenantId},
+            #{partitionId},
+            #{processDefinitionName},
+            #{processDefinitionVersion},
+            #{serializedToolProperties},
+            #{toolName},
+            #{inboundConnectorType},
+            #{businessId}
+    )
+    ON CONFLICT (MESSAGE_SUBSCRIPTION_KEY) DO UPDATE SET
+      PROCESS_DEFINITION_ID      = EXCLUDED.PROCESS_DEFINITION_ID,
+      PROCESS_DEFINITION_KEY     = EXCLUDED.PROCESS_DEFINITION_KEY,
+      PROCESS_INSTANCE_KEY       = EXCLUDED.PROCESS_INSTANCE_KEY,
+      ROOT_PROCESS_INSTANCE_KEY  = EXCLUDED.ROOT_PROCESS_INSTANCE_KEY,
+      FLOW_NODE_ID               = EXCLUDED.FLOW_NODE_ID,
+      FLOW_NODE_INSTANCE_KEY     = EXCLUDED.FLOW_NODE_INSTANCE_KEY,
+      MESSAGE_SUBSCRIPTION_STATE = EXCLUDED.MESSAGE_SUBSCRIPTION_STATE,
+      MESSAGE_SUBSCRIPTION_TYPE  = EXCLUDED.MESSAGE_SUBSCRIPTION_TYPE,
+      DATE_TIME                  = EXCLUDED.DATE_TIME,
+      MESSAGE_NAME               = EXCLUDED.MESSAGE_NAME,
+      CORRELATION_KEY            = EXCLUDED.CORRELATION_KEY,
+      TENANT_ID                  = EXCLUDED.TENANT_ID,
+      PARTITION_ID               = EXCLUDED.PARTITION_ID,
+      PROCESS_DEFINITION_NAME    = EXCLUDED.PROCESS_DEFINITION_NAME,
+      PROCESS_DEFINITION_VERSION = EXCLUDED.PROCESS_DEFINITION_VERSION,
+      TOOL_PROPERTIES            = EXCLUDED.TOOL_PROPERTIES,
+      TOOL_NAME                  = EXCLUDED.TOOL_NAME,
+      INBOUND_CONNECTOR_TYPE     = EXCLUDED.INBOUND_CONNECTOR_TYPE,
+      BUSINESS_ID                = EXCLUDED.BUSINESS_ID
+  </insert>
+
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel" databaseId="mariadb">
+    INSERT INTO ${prefix}MESSAGE_SUBSCRIPTION (
+                                               MESSAGE_SUBSCRIPTION_KEY,
+                                               PROCESS_DEFINITION_ID,
+                                               PROCESS_DEFINITION_KEY,
+                                               PROCESS_INSTANCE_KEY,
+                                               ROOT_PROCESS_INSTANCE_KEY,
+                                               FLOW_NODE_ID,
+                                               FLOW_NODE_INSTANCE_KEY,
+                                               MESSAGE_SUBSCRIPTION_STATE,
+                                               MESSAGE_SUBSCRIPTION_TYPE,
+                                               DATE_TIME,
+                                               MESSAGE_NAME,
+                                               CORRELATION_KEY,
+                                               TENANT_ID,
+                                               PARTITION_ID,
+                                               PROCESS_DEFINITION_NAME,
+                                               PROCESS_DEFINITION_VERSION,
+                                               TOOL_PROPERTIES,
+                                               TOOL_NAME,
+                                               INBOUND_CONNECTOR_TYPE,
+                                               BUSINESS_ID
+    )
+    VALUES (
+            #{messageSubscriptionKey},
+            #{processDefinitionId},
+            #{processDefinitionKey},
+            #{processInstanceKey},
+            #{rootProcessInstanceKey},
+            #{flowNodeId},
+            #{flowNodeInstanceKey},
+            #{messageSubscriptionState},
+            #{messageSubscriptionType},
+            #{dateTime, jdbcType=TIMESTAMP},
+            #{messageName},
+            #{correlationKey},
+            #{tenantId},
+            #{partitionId},
+            #{processDefinitionName},
+            #{processDefinitionVersion},
+            #{serializedToolProperties},
+            #{toolName},
+            #{inboundConnectorType},
+            #{businessId}
+    )
+    ON DUPLICATE KEY UPDATE
+      PROCESS_DEFINITION_ID      = VALUES(PROCESS_DEFINITION_ID),
+      PROCESS_DEFINITION_KEY     = VALUES(PROCESS_DEFINITION_KEY),
+      PROCESS_INSTANCE_KEY       = VALUES(PROCESS_INSTANCE_KEY),
+      ROOT_PROCESS_INSTANCE_KEY  = VALUES(ROOT_PROCESS_INSTANCE_KEY),
+      FLOW_NODE_ID               = VALUES(FLOW_NODE_ID),
+      FLOW_NODE_INSTANCE_KEY     = VALUES(FLOW_NODE_INSTANCE_KEY),
+      MESSAGE_SUBSCRIPTION_STATE = VALUES(MESSAGE_SUBSCRIPTION_STATE),
+      MESSAGE_SUBSCRIPTION_TYPE  = VALUES(MESSAGE_SUBSCRIPTION_TYPE),
+      DATE_TIME                  = VALUES(DATE_TIME),
+      MESSAGE_NAME               = VALUES(MESSAGE_NAME),
+      CORRELATION_KEY            = VALUES(CORRELATION_KEY),
+      TENANT_ID                  = VALUES(TENANT_ID),
+      PARTITION_ID               = VALUES(PARTITION_ID),
+      PROCESS_DEFINITION_NAME    = VALUES(PROCESS_DEFINITION_NAME),
+      PROCESS_DEFINITION_VERSION = VALUES(PROCESS_DEFINITION_VERSION),
+      TOOL_PROPERTIES            = VALUES(TOOL_PROPERTIES),
+      TOOL_NAME                  = VALUES(TOOL_NAME),
+      INBOUND_CONNECTOR_TYPE     = VALUES(INBOUND_CONNECTOR_TYPE),
+      BUSINESS_ID                = VALUES(BUSINESS_ID)
+  </insert>
+
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel" databaseId="mysql">
+    INSERT INTO ${prefix}MESSAGE_SUBSCRIPTION (
+                                               MESSAGE_SUBSCRIPTION_KEY,
+                                               PROCESS_DEFINITION_ID,
+                                               PROCESS_DEFINITION_KEY,
+                                               PROCESS_INSTANCE_KEY,
+                                               ROOT_PROCESS_INSTANCE_KEY,
+                                               FLOW_NODE_ID,
+                                               FLOW_NODE_INSTANCE_KEY,
+                                               MESSAGE_SUBSCRIPTION_STATE,
+                                               MESSAGE_SUBSCRIPTION_TYPE,
+                                               DATE_TIME,
+                                               MESSAGE_NAME,
+                                               CORRELATION_KEY,
+                                               TENANT_ID,
+                                               PARTITION_ID,
+                                               PROCESS_DEFINITION_NAME,
+                                               PROCESS_DEFINITION_VERSION,
+                                               TOOL_PROPERTIES,
+                                               TOOL_NAME,
+                                               INBOUND_CONNECTOR_TYPE,
+                                               BUSINESS_ID
+    )
+    VALUES (
+            #{messageSubscriptionKey},
+            #{processDefinitionId},
+            #{processDefinitionKey},
+            #{processInstanceKey},
+            #{rootProcessInstanceKey},
+            #{flowNodeId},
+            #{flowNodeInstanceKey},
+            #{messageSubscriptionState},
+            #{messageSubscriptionType},
+            #{dateTime, jdbcType=TIMESTAMP},
+            #{messageName},
+            #{correlationKey},
+            #{tenantId},
+            #{partitionId},
+            #{processDefinitionName},
+            #{processDefinitionVersion},
+            #{serializedToolProperties},
+            #{toolName},
+            #{inboundConnectorType},
+            #{businessId}
+    )
+    ON DUPLICATE KEY UPDATE
+      PROCESS_DEFINITION_ID      = VALUES(PROCESS_DEFINITION_ID),
+      PROCESS_DEFINITION_KEY     = VALUES(PROCESS_DEFINITION_KEY),
+      PROCESS_INSTANCE_KEY       = VALUES(PROCESS_INSTANCE_KEY),
+      ROOT_PROCESS_INSTANCE_KEY  = VALUES(ROOT_PROCESS_INSTANCE_KEY),
+      FLOW_NODE_ID               = VALUES(FLOW_NODE_ID),
+      FLOW_NODE_INSTANCE_KEY     = VALUES(FLOW_NODE_INSTANCE_KEY),
+      MESSAGE_SUBSCRIPTION_STATE = VALUES(MESSAGE_SUBSCRIPTION_STATE),
+      MESSAGE_SUBSCRIPTION_TYPE  = VALUES(MESSAGE_SUBSCRIPTION_TYPE),
+      DATE_TIME                  = VALUES(DATE_TIME),
+      MESSAGE_NAME               = VALUES(MESSAGE_NAME),
+      CORRELATION_KEY            = VALUES(CORRELATION_KEY),
+      TENANT_ID                  = VALUES(TENANT_ID),
+      PARTITION_ID               = VALUES(PARTITION_ID),
+      PROCESS_DEFINITION_NAME    = VALUES(PROCESS_DEFINITION_NAME),
+      PROCESS_DEFINITION_VERSION = VALUES(PROCESS_DEFINITION_VERSION),
+      TOOL_PROPERTIES            = VALUES(TOOL_PROPERTIES),
+      TOOL_NAME                  = VALUES(TOOL_NAME),
+      INBOUND_CONNECTOR_TYPE     = VALUES(INBOUND_CONNECTOR_TYPE),
+      BUSINESS_ID                = VALUES(BUSINESS_ID)
+  </insert>
+
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel" databaseId="h2">
+    MERGE INTO ${prefix}MESSAGE_SUBSCRIPTION ms
+      USING dual
+      ON (ms.MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey})
+    WHEN NOT MATCHED THEN
+    INSERT (MESSAGE_SUBSCRIPTION_KEY,
+            PROCESS_DEFINITION_ID,
+            PROCESS_DEFINITION_KEY,
+            PROCESS_INSTANCE_KEY,
+            ROOT_PROCESS_INSTANCE_KEY,
+            FLOW_NODE_ID,
+            FLOW_NODE_INSTANCE_KEY,
+            MESSAGE_SUBSCRIPTION_STATE,
+            MESSAGE_SUBSCRIPTION_TYPE,
+            DATE_TIME,
+            MESSAGE_NAME,
+            CORRELATION_KEY,
+            TENANT_ID,
+            PARTITION_ID,
+            PROCESS_DEFINITION_NAME,
+            PROCESS_DEFINITION_VERSION,
+            TOOL_PROPERTIES,
+            TOOL_NAME,
+            INBOUND_CONNECTOR_TYPE,
+            BUSINESS_ID)
+    VALUES (#{messageSubscriptionKey},
+            #{processDefinitionId},
+            #{processDefinitionKey},
+            #{processInstanceKey},
+            #{rootProcessInstanceKey},
+            #{flowNodeId},
+            #{flowNodeInstanceKey},
+            #{messageSubscriptionState},
+            #{messageSubscriptionType},
+            #{dateTime, jdbcType=TIMESTAMP},
+            #{messageName},
+            #{correlationKey},
+            #{tenantId},
+            #{partitionId},
+            #{processDefinitionName},
+            #{processDefinitionVersion},
+            #{serializedToolProperties},
+            #{toolName},
+            #{inboundConnectorType},
+            #{businessId})
+    WHEN MATCHED THEN UPDATE SET
+      ms.PROCESS_DEFINITION_ID      = #{processDefinitionId},
+      ms.PROCESS_DEFINITION_KEY     = #{processDefinitionKey},
+      ms.PROCESS_INSTANCE_KEY       = #{processInstanceKey},
+      ms.ROOT_PROCESS_INSTANCE_KEY  = #{rootProcessInstanceKey},
+      ms.FLOW_NODE_ID               = #{flowNodeId},
+      ms.FLOW_NODE_INSTANCE_KEY     = #{flowNodeInstanceKey},
+      ms.MESSAGE_SUBSCRIPTION_STATE = #{messageSubscriptionState},
+      ms.MESSAGE_SUBSCRIPTION_TYPE  = #{messageSubscriptionType},
+      ms.DATE_TIME                  = #{dateTime, jdbcType=TIMESTAMP},
+      ms.MESSAGE_NAME               = #{messageName},
+      ms.CORRELATION_KEY            = #{correlationKey},
+      ms.TENANT_ID                  = #{tenantId},
+      ms.PARTITION_ID               = #{partitionId},
+      ms.PROCESS_DEFINITION_NAME    = #{processDefinitionName},
+      ms.PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
+      ms.TOOL_PROPERTIES            = #{serializedToolProperties},
+      ms.TOOL_NAME                  = #{toolName},
+      ms.INBOUND_CONNECTOR_TYPE     = #{inboundConnectorType},
+      ms.BUSINESS_ID                = #{businessId}
+  </insert>
+
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel" databaseId="oracle">
+    MERGE INTO ${prefix}MESSAGE_SUBSCRIPTION ms
+      USING dual
+      ON (ms.MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey})
+    WHEN NOT MATCHED THEN
+    INSERT (MESSAGE_SUBSCRIPTION_KEY,
+            PROCESS_DEFINITION_ID,
+            PROCESS_DEFINITION_KEY,
+            PROCESS_INSTANCE_KEY,
+            ROOT_PROCESS_INSTANCE_KEY,
+            FLOW_NODE_ID,
+            FLOW_NODE_INSTANCE_KEY,
+            MESSAGE_SUBSCRIPTION_STATE,
+            MESSAGE_SUBSCRIPTION_TYPE,
+            DATE_TIME,
+            MESSAGE_NAME,
+            CORRELATION_KEY,
+            TENANT_ID,
+            PARTITION_ID,
+            PROCESS_DEFINITION_NAME,
+            PROCESS_DEFINITION_VERSION,
+            TOOL_PROPERTIES,
+            TOOL_NAME,
+            INBOUND_CONNECTOR_TYPE,
+            BUSINESS_ID)
+    VALUES (#{messageSubscriptionKey},
+            #{processDefinitionId},
+            #{processDefinitionKey},
+            #{processInstanceKey},
+            #{rootProcessInstanceKey},
+            #{flowNodeId},
+            #{flowNodeInstanceKey},
+            #{messageSubscriptionState},
+            #{messageSubscriptionType},
+            #{dateTime, jdbcType=TIMESTAMP},
+            #{messageName},
+            #{correlationKey},
+            #{tenantId},
+            #{partitionId},
+            #{processDefinitionName},
+            #{processDefinitionVersion},
+            #{serializedToolProperties},
+            #{toolName},
+            #{inboundConnectorType},
+            #{businessId})
+    WHEN MATCHED THEN UPDATE SET
+      ms.PROCESS_DEFINITION_ID      = #{processDefinitionId},
+      ms.PROCESS_DEFINITION_KEY     = #{processDefinitionKey},
+      ms.PROCESS_INSTANCE_KEY       = #{processInstanceKey},
+      ms.ROOT_PROCESS_INSTANCE_KEY  = #{rootProcessInstanceKey},
+      ms.FLOW_NODE_ID               = #{flowNodeId},
+      ms.FLOW_NODE_INSTANCE_KEY     = #{flowNodeInstanceKey},
+      ms.MESSAGE_SUBSCRIPTION_STATE = #{messageSubscriptionState},
+      ms.MESSAGE_SUBSCRIPTION_TYPE  = #{messageSubscriptionType},
+      ms.DATE_TIME                  = #{dateTime, jdbcType=TIMESTAMP},
+      ms.MESSAGE_NAME               = #{messageName},
+      ms.CORRELATION_KEY            = #{correlationKey},
+      ms.TENANT_ID                  = #{tenantId},
+      ms.PARTITION_ID               = #{partitionId},
+      ms.PROCESS_DEFINITION_NAME    = #{processDefinitionName},
+      ms.PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
+      ms.TOOL_PROPERTIES            = #{serializedToolProperties},
+      ms.TOOL_NAME                  = #{toolName},
+      ms.INBOUND_CONNECTOR_TYPE     = #{inboundConnectorType},
+      ms.BUSINESS_ID                = #{businessId}
+  </insert>
+
+  <insert id="createIfNotExists"
+    parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel" databaseId="mssql">
+    MERGE INTO ${prefix}MESSAGE_SUBSCRIPTION AS target
+    USING (SELECT 1 AS dummy) AS src
+      ON (target.MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey})
+    WHEN NOT MATCHED THEN
+      INSERT (MESSAGE_SUBSCRIPTION_KEY,
+              PROCESS_DEFINITION_ID,
+              PROCESS_DEFINITION_KEY,
+              PROCESS_INSTANCE_KEY,
+              ROOT_PROCESS_INSTANCE_KEY,
+              FLOW_NODE_ID,
+              FLOW_NODE_INSTANCE_KEY,
+              MESSAGE_SUBSCRIPTION_STATE,
+              MESSAGE_SUBSCRIPTION_TYPE,
+              DATE_TIME,
+              MESSAGE_NAME,
+              CORRELATION_KEY,
+              TENANT_ID,
+              PARTITION_ID,
+              PROCESS_DEFINITION_NAME,
+              PROCESS_DEFINITION_VERSION,
+              TOOL_PROPERTIES,
+              TOOL_NAME,
+              INBOUND_CONNECTOR_TYPE,
+              BUSINESS_ID)
+      VALUES (#{messageSubscriptionKey},
+              #{processDefinitionId},
+              #{processDefinitionKey},
+              #{processInstanceKey},
+              #{rootProcessInstanceKey},
+              #{flowNodeId},
+              #{flowNodeInstanceKey},
+              #{messageSubscriptionState},
+              #{messageSubscriptionType},
+              #{dateTime, jdbcType=TIMESTAMP},
+              #{messageName},
+              #{correlationKey},
+              #{tenantId},
+              #{partitionId},
+              #{processDefinitionName},
+              #{processDefinitionVersion},
+              #{serializedToolProperties},
+              #{toolName},
+              #{inboundConnectorType},
+              #{businessId})
+    WHEN MATCHED THEN UPDATE SET
+      target.PROCESS_DEFINITION_ID      = #{processDefinitionId},
+      target.PROCESS_DEFINITION_KEY     = #{processDefinitionKey},
+      target.PROCESS_INSTANCE_KEY       = #{processInstanceKey},
+      target.ROOT_PROCESS_INSTANCE_KEY  = #{rootProcessInstanceKey},
+      target.FLOW_NODE_ID               = #{flowNodeId},
+      target.FLOW_NODE_INSTANCE_KEY     = #{flowNodeInstanceKey},
+      target.MESSAGE_SUBSCRIPTION_STATE = #{messageSubscriptionState},
+      target.MESSAGE_SUBSCRIPTION_TYPE  = #{messageSubscriptionType},
+      target.DATE_TIME                  = #{dateTime, jdbcType=TIMESTAMP},
+      target.MESSAGE_NAME               = #{messageName},
+      target.CORRELATION_KEY            = #{correlationKey},
+      target.TENANT_ID                  = #{tenantId},
+      target.PARTITION_ID               = #{partitionId},
+      target.PROCESS_DEFINITION_NAME    = #{processDefinitionName},
+      target.PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
+      target.TOOL_PROPERTIES            = #{serializedToolProperties},
+      target.TOOL_NAME                  = #{toolName},
+      target.INBOUND_CONNECTOR_TYPE     = #{inboundConnectorType},
+      target.BUSINESS_ID                = #{businessId};
+  </insert>
+
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
     UPDATE ${prefix}MESSAGE_SUBSCRIPTION
     SET PROCESS_DEFINITION_ID = #{processDefinitionId},

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -549,6 +549,36 @@ class DefaultExecutionQueueTest {
     verify(session).update(eq("statement3"), any());
   }
 
+  @Test
+  public void shouldPreserveInsertionOrderForMessageSubscriptions() {
+    // given - a CORRELATED update queued before the suspend-restore CREATED upsert (INSERT-typed)
+    // for the same row, mirroring a reusable subscription that correlated and is then restored on
+    // suspend within one flush
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.MESSAGE_SUBSCRIPTION,
+            WriteStatementType.UPDATE,
+            1L,
+            "ms.update",
+            "correlated"));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.MESSAGE_SUBSCRIPTION,
+            WriteStatementType.INSERT,
+            1L,
+            "ms.createIfNotExists",
+            "created"));
+
+    // when
+    executionQueue.flush();
+
+    // then - insertion order is preserved, so the later CREATED restore wins. Under the default
+    // INSERT-before-UPDATE sort the upsert would run first and leave the row stale as CORRELATED.
+    final var inOrder = Mockito.inOrder(session);
+    inOrder.verify(session).update(eq("ms.update"), any());
+    inOrder.verify(session).update(eq("ms.createIfNotExists"), any());
+  }
+
   @ParameterizedTest
   @CsvSource({
     // statementId, expectedResult

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/messagesubscription/MessageSubscriptionIT.java
@@ -18,6 +18,7 @@ import io.camunda.it.rdbms.db.fixtures.MessageSubscriptionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.ProcessDefinitionMessageSubscriptionStatisticsEntity;
 import io.camunda.search.filter.MessageSubscriptionFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -79,6 +80,105 @@ public class MessageSubscriptionIT {
         messageSubscriptionReader.findOne(subscription.messageSubscriptionKey()).orElse(null);
 
     compareMessageSubscriptions(instance, roleUpdate);
+  }
+
+  @TestTemplate
+  public void shouldNotFailWhenCreatedTwice(final CamundaRdbmsTestApplication testApplication) {
+    // given a subscription that has already been exported
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final MessageSubscriptionDbReader messageSubscriptionReader =
+        rdbmsService.getMessageSubscriptionReader();
+
+    final var subscription = MessageSubscriptionFixtures.createRandomized(b -> b);
+    MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, subscription);
+
+    // when a CREATED event is exported again for the same key — as the suspend/resume flow does
+    // when restoring the resume manifest and reopening the subscription
+    rdbmsWriters.getMessageSubscriptionWriter().createIfNotExists(subscription);
+    rdbmsWriters.flush();
+
+    // then the row still exists exactly once (no primary-key violation, no duplicate)
+    final var instance =
+        messageSubscriptionReader.findOne(subscription.messageSubscriptionKey()).orElse(null);
+    compareMessageSubscriptions(instance, subscription);
+  }
+
+  @TestTemplate
+  public void shouldRefreshExistingRowOnCreateIfNotExists(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given a subscription already stored in a stale CORRELATED state with stale field values —
+    // this is the state a reusable non-interrupting subscription is left in after a correlation
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final MessageSubscriptionDbReader messageSubscriptionReader =
+        rdbmsService.getMessageSubscriptionReader();
+
+    final var stale =
+        MessageSubscriptionFixtures.createRandomized(
+            b -> b.messageSubscriptionState(MessageSubscriptionState.CORRELATED));
+    MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, stale);
+
+    // when the suspend-close ack re-emits CREATED for the same key with the refreshed projection
+    // (same key/root, but transitioned back to CREATED with new correlation data)
+    final var refreshed =
+        MessageSubscriptionFixtures.createRandomized(
+            b ->
+                b.messageSubscriptionKey(stale.messageSubscriptionKey())
+                    .rootProcessInstanceKey(stale.rootProcessInstanceKey())
+                    .messageSubscriptionState(MessageSubscriptionState.CREATED));
+    rdbmsWriters.getMessageSubscriptionWriter().createIfNotExists(refreshed);
+    rdbmsWriters.flush();
+
+    // then the existing row is upserted to the new projection — state reset CORRELATED → CREATED
+    // and
+    // all other columns refreshed. This fails under a DO-NOTHING-on-conflict implementation, which
+    // would leave the stale CORRELATED row untouched.
+    final var instance =
+        messageSubscriptionReader.findOne(stale.messageSubscriptionKey()).orElse(null);
+    compareMessageSubscriptions(instance, refreshed);
+  }
+
+  @TestTemplate
+  public void shouldPreserveOrderWhenCorrelatedThenCreatedInSameFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given a subscription already stored as CREATED
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final MessageSubscriptionDbReader messageSubscriptionReader =
+        rdbmsService.getMessageSubscriptionReader();
+
+    final var created =
+        MessageSubscriptionFixtures.createRandomized(
+            b -> b.messageSubscriptionState(MessageSubscriptionState.CREATED));
+    MessageSubscriptionFixtures.createAndSaveMessageSubscription(rdbmsWriters, created);
+
+    // when a CORRELATED update (a reusable non-interrupting subscription correlates) and the
+    // suspend-close restore CREATED (createIfNotExists, an INSERT-typed upsert) are queued for the
+    // same row in a single flush, with CORRELATED first. The write queue must run them in insertion
+    // order so the later CREATED wins; the INSERT-before-UPDATE sort would otherwise run the
+    // CREATED
+    // upsert first and leave the row stale as CORRELATED.
+    final var correlated =
+        MessageSubscriptionFixtures.createRandomized(
+            b ->
+                b.messageSubscriptionKey(created.messageSubscriptionKey())
+                    .rootProcessInstanceKey(created.rootProcessInstanceKey())
+                    .messageSubscriptionState(MessageSubscriptionState.CORRELATED));
+    final var restored =
+        MessageSubscriptionFixtures.createRandomized(
+            b ->
+                b.messageSubscriptionKey(created.messageSubscriptionKey())
+                    .rootProcessInstanceKey(created.rootProcessInstanceKey())
+                    .messageSubscriptionState(MessageSubscriptionState.CREATED));
+    rdbmsWriters.getMessageSubscriptionWriter().update(correlated);
+    rdbmsWriters.getMessageSubscriptionWriter().createIfNotExists(restored);
+    rdbmsWriters.flush();
+
+    // then the row reflects the last-queued event (CREATED), not the reordered CORRELATED
+    final var instance =
+        messageSubscriptionReader.findOne(created.messageSubscriptionKey()).orElse(null);
+    compareMessageSubscriptions(instance, restored);
   }
 
   @TestTemplate

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -100,7 +100,10 @@ public final class BpmnProcessors {
         asyncRequestBehavior,
         cslCheck,
         timerChecker,
-        bpmnBehaviors.jobActivationBehavior());
+        bpmnBehaviors.jobActivationBehavior(),
+        subscriptionCommandSender,
+        transientProcessMessageSubscriptionState,
+        clock);
     addBufferedCommandProcessor(writers, typedRecordProcessors, processingState);
 
     final var bpmnStreamProcessor =
@@ -177,7 +180,10 @@ public final class BpmnProcessors {
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
       final DueDateTimerCheckScheduler timerChecker,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final SubscriptionCommandSender subscriptionCommandSender,
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final InstantSource clock) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
@@ -202,7 +208,13 @@ public final class BpmnProcessors {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,
-        new ProcessInstanceSuspendProcessor(processingState, writers, cslCheck));
+        new ProcessInstanceSuspendProcessor(
+            processingState,
+            writers,
+            cslCheck,
+            subscriptionCommandSender,
+            transientProcessMessageSubscriptionState,
+            clock));
   }
 
   private static void addBufferedCommandProcessor(
@@ -237,14 +249,25 @@ public final class BpmnProcessors {
       final Writers writers,
       final InstantSource clock,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+    // One CreateProcessor instance handles both CREATE (the create acknowledgement) and REOPEN (a
+    // manifest re-subscribe drained from the suspend/resume buffer); it branches on the intent.
+    final var createProcessor =
+        new ProcessMessageSubscriptionCreateProcessor(
+            processingState.getProcessMessageSubscriptionState(),
+            processingState.getSuspensionState(),
+            subscriptionCommandSender,
+            writers,
+            transientProcessMessageSubscriptionState,
+            clock);
     typedRecordProcessors
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CREATE,
-            new ProcessMessageSubscriptionCreateProcessor(
-                processingState.getProcessMessageSubscriptionState(),
-                writers,
-                transientProcessMessageSubscriptionState))
+            createProcessor)
+        .onCommand(
+            ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+            ProcessMessageSubscriptionIntent.REOPEN,
+            createProcessor)
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CORRELATE,
@@ -259,7 +282,12 @@ public final class BpmnProcessors {
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.DELETE,
             new ProcessMessageSubscriptionDeleteProcessor(
-                subscriptionState, writers, transientProcessMessageSubscriptionState))
+                subscriptionState,
+                processingState.getSuspensionState(),
+                processingState.getElementInstanceState(),
+                writers,
+                transientProcessMessageSubscriptionState,
+                processingState.getKeyGenerator()))
         .withListener(
             new PendingProcessMessageSubscriptionCheckScheduler(
                 subscriptionCommandSender,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -284,7 +284,6 @@ public final class BpmnProcessors {
             new ProcessMessageSubscriptionDeleteProcessor(
                 subscriptionState,
                 processingState.getSuspensionState(),
-                processingState.getElementInstanceState(),
                 writers,
                 transientProcessMessageSubscriptionState,
                 processingState.getKeyGenerator()))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -676,7 +676,9 @@ public final class CatchEventBehavior {
     final long subscriptionKey = subscription.getRecord().getSubscriptionKey();
 
     stateWriter.appendFollowUpEvent(
-        subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
+        subscription.getKey(),
+        ProcessMessageSubscriptionIntent.DELETING,
+        subscription.getRecord().setClosedForSuspend(false));
 
     sendCloseMessageSubscriptionCommand(
         subscriptionPartitionId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -705,7 +705,8 @@ public final class CatchEventBehavior {
         elementInstanceKey,
         processDefinitionKey,
         messageName,
-        tenantId);
+        tenantId,
+        -1L);
   }
 
   private boolean sendOpenMessageSubscription(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -670,6 +670,11 @@ public final class CatchEventBehavior {
     final long processDefinitionKey = subscription.getRecord().getProcessDefinitionKey();
     final String tenantId = subscription.getRecord().getTenantId();
 
+    // Quote the stored key so the message-side stale-delete guard can reject a close a resume has
+    // superseded (-1 means legacy/unacknowledged). Captured before DELETING, whose applier re-reads
+    // the shared record.
+    final long subscriptionKey = subscription.getRecord().getSubscriptionKey();
+
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
 
@@ -679,7 +684,8 @@ public final class CatchEventBehavior {
         elementInstanceKey,
         processDefinitionKey,
         messageName,
-        subscription.getRecord().getTenantId());
+        subscription.getRecord().getTenantId(),
+        subscriptionKey);
     final var lastSentTime = clock.millis();
 
     // update transient state in a side-effect to ensure that these changes only take effect after
@@ -698,7 +704,8 @@ public final class CatchEventBehavior {
       final long elementInstanceKey,
       final long processDefinitionKey,
       final DirectBuffer messageName,
-      final String tenantId) {
+      final String tenantId,
+      final long subscriptionKey) {
     return subscriptionCommandSender.closeMessageSubscription(
         subscriptionPartitionId,
         processInstanceKey,
@@ -706,7 +713,7 @@ public final class CatchEventBehavior {
         processDefinitionKey,
         messageName,
         tenantId,
-        -1L);
+        subscriptionKey);
   }
 
   private boolean sendOpenMessageSubscription(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -312,7 +312,8 @@ public final class MessageCorrelateBehavior {
                 messageData.messageKey(),
                 messageData.variables(),
                 messageData.correlationKey(),
-                messageData.tenantId()));
+                messageData.tenantId(),
+                subscription.subscriptionKey()));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
-import java.util.function.LongPredicate;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
@@ -223,14 +222,6 @@ public final class MessageCorrelateBehavior {
 
   public void correlateToMessageEvents(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
-    // TODO(#58766): defer correlations to suspended instances so live messages can retry on resume.
-    correlateToMessageEvents(messageData, correlatingSubscriptions, processInstanceKey -> false);
-  }
-
-  public void correlateToMessageEvents(
-      final MessageData messageData,
-      final Subscriptions correlatingSubscriptions,
-      final LongPredicate skipProcessInstance) {
 
     messageSubscriptionState.visitSubscriptions(
         messageData.tenantId(),
@@ -246,8 +237,7 @@ public final class MessageCorrelateBehavior {
           }
 
           if (businessIdMatches(
-                  messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())
-              && !skipProcessInstance.test(subscription.getRecord().getProcessInstanceKey())) {
+              messageData.businessId(), subscription.getRecord().getBusinessIdBuffer())) {
 
             final var correlatingSubscription =
                 subscription

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import static io.camunda.zeebe.engine.Engine.ERROR_MESSAGE_SUSPENDED_PI;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
@@ -34,7 +33,6 @@ import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionStat
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
-import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -50,8 +48,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import org.agrona.collections.MutableBoolean;
-import org.agrona.collections.MutableLong;
 
 public final class MessageCorrelationCorrelateProcessor
     implements TypedRecordProcessor<MessageCorrelationRecord>,
@@ -74,7 +70,6 @@ public final class MessageCorrelationCorrelateProcessor
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final MessageCorrelationMetrics metrics;
-  private final SuspensionState suspensionState;
 
   public MessageCorrelationCorrelateProcessor(
       final Writers writers,
@@ -93,8 +88,7 @@ public final class MessageCorrelationCorrelateProcessor
       final boolean businessIdUniquenessEnabled,
       final RoutingInfo routingInfo,
       final int partitionId,
-      final MessageCorrelationMetrics metrics,
-      final SuspensionState suspensionState) {
+      final MessageCorrelationMetrics metrics) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
@@ -102,7 +96,6 @@ public final class MessageCorrelationCorrelateProcessor
     this.cslCheck = cslCheck;
     this.tenantCheck = tenantCheck;
     this.metrics = metrics;
-    this.suspensionState = suspensionState;
     final var eventHandle =
         new EventHandle(
             keyGenerator,
@@ -181,32 +174,6 @@ public final class MessageCorrelationCorrelateProcessor
       return;
     }
 
-    // Suspension enforcement: a suspended process instance must not receive the message, but active
-    // targets still must. Determine whether at least one eligible (start-event or non-suspended)
-    // target exists. If every collected target is suspended, reject before any state write so the
-    // message is preserved for a retry once the instance resumes; the gate cannot evaluate this up
-    // front because the target instances are only known once subscriptions are collected.
-    final var suspendedTargetKey = new MutableLong(-1L);
-    final var hasEligibleTarget = new MutableBoolean(false);
-    tempCorrelatingSubscriptions.visitSubscriptions(
-        subscription -> {
-          if (subscription.isStartEventSubscription()
-              || !suspensionState.isSuspended(subscription.processInstanceKey())) {
-            hasEligibleTarget.set(true);
-          } else {
-            suspendedTargetKey.set(subscription.processInstanceKey());
-          }
-          return true;
-        },
-        true);
-
-    if (!hasEligibleTarget.get() && suspendedTargetKey.get() > 0) {
-      final var message = String.format(ERROR_MESSAGE_SUSPENDED_PI, suspendedTargetKey.get());
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, message);
-      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, message);
-      return;
-    }
-
     // Now that authorization passed, write the message and correlations to state
     final var messageRecord =
         new MessageRecord()
@@ -222,8 +189,7 @@ public final class MessageCorrelationCorrelateProcessor
 
     // Now actually correlate with state writes
     final var blockedProcessIds = new HashSet<String>();
-    correlateBehavior.correlateToMessageEvents(
-        messageData, correlatingSubscriptions, suspensionState::isSuspended);
+    correlateBehavior.correlateToMessageEvents(messageData, correlatingSubscriptions);
     final var delegatedCrossPartition =
         correlateBehavior.correlateToMessageStartEvents(
             messageData, correlatingSubscriptions, blockedProcessIds);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -126,6 +126,7 @@ public final class MessageCorrelator {
         subscriptionRecord.getMessageKey(),
         subscriptionRecord.getVariablesBuffer(),
         subscriptionRecord.getCorrelationKeyBuffer(),
-        subscriptionRecord.getTenantId());
+        subscriptionRecord.getTenantId(),
+        subscriptionRecord.getSubscriptionKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -175,8 +175,7 @@ public final class MessageEventProcessors {
                 businessIdUniquenessEnabled,
                 routingInfo,
                 partitionId,
-                metrics,
-                processingState.getSuspensionState()))
+                metrics))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REQUEST,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -68,7 +68,11 @@ public final class MessageSubscriptionCreateProcessor
     subscriptionRecord = record.getValue();
     if (subscriptionState.existSubscriptionForElementInstance(
         subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer())) {
-      sendAcknowledgeCommand();
+      final var existing =
+          subscriptionState.get(
+              subscriptionRecord.getElementInstanceKey(),
+              subscriptionRecord.getMessageNameBuffer());
+      sendAcknowledgeCommand(existing != null ? existing.getKey() : -1L);
 
       rejectionWriter.appendRejection(
           record,
@@ -86,6 +90,9 @@ public final class MessageSubscriptionCreateProcessor
   private void handleNewSubscription(final SideEffectWriter sideEffectWriter) {
 
     final var subscriptionKey = keyGenerator.nextKey();
+    // Stamp the key on the record so it is stored in state and echoed back in the open-ack,
+    // allowing the PI side to quote it in future delete commands for staleness detection.
+    subscriptionRecord.setSubscriptionKey(subscriptionKey);
     stateWriter.appendFollowUpEvent(
         subscriptionKey, MessageSubscriptionIntent.CREATED, subscriptionRecord);
 
@@ -93,11 +100,11 @@ public final class MessageSubscriptionCreateProcessor
         messageCorrelator.correlateNextMessage(subscriptionKey, subscriptionRecord);
 
     if (!isMessageCorrelated) {
-      sendAcknowledgeCommand();
+      sendAcknowledgeCommand(subscriptionKey);
     }
   }
 
-  private boolean sendAcknowledgeCommand() {
+  private boolean sendAcknowledgeCommand(final long subscriptionKey) {
     return commandSender.openProcessMessageSubscription(
         subscriptionRecord.getProcessInstanceKey(),
         subscriptionRecord.getElementInstanceKey(),
@@ -105,6 +112,7 @@ public final class MessageSubscriptionCreateProcessor
         subscriptionRecord.getMessageNameBuffer(),
         subscriptionRecord.isInterrupting(),
         subscriptionRecord.getTenantId(),
-        subscriptionRecord.getBusinessIdBuffer());
+        subscriptionRecord.getBusinessIdBuffer(),
+        subscriptionKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -28,6 +28,10 @@ public final class MessageSubscriptionDeleteProcessor
   private static final String NO_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to close message subscription for element with key '%d' and message name '%s', "
           + "but no such message subscription exists";
+  private static final String STALE_DELETE_MESSAGE =
+      "Expected to close message subscription for element with key '%d' and message name '%s' "
+          + "with subscription key '%d', but the current subscription has key '%d'; "
+          + "the delete command is stale and is ignored";
 
   private final MessageSubscriptionState subscriptionState;
   private final SubscriptionCommandSender commandSender;
@@ -56,14 +60,21 @@ public final class MessageSubscriptionDeleteProcessor
         subscriptionState.get(
             subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer());
 
-    if (messageSubscription != null) {
-      stateWriter.appendFollowUpEvent(
-          messageSubscription.getKey(),
-          MessageSubscriptionIntent.DELETED,
-          messageSubscription.getRecord());
-
-    } else {
+    if (messageSubscription == null) {
       rejectCommand(record);
+    } else {
+      final long requestedKey = subscriptionRecord.getSubscriptionKey();
+      final long storedKey = messageSubscription.getKey();
+      if (requestedKey != -1L && storedKey != requestedKey) {
+        // The delete quotes a specific subscription key, but the stored subscription has a
+        // different key, meaning a resume already replaced it with a new subscription. Silently
+        // ack so the PI side stops retrying; do NOT delete the live subscription.
+        rejectStaleCommand(record, requestedKey, storedKey);
+        sendAcknowledgeCommand();
+        return;
+      }
+      stateWriter.appendFollowUpEvent(
+          storedKey, MessageSubscriptionIntent.DELETED, messageSubscription.getRecord());
     }
 
     sendAcknowledgeCommand();
@@ -78,6 +89,22 @@ public final class MessageSubscriptionDeleteProcessor
             BufferUtil.bufferAsString(subscription.getMessageNameBuffer()));
 
     rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
+  }
+
+  private void rejectStaleCommand(
+      final TypedRecord<MessageSubscriptionRecord> record,
+      final long requestedKey,
+      final long storedKey) {
+    final var subscription = record.getValue();
+    final var reason =
+        String.format(
+            STALE_DELETE_MESSAGE,
+            subscription.getElementInstanceKey(),
+            BufferUtil.bufferAsString(subscription.getMessageNameBuffer()),
+            requestedKey,
+            storedKey);
+
+    rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
   }
 
   private boolean sendAcknowledgeCommand() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -66,9 +66,8 @@ public final class MessageSubscriptionDeleteProcessor
       final long requestedKey = subscriptionRecord.getSubscriptionKey();
       final long storedKey = messageSubscription.getKey();
       if (requestedKey != -1L && storedKey != requestedKey) {
-        // The delete quotes a specific subscription key, but the stored subscription has a
-        // different key, meaning a resume already replaced it with a new subscription. Silently
-        // ack so the PI side stops retrying; do NOT delete the live subscription.
+        // A resume already replaced this subscription with a new one; ack so the PI side stops
+        // retrying, and do NOT delete the live replacement.
         rejectStaleCommand(record, requestedKey, storedKey);
         sendAcknowledgeCommand();
         return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -31,6 +32,10 @@ public final class MessageSubscriptionRejectProcessor
 
   private static final String SUBSCRIPTION_NOT_FOUND =
       "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found.";
+  private static final String STALE_REJECT_MESSAGE =
+      "Expected to reject message subscription for element with key '%d' and message name '%s' with "
+          + "subscription key '%d', but the current subscription has key '%d'; the reject command is "
+          + "stale and is ignored";
 
   private final MessageState messageState;
   private final MessageSubscriptionState subscriptionState;
@@ -38,6 +43,7 @@ public final class MessageSubscriptionRejectProcessor
   private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
 
   public MessageSubscriptionRejectProcessor(
       final MessageState messageState,
@@ -51,12 +57,34 @@ public final class MessageSubscriptionRejectProcessor
     this.commandSender = commandSender;
     stateWriter = writers.state();
     responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageSubscriptionRecord> record) {
 
     final MessageSubscriptionRecord subscriptionRecord = record.getValue();
+
+    final var stored =
+        subscriptionState.get(
+            subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer());
+    final long requestedKey = subscriptionRecord.getSubscriptionKey();
+    if (stored != null && requestedKey != -1L && stored.getKey() != requestedKey) {
+      // Stale reject: the stored row is a newer generation, so REJECTED (removing by
+      // element/message
+      // name) would delete the live replacement; reject instead. A buffered message is picked up by
+      // the replacement's own correlateNextMessage.
+      final var reason =
+          String.format(
+              STALE_REJECT_MESSAGE,
+              subscriptionRecord.getElementInstanceKey(),
+              subscriptionRecord.getMessageName(),
+              requestedKey,
+              stored.getKey());
+      rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
+      return;
+    }
+
     stateWriter.appendFollowUpEvent(
         record.getKey(), MessageSubscriptionIntent.REJECTED, subscriptionRecord);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -70,10 +70,9 @@ public final class MessageSubscriptionRejectProcessor
             subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer());
     final long requestedKey = subscriptionRecord.getSubscriptionKey();
     if (stored != null && requestedKey != -1L && stored.getKey() != requestedKey) {
-      // Stale reject: the stored row is a newer generation, so REJECTED (removing by
-      // element/message
-      // name) would delete the live replacement; reject instead. A buffered message is picked up by
-      // the replacement's own correlateNextMessage.
+      // Stale reject: the stored row is a newer generation. REJECTED removes by element/message
+      // name, which would delete the live replacement, so reject instead; its own
+      // correlateNextMessage picks up any buffered message.
       final var reason =
           String.format(
               STALE_REJECT_MESSAGE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -118,7 +118,8 @@ public final class MessageSubscriptionRejectProcessor
         subscription.getMessageKey(),
         subscription.getVariablesBuffer(),
         subscription.getCorrelationKeyBuffer(),
-        subscription.getTenantId());
+        subscription.getTenantId(),
+        subscription.getSubscriptionKey());
   }
 
   private void writeNotCorrelatedResponse(final TypedRecord<MessageSubscriptionRecord> record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionCheckScheduler.java
@@ -57,7 +57,8 @@ public final class PendingMessageSubscriptionCheckScheduler
         record.getMessageKey(),
         record.getVariablesBuffer(),
         record.getCorrelationKeyBuffer(),
-        record.getTenantId());
+        record.getTenantId(),
+        record.getSubscriptionKey());
 
     // Update the sent time for the subscription to avoid it being considered for resending too soon
     final var sentTime = clock.millis();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionCheckScheduler.java
@@ -123,6 +123,7 @@ public final class PendingProcessMessageSubscriptionCheckScheduler
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getProcessDefinitionKey(),
         subscription.getRecord().getMessageNameBuffer(),
-        subscription.getRecord().getTenantId());
+        subscription.getRecord().getTenantId(),
+        subscription.getRecord().getSubscriptionKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -115,15 +115,6 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       rejectCommand(command, RejectionType.INVALID_STATE, ALREADY_CLOSING_MESSAGE);
       return;
 
-    } else if (suspensionState.getSuspensionState(record.getProcessInstanceKey())
-        == SuspensionState.State.SUSPENDED) {
-      // Race window: SUSPEND already deleted the message-side subscription, but this CORRELATE
-      // was already in flight. Reject to release the message-side lock — another active
-      // subscriber can then correlate, or the message returns 404. Gated on exact SUSPENDED, not
-      // isSuspended(); see suspensionBehavior() below for why RESUMING must fall through instead.
-      rejectCommand(command, RejectionType.INVALID_STATE, SUSPENDED_PI_MESSAGE);
-      return;
-
     } else if (isStaleGeneration(record, subscription)) {
       // E.g. a K1 correlate delayed across a suspend/resume cycle that re-subscribed with a new
       // key K2 — applying it would trigger the element against a subscription that no longer
@@ -145,6 +136,17 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       // attempt recovering from a previous acknowledgment that didn't make it to the other
       // partition.
       sendAcknowledgeCommand(record);
+      return;
+
+    } else if (suspensionState.getSuspensionState(record.getProcessInstanceKey())
+        == SuspensionState.State.SUSPENDED) {
+      // Race window: SUSPEND already deleted the message-side subscription, but this CORRELATE
+      // was already in flight. Reject to release the message-side lock — another active
+      // subscriber can then correlate, or the message returns 404. Gated on exact SUSPENDED, not
+      // isSuspended(); see suspensionBehavior() below for why RESUMING must fall through instead.
+      // Checked last so a stale or duplicate correlate goes through those paths instead, without
+      // releasing a live replacement's correlation lock.
+      rejectCommand(command, RejectionType.INVALID_STATE, SUSPENDED_PI_MESSAGE);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.PendingSubscription;
@@ -49,6 +50,13 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   private static final String ALREADY_CLOSING_MESSAGE =
       "Expected to correlate process message subscription with element key '%d' and message name '%s', "
           + "but it is already closing";
+  private static final String SUSPENDED_PI_MESSAGE =
+      "Expected to correlate process message subscription with element key '%d' and message name '%s', "
+          + "but the process instance is suspended";
+  private static final String STALE_KEY_MESSAGE =
+      "Expected to correlate process message subscription with element key '%d' and message name '%s', "
+          + "but the command's subscription key '%d' does not match the current key '%d' — it "
+          + "belongs to a superseded subscription generation";
 
   private final ProcessMessageSubscriptionState subscriptionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
@@ -58,6 +66,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final SideEffectWriter sideEffectWriter;
+  private final SuspensionState suspensionState;
 
   private final EventHandle eventHandle;
 
@@ -73,6 +82,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     this.subscriptionCommandSender = subscriptionCommandSender;
     processState = processingState.getProcessState();
     elementInstanceState = processingState.getElementInstanceState();
+    suspensionState = processingState.getSuspensionState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
@@ -103,6 +113,36 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
     } else if (subscription.isClosing()) {
       rejectCommand(command, RejectionType.INVALID_STATE, ALREADY_CLOSING_MESSAGE);
+      return;
+
+    } else if (suspensionState.getSuspensionState(record.getProcessInstanceKey())
+        == SuspensionState.State.SUSPENDED) {
+      // Race window: SUSPEND was processed (message-side subscriptions are being deleted) but
+      // this CORRELATE was already in flight from the message partition. Reject it so the
+      // message-side lock is released and the message can correlate to another active instance,
+      // or return 404 if no other subscriber exists. On resume, reopened subscriptions pick up
+      // any still-valid buffered messages through the normal CREATE→correlateNextMessage path.
+      //
+      // Gated on the exact SUSPENDED state, not isSuspended(): during RESUMING, an early
+      // reopened subscription may correlate a still-buffered message while later REOPEN commands
+      // are still draining, and that correlation must be allowed to proceed normally.
+      rejectCommand(command, RejectionType.INVALID_STATE, SUSPENDED_PI_MESSAGE);
+      return;
+
+    } else if (isStaleGeneration(record, subscription)) {
+      // The command carries the message-side subscription key it was created for. If it no longer
+      // matches the key currently stored on the PI side, this correlate belongs to a superseded
+      // generation — e.g. a K1 correlate delayed across a suspend/resume cycle that re-subscribed
+      // with a new key K2. Applying it would trigger the element against a subscription that no
+      // longer exists on the message side, so reject it rather than mutate state for K2.
+      final var reason =
+          String.format(
+              STALE_KEY_MESSAGE,
+              elementInstanceKey,
+              messageName,
+              record.getSubscriptionKey(),
+              subscription.getRecord().getSubscriptionKey());
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
       return;
 
     } else if (hasAlreadyBeenCorrelated(record, subscription)) {
@@ -156,6 +196,19 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         catchEvent, elementInstanceKey, elementInstance.getValue(), record.getVariablesBuffer());
 
     sendAcknowledgeCommand(record);
+  }
+
+  /**
+   * A correlate is stale when it quotes a message-side subscription key that no longer matches the
+   * key stored on the PI side. Both keys must be set (non-default): unkeyed/legacy subscriptions
+   * default to -1 and are never treated as stale, preserving backwards compatibility.
+   */
+  private boolean isStaleGeneration(
+      final ProcessMessageSubscriptionRecord command,
+      final ProcessMessageSubscription subscription) {
+    final long commandKey = command.getSubscriptionKey();
+    final long storedKey = subscription.getRecord().getSubscriptionKey();
+    return commandKey != -1L && storedKey != -1L && commandKey != storedKey;
   }
 
   private boolean hasAlreadyBeenCorrelated(
@@ -220,12 +273,18 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         subscription.getMessageKey(),
         subscription.getMessageNameBuffer(),
         subscription.getCorrelationKeyBuffer(),
-        subscription.getTenantId());
+        subscription.getTenantId(),
+        subscription.getSubscriptionKey());
   }
 
   @Override
   public SuspensionBehavior suspensionBehavior(
       final TypedRecord<ProcessMessageSubscriptionRecord> record) {
-    return SuspensionBehavior.BUFFER;
+    // Process unconditionally — buffering would keep the message-partition lock held
+    // indefinitely while the instance is suspended or resuming. The exact-SUSPENDED check
+    // inside processRecord rejects a CORRELATE that arrives during the narrow suspend/close
+    // race window. During RESUMING it must fall through instead: an early reopened subscription
+    // can correlate a still-buffered message while later REOPEN commands are still draining.
+    return SuspensionBehavior.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -117,24 +117,17 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
     } else if (suspensionState.getSuspensionState(record.getProcessInstanceKey())
         == SuspensionState.State.SUSPENDED) {
-      // Race window: SUSPEND was processed (message-side subscriptions are being deleted) but
-      // this CORRELATE was already in flight from the message partition. Reject it so the
-      // message-side lock is released and the message can correlate to another active instance,
-      // or return 404 if no other subscriber exists. On resume, reopened subscriptions pick up
-      // any still-valid buffered messages through the normal CREATE→correlateNextMessage path.
-      //
-      // Gated on the exact SUSPENDED state, not isSuspended(): during RESUMING, an early
-      // reopened subscription may correlate a still-buffered message while later REOPEN commands
-      // are still draining, and that correlation must be allowed to proceed normally.
+      // Race window: SUSPEND already deleted the message-side subscription, but this CORRELATE
+      // was already in flight. Reject to release the message-side lock — another active
+      // subscriber can then correlate, or the message returns 404. Gated on exact SUSPENDED, not
+      // isSuspended(); see suspensionBehavior() below for why RESUMING must fall through instead.
       rejectCommand(command, RejectionType.INVALID_STATE, SUSPENDED_PI_MESSAGE);
       return;
 
     } else if (isStaleGeneration(record, subscription)) {
-      // The command carries the message-side subscription key it was created for. If it no longer
-      // matches the key currently stored on the PI side, this correlate belongs to a superseded
-      // generation — e.g. a K1 correlate delayed across a suspend/resume cycle that re-subscribed
-      // with a new key K2. Applying it would trigger the element against a subscription that no
-      // longer exists on the message side, so reject it rather than mutate state for K2.
+      // E.g. a K1 correlate delayed across a suspend/resume cycle that re-subscribed with a new
+      // key K2 — applying it would trigger the element against a subscription that no longer
+      // exists on the message side.
       final var reason =
           String.format(
               STALE_KEY_MESSAGE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -137,9 +137,9 @@ public final class ProcessMessageSubscriptionCreateProcessor
       final long elementInstanceKey,
       final String messageName,
       final String tenantId) {
-    // Capture scalars before emitting DELETING: the DELETING applier calls updateToClosingState,
-    // which re-reads the shared subscription object from DB and can reset the shared mutable
-    // record.
+    // eventRecord is this processor's reused field; the side effects below run after this
+    // record's processing, by which point eventRecord may hold the next call's data. Capture
+    // scalars now.
     final int partitionId = eventRecord.getSubscriptionPartitionId();
     final long piKey = eventRecord.getProcessInstanceKey();
     final long pdKey = eventRecord.getProcessDefinitionKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -8,12 +8,14 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.PendingSubscription;
@@ -22,6 +24,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 
 @ExcludeAuthorizationCheck
 public final class ProcessMessageSubscriptionCreateProcessor
@@ -33,27 +36,57 @@ public final class ProcessMessageSubscriptionCreateProcessor
   private static final String NOT_OPENING_MSG =
       "Expected to create process message subscription with element key '%d' and message name '%s', "
           + "but it is already %s";
+  private static final String REOPEN_NO_SUBSCRIPTION_MSG =
+      "Expected to reopen process message subscription with element key '%d' and message name '%s', "
+          + "but no such subscription was found — the resume manifest is gone (likely the instance "
+          + "was cancelled while suspended)";
+  private static final String REOPEN_NOT_MANIFEST_MSG =
+      "Expected to reopen process message subscription with element key '%d' and message name '%s', "
+          + "but it is %s rather than an OPENED resume manifest";
 
   private final ProcessMessageSubscriptionState subscriptionState;
+  private final SuspensionState suspensionState;
+  private final SubscriptionCommandSender subscriptionCommandSender;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final SideEffectWriter sideEffectWriter;
+  private final InstantSource clock;
+
+  // Scratch record used to build the follow-up event value. The state API returns a value backed by
+  // the column family's shared mutable object, so we must not mutate it in place — we copy into
+  // this processor-owned instance, stamp the key, and append the copy.
+  private final ProcessMessageSubscriptionRecord eventRecord =
+      new ProcessMessageSubscriptionRecord();
 
   public ProcessMessageSubscriptionCreateProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
+      final SuspensionState suspensionState,
+      final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final InstantSource clock) {
     this.subscriptionState = subscriptionState;
+    this.suspensionState = suspensionState;
+    this.subscriptionCommandSender = subscriptionCommandSender;
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
     stateWriter = writers.state();
     sideEffectWriter = writers.sideEffect();
     rejectionWriter = writers.rejection();
+    this.clock = clock;
   }
 
   @Override
   public void processRecord(final TypedRecord<ProcessMessageSubscriptionRecord> command) {
+    if (command.getIntent() == ProcessMessageSubscriptionIntent.REOPEN) {
+      reopenFromManifest(command);
+      return;
+    }
+    handleCreateAcknowledgement(command);
+  }
 
+  private void handleCreateAcknowledgement(
+      final TypedRecord<ProcessMessageSubscriptionRecord> command) {
     final ProcessMessageSubscriptionRecord subscriptionRecord = command.getValue();
     final long elementInstanceKey = subscriptionRecord.getElementInstanceKey();
     final String tenantId = subscriptionRecord.getTenantId();
@@ -63,21 +96,141 @@ public final class ProcessMessageSubscriptionCreateProcessor
             elementInstanceKey, subscriptionRecord.getMessageNameBuffer(), tenantId);
 
     if (subscription != null && subscription.isOpening()) {
-      stateWriter.appendFollowUpEvent(
-          subscription.getKey(),
-          ProcessMessageSubscriptionIntent.CREATED,
-          subscription.getRecord());
+      // Propagate the message-side subscription key received in the ack so the PI-side record
+      // stores it; the suspend/close paths read it back when sending the close command. Copy the
+      // stored record into a processor-owned scratch instance before mutating: the value returned
+      // by the state API is backed by the column family's shared mutable object.
+      eventRecord.wrap(subscription.getRecord());
+      eventRecord.setSubscriptionKey(subscriptionRecord.getSubscriptionKey());
 
-      // update transient state in a side-effect to ensure that these changes only take effect after
-      // the command has been successfully processed
-      sideEffectWriter.appendSideEffect(
-          () -> {
-            transientProcessMessageSubscriptionState.remove(
-                new PendingSubscription(elementInstanceKey, messageName, tenantId));
-          });
+      if (suspensionState.getSuspensionState(subscription.getRecord().getProcessInstanceKey())
+          == SuspensionState.State.SUSPENDED) {
+        // The instance was suspended while this subscription was still mid-handshake, so the
+        // suspend pass skipped it (there was no confirmed message-side row to close yet). The
+        // handshake has now completed, so a live message-side subscription exists on a suspended
+        // instance — exactly what suspension must avoid. Close it immediately (DELETING → CLOSING,
+        // send the close, enroll for retry) so its delete ack drains it to the OPENED resume
+        // manifest, giving the late handshake a proper completion path instead of leaving an
+        // OPENING row that retries CREATE for the whole suspension.
+        //
+        // Gated on the exact SUSPENDED state, not isSuspended(): during RESUMING, reopened
+        // subscriptions are expected to complete their handshake normally, not be closed again.
+        closeLateHandshake(subscription.getKey(), elementInstanceKey, messageName, tenantId);
+      } else {
+        stateWriter.appendFollowUpEvent(
+            subscription.getKey(), ProcessMessageSubscriptionIntent.CREATED, eventRecord);
+
+        // update transient state in a side-effect to ensure that these changes only take effect
+        // after the command has been successfully processed
+        sideEffectWriter.appendSideEffect(
+            () ->
+                transientProcessMessageSubscriptionState.remove(
+                    new PendingSubscription(elementInstanceKey, messageName, tenantId)));
+      }
     } else {
       rejectCommand(command, subscription);
     }
+  }
+
+  private void closeLateHandshake(
+      final long subscriptionKey,
+      final long elementInstanceKey,
+      final String messageName,
+      final String tenantId) {
+    // Capture scalars before emitting DELETING: the DELETING applier calls updateToClosingState,
+    // which re-reads the shared subscription object from DB and can reset the shared mutable
+    // record.
+    final int partitionId = eventRecord.getSubscriptionPartitionId();
+    final long piKey = eventRecord.getProcessInstanceKey();
+    final long pdKey = eventRecord.getProcessDefinitionKey();
+    final long subKey = eventRecord.getSubscriptionKey();
+
+    stateWriter.appendFollowUpEvent(
+        subscriptionKey, ProcessMessageSubscriptionIntent.DELETING, eventRecord);
+
+    final var pending = new PendingSubscription(elementInstanceKey, messageName, tenantId);
+    sideEffectWriter.appendSideEffect(
+        () -> transientProcessMessageSubscriptionState.update(pending, clock.millis()));
+    sideEffectWriter.appendSideEffect(
+        () ->
+            subscriptionCommandSender.sendDirectCloseMessageSubscription(
+                partitionId,
+                piKey,
+                elementInstanceKey,
+                pdKey,
+                BufferUtil.wrapString(messageName),
+                tenantId,
+                subKey));
+  }
+
+  /**
+   * Re-subscribes one message subscription from its durable resume manifest, for a {@code REOPEN}
+   * command drained from the suspend/resume buffer. Draining one {@code REOPEN} per batch keeps a
+   * large instance's resume from re-subscribing every row in one oversized record batch.
+   */
+  private void reopenFromManifest(final TypedRecord<ProcessMessageSubscriptionRecord> command) {
+    final var commandValue = command.getValue();
+    final long elementInstanceKey = commandValue.getElementInstanceKey();
+    final String messageName = commandValue.getMessageName();
+    final String tenantId = commandValue.getTenantId();
+
+    final ProcessMessageSubscription subscription =
+        subscriptionState.getSubscription(
+            elementInstanceKey, commandValue.getMessageNameBuffer(), tenantId);
+
+    if (subscription == null) {
+      final var reason = String.format(REOPEN_NO_SUBSCRIPTION_MSG, elementInstanceKey, messageName);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
+      return;
+    }
+    if (subscription.isOpening() || subscription.isClosing()) {
+      // REOPEN is buffered only once the close ack restores OPENED, so a non-OPENED row is
+      // unexpected: reject rather than double-open an OPENING row or clobber a CLOSING one.
+      final var state = subscription.isClosing() ? "closing" : "opening";
+      final var reason =
+          String.format(REOPEN_NOT_MANIFEST_MSG, elementInstanceKey, messageName, state);
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
+      return;
+    }
+
+    final var record = subscription.getRecord();
+    // Capture fields before CREATING: its applier re-reads and can reset the shared record.
+    final int partitionId = record.getSubscriptionPartitionId();
+    final long piKey = record.getProcessInstanceKey();
+    final long pdKey = record.getProcessDefinitionKey();
+    final String bpmnProcessId = record.getBpmnProcessId();
+    final String correlationKey = record.getCorrelationKey();
+    final boolean interrupting = record.isInterrupting();
+    final String businessId = record.getBusinessId();
+    final String elementId = record.getElementId();
+    final long rootPiKey = record.getRootProcessInstanceKey();
+    final var elementType = record.getElementType();
+
+    // Reset the generation to -1: re-subscribing makes the message partition assign a fresh key.
+    // Until that key is confirmed (by the open ack, or the CORRELATE sent instead on the
+    // buffered-message path) the old key would make that CORRELATE be rejected as stale. Copy into
+    // the scratch record so the shared state object is not mutated in place.
+    eventRecord.wrap(record);
+    eventRecord.setSubscriptionKey(-1L);
+    stateWriter.appendFollowUpEvent(
+        subscription.getKey(), ProcessMessageSubscriptionIntent.CREATING, eventRecord);
+
+    sideEffectWriter.appendSideEffect(
+        () ->
+            subscriptionCommandSender.sendDirectOpenMessageSubscription(
+                partitionId,
+                piKey,
+                elementInstanceKey,
+                pdKey,
+                BufferUtil.wrapString(bpmnProcessId),
+                BufferUtil.wrapString(messageName),
+                BufferUtil.wrapString(correlationKey),
+                interrupting,
+                tenantId,
+                BufferUtil.wrapString(businessId),
+                BufferUtil.wrapString(elementId),
+                rootPiKey,
+                elementType));
   }
 
   private void rejectCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -146,7 +146,9 @@ public final class ProcessMessageSubscriptionCreateProcessor
     final long subKey = eventRecord.getSubscriptionKey();
 
     stateWriter.appendFollowUpEvent(
-        subscriptionKey, ProcessMessageSubscriptionIntent.DELETING, eventRecord);
+        subscriptionKey,
+        ProcessMessageSubscriptionIntent.DELETING,
+        eventRecord.setClosedForSuspend(true));
 
     final var pending = new PendingSubscription(elementInstanceKey, messageName, tenantId);
     sideEffectWriter.appendSideEffect(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
@@ -46,7 +45,6 @@ public final class ProcessMessageSubscriptionDeleteProcessor
   private final TypedCommandWriter commandWriter;
   private final ProcessMessageSubscriptionState subscriptionState;
   private final SuspensionState suspensionState;
-  private final ElementInstanceState elementInstanceState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
   private final KeyGenerator keyGenerator;
 
@@ -58,13 +56,11 @@ public final class ProcessMessageSubscriptionDeleteProcessor
   public ProcessMessageSubscriptionDeleteProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
       final SuspensionState suspensionState,
-      final ElementInstanceState elementInstanceState,
       final Writers writers,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
       final KeyGenerator keyGenerator) {
     this.subscriptionState = subscriptionState;
     this.suspensionState = suspensionState;
-    this.elementInstanceState = elementInstanceState;
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -98,7 +94,7 @@ public final class ProcessMessageSubscriptionDeleteProcessor
     }
 
     final long processInstanceKey = subscription.getRecord().getProcessInstanceKey();
-    if (isSuspendDrivenClose(processInstanceKey, elementInstanceKey)) {
+    if (subscription.getRecord().isClosedForSuspend()) {
       // Restore the PI-side row to OPENED as the durable resume manifest and buffer a REOPEN so the
       // drain re-subscribes it one row per batch on resume. Snapshot before CREATED, whose applier
       // re-reads the shared record.
@@ -128,21 +124,6 @@ public final class ProcessMessageSubscriptionDeleteProcessor
           transientProcessMessageSubscriptionState.remove(
               new PendingSubscription(elementInstanceKey, messageName, tenantId));
         });
-  }
-
-  /**
-   * DELETING (→ CLOSING) is emitted by normal unsubscribe, migration, cancellation, and the suspend
-   * path. Only the suspend path runs while the instance is suspended <em>and</em> its element is
-   * still active — the others run unsuspended or while the element is already ending — so those two
-   * conditions identify a suspend-driven close, whose ack must restore the manifest, not delete it.
-   */
-  private boolean isSuspendDrivenClose(
-      final long processInstanceKey, final long elementInstanceKey) {
-    if (!suspensionState.isSuspended(processInstanceKey)) {
-      return false;
-    }
-    final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
-    return elementInstance != null && elementInstance.isActive();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -11,15 +11,22 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.PendingSubscription;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.BufferedCommandRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @ExcludeAuthorizationCheck
@@ -29,22 +36,41 @@ public final class ProcessMessageSubscriptionDeleteProcessor
   private static final String NO_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to delete process message subscription for element with key '%d' and message name '%s', "
           + "but no such subscription was found.";
+  private static final String NOT_CLOSING_MESSAGE =
+      "Expected to delete process message subscription for element with key '%d' and message name"
+          + " '%s', but it is not in CLOSING state.";
 
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final SideEffectWriter sideEffectWriter;
+  private final TypedCommandWriter commandWriter;
   private final ProcessMessageSubscriptionState subscriptionState;
+  private final SuspensionState suspensionState;
+  private final ElementInstanceState elementInstanceState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
+  private final KeyGenerator keyGenerator;
+
+  // Scratch copy of the manifest, taken before CREATED (whose applier re-reads the shared record),
+  // so the REOPEN command we buffer keeps the right field values.
+  private final ProcessMessageSubscriptionRecord reopenScratch =
+      new ProcessMessageSubscriptionRecord();
 
   public ProcessMessageSubscriptionDeleteProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
+      final SuspensionState suspensionState,
+      final ElementInstanceState elementInstanceState,
       final Writers writers,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final KeyGenerator keyGenerator) {
     this.subscriptionState = subscriptionState;
+    this.suspensionState = suspensionState;
+    this.elementInstanceState = elementInstanceState;
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
+    this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
+    commandWriter = writers.command();
   }
 
   @Override
@@ -63,8 +89,37 @@ public final class ProcessMessageSubscriptionDeleteProcessor
       return;
     }
 
-    stateWriter.appendFollowUpEvent(
-        subscription.getKey(), ProcessMessageSubscriptionIntent.DELETED, subscription.getRecord());
+    if (!subscription.isClosing()) {
+      // DELETE ack for a row never put into CLOSING — a protocol violation; emit a terminal
+      // rejection so replay is deterministic rather than a silent gap.
+      final var reason = String.format(NOT_CLOSING_MESSAGE, elementInstanceKey, messageName);
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
+      return;
+    }
+
+    final long processInstanceKey = subscription.getRecord().getProcessInstanceKey();
+    if (isSuspendDrivenClose(processInstanceKey, elementInstanceKey)) {
+      // Restore the PI-side row to OPENED as the durable resume manifest and buffer a REOPEN so the
+      // drain re-subscribes it one row per batch on resume. Snapshot before CREATED, whose applier
+      // re-reads the shared record.
+      reopenScratch.wrap(subscription.getRecord());
+      stateWriter.appendFollowUpEvent(
+          subscription.getKey(),
+          ProcessMessageSubscriptionIntent.CREATED,
+          subscription.getRecord());
+      bufferReopenCommand(subscription.getKey(), reopenScratch);
+      retriggerDrainIfResuming(processInstanceKey, reopenScratch);
+    } else {
+      stateWriter.appendFollowUpEvent(
+          subscription.getKey(),
+          ProcessMessageSubscriptionIntent.DELETED,
+          subscription.getRecord());
+      // A non-suspend close (e.g. a buffered command terminating the element mid-resume) can clear
+      // the last CLOSING row while the instance is RESUMING and the drain is parked waiting on it.
+      // Re-wake the drain here too, otherwise the instance stays RESUMING forever. Self-gates on
+      // RESUMING, so it is a no-op for the common unsuspended close.
+      retriggerDrainIfResuming(processInstanceKey, subscription.getRecord());
+    }
 
     // update transient state in a side-effect to ensure that these changes only take effect after
     // the command has been successfully processed
@@ -73,6 +128,61 @@ public final class ProcessMessageSubscriptionDeleteProcessor
           transientProcessMessageSubscriptionState.remove(
               new PendingSubscription(elementInstanceKey, messageName, tenantId));
         });
+  }
+
+  /**
+   * DELETING (→ CLOSING) is emitted by normal unsubscribe, migration, cancellation, and the suspend
+   * path. Only the suspend path runs while the instance is suspended <em>and</em> its element is
+   * still active — the others run unsuspended or while the element is already ending — so those two
+   * conditions identify a suspend-driven close, whose ack must restore the manifest, not delete it.
+   */
+  private boolean isSuspendDrivenClose(
+      final long processInstanceKey, final long elementInstanceKey) {
+    if (!suspensionState.isSuspended(processInstanceKey)) {
+      return false;
+    }
+    final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+    return elementInstance != null && elementInstance.isActive();
+  }
+
+  /**
+   * Buffers a {@code REOPEN} for the restored manifest row (mirroring {@code
+   * CommandBufferingBehavior}); the drain replays it one row per batch on resume. Consumed exactly
+   * once (drain writes {@code DRAINED}), so a later CREATE ack flipping the row's state cannot
+   * re-reopen it — hence no resume cursor is needed.
+   */
+  private void bufferReopenCommand(
+      final long subscriptionKey, final ProcessMessageSubscriptionRecord manifest) {
+    final var bufferedCommandRecord =
+        new BufferedCommandRecord()
+            .setProcessInstanceKey(manifest.getProcessInstanceKey())
+            .setProcessDefinitionKey(manifest.getProcessDefinitionKey())
+            .setTenantId(manifest.getTenantId())
+            .setCommandKey(subscriptionKey)
+            .setValueType(ValueType.PROCESS_MESSAGE_SUBSCRIPTION)
+            .setIntent(ProcessMessageSubscriptionIntent.REOPEN)
+            .setCommandValue(manifest);
+    stateWriter.appendFollowUpEvent(
+        keyGenerator.nextKey(), BufferedCommandIntent.BUFFERED, bufferedCommandRecord);
+  }
+
+  /**
+   * If the close acks while the instance is already RESUMING, the drain may have emptied the buffer
+   * and be waiting; the just-buffered REOPEN needs a fresh {@code DRAIN} to be picked up. The drain
+   * re-checks state, so triggering once per draining row is safe.
+   */
+  private void retriggerDrainIfResuming(
+      final long processInstanceKey, final ProcessMessageSubscriptionRecord manifest) {
+    if (suspensionState.getSuspensionState(processInstanceKey) != SuspensionState.State.RESUMING) {
+      return;
+    }
+    commandWriter.appendFollowUpCommand(
+        processInstanceKey,
+        BufferedCommandIntent.DRAIN,
+        new BufferedCommandRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setProcessDefinitionKey(manifest.getProcessDefinitionKey())
+            .setTenantId(manifest.getTenantId()));
   }
 
   private void rejectCommand(final TypedRecord<ProcessMessageSubscriptionRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -33,6 +33,7 @@ public final class Subscriptions {
             subscription.getProcessInstanceKey(),
             subscription.getElementInstanceKey(),
             subscription.getProcessDefinitionKey(),
+            subscription.getSubscriptionKey(),
             false);
     addSubscriptionInternal(newSubscription);
   }
@@ -44,6 +45,8 @@ public final class Subscriptions {
             subscription.getProcessInstanceKey(),
             0L,
             subscription.getProcessDefinitionKey(),
+            // start-event subscriptions have no message-side subscription key
+            -1L,
             true);
     addSubscriptionInternal(newSubscription);
   }
@@ -110,6 +113,7 @@ public final class Subscriptions {
       long processInstanceKey,
       long elementInstanceKey,
       long processDefinitionKey,
+      long subscriptionKey,
       boolean isStartEventSubscription) {
     /* clone the bpmnProcessId buffer */
     public static Subscription cloned(
@@ -117,12 +121,14 @@ public final class Subscriptions {
         final long processInstanceKey,
         final long elementInstanceKey,
         final long processDefinitionKey,
+        final long subscriptionKey,
         final boolean isStartEventSubscription) {
       return new Subscription(
           wrapInBufferIfNeeded(cloneBuffer(bpmnProcessId)),
           processInstanceKey,
           elementInstanceKey,
           processDefinitionKey,
+          subscriptionKey,
           isStartEventSubscription);
     }
 
@@ -133,6 +139,7 @@ public final class Subscriptions {
           subscription.processInstanceKey(),
           subscription.elementInstanceKey(),
           subscription.processDefinitionKey(),
+          subscription.subscriptionKey(),
           subscription.isStartEventSubscription);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -152,7 +152,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer messageName,
       final boolean closeOnCorrelate,
       final String tenantId,
-      final DirectBuffer businessId) {
+      final DirectBuffer businessId,
+      final long subscriptionKey) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -166,7 +167,8 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName)
             .setInterrupting(closeOnCorrelate)
             .setTenantId(tenantId)
-            .setBusinessId(businessId));
+            .setBusinessId(businessId)
+            .setSubscriptionKey(subscriptionKey));
   }
 
   public boolean correlateProcessMessageSubscription(
@@ -178,7 +180,8 @@ public class SubscriptionCommandSender {
       final long messageKey,
       final DirectBuffer variables,
       final DirectBuffer correlationKey,
-      final String tenantId) {
+      final String tenantId,
+      final long subscriptionKey) {
     return handleFollowUpCommandBasedOnPartition(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -193,7 +196,8 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName)
             .setVariables(variables)
             .setCorrelationKey(correlationKey)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setSubscriptionKey(subscriptionKey));
   }
 
   /**
@@ -209,6 +213,8 @@ public class SubscriptionCommandSender {
    * @param variables the variables of the message
    * @param correlationKey the correlation key for which the message should be correlated
    * @param tenantId the tenant the message subscription is correlated for
+   * @param subscriptionKey the message-side subscription key, propagated so the PI side stores it
+   *     for staleness detection on later delete commands
    */
   public void sendDirectCorrelateProcessMessageSubscription(
       final long processInstanceKey,
@@ -219,7 +225,8 @@ public class SubscriptionCommandSender {
       final long messageKey,
       final DirectBuffer variables,
       final DirectBuffer correlationKey,
-      final String tenantId) {
+      final String tenantId,
+      final long subscriptionKey) {
     interPartitionCommandSender.sendCommand(
         Protocol.decodePartitionId(processInstanceKey),
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -234,7 +241,8 @@ public class SubscriptionCommandSender {
             .setMessageName(messageName)
             .setVariables(variables)
             .setCorrelationKey(correlationKey)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setSubscriptionKey(subscriptionKey));
   }
 
   public boolean correlateMessageSubscription(
@@ -266,7 +274,8 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final long processDefinitionKey,
       final DirectBuffer messageName,
-      final String tenantId) {
+      final String tenantId,
+      final long subscriptionKey) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -277,7 +286,8 @@ public class SubscriptionCommandSender {
             .setProcessDefinitionKey(processDefinitionKey)
             .setMessageKey(-1L)
             .setMessageName(messageName)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setSubscriptionKey(subscriptionKey));
   }
 
   /**
@@ -297,7 +307,8 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final long processDefinitionKey,
       final DirectBuffer messageName,
-      final String tenantId) {
+      final String tenantId,
+      final long subscriptionKey) {
     interPartitionCommandSender.sendCommand(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -308,7 +319,8 @@ public class SubscriptionCommandSender {
             .setProcessDefinitionKey(processDefinitionKey)
             .setMessageKey(-1L)
             .setMessageName(messageName)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setSubscriptionKey(subscriptionKey));
   }
 
   public boolean closeProcessMessageSubscription(
@@ -340,7 +352,8 @@ public class SubscriptionCommandSender {
       final long messageKey,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
-      final String tenantId) {
+      final String tenantId,
+      final long subscriptionKey) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
         ValueType.MESSAGE_SUBSCRIPTION,
@@ -354,7 +367,8 @@ public class SubscriptionCommandSender {
             .setCorrelationKey(correlationKey)
             .setMessageKey(messageKey)
             .setInterrupting(false)
-            .setTenantId(tenantId));
+            .setTenantId(tenantId)
+            .setSubscriptionKey(subscriptionKey));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessor.java
@@ -13,15 +13,23 @@ import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.Suspen
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.BufferedCommand;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.BufferedCommandRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.ArrayDeque;
+import java.util.function.Consumer;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -42,15 +50,26 @@ import org.jspecify.annotations.NullMarked;
 public final class BufferedCommandDrainProcessor
     implements TypedRecordProcessor<BufferedCommandRecord>, SuspensionAware<BufferedCommandRecord> {
 
+  private static final String WAITING_CLOSE_ACKS_MESSAGE =
+      "Expected to finish draining process instance '%d', but some message subscriptions are still "
+          + "closing — will retry once their delete acknowledgements arrive and buffer their reopen "
+          + "commands.";
+
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
+  private final TypedRejectionWriter rejectionWriter;
   private final SuspensionState suspensionState;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessMessageSubscriptionState processMessageSubscriptionState;
 
   public BufferedCommandDrainProcessor(
       final ProcessingState processingState, final Writers writers) {
     stateWriter = writers.state();
     commandWriter = writers.command();
+    rejectionWriter = writers.rejection();
     suspensionState = processingState.getSuspensionState();
+    elementInstanceState = processingState.getElementInstanceState();
+    processMessageSubscriptionState = processingState.getProcessMessageSubscriptionState();
   }
 
   @Override
@@ -60,7 +79,7 @@ public final class BufferedCommandDrainProcessor
 
     final var buffered = suspensionState.getOldestBufferedCommand(processInstanceKey).orElse(null);
     if (buffered == null) {
-      appendResumeJobs(drainValue);
+      advanceOrWait(command, drainValue);
       return;
     }
 
@@ -70,9 +89,69 @@ public final class BufferedCommandDrainProcessor
     // DRAINED already applied (event appliers run synchronously), so this reflects the buffer as
     // it stands now, without an extra empty DRAIN cycle to find out
     if (suspensionState.getOldestBufferedCommand(processInstanceKey).isEmpty()) {
-      appendResumeJobs(drainValue);
+      advanceOrWait(command, drainValue);
     } else {
       appendNextDrainCommand(drainValue);
+    }
+  }
+
+  /**
+   * Buffer drained. If a suspend-driven close is still CLOSING, its ack will restore the manifest
+   * and buffer a {@code REOPEN}, so advancing to {@code RESUME_JOBS} now would finish the resume
+   * before that row is re-subscribed; reject and wait (the delete-ack re-triggers a {@code DRAIN}).
+   * {@code DRAIN} does not ban on error, so the rejection is a safe terminal record. Otherwise hand
+   * off to {@code RESUME_JOBS}.
+   *
+   * <p>This resume-side wait exists only because suspend completes ({@code SUSPENDED}) while its
+   * closes are still in flight, so resume can start with subscriptions still CLOSING. Once #61057
+   * introduces a {@code SUSPENDING} state that finishes all closes before writing {@code
+   * SUSPENDED}, {@code SUSPENDED} guarantees "all closed" and this gate (and {@link
+   * #hasClosingSubscriptions}) can be removed.
+   */
+  private void advanceOrWait(
+      final TypedRecord<BufferedCommandRecord> command, final BufferedCommandRecord drainValue) {
+    if (hasClosingSubscriptions(drainValue.getProcessInstanceKey())) {
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.INVALID_STATE,
+          WAITING_CLOSE_ACKS_MESSAGE.formatted(drainValue.getProcessInstanceKey()));
+      return;
+    }
+    appendResumeJobs(drainValue);
+  }
+
+  /** Read-only BFS over the element-instance tree: reports whether any subscription is CLOSING. */
+  private boolean hasClosingSubscriptions(final long processInstanceKey) {
+    final boolean[] hasClosing = {false};
+    visitTreeSubscriptions(
+        processInstanceKey,
+        subscription -> {
+          if (subscription.isClosing()) {
+            hasClosing[0] = true;
+          }
+        });
+    return hasClosing[0];
+  }
+
+  private void visitTreeSubscriptions(
+      final long processInstanceKey, final Consumer<ProcessMessageSubscription> visitor) {
+    final var root = elementInstanceState.getInstance(processInstanceKey);
+    if (root == null) {
+      return;
+    }
+    final var queue = new ArrayDeque<ElementInstance>();
+    queue.add(root);
+    while (!queue.isEmpty()) {
+      final var elementInstance = queue.poll();
+      processMessageSubscriptionState.visitElementSubscriptions(
+          elementInstance.getKey(),
+          subscription -> {
+            visitor.accept(subscription);
+            return true;
+          });
+      elementInstanceState.getChildren(elementInstance.getKey()).stream()
+          .filter(child -> child.getValue().getProcessInstanceKey() == processInstanceKey)
+          .forEach(queue::add);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -11,6 +11,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -31,6 +33,7 @@ import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.time.InstantSource;
 
 public final class ProcessInstanceSuspendProcessor
     implements TypedRecordProcessor<ProcessInstanceRecord>, SuspensionAware<ProcessInstanceRecord> {
@@ -53,11 +56,15 @@ public final class ProcessInstanceSuspendProcessor
   private final AsyncRequestState asyncRequestState;
   private final SuspensionState suspensionState;
   private final ProcessInstanceSuspensionJobBehavior suspensionJobBehavior;
+  private final ProcessInstanceSuspensionMessageSubscriptionBehavior suspensionSubscriptionBehavior;
 
   public ProcessInstanceSuspendProcessor(
       final ProcessingState processingState,
       final Writers writers,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final SubscriptionCommandSender subscriptionCommandSender,
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final InstantSource clock) {
     elementInstanceState = processingState.getElementInstanceState();
     responseWriter = writers.response();
     stateWriter = writers.state();
@@ -68,6 +75,15 @@ public final class ProcessInstanceSuspendProcessor
     suspensionJobBehavior =
         new ProcessInstanceSuspensionJobBehavior(
             elementInstanceState, processingState.getJobState(), stateWriter);
+    suspensionSubscriptionBehavior =
+        new ProcessInstanceSuspensionMessageSubscriptionBehavior(
+            elementInstanceState,
+            processingState.getProcessMessageSubscriptionState(),
+            stateWriter,
+            writers.sideEffect(),
+            subscriptionCommandSender,
+            transientProcessMessageSubscriptionState,
+            clock);
   }
 
   @Override
@@ -82,6 +98,7 @@ public final class ProcessInstanceSuspendProcessor
     // Park jobs before the instance-level SUSPENDED event so suspension is complete when the
     // marker is written. A later SUSPENDING intermediate state can chunk this work first.
     suspensionJobBehavior.suspendJobs(command.getKey());
+    suspensionSubscriptionBehavior.closeSubscriptions(command.getKey());
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.SUSPENDED, value);
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.SUSPENDED, value, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionMessageSubscriptionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionMessageSubscriptionBehavior.java
@@ -57,17 +57,17 @@ public final class ProcessInstanceSuspensionMessageSubscriptionBehavior {
    * Walks the element-instance tree BFS and initiates a durable, retryable close of every {@code
    * OPENED} process message subscription.
    *
-   * <p>For each subscription this emits a {@code DELETING} event (putting the PI-side row into
-   * {@code CLOSING} state), enqueues the subscription in the pending-retry transient index, and
-   * sends the {@code MESSAGE_SUBSCRIPTION.DELETE} command to the message partition as a
-   * side-effect. On failover, {@link
+   * <p>For each subscription this emits a {@code DELETING} event with {@code closedForSuspend} set,
+   * putting the PI-side row into {@code CLOSING} state, enqueues the subscription in the
+   * pending-retry transient index, and sends the {@code MESSAGE_SUBSCRIPTION.DELETE} command to the
+   * message partition as a side-effect. On failover, {@link
    * io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState#onRecovered} re-adds
    * all {@code CLOSING} rows to the transient index so the {@link
    * PendingProcessMessageSubscriptionCheckScheduler} picks them up and resends the close command.
    *
-   * <p>When the delete ack arrives, {@link ProcessMessageSubscriptionDeleteProcessor} detects that
-   * the instance is still suspended and emits {@code CREATED} (transitioning the row back to {@code
-   * OPENED}) instead of {@code DELETED}, preserving it as a resume manifest.
+   * <p>When the delete ack arrives, {@link ProcessMessageSubscriptionDeleteProcessor} reads that
+   * flag off the row and emits {@code CREATED} (transitioning it back to {@code OPENED}) instead of
+   * {@code DELETED}, preserving it as a resume manifest.
    *
    * <p>Subscriptions in {@code OPENING} or {@code CLOSING} state are skipped: {@code OPENING} ones
    * are mid-handshake (the message-side row may not exist yet; the CREATE ack handler will close it
@@ -104,7 +104,9 @@ public final class ProcessInstanceSuspensionMessageSubscriptionBehavior {
               final String tenantId = record.getTenantId();
 
               stateWriter.appendFollowUpEvent(
-                  subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, record);
+                  subscription.getKey(),
+                  ProcessMessageSubscriptionIntent.DELETING,
+                  record.setClosedForSuspend(true));
 
               final var pending = new PendingSubscription(elemKey, messageName, tenantId);
               sideEffectWriter.appendSideEffect(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionMessageSubscriptionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionMessageSubscriptionBehavior.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
+import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.PendingSubscription;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
+import java.util.ArrayDeque;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Closes the message subscriptions of a process instance while it is suspended, mirroring {@link
+ * ProcessInstanceSuspensionJobBehavior} for jobs.
+ */
+@NullMarked
+public final class ProcessInstanceSuspensionMessageSubscriptionBehavior {
+
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessMessageSubscriptionState processMessageSubscriptionState;
+  private final StateWriter stateWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final SubscriptionCommandSender subscriptionCommandSender;
+  private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
+  private final InstantSource clock;
+
+  public ProcessInstanceSuspensionMessageSubscriptionBehavior(
+      final ElementInstanceState elementInstanceState,
+      final ProcessMessageSubscriptionState processMessageSubscriptionState,
+      final StateWriter stateWriter,
+      final SideEffectWriter sideEffectWriter,
+      final SubscriptionCommandSender subscriptionCommandSender,
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final InstantSource clock) {
+    this.elementInstanceState = elementInstanceState;
+    this.processMessageSubscriptionState = processMessageSubscriptionState;
+    this.stateWriter = stateWriter;
+    this.sideEffectWriter = sideEffectWriter;
+    this.subscriptionCommandSender = subscriptionCommandSender;
+    this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
+    this.clock = clock;
+  }
+
+  /**
+   * Walks the element-instance tree BFS and initiates a durable, retryable close of every {@code
+   * OPENED} process message subscription.
+   *
+   * <p>For each subscription this emits a {@code DELETING} event (putting the PI-side row into
+   * {@code CLOSING} state), enqueues the subscription in the pending-retry transient index, and
+   * sends the {@code MESSAGE_SUBSCRIPTION.DELETE} command to the message partition as a
+   * side-effect. On failover, {@link
+   * io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState#onRecovered} re-adds
+   * all {@code CLOSING} rows to the transient index so the {@link
+   * PendingProcessMessageSubscriptionCheckScheduler} picks them up and resends the close command.
+   *
+   * <p>When the delete ack arrives, {@link ProcessMessageSubscriptionDeleteProcessor} detects that
+   * the instance is still suspended and emits {@code CREATED} (transitioning the row back to {@code
+   * OPENED}) instead of {@code DELETED}, preserving it as a resume manifest.
+   *
+   * <p>Subscriptions in {@code OPENING} or {@code CLOSING} state are skipped: {@code OPENING} ones
+   * are mid-handshake (the message-side row may not exist yet; the CREATE ack handler will close it
+   * when the instance is still suspended), and {@code CLOSING} ones are already being torn down.
+   *
+   * <p>All closes are emitted in this single SUSPEND batch, so an instance with more concurrent
+   * message subscriptions than fit in one record batch (~10K) would exceed the limit and be
+   * rejected. Chunking the closes across cycles is deferred — same limitation as job suspension;
+   * see <a href="https://github.com/camunda/camunda/issues/61057">#61057</a>.
+   */
+  public void closeSubscriptions(final long processInstanceKey) {
+    final var root = elementInstanceState.getInstance(processInstanceKey);
+    if (root == null) {
+      return;
+    }
+    final var queue = new ArrayDeque<ElementInstance>();
+    queue.add(root);
+    while (!queue.isEmpty()) {
+      final var elementInstance = queue.poll();
+      processMessageSubscriptionState.visitElementSubscriptions(
+          elementInstance.getKey(),
+          subscription -> {
+            if (!subscription.isOpening() && !subscription.isClosing()) {
+              final var record = subscription.getRecord();
+              // Capture subscriptionKey before emitting the DELETING event: the DELETING applier
+              // calls updateToClosingState, which re-reads the shared subscription object from DB
+              // and can reset subscriptionKey to -1 on the shared mutable record instance.
+              final int partitionId = record.getSubscriptionPartitionId();
+              final long piKey = record.getProcessInstanceKey();
+              final long elemKey = record.getElementInstanceKey();
+              final long pdKey = record.getProcessDefinitionKey();
+              final long subKey = record.getSubscriptionKey();
+              final String messageName = record.getMessageName();
+              final String tenantId = record.getTenantId();
+
+              stateWriter.appendFollowUpEvent(
+                  subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, record);
+
+              final var pending = new PendingSubscription(elemKey, messageName, tenantId);
+              sideEffectWriter.appendSideEffect(
+                  () -> transientProcessMessageSubscriptionState.update(pending, clock.millis()));
+              sideEffectWriter.appendSideEffect(
+                  () ->
+                      subscriptionCommandSender.sendDirectCloseMessageSubscription(
+                          partitionId,
+                          piKey,
+                          elemKey,
+                          pdKey,
+                          BufferUtil.wrapString(messageName),
+                          tenantId,
+                          subKey));
+            }
+            return true;
+          });
+      elementInstanceState.getChildren(elementInstance.getKey()).stream()
+          .filter(child -> child.getValue().getProcessInstanceKey() == processInstanceKey)
+          .forEach(queue::add);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -732,6 +732,10 @@ public final class EventAppliers implements EventApplier {
         ProcessMessageSubscriptionIntent.CREATING,
         new ProcessMessageSubscriptionCreatingApplier(subscriptionState));
     register(
+        ProcessMessageSubscriptionIntent.CREATING,
+        2,
+        new ProcessMessageSubscriptionCreatingV2Applier(subscriptionState));
+    register(
         ProcessMessageSubscriptionIntent.CREATED,
         new ProcessMessageSubscriptionCreatedApplier(subscriptionState));
     register(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatingV2Applier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+
+/**
+ * Version 2 of the {@code CREATING} applier. Unlike v1 (which only inserts a new row), v2 also
+ * handles the resume re-subscribe path, where a {@code CREATING} event is emitted for a row that
+ * already exists in {@code OPENED} state (the durable resume manifest kept by the suspend path).
+ *
+ * <p>The behaviour is an upsert:
+ *
+ * <ul>
+ *   <li>row does not exist → {@link MutableProcessMessageSubscriptionState#put} (first-time
+ *       subscription, identical to v1)
+ *   <li>row already exists → {@link MutableProcessMessageSubscriptionState#updateToOpeningState},
+ *       which transitions {@code OPENED → OPENING} and enrolls the row in the pending-retry
+ *       transient index so the open command is retried after a dropped send or leader failover
+ * </ul>
+ *
+ * <p>v1 is retained unchanged and remains registered so that {@code CREATING} events written by
+ * released versions (record version 1) replay byte-identically. Only new events written by this
+ * version onward carry record version 2 and are applied here.
+ */
+public final class ProcessMessageSubscriptionCreatingV2Applier
+    implements TypedEventApplier<
+        ProcessMessageSubscriptionIntent, ProcessMessageSubscriptionRecord> {
+
+  private final MutableProcessMessageSubscriptionState subscriptionState;
+
+  public ProcessMessageSubscriptionCreatingV2Applier(
+      final MutableProcessMessageSubscriptionState subscriptionState) {
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
+    final var existing =
+        subscriptionState.getSubscription(
+            value.getElementInstanceKey(), value.getMessageNameBuffer(), value.getTenantId());
+    if (existing != null) {
+      subscriptionState.updateToOpeningState(value);
+    } else {
+      subscriptionState.put(key, value);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -128,7 +128,10 @@ public final class DbProcessMessageSubscriptionState
         record,
         s -> {
           s.setRecord(record).setOpened();
-          s.getRecord().setSubscriptionKey(subscriptionKey);
+          // Reset, not preserved: a future close site that forgets to set this explicitly then
+          // inherits false (delete) instead of a stale true from an earlier suspend cycle, which
+          // would wrongly restore the row instead of deleting it.
+          s.getRecord().setSubscriptionKey(subscriptionKey).setClosedForSuspend(false);
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -135,11 +135,12 @@ public final class DbProcessMessageSubscriptionState
   @Override
   public void updateToClosingState(final ProcessMessageSubscriptionRecord record) {
     final long subscriptionKey = record.getSubscriptionKey();
+    final boolean closedForSuspend = record.isClosedForSuspend();
     update(
         record,
         s -> {
           s.setRecord(record).setClosing();
-          s.getRecord().setSubscriptionKey(subscriptionKey);
+          s.getRecord().setSubscriptionKey(subscriptionKey).setClosedForSuspend(closedForSuspend);
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -99,7 +99,17 @@ public final class DbProcessMessageSubscriptionState
 
   @Override
   public void updateToOpeningState(final ProcessMessageSubscriptionRecord record) {
-    update(record, s -> s.setRecord(record).setOpening());
+    // Capture subscriptionKey before the update call: the shared processMessageSubscription object
+    // returned by getSubscription() is the same instance as record.getRecord() when the caller
+    // passes the shared visitor object. getSubscription() re-reads from DB and resets all fields
+    // (including subscriptionKey to -1), so we capture it here to survive the reset.
+    final long subscriptionKey = record.getSubscriptionKey();
+    update(
+        record,
+        s -> {
+          s.setRecord(record).setOpening();
+          s.getRecord().setSubscriptionKey(subscriptionKey);
+        });
     transientState.update(
         new PendingSubscription(
             record.getElementInstanceKey(), record.getMessageName(), record.getTenantId()),
@@ -108,12 +118,29 @@ public final class DbProcessMessageSubscriptionState
 
   @Override
   public void updateToOpenedState(final ProcessMessageSubscriptionRecord record) {
-    update(record, s -> s.setRecord(record).setOpened());
+    // This method is transitively part of the released v1 CREATED and CORRELATED appliers. The
+    // subscriptionKey preservation added here is replay-safe: records written before the field
+    // existed deserialize it to its default (-1), so both old and new code produce identical state
+    // for pre-feature events. Only events that actually carry a real subscriptionKey (written by
+    // this version onward) observe the corrected value, so no applier version bump is required.
+    final long subscriptionKey = record.getSubscriptionKey();
+    update(
+        record,
+        s -> {
+          s.setRecord(record).setOpened();
+          s.getRecord().setSubscriptionKey(subscriptionKey);
+        });
   }
 
   @Override
   public void updateToClosingState(final ProcessMessageSubscriptionRecord record) {
-    update(record, s -> s.setRecord(record).setClosing());
+    final long subscriptionKey = record.getSubscriptionKey();
+    update(
+        record,
+        s -> {
+          s.setRecord(record).setClosing();
+          s.getRecord().setSubscriptionKey(subscriptionKey);
+        });
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -153,7 +154,8 @@ public final class MessageStreamProcessorTest {
             any(),
             anyBoolean(),
             eq(TenantOwned.DEFAULT_TENANT_IDENTIFIER),
-            any());
+            any(),
+            anyLong());
   }
 
   @Test
@@ -316,7 +318,8 @@ public final class MessageStreamProcessorTest {
             eq(messageKey),
             any(),
             any(),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
   }
 
   @Test
@@ -362,7 +365,8 @@ public final class MessageStreamProcessorTest {
             eq(firstMessage.getKey()),
             any(),
             any(),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
 
     verify(spySubscriptionCommandSender, timeout(5_000))
         .correlateProcessMessageSubscription(
@@ -374,7 +378,8 @@ public final class MessageStreamProcessorTest {
             eq(lastMessageKey),
             any(),
             any(),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
   }
 
   @Test
@@ -477,7 +482,8 @@ public final class MessageStreamProcessorTest {
             eq(messageKey),
             any(DirectBuffer.class),
             eq(firstSubscription.getCorrelationKeyBuffer()),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
 
     verify(spySubscriptionCommandSender, timeout(5_000))
         .correlateProcessMessageSubscription(
@@ -489,7 +495,8 @@ public final class MessageStreamProcessorTest {
             eq(messageKey),
             any(DirectBuffer.class),
             eq(secondSubscription.getCorrelationKeyBuffer()),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
   }
 
   private void assertAllMessagesReceived(final MessageSubscriptionRecord subscription) {
@@ -517,7 +524,8 @@ public final class MessageStreamProcessorTest {
             eq(firstMessageKey),
             any(),
             eq(subscription.getCorrelationKeyBuffer()),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
 
     verify(spySubscriptionCommandSender, timeout(5_000))
         .correlateProcessMessageSubscription(
@@ -529,7 +537,8 @@ public final class MessageStreamProcessorTest {
             eq(lastMessageKey),
             any(),
             eq(subscription.getCorrelationKeyBuffer()),
-            eq(DEFAULT_TENANT));
+            eq(DEFAULT_TENANT),
+            anyLong());
   }
 
   private MessageSubscriptionRecord messageSubscription() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionCrossPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionCrossPartitionTest.java
@@ -111,10 +111,9 @@ public final class MessageSuspensionCrossPartitionTest {
   @Test
   public void shouldReturnNotFoundForCrossPartitionDirectCorrelateWhileSuspended() {
     // given - an instance on one partition with its message subscription on another, then
-    // suspended.
-    // Regression for #60648: a direct/synchronous correlate to a suspended instance whose
-    // subscription lives on a remote partition must get a prompt terminal rejection instead of
-    // hanging until the gateway deadline.
+    // suspended. Regression for #60648: a direct/synchronous correlate to a suspended instance
+    // whose subscription lives on a remote partition must get a prompt terminal rejection instead
+    // of hanging until the gateway deadline.
     final String processId = Strings.newRandomValidBpmnId();
     final String messageName = Strings.newRandomValidBpmnId();
     final String correlationKey = correlationKeyForPartitionOtherThan(PROCESS_INSTANCE_PARTITION);
@@ -139,8 +138,7 @@ public final class MessageSuspensionCrossPartitionTest {
         .await();
 
     // when - a direct correlate routes to the subscription partition (by correlation key), where
-    // the
-    // subscription no longer exists
+    // the subscription no longer exists
     final Record<MessageCorrelationRecordValue> rejection =
         engine
             .messageCorrelation()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionCrossPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionCrossPartitionTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Suspension removes the message-side {@code MessageSubscription} and re-opens it on resume. Both
+ * the removal and the re-open are driven by inter-partition commands from the suspend/resume
+ * processors on the process instance's partition to the subscription's partition. A single
+ * partition collapses that hop into a local write, so it never exercises the cross-partition path.
+ * These tests force the subscription onto a different partition than the instance to cover it.
+ */
+public final class MessageSuspensionCrossPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+  private static final int PROCESS_INSTANCE_PARTITION = 1;
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldReopenCrossPartitionSubscriptionAndPickUpBufferedMessageOnResume() {
+    // given - an instance on one partition with its message subscription on another, then suspended
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = correlationKeyForPartitionOtherThan(PROCESS_INSTANCE_PARTITION);
+    final int subscriptionPartition = getSubscriptionPartitionId(correlationKey);
+
+    final long processInstanceKey =
+        deployAndStart(processId, messageName, correlationKey, PROCESS_INSTANCE_PARTITION);
+
+    final Record<MessageSubscriptionRecordValue> created =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    // the subscription genuinely lives on a different partition than the instance
+    assertThat(created.getPartitionId()).isEqualTo(subscriptionPartition);
+    assertThat(subscriptionPartition).isNotEqualTo(PROCESS_INSTANCE_PARTITION);
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // suspend must reach across partitions to delete the message-side subscription
+    final Record<MessageSubscriptionRecordValue> deleted =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(deleted.getPartitionId()).isEqualTo(subscriptionPartition);
+
+    // publish while suspended: no subscriber on the remote partition → message buffers with a TTL
+    engine
+        .message()
+        .onPartition(subscriptionPartition)
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .withTimeToLive(Duration.ofMinutes(1))
+        .publish();
+
+    // when - resume; the resume processor re-opens the subscription across partitions and the
+    // subscription-create handler picks up the buffered message immediately
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the subscription is re-created on the remote partition and correlates the buffer,
+    // completing the instance
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getPartitionId)
+        .containsExactly(subscriptionPartition, subscriptionPartition);
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  @Test
+  public void shouldReturnNotFoundForCrossPartitionDirectCorrelateWhileSuspended() {
+    // given - an instance on one partition with its message subscription on another, then
+    // suspended.
+    // Regression for #60648: a direct/synchronous correlate to a suspended instance whose
+    // subscription lives on a remote partition must get a prompt terminal rejection instead of
+    // hanging until the gateway deadline.
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = correlationKeyForPartitionOtherThan(PROCESS_INSTANCE_PARTITION);
+    final int subscriptionPartition = getSubscriptionPartitionId(correlationKey);
+
+    final long processInstanceKey =
+        deployAndStart(processId, messageName, correlationKey, PROCESS_INSTANCE_PARTITION);
+
+    final Record<MessageSubscriptionRecordValue> created =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    // the subscription genuinely lives on a different partition than the instance
+    assertThat(created.getPartitionId()).isEqualTo(subscriptionPartition);
+    assertThat(subscriptionPartition).isNotEqualTo(PROCESS_INSTANCE_PARTITION);
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // suspend deletes the message-side subscription on the remote partition
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - a direct correlate routes to the subscription partition (by correlation key), where
+    // the
+    // subscription no longer exists
+    final Record<MessageCorrelationRecordValue> rejection =
+        engine
+            .messageCorrelation()
+            .withName(messageName)
+            .withCorrelationKey(correlationKey)
+            .expectRejection()
+            .correlate();
+
+    // then - prompt NOT_FOUND, not a hung request: the suspended instance has no message-side
+    // subscription, so the existing not-found path fires on the subscription partition
+    assertThat(rejection.getPartitionId()).isEqualTo(subscriptionPartition);
+    Assertions.assertThat(rejection)
+        .hasIntent(MessageCorrelationIntent.CORRELATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  private long deployAndStart(
+      final String processId,
+      final String messageName,
+      final String correlationKey,
+      final int partitionId) {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(
+                    "msg",
+                    e ->
+                        e.message(
+                            m ->
+                                m.name(messageName)
+                                    .zeebeCorrelationKey("=\"%s\"".formatted(correlationKey))))
+                .endEvent()
+                .done())
+        .deploy();
+    return engine.processInstance().ofBpmnProcessId(processId).onPartition(partitionId).create();
+  }
+
+  /** Generates a correlation key whose subscription partition differs from the given one. */
+  private String correlationKeyForPartitionOtherThan(final int partitionId) {
+    for (int i = 0; ; i++) {
+      final String candidate = "key-" + i;
+      if (getSubscriptionPartitionId(candidate) != partitionId) {
+        return candidate;
+      }
+    }
+  }
+
+  private int getSubscriptionPartitionId(final String correlationKey) {
+    final List<Integer> partitionIds = engine.getPartitionIds();
+    return SubscriptionUtil.getSubscriptionPartitionId(
+        BufferUtil.wrapString(correlationKey), partitionIds.size());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageSuspensionGateTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,8 +37,9 @@ public final class MessageSuspensionGateTest {
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldRejectMessageCorrelateWhileSuspended() {
-    // given - an instance waiting on an intermediate message catch event, then suspended
+  public void shouldReturnNotFoundWhileSuspended() {
+    // given - an instance waiting on an intermediate message catch event, then suspended.
+    // Suspension tears down the message-side subscription so no active subscriber exists.
     final String processId = Strings.newRandomValidBpmnId();
     final String messageName = Strings.newRandomValidBpmnId();
     final String correlationKey = Strings.newRandomValidBpmnId();
@@ -56,24 +59,29 @@ public final class MessageSuspensionGateTest {
             .expectRejection()
             .correlate();
 
-    // then - the correlate command is rejected, referencing the suspended instance
+    // then - NOT_FOUND because the message-side subscription was removed on suspend;
+    // subscriptions are re-created only on resume (COMPLETE_RESUMING)
     Assertions.assertThat(rejection)
         .hasIntent(MessageCorrelationIntent.CORRELATE)
-        .hasRejectionType(RejectionType.INVALID_STATE);
-    assertThat(rejection.getRejectionReason())
-        .contains("process instance with key '" + processInstanceKey + "'");
+        .hasRejectionType(RejectionType.NOT_FOUND);
   }
 
   @Test
-  public void shouldRejectMessageCorrelateWhileResuming() {
-    // given - an instance waiting on a message catch event, with the RESUMING marker seeded
-    // directly to isolate the gate from the drain that puts the instance into that state
+  public void shouldReturnNotFoundWhileResuming() {
+    // given - suspend an instance (tears down the message-side subscription), then artificially
+    // seed RESUMING to simulate the mid-resume window before COMPLETE_RESUMING re-opens it.
+    // During that window there is no active message-side subscriber.
     final String processId = Strings.newRandomValidBpmnId();
     final String messageName = Strings.newRandomValidBpmnId();
     final String correlationKey = Strings.newRandomValidBpmnId();
     final long processInstanceKey =
         deployAndStartProcessWithMessageCatchEvent(processId, messageName, correlationKey);
     RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    // Wait for the message-side subscription to be deleted before seeding RESUMING
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
         .withProcessInstanceKey(processInstanceKey)
         .await();
     ((MutableProcessingState) ENGINE.getProcessingState())
@@ -89,12 +97,10 @@ public final class MessageSuspensionGateTest {
             .expectRejection()
             .correlate();
 
-    // then - the correlate command is rejected just like while SUSPENDED
+    // then - NOT_FOUND: subscriptions are not yet re-created during the RESUMING window
     Assertions.assertThat(rejection)
         .hasIntent(MessageCorrelationIntent.CORRELATE)
-        .hasRejectionType(RejectionType.INVALID_STATE);
-    assertThat(rejection.getRejectionReason())
-        .contains("process instance with key '" + processInstanceKey + "'");
+        .hasRejectionType(RejectionType.NOT_FOUND);
   }
 
   @Test
@@ -163,6 +169,132 @@ public final class MessageSuspensionGateTest {
                 .limit(1))
         .extracting(r -> r.getValue().getProcessInstanceKey())
         .containsExactly(activeInstanceKey);
+  }
+
+  @Test
+  public void shouldCorrelateToSingleActiveTargetAmongMultipleSuspendedInstances() {
+    // given - three suspended instances and one active, all subscribed to the same message
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    final long suspendedKey1 =
+        deployAndStartProcessWithMessageCatchEvent(
+            Strings.newRandomValidBpmnId(), messageName, correlationKey);
+    final long suspendedKey2 =
+        deployAndStartProcessWithMessageCatchEvent(
+            Strings.newRandomValidBpmnId(), messageName, correlationKey);
+    final long suspendedKey3 =
+        deployAndStartProcessWithMessageCatchEvent(
+            Strings.newRandomValidBpmnId(), messageName, correlationKey);
+    final long activeKey =
+        deployAndStartProcessWithMessageCatchEvent(
+            Strings.newRandomValidBpmnId(), messageName, correlationKey);
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(suspendedKey1)
+        .await();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(suspendedKey2)
+        .await();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(suspendedKey3)
+        .await();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(activeKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(suspendedKey1).suspend();
+    ENGINE.processInstance().withInstanceKey(suspendedKey2).suspend();
+    ENGINE.processInstance().withInstanceKey(suspendedKey3).suspend();
+
+    // when
+    ENGINE
+        .messageCorrelation()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .correlate();
+
+    // then - only the active instance receives the message; the three suspended ones are skipped
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(activeKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATED)
+                .withMessageName(messageName)
+                .limit(1))
+        .extracting(r -> r.getValue().getProcessInstanceKey())
+        .containsExactly(activeKey);
+  }
+
+  @Test
+  public void shouldCorrelateMessageAfterResume() {
+    // given - suspend an instance, then resume it; subscriptions are re-created on resume
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithMessageCatchEvent(processId, messageName, correlationKey);
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+    // Wait for the message-side subscription to be re-created by reopenMessageSubscriptions
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - send a fresh message after resume
+    ENGINE
+        .messageCorrelation()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .correlate();
+
+    // then - the resumed instance correlates and completes normally
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  @Test
+  public void shouldPickUpMessageWithTTLOnResume() {
+    // given - suspend the instance (removing message-side subscription), publish a message while
+    // suspended so it buffers, then resume; reopenMessageSubscriptions re-creates the subscription
+    // and MessageSubscriptionCreateProcessor calls correlateNextMessage immediately on CREATE.
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    final long processInstanceKey =
+        deployAndStartProcessWithMessageCatchEvent(processId, messageName, correlationKey);
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    // Ensure the message-side subscription is fully deleted before publishing
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // publish while suspended: no active subscriber → message buffers with a 1-minute TTL
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .withTimeToLive(Duration.ofMinutes(1))
+        .publish();
+
+    // when - resume; subscription is re-created and correlateNextMessage picks up the buffer
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - the buffered message correlates automatically and the instance completes
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
   }
 
   private long deployAndStartProcessWithMessageCatchEvent(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -122,7 +122,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_KEY,
         DEFAULT_VARIABLES,
         DEFAULT_CORRELATION_KEY,
-        DEFAULT_TENANT);
+        DEFAULT_TENANT,
+        1L);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -143,7 +144,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_KEY,
         DEFAULT_VARIABLES,
         DEFAULT_CORRELATION_KEY,
-        DEFAULT_TENANT);
+        DEFAULT_TENANT,
+        1L);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -164,7 +166,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_KEY,
         DEFAULT_VARIABLES,
         DEFAULT_CORRELATION_KEY,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        1L);
 
     // then
     verify(mockInterPartitionCommandSender)
@@ -188,7 +191,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_DEFINITION_KEY,
         DEFAULT_MESSAGE_NAME,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        -1L);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -206,7 +210,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_DEFINITION_KEY,
         DEFAULT_MESSAGE_NAME,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        -1L);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -224,7 +229,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_DEFINITION_KEY,
         DEFAULT_MESSAGE_NAME,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        -1L);
 
     // then
     verify(mockInterPartitionCommandSender)
@@ -330,7 +336,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         true,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
-        DEFAULT_BUSINESS_ID);
+        DEFAULT_BUSINESS_ID,
+        -1L);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -349,7 +356,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_NAME,
         true,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
-        DEFAULT_BUSINESS_ID);
+        DEFAULT_BUSINESS_ID,
+        -1L);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());
@@ -370,7 +378,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_KEY,
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        -1L);
 
     // then
     verify(mockProcessingResultBuilder).appendPostCommitTask(any());
@@ -391,7 +400,8 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_MESSAGE_KEY,
         DEFAULT_MESSAGE_NAME,
         DEFAULT_CORRELATION_KEY,
-        TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        TenantOwned.DEFAULT_TENANT_IDENTIFIER,
+        -1L);
 
     // then
     verify(mockProcessingResultBuilder, never()).appendPostCommitTask(any());

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessMessageSubscription_CREATING_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessMessageSubscription_CREATING_v2.golden
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+
+/**
+ * Version 2 of the {@code CREATING} applier. Unlike v1 (which only inserts a new row), v2 also
+ * handles the resume re-subscribe path, where a {@code CREATING} event is emitted for a row that
+ * already exists in {@code OPENED} state (the durable resume manifest kept by the suspend path).
+ *
+ * <p>The behaviour is an upsert:
+ *
+ * <ul>
+ *   <li>row does not exist → {@link MutableProcessMessageSubscriptionState#put} (first-time
+ *       subscription, identical to v1)
+ *   <li>row already exists → {@link MutableProcessMessageSubscriptionState#updateToOpeningState},
+ *       which transitions {@code OPENED → OPENING} and enrolls the row in the pending-retry
+ *       transient index so the open command is retried after a dropped send or leader failover
+ * </ul>
+ *
+ * <p>v1 is retained unchanged and remains registered so that {@code CREATING} events written by
+ * released versions (record version 1) replay byte-identically. Only new events written by this
+ * version onward carry record version 2 and are applied here.
+ */
+public final class ProcessMessageSubscriptionCreatingV2Applier
+    implements TypedEventApplier<
+        ProcessMessageSubscriptionIntent, ProcessMessageSubscriptionRecord> {
+
+  private final MutableProcessMessageSubscriptionState subscriptionState;
+
+  public ProcessMessageSubscriptionCreatingV2Applier(
+      final MutableProcessMessageSubscriptionState subscriptionState) {
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
+    final var existing =
+        subscriptionState.getSubscription(
+            value.getElementInstanceKey(), value.getMessageNameBuffer(), value.getTenantId());
+    if (existing != null) {
+      subscriptionState.updateToOpeningState(value);
+    } else {
+      subscriptionState.put(key, value);
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-subscription-template.json
@@ -63,6 +63,10 @@
             },
             "elementType": {
               "type": "keyword"
+            },
+            "subscriptionKey": {
+              "type": "long",
+              "index": false
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-message-subscription-template.json
@@ -64,6 +64,10 @@
             "subscriptionKey": {
               "type": "long",
               "index": false
+            },
+            "closedForSuspend": {
+              "type": "boolean",
+              "index": false
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-message-subscription-template.json
@@ -60,6 +60,10 @@
             },
             "elementType": {
               "type": "keyword"
+            },
+            "subscriptionKey": {
+              "type": "long",
+              "index": false
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -93,18 +93,18 @@ final class BulkIndexRequestTest {
     recordAsMap.remove("agent");
     recordAsMap.remove("requestChannelType");
     recordAsMap.remove("requestToolName");
-    // the storage ordinal key is stripped from every record value during serialization; it can
-    // appear at any nesting level (e.g. embedded job records), so remove it recursively
-    removeStorageOrdinalKeys(recordAsMap);
+    // storageOrdinalKey is stripped from record values during serialization;
+    // it can appear at any nesting level (e.g. embedded job records), so remove it recursively
+    removeStrippedKeys(recordAsMap);
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
-  private static void removeStorageOrdinalKeys(final Object node) {
+  private static void removeStrippedKeys(final Object node) {
     if (node instanceof final Map<?, ?> map) {
       map.remove("storageOrdinalKey");
-      map.values().forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+      map.values().forEach(BulkIndexRequestTest::removeStrippedKeys);
     } else if (node instanceof final Collection<?> collection) {
-      collection.forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+      collection.forEach(BulkIndexRequestTest::removeStrippedKeys);
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-subscription-template.json
@@ -69,6 +69,10 @@
             },
             "elementType": {
               "type": "keyword"
+            },
+            "subscriptionKey": {
+              "type": "long",
+              "index": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-message-subscription-template.json
@@ -70,6 +70,10 @@
             "subscriptionKey": {
               "type": "long",
               "index": false
+            },
+            "closedForSuspend": {
+              "type": "boolean",
+              "index": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-message-subscription-template.json
@@ -66,6 +66,10 @@
             },
             "elementType": {
               "type": "keyword"
+            },
+            "subscriptionKey": {
+              "type": "long",
+              "index": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -93,18 +93,18 @@ final class BulkIndexRequestTest {
     recordAsMap.remove("agent");
     recordAsMap.remove("requestChannelType");
     recordAsMap.remove("requestToolName");
-    // the storage ordinal key is stripped from every record value during serialization; it can
-    // appear at any nesting level (e.g. embedded job records), so remove it recursively
-    removeStorageOrdinalKeys(recordAsMap);
+    // storageOrdinalKey is stripped from record values during serialization;
+    // it can appear at any nesting level (e.g. embedded job records), so remove it recursively
+    removeStrippedKeys(recordAsMap);
     return MAPPER.writeValueAsBytes(recordAsMap).length;
   }
 
-  private static void removeStorageOrdinalKeys(final Object node) {
+  private static void removeStrippedKeys(final Object node) {
     if (node instanceof final Map<?, ?> map) {
       map.remove("storageOrdinalKey");
-      map.values().forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+      map.values().forEach(BulkIndexRequestTest::removeStrippedKeys);
     } else if (node instanceof final Collection<?> collection) {
-      collection.forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+      collection.forEach(BulkIndexRequestTest::removeStrippedKeys);
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -59,7 +59,10 @@ public class MessageSubscriptionExportHandler
   public void export(final Record<ProcessMessageSubscriptionRecordValue> record) {
     switch (record.getIntent()) {
       case ProcessMessageSubscriptionIntent.CREATED:
-        messageSubscriptionWriter.create(map(record));
+        // Idempotent: the suspend/resume flow reuses the same subscription key and re-emits CREATED
+        // (manifest restore on suspend-close ack, and reopen on resume). A plain insert would hit
+        // the existing primary key on the second CREATED and stall the exporter.
+        messageSubscriptionWriter.createIfNotExists(map(record));
         break;
       case ProcessMessageSubscriptionIntent.CORRELATED,
       ProcessMessageSubscriptionIntent.DELETED,

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -97,7 +97,8 @@ final class MessageSubscriptionExportHandlerTest {
     underTest.export(record);
 
     // then
-    verify(writer).create(any());
+    // CREATED uses an idempotent insert: the suspend/resume flow re-emits CREATED for the same key.
+    verify(writer).createIfNotExists(any());
   }
 
   @ParameterizedTest
@@ -211,7 +212,7 @@ final class MessageSubscriptionExportHandlerTest {
             ProcessMessageSubscriptionIntent.CREATED,
             MessageSubscriptionState.CREATED,
             (BiConsumer<MessageSubscriptionWriter, ArgumentCaptor<MessageSubscriptionDbModel>>)
-                (writer, captor) -> verify(writer).create(captor.capture())),
+                (writer, captor) -> verify(writer).createIfNotExists(captor.capture())),
         Arguments.of(
             ProcessMessageSubscriptionIntent.CORRELATED,
             MessageSubscriptionState.CORRELATED,
@@ -246,7 +247,7 @@ final class MessageSubscriptionExportHandlerTest {
 
     // then — no exception, enrichment fields fall back to null / empty map
     final var captor = ArgumentCaptor.forClass(MessageSubscriptionDbModel.class);
-    verify(writer).create(captor.capture());
+    verify(writer).createIfNotExists(captor.capture());
     final MessageSubscriptionDbModel model = captor.getValue();
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
@@ -283,7 +284,8 @@ final class MessageSubscriptionExportHandlerTest {
 
     // then
     final var captor = ArgumentCaptor.forClass(MessageSubscriptionDbModel.class);
-    verify(writer).create(captor.capture());
+    // CREATED uses an idempotent insert: the suspend/resume flow re-emits CREATED for the same key.
+    verify(writer).createIfNotExists(captor.capture());
     assertThat(captor.getValue().businessId()).isNull();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -46,6 +46,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
+  private static final StringValue SUBSCRIPTION_KEY_KEY = new StringValue("subscriptionKey");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -68,9 +69,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+  private final LongProperty subscriptionKeyProp = new LongProperty(SUBSCRIPTION_KEY_KEY, -1L);
 
   public MessageSubscriptionRecord() {
-    super(15);
+    super(16);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -85,7 +87,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
-        .declareProperty(elementTypeProp);
+        .declareProperty(elementTypeProp)
+        .declareProperty(subscriptionKeyProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -104,6 +107,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
     setStorageOrdinalKey(record.getStorageOrdinalKey());
     setElementType(record.getElementType());
+    setSubscriptionKey(record.getSubscriptionKey());
   }
 
   @JsonIgnore
@@ -293,6 +297,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
     storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
+  @Override
+  public long getSubscriptionKey() {
+    return subscriptionKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setSubscriptionKey(final long subscriptionKey) {
+    subscriptionKeyProp.setValue(subscriptionKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -47,6 +47,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
+  private static final StringValue SUBSCRIPTION_KEY_KEY = new StringValue("subscriptionKey");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -70,9 +71,10 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+  private final LongProperty subscriptionKeyProp = new LongProperty(SUBSCRIPTION_KEY_KEY, -1L);
 
   public ProcessMessageSubscriptionRecord() {
-    super(16);
+    super(17);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -88,7 +90,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
-        .declareProperty(elementTypeProp);
+        .declareProperty(elementTypeProp)
+        .declareProperty(subscriptionKeyProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -108,6 +111,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setStorageOrdinalKey(record.getStorageOrdinalKey());
     setBusinessId(record.getBusinessIdBuffer());
     setElementType(record.getElementType());
+    setSubscriptionKey(record.getSubscriptionKey());
   }
 
   @JsonIgnore
@@ -302,6 +306,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
     storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
+  @Override
+  public long getSubscriptionKey() {
+    return subscriptionKeyProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setSubscriptionKey(final long subscriptionKey) {
+    subscriptionKeyProp.setValue(subscriptionKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -48,6 +48,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
   private static final StringValue SUBSCRIPTION_KEY_KEY = new StringValue("subscriptionKey");
+  private static final StringValue CLOSED_FOR_SUSPEND_KEY = new StringValue("closedForSuspend");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -72,9 +73,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
   private final LongProperty subscriptionKeyProp = new LongProperty(SUBSCRIPTION_KEY_KEY, -1L);
+  private final BooleanProperty closedForSuspendProp =
+      new BooleanProperty(CLOSED_FOR_SUSPEND_KEY, false);
 
   public ProcessMessageSubscriptionRecord() {
-    super(17);
+    super(18);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -91,7 +94,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
         .declareProperty(elementTypeProp)
-        .declareProperty(subscriptionKeyProp);
+        .declareProperty(subscriptionKeyProp)
+        .declareProperty(closedForSuspendProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -112,6 +116,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setBusinessId(record.getBusinessIdBuffer());
     setElementType(record.getElementType());
     setSubscriptionKey(record.getSubscriptionKey());
+    setClosedForSuspend(record.isClosedForSuspend());
   }
 
   @JsonIgnore
@@ -316,6 +321,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setSubscriptionKey(final long subscriptionKey) {
     subscriptionKeyProp.setValue(subscriptionKey);
+    return this;
+  }
+
+  @Override
+  public boolean isClosedForSuspend() {
+    return closedForSuspendProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setClosedForSuspend(final boolean closedForSuspend) {
+    closedForSuspendProp.setValue(closedForSuspend);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1589,7 +1589,8 @@ final class JsonSerializableToJsonTest {
                   .setBusinessId("biz-42")
                   .setStorageOrdinalKey(storageOrdinalKey)
                   .setElementType(BpmnElementType.RECEIVE_TASK)
-                  .setSubscriptionKey(subscriptionKey);
+                  .setSubscriptionKey(subscriptionKey)
+                  .setClosedForSuspend(true);
             },
         """
                 {
@@ -1610,7 +1611,8 @@ final class JsonSerializableToJsonTest {
                   "businessId": "biz-42",
                   "storageOrdinalKey": 8,
                   "elementType": "RECEIVE_TASK",
-                  "subscriptionKey": 42
+                  "subscriptionKey": 42,
+                  "closedForSuspend": true
                 }
                 """
       },
@@ -1648,7 +1650,8 @@ final class JsonSerializableToJsonTest {
                   "businessId": "",
                   "storageOrdinalKey": 0,
                   "elementType": "UNSPECIFIED",
-                  "subscriptionKey": -1
+                  "subscriptionKey": -1,
+                  "closedForSuspend": false
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1475,6 +1475,7 @@ final class JsonSerializableToJsonTest {
               final String correlationKey = "key";
               final long messageKey = 3L;
               final int storageOrdinalKey = 8;
+              final long subscriptionKey = 42L;
 
               return new MessageSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -1489,7 +1490,8 @@ final class JsonSerializableToJsonTest {
                   .setElementId("catch-1")
                   .setRootProcessInstanceKey(99L)
                   .setStorageOrdinalKey(storageOrdinalKey)
-                  .setElementType(BpmnElementType.RECEIVE_TASK);
+                  .setElementType(BpmnElementType.RECEIVE_TASK)
+                  .setSubscriptionKey(subscriptionKey);
             },
         """
                 {
@@ -1509,7 +1511,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "catch-1",
                   "rootProcessInstanceKey": 99,
                   "storageOrdinalKey": 8,
-                  "elementType": "RECEIVE_TASK"
+                  "elementType": "RECEIVE_TASK",
+                  "subscriptionKey": 42
                 }
                 """
       },
@@ -1544,7 +1547,8 @@ final class JsonSerializableToJsonTest {
                   "elementId": "",
                   "rootProcessInstanceKey": -1,
                   "storageOrdinalKey": 0,
-                  "elementType": "UNSPECIFIED"
+                  "elementType": "UNSPECIFIED",
+                  "subscriptionKey": -1
                 }
                 """
       },
@@ -1568,6 +1572,7 @@ final class JsonSerializableToJsonTest {
               final String correlationKey = "key";
               final long rootProcessInstanceKey = 5678L;
               final int storageOrdinalKey = 8;
+              final long subscriptionKey = 42L;
 
               return new ProcessMessageSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -1583,7 +1588,8 @@ final class JsonSerializableToJsonTest {
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
                   .setBusinessId("biz-42")
                   .setStorageOrdinalKey(storageOrdinalKey)
-                  .setElementType(BpmnElementType.RECEIVE_TASK);
+                  .setElementType(BpmnElementType.RECEIVE_TASK)
+                  .setSubscriptionKey(subscriptionKey);
             },
         """
                 {
@@ -1603,7 +1609,8 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": 5678,
                   "businessId": "biz-42",
                   "storageOrdinalKey": 8,
-                  "elementType": "RECEIVE_TASK"
+                  "elementType": "RECEIVE_TASK",
+                  "subscriptionKey": 42
                 }
                 """
       },
@@ -1640,7 +1647,8 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": -1,
                   "businessId": "",
                   "storageOrdinalKey": 0,
-                  "elementType": "UNSPECIFIED"
+                  "elementType": "UNSPECIFIED",
+                  "subscriptionKey": -1
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -46,6 +46,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new StringValue("rootProcessInstanceKey");
   private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
+  private static final StringValue SUBSCRIPTION_KEY_KEY = new StringValue("subscriptionKey");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
@@ -68,9 +69,10 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+  private final LongProperty subscriptionKeyProp = new LongProperty(SUBSCRIPTION_KEY_KEY, -1L);
 
   public MessageSubscriptionRecord() {
-    super(15);
+    super(16);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -85,7 +87,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
-        .declareProperty(elementTypeProp);
+        .declareProperty(elementTypeProp)
+        .declareProperty(subscriptionKeyProp);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -104,6 +107,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
     setStorageOrdinalKey(record.getStorageOrdinalKey());
     setElementType(record.getElementType());
+    setSubscriptionKey(record.getSubscriptionKey());
   }
 
   @JsonIgnore
@@ -293,6 +297,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
 
   public MessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
     storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
+  @Override
+  public long getSubscriptionKey() {
+    return subscriptionKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setSubscriptionKey(final long subscriptionKey) {
+    subscriptionKeyProp.setValue(subscriptionKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -47,6 +47,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
+  private static final StringValue SUBSCRIPTION_KEY_KEY = new StringValue("subscriptionKey");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -70,9 +71,10 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+  private final LongProperty subscriptionKeyProp = new LongProperty(SUBSCRIPTION_KEY_KEY, -1L);
 
   public ProcessMessageSubscriptionRecord() {
-    super(16);
+    super(17);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -88,7 +90,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
-        .declareProperty(elementTypeProp);
+        .declareProperty(elementTypeProp)
+        .declareProperty(subscriptionKeyProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -108,6 +111,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setStorageOrdinalKey(record.getStorageOrdinalKey());
     setBusinessId(record.getBusinessIdBuffer());
     setElementType(record.getElementType());
+    setSubscriptionKey(record.getSubscriptionKey());
   }
 
   @JsonIgnore
@@ -302,6 +306,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
     storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
+  @Override
+  public long getSubscriptionKey() {
+    return subscriptionKeyProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setSubscriptionKey(final long subscriptionKey) {
+    subscriptionKeyProp.setValue(subscriptionKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -48,6 +48,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
   private static final StringValue SUBSCRIPTION_KEY_KEY = new StringValue("subscriptionKey");
+  private static final StringValue CLOSED_FOR_SUSPEND_KEY = new StringValue("closedForSuspend");
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
@@ -72,9 +73,11 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
   private final LongProperty subscriptionKeyProp = new LongProperty(SUBSCRIPTION_KEY_KEY, -1L);
+  private final BooleanProperty closedForSuspendProp =
+      new BooleanProperty(CLOSED_FOR_SUSPEND_KEY, false);
 
   public ProcessMessageSubscriptionRecord() {
-    super(17);
+    super(18);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -91,7 +94,8 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
         .declareProperty(elementTypeProp)
-        .declareProperty(subscriptionKeyProp);
+        .declareProperty(subscriptionKeyProp)
+        .declareProperty(closedForSuspendProp);
   }
 
   public void wrap(final ProcessMessageSubscriptionRecord record) {
@@ -112,6 +116,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setBusinessId(record.getBusinessIdBuffer());
     setElementType(record.getElementType());
     setSubscriptionKey(record.getSubscriptionKey());
+    setClosedForSuspend(record.isClosedForSuspend());
   }
 
   @JsonIgnore
@@ -316,6 +321,16 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   public ProcessMessageSubscriptionRecord setSubscriptionKey(final long subscriptionKey) {
     subscriptionKeyProp.setValue(subscriptionKey);
+    return this;
+  }
+
+  @Override
+  public boolean isClosedForSuspend() {
+    return closedForSuspendProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setClosedForSuspend(final boolean closedForSuspend) {
+    closedForSuspendProp.setValue(closedForSuspend);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -27,7 +27,15 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
   DELETE((short) 6),
   DELETED((short) 7),
 
-  MIGRATED((short) 8);
+  MIGRATED((short) 8),
+
+  /**
+   * Command to re-open a message subscription from its durable resume manifest, buffered per
+   * process instance on suspend-close ack and drained one-per-batch on resume. Distinct from {@link
+   * #CREATE} (the create acknowledgement, which expects an {@code OPENING} row); {@code REOPEN}
+   * starts from the {@code OPENED} manifest row.
+   */
+  REOPEN((short) 9);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -81,6 +89,8 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
         return DELETED;
       case 8:
         return MIGRATED;
+      case 9:
+        return REOPEN;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -114,4 +114,19 @@ public interface MessageSubscriptionRecordValue
    * @since 8.10
    */
   BpmnElementType getElementType();
+
+  /**
+   * Returns the generation key of the message-side subscription, assigned when the subscription is
+   * created on the message partition. Used to guard delete commands against stale races: a delete
+   * that quotes an old key is rejected rather than deleting a freshly re-created subscription.
+   *
+   * <p>This is a per-generation key, not a stable identity. {@code -1} means "unset": a
+   * subscription created before this field was introduced, or a CREATE command record before {@code
+   * MessageSubscriptionCreateProcessor} assigns the key. Do not interpret {@code -1} as
+   * legacy-only.
+   *
+   * @return the subscription key, or {@code -1} if unset
+   * @since 8.10
+   */
+  long getSubscriptionKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -121,4 +121,12 @@ public interface ProcessMessageSubscriptionRecordValue
    * @since 8.10
    */
   long getSubscriptionKey();
+
+  /**
+   * @return {@code true} if this subscription was closed by the suspend flow, meaning the delete
+   *     acknowledgement must restore this row as a resume manifest instead of deleting it; {@code
+   *     false} for a normal close (unsubscribe, cancellation, migration) or a legacy record
+   * @since 8.11
+   */
+  boolean isClosedForSuspend();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -105,4 +105,20 @@ public interface ProcessMessageSubscriptionRecordValue
    * @since 8.10
    */
   BpmnElementType getElementType();
+
+  /**
+   * Returns the generation key of the message-side subscription, assigned when the subscription is
+   * created on the message partition and echoed back to the process instance partition in the open
+   * acknowledgement. Used to guard delete/correlate commands against stale races.
+   *
+   * <p>This is a per-generation key, not a stable identity across suspend/resume: {@code
+   * reopenFromManifest} resets it to {@code -1} when a suspended subscription is reopened, until
+   * the replacement's open acknowledgement assigns the new key. {@code -1} therefore means "unset"
+   * — a subscription created before this field was introduced, or one currently being reopened —
+   * and must not be cached or interpreted as legacy-only across generations.
+   *
+   * @return the subscription key, or {@code -1} if unset
+   * @since 8.10
+   */
+  long getSubscriptionKey();
 }


### PR DESCRIPTION
## Description

Fixes message correlation behaviour for suspended process instances (issues #58766 and #60648).

### Problem

The previous approach buffered `ProcessMessageSubscription.CORRELATE` commands while an instance was suspended. This held the message-partition correlation lock indefinitely, preventing other active subscribers of the same message from receiving it. Cross-partition suspension checks in `MessageCorrelationCorrelateProcessor` were also broken because suspension state is partition-local.

### Solution (Solution 3 – Reject and Re-subscribe)

**Suspend.** `ProcessInstanceSuspendProcessor` walks the element-instance tree and, for every `OPENED` `ProcessMessageSubscription`, emits `DELETING` (moving the PI-side row to `CLOSING`), enrolls it in the pending-retry index, and sends `closeMessageSubscription` to the message partition. The message partition removes its `MessageSubscription` row. The tree-walk close lives in a dedicated `ProcessInstanceSuspensionMessageSubscriptionBehavior`, mirroring the existing `ProcessInstanceSuspensionJobBehavior` for jobs, so the processor reads as orchestration.

**Close ack → resume manifest.** When the delete ack returns, `ProcessMessageSubscriptionDeleteProcessor` detects a suspend-driven close (instance suspended **and** element still active) and re-emits `CREATED`, transitioning the PI-side row back to `OPENED` so it serves as a durable resume manifest. A normal user-driven unsubscribe writes `DELETING` while the element is already ending, so its ack deletes the row as before (guarded by `isClosing()` + the suspend-driven discriminator).

**Resume (chunked).** Re-subscription is not done in one batch. Each suspend-driven close ack buffers a `ProcessMessageSubscription.REOPEN` command (a new intent) into the per-instance suspend buffer. On resume, `BufferedCommandDrainProcessor` drains these one per batch, so re-subscribing a large instance never accumulates into a single oversized record batch. Each `REOPEN` is handled by `ProcessMessageSubscriptionCreateProcessor` (which branches on the intent): it re-emits `CREATING` (v2 applier, `OPENED → OPENING`) and sends `openMessageSubscription`. The drain advances to `RESUME_JOBS` only once the buffer is empty and no subscription is still `CLOSING`; a late ack re-triggers a `DRAIN`. `ProcessInstanceCompleteResumingProcessor` is now purely the `RESUMED` finalizer. On `CREATE`, `correlateNextMessage` gives TTL-correct pickup of any message buffered while suspended.

**Stale-generation guard.** A `subscriptionKey` field identifies a subscription generation. Reopen resets it to `-1` (the message partition assigns a fresh key on re-subscribe); the PI-side correlate, message-side delete, message-side reject, and normal unsubscribe all quote/validate it so a command delayed across a suspend/resume cycle cannot correlate to, delete, or reject a replacement subscription.

**Correlate / cross-partition.** `ProcessMessageSubscriptionCorrelateProcessor` switches from `BUFFER` to `PROCESS` and rejects a `CORRELATE` that arrives for a suspended instance (releasing the message-partition lock) or that quotes a superseded generation. `MessageCorrelationCorrelateProcessor` loses the broken partition-local suspension check; with Solution 3 a suspended instance has no message-side subscription, so the existing `NOT_FOUND` path fires naturally.

**RDBMS.** The message-subscription exporter's `createIfNotExists` is a full upsert (all vendors), so a re-emitted `CREATED` refreshes a row that may be stale (`CORRELATED → CREATED`) rather than leaving it untouched. The `MESSAGE_SUBSCRIPTION` write-queue context is set to preserve insertion order: the restore `CREATED` is an INSERT-typed upsert, and the default INSERT-before-UPDATE sort would otherwise run it ahead of an earlier-queued `CORRELATED` update in the same flush, leaving the row stale as `CORRELATED`.

### Known limitation

Suspend still closes all subscriptions in a single `SUSPEND` batch, so an instance with more concurrent message subscriptions than fit in one record batch (~10K) is rejected — the same limit as job suspension (#60612). Chunking the closes across suspension cycles is tracked as a Phase 5 follow-up: #61057.

### Deferred hardening (#61099)

A few narrow suspend/resume edge cases are tracked as Phase 4 hardening in #61099 rather than fixed here, since each needs a durable, versioned late-handshake/release transition and a repro test first: a `CORRELATE`/`REJECT` delayed across a generation change is rejected locally but does not yet release the message-partition correlation lock without deleting the replacement; and an `OPENING` subscription that correlates a buffered TTL message while suspended live-locks on CREATE/reject retries for the TTL (no corruption, self-heals on resume).

### Tests

- `MessageSuspensionGateTest` — correlation routing while suspended/resuming, pickup of a message with TTL on resume, correlate after resume
- `MessageSuspensionCrossPartitionTest` — cross-partition subscription removal on suspend and re-open + buffered-message pickup on resume; and a direct/synchronous correlate to a suspended instance whose subscription lives on a remote partition returns a prompt `NOT_FOUND` (regression for #60648)
- `ProcessInstanceSuspensionGateTest` — cancel/terminate of a suspended instance, buffered-command clearing
- `BufferedCommandDrainProcessorTest`, `ProcessInstanceCompleteResumingProcessorTest` — drain gating and resume finalization
- `MessageSubscriptionIT#shouldRefreshExistingRowOnCreateIfNotExists` — cross-database `CORRELATED → CREATED` upsert refresh; `#shouldPreserveOrderWhenCorrelatedThenCreatedInSameFlush` — the same-flush ordering fix end-to-end
- `DefaultExecutionQueueTest#shouldPreserveInsertionOrderForMessageSubscriptions` — the write-queue keeps `CORRELATED`-before-`CREATED` insertion order
- Applier and record golden files updated for the new `subscriptionKey` field and the v2 `CREATING` applier

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58766
closes #60648

Follow-ups: #61057 (Phase 5 — chunk suspend-close across cycles + code-structure cleanups), #61099 (Phase 4 — release the correlation lock on stale-generation / OPENING edge cases).

