### PR TITLE
fix: sync operate theme with other components

### DIFF
--- a/operate/client/src/modules/stores/currentTheme.test.ts
+++ b/operate/client/src/modules/stores/currentTheme.test.ts
@@ -8,12 +8,10 @@
 
 import {currentTheme} from './currentTheme';
 
-import {getStateLocally, clearStateLocally} from 'modules/utils/localStorage';
-
 describe('stores/currentTheme', () => {
-  beforeEach(() => {
+  afterEach(() => {
+    localStorage.clear();
     currentTheme.reset();
-    clearStateLocally();
   });
 
   it('should select the system theme by default', () => {
@@ -26,17 +24,17 @@ describe('stores/currentTheme', () => {
     currentTheme.changeTheme('dark');
 
     expect(currentTheme.state.selectedTheme).toBe('dark');
-    expect(getStateLocally().theme).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('"dark"');
     expect(currentTheme.theme).toBe('dark');
 
     currentTheme.changeTheme('light');
     expect(currentTheme.state.selectedTheme).toBe('light');
-    expect(getStateLocally().theme).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('"light"');
     expect(currentTheme.theme).toBe('light');
 
     currentTheme.changeTheme('system');
     expect(currentTheme.state.selectedTheme).toBe('system');
-    expect(getStateLocally().theme).toBe('system');
+    expect(localStorage.getItem('theme')).toBe('"system"');
     expect(currentTheme.theme).toBe('light');
   });
 });

--- a/operate/client/src/modules/stores/currentTheme.ts
+++ b/operate/client/src/modules/stores/currentTheme.ts
@@ -8,8 +8,7 @@
 
 import {makeAutoObservable} from 'mobx';
 import {tracking} from 'modules/tracking';
-
-import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
+import {getStateLocally} from 'modules/utils/localStorage';
 
 type ThemeType = 'light' | 'dark' | 'system';
 type State = {
@@ -24,7 +23,7 @@ const THEME_NAME = {
   SYSTEM: 'system',
 } as const;
 
-const STORED_THEME: ThemeType = getStateLocally()[STORAGE_KEY];
+const STORED_THEME: ThemeType = getStateLocally(STORAGE_KEY);
 const INITIAL_STATE: State = {
   selectedTheme: Object.values(THEME_NAME).includes(STORED_THEME)
     ? STORED_THEME
@@ -62,9 +61,7 @@ class CurrentTheme {
 
     this.state.selectedTheme = theme;
 
-    storeStateLocally({
-      [STORAGE_KEY]: theme,
-    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(theme));
   };
 
   updateSystemPreference = (theme: 'light' | 'dark') => {
@@ -83,9 +80,7 @@ class CurrentTheme {
     });
 
     this.state.selectedTheme = nextTheme;
-    storeStateLocally({
-      [STORAGE_KEY]: nextTheme,
-    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(nextTheme));
   };
 
   reset = () => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR syncs the local storage key with the other components in OC so the setting persist across projects. This changes relates to this epic https://github.com/camunda/product-hub/issues/3447

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates https://github.com/camunda/product-hub/issues/3447
