### PR TITLE
fix: validate id_token issuer and audience in legacy CCSaaS login

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -890,6 +890,9 @@
             <ignoredUnusedDeclaredDependency>org.junit.platform:junit-platform-suite</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-jackson2</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-actuator</ignoredUnusedDeclaredDependency>
+            <!-- Never referenced by Java code on purpose: exists only to give the reactor a real
+                 build-order edge, see the dependency's own comment above. -->
+            <ignoredUnusedDeclaredDependency>io.camunda.optimize:optimize-client:jar</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <ignoredNonTestScopedDependencies>
             <!-- No production class references it: CSL's WebSessionConfiguration is what needs it

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -47,6 +47,20 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Not used by any Java code: this module has no formal dependency on optimize-client's
+         jar, only a raw filesystem reference to its ../client/dist build output (see the
+         resources section below). Under a parallel (-T1C) reactor build, that leaves no
+         guarantee optimize-client's frontend build finishes before this module reads that
+         directory, so an unlucky race can package a jar with no index.html. Declaring this
+         dependency (provided, so it never reaches the runtime classpath/fat jar) gives Maven a
+         real reactor edge forcing optimize-client to build first. -->
+    <dependency>
+      <groupId>io.camunda.optimize</groupId>
+      <artifactId>optimize-client</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Camunda dependencies -->
     <dependency>
       <groupId>org.camunda.bpm.model</groupId>

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -62,6 +62,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenValidator;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
@@ -256,19 +257,21 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
   @Bean
   public JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory() {
     final var decoderFactory = new OidcIdTokenDecoderFactory();
-    decoderFactory.setJwtValidatorFactory(clientRegistration -> createIdTokenValidators());
+    decoderFactory.setJwtValidatorFactory(this::createIdTokenValidators);
     return decoderFactory;
   }
 
   /** Creates JWT validators specifically for ID token validation during OAuth2 login */
   @SuppressWarnings("unchecked")
-  private OAuth2TokenValidator<Jwt> createIdTokenValidators() {
-    // Only include role validation for ID tokens
+  OAuth2TokenValidator<Jwt> createIdTokenValidators(final ClientRegistration clientRegistration) {
+    // Restores the issuer/audience checks Spring's OIDC login normally applies (OIDC Core
+    // §3.1.3.7), which this class's custom validator factory would otherwise silently drop.
+    final OAuth2TokenValidator<Jwt> oidcIdTokenValidator =
+        new OidcIdTokenValidator(clientRegistration);
     final OAuth2TokenValidator<Jwt> roleValidator =
         new RoleValidator(ALLOWED_ORG_ROLES, getAuth0Configuration().getOrganizationId());
 
-    // The role validation uses organization claims which are present in ID tokens
-    return JwtValidators.createDefaultWithValidators(roleValidator);
+    return JwtValidators.createDefaultWithValidators(oidcIdTokenValidator, roleValidator);
   }
 
   @SuppressWarnings("unchecked")

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
@@ -85,7 +85,10 @@ public class CCSaasAuth0WebSecurityConfig {
             .clientSecret(getAuth0Configuration().getClientSecret())
             .jwkSetUri(
                 String.format(
-                    URL_TEMPLATE, getAuth0Configuration().getDomain(), AUTH0_JWKS_ENDPOINT));
+                    URL_TEMPLATE, getAuth0Configuration().getDomain(), AUTH0_JWKS_ENDPOINT))
+            // Auth0 login id_tokens carry this as their `iss` claim (trailing slash required); used
+            // by CCSaaSSecurityConfigurerAdapter's idTokenDecoderFactory to validate it.
+            .issuerUri(buildAuth0DomainUrl("/"));
     return new InMemoryClientRegistrationRepository(List.of(builder.build()));
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
@@ -88,12 +88,22 @@ public class CCSaasAuth0WebSecurityConfig {
                     URL_TEMPLATE, getAuth0Configuration().getDomain(), AUTH0_JWKS_ENDPOINT))
             // Auth0 login id_tokens carry this as their `iss` claim (trailing slash required); used
             // by CCSaaSSecurityConfigurerAdapter's idTokenDecoderFactory to validate it.
-            .issuerUri(buildAuth0DomainUrl("/"));
+            .issuerUri(buildAuth0IssuerUri());
     return new InMemoryClientRegistrationRepository(List.of(builder.build()));
   }
 
   private String buildAuth0DomainUrl(final String path) {
     return String.format(URL_TEMPLATE, getAuth0Configuration().getDomain(), path);
+  }
+
+  // Strips any operator-configured trailing slash off domain first: an unstripped "domain/" would
+  // otherwise produce "https://domain//", which fails OidcIdTokenValidator's strict iss match even
+  // though the other endpoints built from domain tolerate the double slash.
+  private String buildAuth0IssuerUri() {
+    final String domain = getAuth0Configuration().getDomain();
+    final String normalizedDomain =
+        domain.endsWith("/") ? domain.substring(0, domain.length() - 1) : domain;
+    return String.format(URL_TEMPLATE, normalizedDomain, "/");
   }
 
   private String buildAuth0CustomDomainUrl(final String path) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
@@ -86,24 +86,15 @@ public class CCSaasAuth0WebSecurityConfig {
             .jwkSetUri(
                 String.format(
                     URL_TEMPLATE, getAuth0Configuration().getDomain(), AUTH0_JWKS_ENDPOINT))
-            // Auth0 login id_tokens carry this as their `iss` claim (trailing slash required); used
-            // by CCSaaSSecurityConfigurerAdapter's idTokenDecoderFactory to validate it.
-            .issuerUri(buildAuth0IssuerUri());
+            // Auth0 login id_tokens carry the custom domain (the one the authorization endpoint
+            // above also uses) as their `iss` claim; used by CCSaaSSecurityConfigurerAdapter's
+            // idTokenDecoderFactory to validate it.
+            .issuerUri(buildAuth0CustomDomainUrl("/"));
     return new InMemoryClientRegistrationRepository(List.of(builder.build()));
   }
 
   private String buildAuth0DomainUrl(final String path) {
     return String.format(URL_TEMPLATE, getAuth0Configuration().getDomain(), path);
-  }
-
-  // Strips any operator-configured trailing slash off domain first: an unstripped "domain/" would
-  // otherwise produce "https://domain//", which fails OidcIdTokenValidator's strict iss match even
-  // though the other endpoints built from domain tolerate the double slash.
-  private String buildAuth0IssuerUri() {
-    final String domain = getAuth0Configuration().getDomain();
-    final String normalizedDomain =
-        domain.endsWith("/") ? domain.substring(0, domain.length() - 1) : domain;
-    return String.format(URL_TEMPLATE, normalizedDomain, "/");
   }
 
   private String buildAuth0CustomDomainUrl(final String path) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapterTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.cloud;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.rest.security.CustomPreAuthenticatedAuthenticationProvider;
+import io.camunda.optimize.service.security.AuthCookieService;
+import io.camunda.optimize.service.security.SessionService;
+import io.camunda.optimize.service.security.UserIdMigrationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
+import io.camunda.optimize.service.util.configuration.security.CloudAuthConfiguration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@ExtendWith(MockitoExtension.class)
+class CCSaaSSecurityConfigurerAdapterTest {
+
+  private static final String CLIENT_ID = "optimize-client-id";
+  private static final String ISSUER = "https://tenant.auth0.com/";
+  private static final String ORGANIZATION_ID = "org-1";
+
+  @Mock private ConfigurationService configurationService;
+  @Mock private CustomPreAuthenticatedAuthenticationProvider preAuthenticatedAuthenticationProvider;
+  @Mock private SessionService sessionService;
+  @Mock private AuthCookieService authCookieService;
+  @Mock private ClientRegistrationRepository clientRegistrationRepository;
+  @Mock private OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+  @Mock private UserIdMigrationService userIdMigrationService;
+  @Mock private AuthConfiguration authConfiguration;
+  @Mock private CloudAuthConfiguration cloudAuthConfiguration;
+
+  private CCSaaSSecurityConfigurerAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
+    when(authConfiguration.getCloudAuthConfiguration()).thenReturn(cloudAuthConfiguration);
+    when(cloudAuthConfiguration.getOrganizationId()).thenReturn(ORGANIZATION_ID);
+
+    adapter =
+        new CCSaaSSecurityConfigurerAdapter(
+            configurationService,
+            preAuthenticatedAuthenticationProvider,
+            sessionService,
+            authCookieService,
+            clientRegistrationRepository,
+            oAuth2AuthorizedClientService,
+            userIdMigrationService);
+  }
+
+  private OAuth2TokenValidator<Jwt> validator() {
+    return adapter.createIdTokenValidators(clientRegistration());
+  }
+
+  @Test
+  void shouldAcceptIdTokenWithValidIssuerAudienceAndRole() {
+    final OAuth2TokenValidator<Jwt> validator = validator();
+
+    assertThat(validator.validate(idToken(ISSUER, CLIENT_ID, ORGANIZATION_ID)).hasErrors())
+        .isFalse();
+  }
+
+  @Test
+  void shouldRejectIdTokenWithMismatchedIssuer() {
+    final OAuth2TokenValidator<Jwt> validator = validator();
+
+    assertThat(
+            validator
+                .validate(
+                    idToken("https://a-different-tenant.auth0.com/", CLIENT_ID, ORGANIZATION_ID))
+                .hasErrors())
+        .isTrue();
+  }
+
+  @Test
+  void shouldRejectIdTokenWithMismatchedAudience() {
+    final OAuth2TokenValidator<Jwt> validator = validator();
+
+    assertThat(
+            validator
+                .validate(idToken(ISSUER, "some-other-registered-app", ORGANIZATION_ID))
+                .hasErrors())
+        .isTrue();
+  }
+
+  @Test
+  void shouldRejectIdTokenWithDisallowedOrganization() {
+    final OAuth2TokenValidator<Jwt> validator = validator();
+
+    assertThat(validator.validate(idToken(ISSUER, CLIENT_ID, "some-other-org")).hasErrors())
+        .isTrue();
+  }
+
+  private static ClientRegistration clientRegistration() {
+    return ClientRegistration.withRegistrationId("auth0")
+        .clientId(CLIENT_ID)
+        .clientSecret("secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/sso-callback")
+        .authorizationUri("https://custom.auth0.com/authorize")
+        .tokenUri("https://tenant.auth0.com/oauth/token")
+        .issuerUri(ISSUER)
+        .build();
+  }
+
+  private static Jwt idToken(
+      final String issuer, final String audience, final String organizationId) {
+    final Instant now = Instant.now();
+    return Jwt.withTokenValue("token")
+        .header("alg", "none")
+        .issuer(issuer)
+        .audience(List.of(audience))
+        .subject("user-1")
+        .issuedAt(now)
+        .expiresAt(now.plusSeconds(300))
+        .claim(
+            "https://camunda.com/orgs",
+            List.of(Map.of("id", organizationId, "roles", List.of("admin"))))
+        .build();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapterTest.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.rest.security.cloud;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.rest.security.CustomPreAuthenticatedAuthenticationProvider;
@@ -20,6 +21,7 @@ import io.camunda.optimize.service.util.configuration.security.CloudAuthConfigur
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -36,7 +37,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
 class CCSaaSSecurityConfigurerAdapterTest {
 
   private static final String CLIENT_ID = "optimize-client-id";
-  private static final String ISSUER = "https://tenant.auth0.com/";
+  // Deliberately distinct from CUSTOM_DOMAIN below: if CCSaasAuth0WebSecurityConfig ever derives
+  // the issuer from the wrong one of the two configured domains, only using a real (not
+  // hand-built) ClientRegistration in this test lets that mixup fail here.
+  private static final String BACKEND_DOMAIN = "tenant.eu.auth0.com";
+  private static final String CUSTOM_DOMAIN = "weblogin.example.com";
+  private static final String ISSUER = "https://" + CUSTOM_DOMAIN + "/";
   private static final String ORGANIZATION_ID = "org-1";
 
   @Mock private ConfigurationService configurationService;
@@ -50,12 +56,21 @@ class CCSaaSSecurityConfigurerAdapterTest {
   @Mock private CloudAuthConfiguration cloudAuthConfiguration;
 
   private CCSaaSSecurityConfigurerAdapter adapter;
+  private ClientRegistration clientRegistration;
 
   @BeforeEach
   void setUp() {
     when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
     when(authConfiguration.getCloudAuthConfiguration()).thenReturn(cloudAuthConfiguration);
     when(cloudAuthConfiguration.getOrganizationId()).thenReturn(ORGANIZATION_ID);
+    when(cloudAuthConfiguration.getDomain()).thenReturn(BACKEND_DOMAIN);
+    when(cloudAuthConfiguration.getCustomDomain()).thenReturn(CUSTOM_DOMAIN);
+    when(cloudAuthConfiguration.getClientId()).thenReturn(CLIENT_ID);
+    when(cloudAuthConfiguration.getClientSecret()).thenReturn("client-secret");
+    lenient().when(cloudAuthConfiguration.getClusterId()).thenReturn("cluster-1");
+    lenient()
+        .when(cloudAuthConfiguration.getUserAccessTokenAudience())
+        .thenReturn(Optional.empty());
 
     adapter =
         new CCSaaSSecurityConfigurerAdapter(
@@ -66,10 +81,17 @@ class CCSaaSSecurityConfigurerAdapterTest {
             clientRegistrationRepository,
             oAuth2AuthorizedClientService,
             userIdMigrationService);
+
+    // The real registration built by the sibling config class, not a hand-built one, so the two
+    // classes are exercised together and a domain/customDomain mixup in either would surface here.
+    clientRegistration =
+        new CCSaasAuth0WebSecurityConfig(configurationService)
+            .clientRegistrationRepository()
+            .findByRegistrationId(CCSaasAuth0WebSecurityConfig.AUTH_0_CLIENT_REGISTRATION_ID);
   }
 
   private OAuth2TokenValidator<Jwt> validator() {
-    return adapter.createIdTokenValidators(clientRegistration());
+    return adapter.createIdTokenValidators(clientRegistration);
   }
 
   @Test
@@ -109,18 +131,6 @@ class CCSaaSSecurityConfigurerAdapterTest {
 
     assertThat(validator.validate(idToken(ISSUER, CLIENT_ID, "some-other-org")).hasErrors())
         .isTrue();
-  }
-
-  private static ClientRegistration clientRegistration() {
-    return ClientRegistration.withRegistrationId("auth0")
-        .clientId(CLIENT_ID)
-        .clientSecret("secret")
-        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-        .redirectUri("{baseUrl}/sso-callback")
-        .authorizationUri("https://custom.auth0.com/authorize")
-        .tokenUri("https://tenant.auth0.com/oauth/token")
-        .issuerUri(ISSUER)
-        .build();
   }
 
   private static Jwt idToken(

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfigTest.java
@@ -14,10 +14,9 @@ import static org.mockito.Mockito.when;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
 import io.camunda.optimize.service.util.configuration.security.CloudAuthConfiguration;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -26,49 +25,53 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 @ExtendWith(MockitoExtension.class)
 class CCSaasAuth0WebSecurityConfigTest {
 
+  // Distinct on purpose: distinguishes which of the two the issuer/JWKS URI is built from, rather
+  // than passing accidentally because both configured values happen to match.
+  private static final String BACKEND_DOMAIN = "tenant.eu.auth0.com";
+  private static final String CUSTOM_DOMAIN = "weblogin.example.com";
+
   @Mock private ConfigurationService configurationService;
   @Mock private AuthConfiguration authConfiguration;
   @Mock private CloudAuthConfiguration cloudAuthConfiguration;
 
-  @ParameterizedTest
-  @ValueSource(strings = {"tenant.auth0.com", "tenant.auth0.com/"})
-  void shouldBuildIssuerUriWithoutDoubleSlashRegardlessOfTrailingSlashOnDomain(
-      final String domain) {
-    stubCloudAuthConfiguration(domain);
+  @Test
+  void shouldBuildIssuerUriFromCustomDomainNotBackendDomain() {
+    stubCloudAuthConfiguration();
 
-    final CCSaasAuth0WebSecurityConfig config =
-        new CCSaasAuth0WebSecurityConfig(configurationService);
-    final ClientRegistrationRepository repository = config.clientRegistrationRepository();
-    final ClientRegistration registration =
-        repository.findByRegistrationId(CCSaasAuth0WebSecurityConfig.AUTH_0_CLIENT_REGISTRATION_ID);
+    final ClientRegistration registration = registration();
 
     assertThat(registration.getProviderDetails().getIssuerUri())
-        .isEqualTo("https://tenant.auth0.com/");
+        .isEqualTo("https://" + CUSTOM_DOMAIN + "/");
   }
 
   @Test
-  void shouldBuildJwksUriUnaffectedByIssuerNormalization() {
-    stubCloudAuthConfiguration("tenant.auth0.com");
+  void shouldBuildJwksUriFromBackendDomainNotCustomDomain() {
+    stubCloudAuthConfiguration();
 
+    final ClientRegistration registration = registration();
+
+    assertThat(registration.getProviderDetails().getJwkSetUri())
+        .isEqualTo("https://" + BACKEND_DOMAIN + "/.well-known/jwks.json");
+  }
+
+  private ClientRegistration registration() {
     final CCSaasAuth0WebSecurityConfig config =
         new CCSaasAuth0WebSecurityConfig(configurationService);
     final ClientRegistrationRepository repository = config.clientRegistrationRepository();
-    final ClientRegistration registration =
-        repository.findByRegistrationId(CCSaasAuth0WebSecurityConfig.AUTH_0_CLIENT_REGISTRATION_ID);
-
-    assertThat(registration.getProviderDetails().getJwkSetUri())
-        .isEqualTo("https://tenant.auth0.com/.well-known/jwks.json");
+    return repository.findByRegistrationId(
+        CCSaasAuth0WebSecurityConfig.AUTH_0_CLIENT_REGISTRATION_ID);
   }
 
-  private void stubCloudAuthConfiguration(final String domain) {
+  private void stubCloudAuthConfiguration() {
     when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
     when(authConfiguration.getCloudAuthConfiguration()).thenReturn(cloudAuthConfiguration);
-    when(cloudAuthConfiguration.getDomain()).thenReturn(domain);
+    when(cloudAuthConfiguration.getDomain()).thenReturn(BACKEND_DOMAIN);
+    when(cloudAuthConfiguration.getCustomDomain()).thenReturn(CUSTOM_DOMAIN);
     when(cloudAuthConfiguration.getClientId()).thenReturn("optimize-client-id");
     when(cloudAuthConfiguration.getClientSecret()).thenReturn("client-secret");
     lenient().when(cloudAuthConfiguration.getClusterId()).thenReturn("cluster-1");
     lenient()
         .when(cloudAuthConfiguration.getUserAccessTokenAudience())
-        .thenReturn(java.util.Optional.empty());
+        .thenReturn(Optional.empty());
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfigTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.cloud;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
+import io.camunda.optimize.service.util.configuration.security.CloudAuthConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CCSaasAuth0WebSecurityConfigTest {
+
+  @Mock private ConfigurationService configurationService;
+  @Mock private AuthConfiguration authConfiguration;
+  @Mock private CloudAuthConfiguration cloudAuthConfiguration;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"tenant.auth0.com", "tenant.auth0.com/"})
+  void shouldBuildIssuerUriWithoutDoubleSlashRegardlessOfTrailingSlashOnDomain(
+      final String domain) {
+    stubCloudAuthConfiguration(domain);
+
+    final CCSaasAuth0WebSecurityConfig config =
+        new CCSaasAuth0WebSecurityConfig(configurationService);
+    final ClientRegistrationRepository repository = config.clientRegistrationRepository();
+    final ClientRegistration registration =
+        repository.findByRegistrationId(CCSaasAuth0WebSecurityConfig.AUTH_0_CLIENT_REGISTRATION_ID);
+
+    assertThat(registration.getProviderDetails().getIssuerUri())
+        .isEqualTo("https://tenant.auth0.com/");
+  }
+
+  @Test
+  void shouldBuildJwksUriUnaffectedByIssuerNormalization() {
+    stubCloudAuthConfiguration("tenant.auth0.com");
+
+    final CCSaasAuth0WebSecurityConfig config =
+        new CCSaasAuth0WebSecurityConfig(configurationService);
+    final ClientRegistrationRepository repository = config.clientRegistrationRepository();
+    final ClientRegistration registration =
+        repository.findByRegistrationId(CCSaasAuth0WebSecurityConfig.AUTH_0_CLIENT_REGISTRATION_ID);
+
+    assertThat(registration.getProviderDetails().getJwkSetUri())
+        .isEqualTo("https://tenant.auth0.com/.well-known/jwks.json");
+  }
+
+  private void stubCloudAuthConfiguration(final String domain) {
+    when(configurationService.getAuthConfiguration()).thenReturn(authConfiguration);
+    when(authConfiguration.getCloudAuthConfiguration()).thenReturn(cloudAuthConfiguration);
+    when(cloudAuthConfiguration.getDomain()).thenReturn(domain);
+    when(cloudAuthConfiguration.getClientId()).thenReturn("optimize-client-id");
+    when(cloudAuthConfiguration.getClientSecret()).thenReturn("client-secret");
+    lenient().when(cloudAuthConfiguration.getClusterId()).thenReturn("cluster-1");
+    lenient()
+        .when(cloudAuthConfiguration.getUserAccessTokenAudience())
+        .thenReturn(java.util.Optional.empty());
+  }
+}


### PR DESCRIPTION
## Summary
- The legacy (pre-CSL) CCSaaS security config's id_token validator dropped the `iss`/`aud` checks (OIDC Core §3.1.3.7) that Spring's `OidcIdTokenValidator` normally applies, so a validly-signed Auth0 token issued for a different registered Camunda application wasn't rejected as out-of-scope for Optimize.
- The org/role check is independent of `aud` and still gates access correctly — this closes a token-scoping hardening gap, not an auth bypass.
- Restores `iss`/`aud` validation by giving Optimize's Auth0 `ClientRegistration` an issuer and wiring Spring's own `OidcIdTokenValidator` into the id_token validator chain. No new configuration or custom validator infrastructure needed.
  - The issuer must be derived from the **custom** Auth0 domain (`CAMUNDA_OPTIMIZE_AUTH0_DOMAIN` / `getCustomDomain()`), not the backend domain (`CAMUNDA_OPTIMIZE_AUTH0_BACKENDDOMAIN` / `getDomain()`) — the login id_token's `iss` claim carries the custom domain, same as `authorizationUri` already uses, and the same value the CSL compatibility bridge already derives its issuer from. Using the backend domain here was an earlier mistake in this PR, caught in review and fixed in 50cc6fb.
- Scoped to the legacy validator only; the CSL path (`optimize.security.csl.enabled=true`) is untouched.

## Test plan
- [x] Added `CCSaaSSecurityConfigurerAdapterTest` covering: valid issuer+audience+role succeeds, mismatched issuer rejected, mismatched audience rejected, disallowed org rejected (regression)
- [x] Added `CCSaasAuth0WebSecurityConfigTest` covering: issuer built from the custom domain (not the backend domain), JWKS URI unaffected
- [x] `./mvnw verify -pl optimize/backend -Dtest=CCSaaSSecurityConfigurerAdapterTest,CCSaasAuth0WebSecurityConfigTest -DskipTests=false -DskipITs -Dquickly` — pass
- [x] `./mvnw verify -pl optimize/backend -Dtest=CslSecurityChainSelectionTest,OptimizeCloudSecurityConfigurationTest -DskipTests=false -DskipITs -Dquickly` — pass (CSL path unaffected)
- [x] Verified in SaaS: deployed a generation with `optimize.security.csl.enabled=false` using an image built from this branch and confirmed a successful login end-to-end through Auth0
