### PR TITLE
feat: allow the business-value overview sweep to be switched off

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -36,6 +36,7 @@ import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
 import io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex;
 import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -102,6 +103,7 @@ public class BusinessValueOverviewComputeService {
   private final PlainReportEvaluationHandler reportEvaluationHandler;
   private final MappingMetadataRepository mappingMetadataRepository;
   private final SearchLimitsRepository searchLimitsRepository;
+  private final ConfigurationService configurationService;
 
   public BusinessValueOverviewComputeService(
       final BusinessValueTargetRepository targetRepository,
@@ -110,7 +112,8 @@ public class BusinessValueOverviewComputeService {
       final ReportService reportService,
       final PlainReportEvaluationHandler reportEvaluationHandler,
       final MappingMetadataRepository mappingMetadataRepository,
-      final SearchLimitsRepository searchLimitsRepository) {
+      final SearchLimitsRepository searchLimitsRepository,
+      final ConfigurationService configurationService) {
     this.targetRepository = targetRepository;
     this.overviewWriter = overviewWriter;
     this.definitionService = definitionService;
@@ -118,11 +121,22 @@ public class BusinessValueOverviewComputeService {
     this.reportEvaluationHandler = reportEvaluationHandler;
     this.mappingMetadataRepository = mappingMetadataRepository;
     this.searchLimitsRepository = searchLimitsRepository;
+    this.configurationService = configurationService;
   }
 
   public void computeOverviewRows(final List<MetricRange> ranges) {
     if (ranges == null || ranges.isEmpty()) {
       throw new IllegalArgumentException("ranges must not be null or empty");
+    }
+
+    // Guarded here rather than at the call sites so every caller is covered — the scheduler tick,
+    // the stale-read backstop, and whatever calls in next — and so flipping the flag takes effect
+    // on the next invocation without a restart, which is the point of having it during an incident.
+    if (!configurationService.getBusinessValueConfiguration().isOverviewComputeEnabled()) {
+      LOG.info(
+          "Business-value overview compute is disabled by configuration; skipping. "
+              + "Existing rows remain readable but will not advance until it is re-enabled.");
+      return;
     }
 
     final List<DefinitionEntry> definitions = resolveDefinitions();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -129,9 +129,10 @@ public class BusinessValueOverviewComputeService {
       throw new IllegalArgumentException("ranges must not be null or empty");
     }
 
-    // Guarded here rather than at the call sites so every caller is covered — the scheduler tick,
-    // the stale-read backstop, and whatever calls in next — and so flipping the flag takes effect
-    // on the next invocation without a restart, which is the point of having it during an incident.
+    // Guarded here rather than at the call sites so every caller is covered: the scheduler tick,
+    // the stale-read backstop, and whatever calls in next. Note the flag is read from configuration
+    // that is parsed once at startup — ConfigurationReloadable is only driven by test
+    // infrastructure — so changing it requires restarting Optimize.
     if (!configurationService.getBusinessValueConfiguration().isOverviewComputeEnabled()) {
       LOG.info(
           "Business-value overview compute is disabled by configuration; skipping. "

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
@@ -294,6 +294,11 @@ public class BusinessValueOverviewReadService {
   }
 
   private void triggerFullScopeBackstop() {
+    // Checked before the coalescing flag so a disabled sweep does not leave it set, and so reads
+    // do not queue work that would return immediately.
+    if (!configurationService.getBusinessValueConfiguration().isOverviewComputeEnabled()) {
+      return;
+    }
     if (!backstopInFlight.compareAndSet(false, true)) {
       // Another reader has already scheduled the full-scope recompute; nothing to do.
       return;

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
@@ -10,8 +10,8 @@ package io.camunda.optimize.service.businessvalue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.DefinitionType;
@@ -33,6 +33,8 @@ import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
+import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
 import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
@@ -54,23 +56,32 @@ class BusinessValueOverviewComputeKillSwitchTest {
 
   private BusinessValueOverviewWriter overviewWriter;
   private PlainReportEvaluationHandler reportEvaluationHandler;
+  private BusinessValueTargetRepository targetRepository;
+  private DefinitionService definitionService;
+  private MappingMetadataRepository mappingMetadataRepository;
+  private SearchLimitsRepository searchLimitsRepository;
   private BusinessValueConfiguration businessValueConfiguration;
   private BusinessValueOverviewComputeService computeService;
 
   @BeforeEach
   void setUp() {
-    final BusinessValueTargetRepository targetRepository =
-        mock(BusinessValueTargetRepository.class);
+    targetRepository = mock(BusinessValueTargetRepository.class);
     overviewWriter = mock(BusinessValueOverviewWriter.class);
-    final DefinitionService definitionService = mock(DefinitionService.class);
+    definitionService = mock(DefinitionService.class);
     final ReportService reportService = mock(ReportService.class);
     reportEvaluationHandler = mock(PlainReportEvaluationHandler.class);
     final ConfigurationService configurationService = mock(ConfigurationService.class);
+    mappingMetadataRepository = mock(MappingMetadataRepository.class);
+    searchLimitsRepository = mock(SearchLimitsRepository.class);
     businessValueConfiguration = new BusinessValueConfiguration();
 
     when(configurationService.getBusinessValueConfiguration())
         .thenReturn(businessValueConfiguration);
     when(targetRepository.scanAll()).thenReturn(List.of());
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(java.util.Set.of("invoice-process"));
+    when(searchLimitsRepository.aggregationBucketLimit()).thenReturn(1000);
+    when(searchLimitsRepository.indexNamePrefix()).thenReturn("optimize");
     when(reportService.getReportDefinition(anyString())).thenAnswer(invocation -> seededReport());
     when(reportEvaluationHandler.evaluateReport(any(ReportEvaluationInfo.class)))
         .thenAnswer(invocation -> emptyEvaluationResult());
@@ -92,6 +103,8 @@ class BusinessValueOverviewComputeKillSwitchTest {
             definitionService,
             reportService,
             reportEvaluationHandler,
+            mappingMetadataRepository,
+            searchLimitsRepository,
             configurationService);
   }
 
@@ -126,10 +139,17 @@ class BusinessValueOverviewComputeKillSwitchTest {
     // when a tick fires
     computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
 
-    // then no report is evaluated and no row is written — a switch that returned early but still
-    // queried would not relieve the load it exists to relieve
-    verify(reportEvaluationHandler, never()).evaluateReport(any(ReportEvaluationInfo.class));
-    verify(overviewWriter, never()).bulkUpsertFromScheduler(any());
+    // then nothing the sweep would have done happens. Asserting only on evaluation and the write
+    // would leave the rest of the sweep untested — the definition scan, the target scan and the
+    // instance-index lookup are all database round trips this switch exists to stop, and each one
+    // sits before a chunk is ever built.
+    verifyNoInteractions(
+        reportEvaluationHandler,
+        overviewWriter,
+        definitionService,
+        targetRepository,
+        mappingMetadataRepository,
+        searchLimitsRepository);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.businessvalue;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.RoleType;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.AuthorizedReportEvaluationResult;
+import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
+import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.view.ProcessViewEntity;
+import io.camunda.optimize.dto.optimize.query.report.single.result.MeasureDto;
+import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
+import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
+import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
+import io.camunda.optimize.service.report.ReportService;
+import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the operational kill switch for the overview sweep. The value of a kill switch is entirely
+ * in whether it actually stops work, so these assert that no report is evaluated and nothing is
+ * written — not merely that the method returned.
+ */
+class BusinessValueOverviewComputeKillSwitchTest {
+
+  private static final String TENANT = "<default>";
+
+  private BusinessValueOverviewWriter overviewWriter;
+  private PlainReportEvaluationHandler reportEvaluationHandler;
+  private BusinessValueConfiguration businessValueConfiguration;
+  private BusinessValueOverviewComputeService computeService;
+
+  @BeforeEach
+  void setUp() {
+    final BusinessValueTargetRepository targetRepository =
+        mock(BusinessValueTargetRepository.class);
+    overviewWriter = mock(BusinessValueOverviewWriter.class);
+    final DefinitionService definitionService = mock(DefinitionService.class);
+    final ReportService reportService = mock(ReportService.class);
+    reportEvaluationHandler = mock(PlainReportEvaluationHandler.class);
+    final ConfigurationService configurationService = mock(ConfigurationService.class);
+    businessValueConfiguration = new BusinessValueConfiguration();
+
+    when(configurationService.getBusinessValueConfiguration())
+        .thenReturn(businessValueConfiguration);
+    when(targetRepository.scanAll()).thenReturn(List.of());
+    when(reportService.getReportDefinition(anyString())).thenAnswer(invocation -> seededReport());
+    when(reportEvaluationHandler.evaluateReport(any(ReportEvaluationInfo.class)))
+        .thenAnswer(invocation -> emptyEvaluationResult());
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(
+            List.of(
+                new DefinitionWithTenantIdsDto(
+                    "invoice-process",
+                    "Invoice",
+                    DefinitionType.PROCESS,
+                    // getTenantIds() sorts in place, so this list has to be mutable
+                    new ArrayList<>(List.of(TENANT)),
+                    Collections.emptySet())));
+
+    computeService =
+        new BusinessValueOverviewComputeService(
+            targetRepository,
+            overviewWriter,
+            definitionService,
+            reportService,
+            reportEvaluationHandler,
+            configurationService);
+  }
+
+  private static SingleProcessReportDefinitionRequestDto seededReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.PROCESS_INSTANCE, ViewProperty.DURATION))
+            .groupBy(new ProcessDefinitionKeyGroupByDto())
+            .build();
+    reportData.setBusinessValueReport(true);
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto();
+    report.setData(reportData);
+    return report;
+  }
+
+  private static AuthorizedReportEvaluationResult emptyEvaluationResult() {
+    final SingleProcessReportDefinitionRequestDto report = seededReport();
+    final MapCommandResult commandResult =
+        new MapCommandResult(
+            List.of(MeasureDto.of(List.<MapResultEntryDto>of())), report.getData());
+    return new AuthorizedReportEvaluationResult(
+        new SingleReportEvaluationResult<>(report, commandResult), RoleType.VIEWER);
+  }
+
+  @Test
+  void shouldNotEvaluateOrWriteAnythingWhenComputeIsDisabled() {
+    // given the sweep is switched off
+    businessValueConfiguration.setOverviewComputeEnabled(false);
+
+    // when a tick fires
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then no report is evaluated and no row is written — a switch that returned early but still
+    // queried would not relieve the load it exists to relieve
+    verify(reportEvaluationHandler, never()).evaluateReport(any(ReportEvaluationInfo.class));
+    verify(overviewWriter, never()).bulkUpsertFromScheduler(any());
+  }
+
+  @Test
+  void shouldSweepWhenComputeIsEnabled() {
+    // given the sweep is switched on
+    businessValueConfiguration.setOverviewComputeEnabled(true);
+
+    // when a tick fires
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the sweep runs and writes, so the disabled case above is a real difference rather than
+    // a no-op the fixture would have produced anyway
+    verify(overviewWriter).bulkUpsertFromScheduler(any());
+  }
+
+  @Test
+  void shouldSweepWhenTheFlagIsAbsentFromConfiguration() {
+    // given no explicit setting, as on any deployment that has not opted in
+    businessValueConfiguration.setOverviewComputeEnabled(null);
+
+    // when a tick fires
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the sweep still runs: a kill switch that failed closed would silently disable the
+    // feature on a configuration mistake, which is the opposite of what it is for
+    verify(overviewWriter).bulkUpsertFromScheduler(any());
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
@@ -43,6 +43,8 @@ import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
 import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
+import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,7 +119,8 @@ class BusinessValueOverviewComputeServiceTest {
             reportService,
             reportEvaluationHandler,
             mappingMetadataRepository,
-            searchLimitsWithBucketLimit(1000));
+            searchLimitsWithBucketLimit(1000),
+            enabledConfiguration());
   }
 
   private void stubEvaluation() {
@@ -514,15 +517,7 @@ class BusinessValueOverviewComputeServiceTest {
   @Test
   void shouldChunkBelowALoweredAggregationBucketLimit() {
     // given a bucket limit smaller than the default chunk size
-    computeService =
-        new BusinessValueOverviewComputeService(
-            targetRepository,
-            overviewWriter,
-            definitionService,
-            reportService,
-            reportEvaluationHandler,
-            mappingMetadataRepository,
-            searchLimitsWithBucketLimit(10));
+    computeService = computeServiceWith(searchLimitsWithBucketLimit(10));
     givenDefinitions(DEFAULT_TENANT, 20);
 
     // when computing a single range
@@ -542,7 +537,8 @@ class BusinessValueOverviewComputeServiceTest {
         reportService,
         reportEvaluationHandler,
         mappingMetadataRepository,
-        searchLimits);
+        searchLimits,
+        enabledConfiguration());
   }
 
   /** The definition keys pinned onto each evaluation, in invocation order. */
@@ -669,6 +665,14 @@ class BusinessValueOverviewComputeServiceTest {
       return definition.getTenantIds().stream().findFirst().map(valuesByTenant::get).orElse(null);
     }
     return stubbedValuesByKey.get(definition.getKey());
+  }
+
+  /** The sweep is enabled unless a deployment turns it off; these tests all assume it is on. */
+  private static ConfigurationService enabledConfiguration() {
+    final ConfigurationService configurationService = mock(ConfigurationService.class);
+    when(configurationService.getBusinessValueConfiguration())
+        .thenReturn(new BusinessValueConfiguration());
+    return configurationService;
   }
 
   private static SearchLimitsRepository searchLimitsWithBucketLimit(final int bucketLimit) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -55,6 +55,7 @@ class BusinessValueOverviewReadServiceTest {
   private DefinitionService definitionService;
   private BusinessValueOverviewComputeService computeService;
   private BusinessValueOverviewReadService readService;
+  private BusinessValueConfiguration businessValueConfiguration;
 
   @BeforeEach
   void setUp() {
@@ -63,7 +64,7 @@ class BusinessValueOverviewReadServiceTest {
     definitionService = mock(DefinitionService.class);
     computeService = mock(BusinessValueOverviewComputeService.class);
     final ConfigurationService configurationService = mock(ConfigurationService.class);
-    final BusinessValueConfiguration businessValueConfiguration = new BusinessValueConfiguration();
+    businessValueConfiguration = new BusinessValueConfiguration();
     businessValueConfiguration.setOverviewRefreshInterval(REFRESH_INTERVAL_SECONDS);
     when(configurationService.getBusinessValueConfiguration())
         .thenReturn(businessValueConfiguration);
@@ -376,6 +377,29 @@ class BusinessValueOverviewReadServiceTest {
     Awaitility.await()
         .untilAsserted(
             () -> verify(computeService).computeOverviewRows(eq(List.of(MetricRange.values()))));
+  }
+
+  @Test
+  void shouldNotFireTheBackstopWhenComputeIsDisabled() {
+    // given a stale row that would otherwise trigger a recompute, and the sweep switched off
+    businessValueConfiguration.setOverviewComputeEnabled(false);
+    final BusinessValueOverviewDto staleRow =
+        stamp(
+            row(TENANT_A, "proc-stale", cyc(6_000L, 8_000L, true), autoNull(), 1, 1),
+            NOW.minusSeconds(3L * REFRESH_INTERVAL_SECONDS));
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(List.of(staleRow));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "proc-stale"));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then no recompute is queued — otherwise disabling the sweep would still let every read spawn
+    // the work it was disabled to prevent — and the read still serves its (now frozen) rows
+    verify(computeService, never()).computeOverviewRows(any());
+    assertThat(response).isNotNull();
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(1);
   }
 
   @Test

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/BusinessValueConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/BusinessValueConfiguration.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 public class BusinessValueConfiguration {
 
   private Long overviewRefreshInterval;
+  private Boolean overviewComputeEnabled;
 
   public BusinessValueConfiguration() {}
 
@@ -23,9 +24,29 @@ public class BusinessValueConfiguration {
     this.overviewRefreshInterval = overviewRefreshInterval;
   }
 
+  /**
+   * Whether the business-value overview sweep may run. Turning it off stops the background
+   * computation without taking the dashboard down: existing rows stay readable, they simply stop
+   * advancing.
+   *
+   * <p>Absent configuration reads as enabled. A kill switch that failed closed would silently
+   * disable the feature on a configuration mistake, which is the opposite of what it is for.
+   */
+  public boolean isOverviewComputeEnabled() {
+    return overviewComputeEnabled == null || overviewComputeEnabled;
+  }
+
+  public Boolean getOverviewComputeEnabled() {
+    return overviewComputeEnabled;
+  }
+
+  public void setOverviewComputeEnabled(final Boolean overviewComputeEnabled) {
+    this.overviewComputeEnabled = overviewComputeEnabled;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(overviewRefreshInterval);
+    return Objects.hash(overviewRefreshInterval, overviewComputeEnabled);
   }
 
   @Override
@@ -37,13 +58,16 @@ public class BusinessValueConfiguration {
       return false;
     }
     final BusinessValueConfiguration that = (BusinessValueConfiguration) o;
-    return Objects.equals(overviewRefreshInterval, that.overviewRefreshInterval);
+    return Objects.equals(overviewRefreshInterval, that.overviewRefreshInterval)
+        && Objects.equals(overviewComputeEnabled, that.overviewComputeEnabled);
   }
 
   @Override
   public String toString() {
     return "BusinessValueConfiguration(overviewRefreshInterval="
         + getOverviewRefreshInterval()
+        + ", overviewComputeEnabled="
+        + getOverviewComputeEnabled()
         + ")";
   }
 }

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -582,6 +582,12 @@ businessValue:
   # How often the business-value overview index is refreshed for all definitions and all range
   # presets (7d, 30d, 3m, 6m). The given number is the interval in seconds. Default: 24h.
   overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:86400}
+  # Kill switch for the background overview computation. Set to false to stop the sweep without
+  # taking the dashboard down: existing rows stay readable and the endpoint keeps serving, the
+  # numbers simply stop advancing until it is re-enabled. Takes effect on the next tick, no restart
+  # required. Scoped to the sweep only — it does not affect the overview or target endpoints, nor
+  # the dashboard tiles, which are evaluated per request.
+  overviewComputeEnabled: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_COMPUTE_ENABLED:true}
 
 export:
   csv:

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -584,9 +584,9 @@ businessValue:
   overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:86400}
   # Kill switch for the background overview computation. Set to false to stop the sweep without
   # taking the dashboard down: existing rows stay readable and the endpoint keeps serving, the
-  # numbers simply stop advancing until it is re-enabled. Takes effect on the next tick, no restart
-  # required. Scoped to the sweep only — it does not affect the overview or target endpoints, nor
-  # the dashboard tiles, which are evaluated per request.
+  # numbers simply stop advancing until it is re-enabled. Requires an Optimize restart to take
+  # effect, as configuration is read once at startup. Scoped to the sweep only — it does not affect
+  # the overview or target endpoints, nor the dashboard tiles, which are evaluated per request.
   overviewComputeEnabled: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_COMPUTE_ENABLED:true}
 
 export:

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/BusinessValueConfigurationTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/BusinessValueConfigurationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.util.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A kill switch is worth nothing if its value never reaches the code that reads it, and that
+ * failure is silent: the flag would simply appear to do nothing. These assert the wiring itself.
+ */
+class BusinessValueConfigurationTest {
+
+  @Test
+  void shouldBindTheOverviewComputeFlagFromTheShippedConfiguration() {
+    // given the configuration Optimize actually ships
+    final ConfigurationService configurationService =
+        ConfigurationServiceBuilder.createDefaultConfiguration();
+
+    // when the business-value configuration is read
+    final BusinessValueConfiguration businessValue =
+        configurationService.getBusinessValueConfiguration();
+
+    // then the value comes from the file rather than from the null fallback. Asserting on
+    // isOverviewComputeEnabled() alone would pass even if the key never bound, since it reads null
+    // as enabled — so the raw value is what proves the wiring.
+    assertThat(businessValue.getOverviewComputeEnabled())
+        .as("businessValue.overviewComputeEnabled must bind from service-config.yaml")
+        .isNotNull()
+        .isTrue();
+    assertThat(businessValue.isOverviewComputeEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldTreatAbsentConfigurationAsEnabled() {
+    // given a configuration where the flag was never set
+    final BusinessValueConfiguration businessValue = new BusinessValueConfiguration();
+
+    // when the effective value is read
+    // then the sweep runs: failing closed would silently disable the feature on a configuration
+    // mistake, which is the opposite of what a kill switch is for
+    assertThat(businessValue.getOverviewComputeEnabled()).isNull();
+    assertThat(businessValue.isOverviewComputeEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldHonourAnExplicitFalse() {
+    // given the switch is thrown
+    final BusinessValueConfiguration businessValue = new BusinessValueConfiguration();
+    businessValue.setOverviewComputeEnabled(false);
+
+    // when the effective value is read
+    // then it is off
+    assertThat(businessValue.isOverviewComputeEnabled()).isFalse();
+  }
+}


### PR DESCRIPTION
## Description

The business-value overview sweep evaluates two seeded reports per **(tenant, definition, range)** on every tick, so its cost grows with the size of the process catalog. On a large-volume installation that is a plausible source of Elasticsearch load, and there is currently no way to stop it.

`businessValue.overviewComputeEnabled` (default `true`, env `CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_COMPUTE_ENABLED`) turns the sweep off **without taking the dashboard down** — existing rows stay readable and the endpoint keeps serving, the numbers simply stop advancing. During an incident, stale data beats an error page.

**Requires an Optimize restart to take effect** — `ConfigurationService` parses the configuration once at construction, and `ConfigurationReloadable` is only driven by test infrastructure. The trade is therefore a config change plus a restart instead of a code revert plus a redeploy, which is still clearly worth having. (Caught by Copilot review; my original wording claimed otherwise and would have cost an operator time.)

**Why not just raise `overviewRefreshInterval`?** It happens to work — the stale-read threshold derives from the same value, so the backstop doesn't compensate — but only by accident, and `overviewRefreshInterval: 315360000` reads as "very slow refresh" rather than "off" to whoever finds it at 2am.

**Where the guard lives.** Inside `computeOverviewRows` rather than at the call sites, so every entry point is covered (scheduler tick, stale-read backstop, and whatever calls in next), and so the flag is read per invocation rather than at startup. The backstop additionally checks before queueing, so reads don't spawn work that returns immediately.

**Absent configuration reads as enabled.** A kill switch that failed closed would silently disable the feature on a configuration mistake.

## Scope

Deliberately the sweep alone. It does **not** affect:

- the overview or target endpoints
- the dashboard tiles, which are evaluated per request

So it is not a lever for load originating there — hence the name `overviewCompute` rather than something broader.

## Known gap

The response carries no freshness indicator, so with compute disabled users see frozen numbers with no signal that they are frozen. `lastComputedAt` is already on every row and the read service already computes staleness for the backstop, so surfacing it is cheap — but it is an additive change to a public response contract, so raising it separately rather than bundling it here.

## Testing

Assertions are that nothing is evaluated and nothing is written when disabled, rather than that the method returned — a switch that returned early but still queried would not relieve the load it exists to relieve.

Verified by mutation: removing the compute guard fails `shouldNotEvaluateOrWriteAnythingWhenComputeIsDisabled`; removing the backstop guard fails `shouldNotFireTheBackstopWhenComputeIsDisabled`.

The configuration wiring is tested too, because a kill switch whose value never reaches the code reading it fails **silently** — it just appears to do nothing. Asserting on `isOverviewComputeEnabled()` alone would not catch that, since it reads an unbound null as enabled, so the raw value is asserted against the configuration Optimize actually ships. Also verified end to end that `CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_COMPUTE_ENABLED=false` reaches the config as `false`.

Unit suite for `optimize/backend` + `optimize-commons`: **1105 tests, 0 failures.**

## Checklist

- [ ] Enable backports when necessary — **this one likely wants them**: the load risk exists on released branches, and a kill switch you cannot backport is a kill switch you do not have when the incident is on an older version.

## Related issues

Split out of the fan-in work in #60690, which reduces the sweep's cost but does not remove the need for an operational off-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
