### PR TITLE
fix: support businessId in message subscription search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
@@ -30,6 +30,23 @@ import java.util.function.Consumer;
 public interface MessageSubscriptionFilter extends SearchRequestFilter {
 
   /**
+   * Filter by business id.
+   *
+   * @param businessId the business id inherited from the subscribing process instance
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter businessId(String businessId);
+
+  /**
+   * Filter by business id using a {@link StringProperty} consumer. Supports advanced string
+   * operators including {@code $like} with wildcards.
+   *
+   * @param fn the business id {@link StringProperty} consumer for the message subscription
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter businessId(Consumer<StringProperty> fn);
+
+  /**
    * Filter by message subscription key.
    *
    * @param messageSubscriptionKey key of the message subscription

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
@@ -24,6 +24,15 @@ public interface MessageSubscription {
 
   Long getMessageSubscriptionKey();
 
+  /**
+   * Returns the business id inherited from the subscribing process instance when this message
+   * subscription was opened.
+   *
+   * @return the business id, or {@code null} when the process instance has no business id or for
+   *     message start event subscriptions
+   */
+  String getBusinessId();
+
   String getProcessDefinitionId();
 
   Long getProcessDefinitionKey();

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/MessageSubscriptionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/MessageSubscriptionSort.java
@@ -19,6 +19,8 @@ import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSo
 
 public interface MessageSubscriptionSort extends SearchRequestSort<MessageSubscriptionSort> {
 
+  MessageSubscriptionSort businessId();
+
   MessageSubscriptionSort messageSubscriptionKey();
 
   MessageSubscriptionSort processDefinitionId();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
@@ -46,6 +46,19 @@ public class MessageSubscriptionFilterImpl
   }
 
   @Override
+  public MessageSubscriptionFilter businessId(final String businessId) {
+    return businessId(f -> f.eq(businessId));
+  }
+
+  @Override
+  public MessageSubscriptionFilter businessId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBusinessId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   public MessageSubscriptionFilter messageSubscriptionKey(final Long messageSubscriptionKey) {
     return messageSubscriptionKey(f -> f.eq(messageSubscriptionKey));
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 public class MessageSubscriptionImpl implements MessageSubscription {
 
   private final Long messageSubscriptionKey;
+  private final String businessId;
   private final String processDefinitionId;
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
@@ -48,6 +49,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
 
   public MessageSubscriptionImpl(final MessageSubscriptionResult item) {
     messageSubscriptionKey = ParseUtil.parseLongOrNull(item.getMessageSubscriptionKey());
+    businessId = item.getBusinessId();
     processDefinitionId = item.getProcessDefinitionId();
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
@@ -72,6 +74,11 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   @Override
   public Long getMessageSubscriptionKey() {
     return messageSubscriptionKey;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessId;
   }
 
   @Override
@@ -163,6 +170,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   public int hashCode() {
     return Objects.hash(
         messageSubscriptionKey,
+        businessId,
         processDefinitionId,
         processDefinitionKey,
         processInstanceKey,
@@ -192,6 +200,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
     }
     final MessageSubscriptionImpl subscription = (MessageSubscriptionImpl) o;
     return Objects.equals(messageSubscriptionKey, subscription.messageSubscriptionKey)
+        && Objects.equals(businessId, subscription.businessId)
         && Objects.equals(processDefinitionId, subscription.processDefinitionId)
         && Objects.equals(processDefinitionKey, subscription.processDefinitionKey)
         && Objects.equals(processInstanceKey, subscription.processInstanceKey)

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/MessageSubscriptionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/MessageSubscriptionSortImpl.java
@@ -22,6 +22,11 @@ public class MessageSubscriptionSortImpl extends SearchRequestSortBase<MessageSu
     implements MessageSubscriptionSort {
 
   @Override
+  public MessageSubscriptionSort businessId() {
+    return field("businessId");
+  }
+
+  @Override
   public MessageSubscriptionSort messageSubscriptionKey() {
     return field("messageSubscriptionKey");
   }

--- a/clients/java/src/test/java/io/camunda/client/messagesubscription/SearchMessageSubscriptionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/messagesubscription/SearchMessageSubscriptionTest.java
@@ -63,6 +63,7 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
         .filter(
             f ->
                 f.messageSubscriptionKey(123L)
+                    .businessId("business-id")
                     .processDefinitionId("process-definition-id")
                     .processInstanceKey(456L)
                     .elementId("element-id")
@@ -82,6 +83,8 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
     final MessageSubscriptionSearchQuery request =
         gatewayService.getLastRequest(MessageSubscriptionSearchQuery.class);
     assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter().getBusinessId()).isNotNull();
+    assertThat(request.getFilter().getBusinessId().get$Eq()).isEqualTo("business-id");
     assertThat(request.getFilter().getMessageSubscriptionKey()).isNotNull();
     assertThat(request.getFilter().getMessageSubscriptionKey().get$Eq()).isEqualTo("123");
     assertThat(request.getFilter().getProcessDefinitionId()).isNotNull();
@@ -124,6 +127,8 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
             s ->
                 s.messageSubscriptionKey()
                     .asc()
+                    .businessId()
+                    .asc()
                     .processDefinitionId()
                     .desc()
                     .processInstanceKey()
@@ -157,19 +162,20 @@ public class SearchMessageSubscriptionTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromMessageSubscriptionSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts).hasSize(13);
+    assertThat(sorts).hasSize(14);
     assertSort(sorts.get(0), "messageSubscriptionKey", SortOrderEnum.ASC);
-    assertSort(sorts.get(1), "processDefinitionId", SortOrderEnum.DESC);
-    assertSort(sorts.get(2), "processInstanceKey", SortOrderEnum.DESC);
-    assertSort(sorts.get(3), "elementId", SortOrderEnum.ASC);
-    assertSort(sorts.get(4), "elementInstanceKey", SortOrderEnum.DESC);
-    assertSort(sorts.get(5), "messageSubscriptionState", SortOrderEnum.ASC);
-    assertSort(sorts.get(6), "messageSubscriptionType", SortOrderEnum.DESC);
-    assertSort(sorts.get(7), "lastUpdatedDate", SortOrderEnum.DESC);
-    assertSort(sorts.get(8), "messageName", SortOrderEnum.ASC);
-    assertSort(sorts.get(9), "correlationKey", SortOrderEnum.DESC);
-    assertSort(sorts.get(10), "tenantId", SortOrderEnum.ASC);
-    assertSort(sorts.get(11), "processDefinitionName", SortOrderEnum.DESC);
-    assertSort(sorts.get(12), "processDefinitionVersion", SortOrderEnum.ASC);
+    assertSort(sorts.get(1), "businessId", SortOrderEnum.ASC);
+    assertSort(sorts.get(2), "processDefinitionId", SortOrderEnum.DESC);
+    assertSort(sorts.get(3), "processInstanceKey", SortOrderEnum.DESC);
+    assertSort(sorts.get(4), "elementId", SortOrderEnum.ASC);
+    assertSort(sorts.get(5), "elementInstanceKey", SortOrderEnum.DESC);
+    assertSort(sorts.get(6), "messageSubscriptionState", SortOrderEnum.ASC);
+    assertSort(sorts.get(7), "messageSubscriptionType", SortOrderEnum.DESC);
+    assertSort(sorts.get(8), "lastUpdatedDate", SortOrderEnum.DESC);
+    assertSort(sorts.get(9), "messageName", SortOrderEnum.ASC);
+    assertSort(sorts.get(10), "correlationKey", SortOrderEnum.DESC);
+    assertSort(sorts.get(11), "tenantId", SortOrderEnum.ASC);
+    assertSort(sorts.get(12), "processDefinitionName", SortOrderEnum.DESC);
+    assertSort(sorts.get(13), "processDefinitionVersion", SortOrderEnum.ASC);
   }
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -519,6 +519,17 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="add_business_id_to_message_subscription" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="BUSINESS_ID"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}MESSAGE_SUBSCRIPTION">
+      <column name="BUSINESS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
   <changeSet id="add_business_id_to_correlated_message_subscription" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -35,6 +35,7 @@ public class MessageSubscriptionEntityMapper {
         .toolProperties(messageSubscriptionDbModel.toolProperties())
         .toolName(messageSubscriptionDbModel.toolName())
         .inboundConnectorType(messageSubscriptionDbModel.inboundConnectorType())
+        .businessId(messageSubscriptionDbModel.businessId())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
@@ -25,7 +25,8 @@ public enum MessageSubscriptionColumn implements SearchColumn<MessageSubscriptio
   PROCESS_DEFINITION_NAME("processDefinitionName"),
   PROCESS_DEFINITION_VERSION("processDefinitionVersion"),
   TOOL_NAME("toolName"),
-  INBOUND_CONNECTOR_TYPE("inboundConnectorType");
+  INBOUND_CONNECTOR_TYPE("inboundConnectorType"),
+  BUSINESS_ID("businessId");
 
   private final String property;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -36,7 +36,8 @@ public record MessageSubscriptionDbModel(
     Integer processDefinitionVersion,
     String serializedToolProperties,
     String toolName,
-    String inboundConnectorType)
+    String inboundConnectorType,
+    String businessId)
     implements Copyable<MessageSubscriptionDbModel> {
 
   public Map<String, String> toolProperties() {
@@ -72,7 +73,8 @@ public record MessageSubscriptionDbModel(
         processDefinitionVersion,
         serializedToolProperties,
         truncatedToolName,
-        truncatedInboundConnectorType);
+        truncatedInboundConnectorType,
+        businessId);
   }
 
   @Override
@@ -102,7 +104,8 @@ public record MessageSubscriptionDbModel(
         .processDefinitionName(processDefinitionName)
         .processDefinitionVersion(processDefinitionVersion)
         .toolName(toolName)
-        .inboundConnectorType(inboundConnectorType);
+        .inboundConnectorType(inboundConnectorType)
+        .businessId(businessId);
   }
 
   public static class Builder implements ObjectBuilder<MessageSubscriptionDbModel> {
@@ -125,6 +128,7 @@ public record MessageSubscriptionDbModel(
     private String serializedToolProperties;
     private String toolName;
     private String inboundConnectorType;
+    private String businessId;
 
     public Builder() {}
 
@@ -208,6 +212,11 @@ public record MessageSubscriptionDbModel(
       return this;
     }
 
+    public Builder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -254,7 +263,8 @@ public record MessageSubscriptionDbModel(
           processDefinitionVersion,
           serializedToolProperties,
           toolName,
-          inboundConnectorType);
+          inboundConnectorType,
+          businessId);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -45,7 +45,8 @@
     PROCESS_DEFINITION_VERSION,
     TOOL_PROPERTIES,
     TOOL_NAME,
-    INBOUND_CONNECTOR_TYPE
+    INBOUND_CONNECTOR_TYPE,
+    BUSINESS_ID
     FROM ${prefix}MESSAGE_SUBSCRIPTION
 
     <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchAndAuthFilter" />
@@ -202,6 +203,7 @@
       <arg column="TOOL_PROPERTIES" javaType="java.lang.String" name="serializedToolProperties" />
       <arg column="TOOL_NAME" javaType="java.lang.String" name="toolName" />
       <arg column="INBOUND_CONNECTOR_TYPE" javaType="java.lang.String" name="inboundConnectorType" />
+      <arg column="BUSINESS_ID" javaType="java.lang.String" name="businessId" />
     </constructor>
   </resultMap>
 
@@ -226,7 +228,8 @@
                                                PROCESS_DEFINITION_VERSION,
                                                TOOL_PROPERTIES,
                                                TOOL_NAME,
-                                               INBOUND_CONNECTOR_TYPE
+                                               INBOUND_CONNECTOR_TYPE,
+                                               BUSINESS_ID
     )
     VALUES (
             #{messageSubscriptionKey},
@@ -247,7 +250,8 @@
             #{processDefinitionVersion},
             #{serializedToolProperties},
             #{toolName},
-            #{inboundConnectorType}
+            #{inboundConnectorType},
+            #{businessId}
     )
   </insert>
 
@@ -268,7 +272,8 @@
         PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
         TOOL_PROPERTIES = #{serializedToolProperties},
         TOOL_NAME = #{toolName},
-        INBOUND_CONNECTOR_TYPE = #{inboundConnectorType}
+        INBOUND_CONNECTOR_TYPE = #{inboundConnectorType},
+        BUSINESS_ID = #{businessId}
     WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}
   </update>
 

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -173,6 +173,12 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
+    <if test="filter.businessIdOperations != null and !filter.businessIdOperations.isEmpty()">
+      <foreach collection="filter.businessIdOperations" item="operation">
+        AND BUSINESS_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1195,6 +1195,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getInboundConnectorType())
           .map(mapToStringOperations())
           .ifPresent(builder::inboundConnectorTypeOperations);
+      ofNullable(filter.getBusinessId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::businessIdOperations);
     }
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1324,6 +1324,7 @@ public final class SearchQueryResponseMapper {
   private static MessageSubscriptionResult toMessageSubscription(
       final MessageSubscriptionEntity messageSubscription) {
     return MessageSubscriptionResult.Builder.create()
+        .businessId(messageSubscription.businessId())
         .rootProcessInstanceKey(keyToStringOrNull(messageSubscription.rootProcessInstanceKey()))
         .correlationKey(messageSubscription.correlationKey())
         .elementId(messageSubscription.flowNodeId())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -864,6 +864,7 @@ public class SearchQuerySortRequestMapper {
         case PROCESS_DEFINITION_VERSION -> builder.processDefinitionVersion();
         case TOOL_NAME -> builder.toolName();
         case INBOUND_CONNECTOR_TYPE -> builder.inboundConnectorType();
+        case BUSINESS_ID -> builder.businessId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionBusinessIdSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionBusinessIdSearchIT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.waitForMessageSubscriptions;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.MessageSubscriptionType;
+import io.camunda.client.api.search.response.MessageSubscription;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the businessId of the subscribing process instance flows end to end (engine ->
+ * exporter -> secondary storage -> search API) for the {@code /v2/message-subscriptions/search}
+ * endpoint, and can be read back, filtered, and sorted on every secondary storage backend.
+ *
+ * <p>Two instances are started through a message start event, each carrying a distinct business id;
+ * each instance then parks on three parallel receive tasks, whose {@code PROCESS_EVENT} message
+ * subscriptions capture that business id when they are opened.
+ *
+ * <p>Intentionally a plain {@code @MultiDbTest} (not {@code @CompatibilityTest}): stamping the
+ * subscribing instance's businessId onto its message subscriptions is new in 8.10, so it cannot be
+ * asserted against an older broker that does not emit it.
+ */
+@MultiDbTest
+public class MessageSubscriptionBusinessIdSearchIT {
+
+  private static final String START_MESSAGE_NAME = "Start";
+  private static final String BUSINESS_ID_A = "msgsub-order-100";
+  private static final String BUSINESS_ID_B = "msgsub-order-200";
+  private static final int RECEIVE_TASKS_PER_INSTANCE = 3;
+  private static final int EXPECTED_PROCESS_EVENT_SUBSCRIPTIONS = 2 * RECEIVE_TASKS_PER_INSTANCE;
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    deployResource(
+        camundaClient, "process/process_with_message_start_and_parallel_receive_tasks.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    // start two instances through the message start event, each carrying a distinct business id;
+    // each instance parks on the three parallel receive tasks, whose subscriptions capture it
+    startProcessViaMessageStartWithBusinessId(BUSINESS_ID_A);
+    startProcessViaMessageStartWithBusinessId(BUSINESS_ID_B);
+
+    waitForProcessInstancesToStart(camundaClient, 2);
+    waitForMessageSubscriptions(
+        camundaClient,
+        f -> f.messageSubscriptionType(MessageSubscriptionType.PROCESS_EVENT),
+        EXPECTED_PROCESS_EVENT_SUBSCRIPTIONS);
+  }
+
+  @Test
+  void shouldExposeBusinessIdOnMessageSubscriptions() {
+    // when
+    final var processEventSubscriptions = searchProcessEventSubscriptions();
+
+    // then each receive-task subscription carries its subscribing instance's business id
+    assertThat(processEventSubscriptions)
+        .hasSize(EXPECTED_PROCESS_EVENT_SUBSCRIPTIONS)
+        .extracting(MessageSubscription::getBusinessId)
+        .containsExactlyInAnyOrder(
+            BUSINESS_ID_A,
+            BUSINESS_ID_A,
+            BUSINESS_ID_A,
+            BUSINESS_ID_B,
+            BUSINESS_ID_B,
+            BUSINESS_ID_B);
+  }
+
+  @Test
+  void shouldFilterByBusinessIdEquals() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId(BUSINESS_ID_A))
+            .send()
+            .join();
+
+    // then only the subscriptions of the instance carrying that business id are returned
+    assertThat(searchResponse.items())
+        .hasSize(RECEIVE_TASKS_PER_INSTANCE)
+        .extracting(MessageSubscription::getBusinessId)
+        .containsOnly(BUSINESS_ID_A);
+  }
+
+  @Test
+  void shouldFilterByBusinessIdLikeWildcard() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId(b -> b.like("msgsub-order-*")))
+            .send()
+            .join();
+
+    // then both instances' subscriptions match the wildcard
+    assertThat(searchResponse.items())
+        .hasSize(EXPECTED_PROCESS_EVENT_SUBSCRIPTIONS)
+        .extracting(MessageSubscription::getBusinessId)
+        .containsOnly(BUSINESS_ID_A, BUSINESS_ID_B);
+  }
+
+  @Test
+  void shouldFilterByBusinessIdExists() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId(b -> b.exists(true)))
+            .send()
+            .join();
+
+    // then only subscriptions that carry a business id are returned; the message-start-event
+    // subscription has none and is excluded
+    assertThat(searchResponse.items())
+        .hasSize(EXPECTED_PROCESS_EVENT_SUBSCRIPTIONS)
+        .extracting(MessageSubscription::getBusinessId)
+        .containsOnly(BUSINESS_ID_A, BUSINESS_ID_B);
+  }
+
+  @Test
+  void shouldReturnEmptyForNonMatchingBusinessId() {
+    // when
+    final var searchResponse =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.businessId("does-not-exist"))
+            .send()
+            .join();
+
+    // then
+    assertThat(searchResponse.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortByBusinessId() {
+    // when ascending
+    final var ascending =
+        processEventBusinessIds(
+            camundaClient
+                .newMessageSubscriptionSearchRequest()
+                .sort(s -> s.businessId().asc())
+                .send()
+                .join()
+                .items());
+
+    // when descending
+    final var descending =
+        processEventBusinessIds(
+            camundaClient
+                .newMessageSubscriptionSearchRequest()
+                .sort(s -> s.businessId().desc())
+                .send()
+                .join()
+                .items());
+
+    // then subscriptions are ordered by business id, with all of one instance before the other
+    assertThat(ascending)
+        .containsExactly(
+            BUSINESS_ID_A,
+            BUSINESS_ID_A,
+            BUSINESS_ID_A,
+            BUSINESS_ID_B,
+            BUSINESS_ID_B,
+            BUSINESS_ID_B);
+    assertThat(descending)
+        .containsExactly(
+            BUSINESS_ID_B,
+            BUSINESS_ID_B,
+            BUSINESS_ID_B,
+            BUSINESS_ID_A,
+            BUSINESS_ID_A,
+            BUSINESS_ID_A);
+  }
+
+  private static List<MessageSubscription> searchProcessEventSubscriptions() {
+    return camundaClient
+        .newMessageSubscriptionSearchRequest()
+        .filter(f -> f.messageSubscriptionType(MessageSubscriptionType.PROCESS_EVENT))
+        .send()
+        .join()
+        .items();
+  }
+
+  private static List<String> processEventBusinessIds(final List<MessageSubscription> items) {
+    return items.stream()
+        .filter(s -> s.getMessageSubscriptionType() == MessageSubscriptionType.PROCESS_EVENT)
+        .map(MessageSubscription::getBusinessId)
+        .toList();
+  }
+
+  private static void startProcessViaMessageStartWithBusinessId(final String businessId) {
+    camundaClient
+        .newCorrelateMessageCommand()
+        .messageName(START_MESSAGE_NAME)
+        .withoutCorrelationKey()
+        .businessId(businessId)
+        .execute();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
@@ -30,6 +30,7 @@ public final class MessageSubscriptionFixtures extends CommonFixtures {
         new Builder()
             .messageName("messageName-" + UUID.randomUUID())
             .correlationKey("correlationKey-" + UUID.randomUUID())
+            .businessId("businessId-" + UUID.randomUUID())
             .tenantId("tenant-" + UUID.randomUUID())
             .partitionId((int) (Math.random() * 10))
             .flowNodeId("flowNode-" + UUID.randomUUID())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -38,7 +38,8 @@ public class MessageSubscriptionEntityTransformer
         value.getProcessDefinitionVersion(),
         value.getToolProperties(),
         value.getToolName(),
-        value.getInboundConnectorType());
+        value.getInboundConnectorType(),
+        value.getBusinessId());
   }
 
   private io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
@@ -15,6 +15,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperatio
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.DATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.EVENT_SOURCE_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_ID;
@@ -64,7 +65,8 @@ public class MessageSubscriptionFilterTransformer
         stringOperations(PROCESS_DEFINITION_NAME, filter.processDefinitionNameOperations()),
         intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()),
         stringOperations(TOOL_NAME, filter.toolNameOperations()),
-        stringOperations(INBOUND_CONNECTOR_TYPE, filter.inboundConnectorTypeOperations()));
+        stringOperations(INBOUND_CONNECTOR_TYPE, filter.inboundConnectorTypeOperations()),
+        stringOperations(BUSINESS_ID, filter.businessIdOperations()));
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.sort;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.BUSINESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.DATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_INSTANCE_KEY;
@@ -41,6 +42,7 @@ public class MessageSubscriptionFieldSortingTransformer implements FieldSortingT
       case "tenantId" -> TENANT_ID;
       case "toolName" -> TOOL_NAME;
       case "inboundConnectorType" -> INBOUND_CONNECTOR_TYPE;
+      case "businessId" -> BUSINESS_ID;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionQueryTransformerTest.java
@@ -173,7 +173,12 @@ public class MessageSubscriptionQueryTransformerTest extends AbstractTransformer
             (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
                 b -> b.inboundConnectorTypes("io.camunda:http-webhook:1"),
             "inboundConnectorType",
-            "io.camunda:http-webhook:1"));
+            "io.camunda:http-webhook:1"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.businessIds("msgsub-order-100"),
+            "businessId",
+            "msgsub-order-100"));
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionSortTest.java
@@ -42,7 +42,8 @@ public class MessageSubscriptionSortTest extends AbstractSortTransformerTest {
         new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()),
         new TestArguments("toolName", SortOrder.ASC, s -> s.toolName().asc()),
         new TestArguments(
-            "inboundConnectorType", SortOrder.DESC, s -> s.inboundConnectorType().desc()));
+            "inboundConnectorType", SortOrder.DESC, s -> s.inboundConnectorType().desc()),
+        new TestArguments("businessId", SortOrder.ASC, s -> s.businessId().asc()));
   }
 
   @ParameterizedTest

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -35,7 +35,8 @@ public record MessageSubscriptionEntity(
     @Nullable Integer processDefinitionVersion,
     Map<String, String> toolProperties,
     @Nullable String toolName,
-    @Nullable String inboundConnectorType)
+    @Nullable String inboundConnectorType,
+    @Nullable String businessId)
     implements TenantOwnedEntity {
 
   public MessageSubscriptionEntity {
@@ -79,6 +80,7 @@ public record MessageSubscriptionEntity(
     private @Nullable Map<String, String> toolProperties;
     private @Nullable String toolName;
     private @Nullable String inboundConnectorType;
+    private @Nullable String businessId;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -151,6 +153,11 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
+    public Builder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -191,7 +198,8 @@ public record MessageSubscriptionEntity(
           processDefinitionVersion,
           toolProperties,
           toolName,
-          inboundConnectorType);
+          inboundConnectorType,
+          businessId);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
@@ -33,7 +33,8 @@ public record MessageSubscriptionFilter(
     List<Operation<String>> processDefinitionNameOperations,
     List<Operation<Integer>> processDefinitionVersionOperations,
     List<Operation<String>> toolNameOperations,
-    List<Operation<String>> inboundConnectorTypeOperations)
+    List<Operation<String>> inboundConnectorTypeOperations,
+    List<Operation<String>> businessIdOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<MessageSubscriptionFilter> {
@@ -54,6 +55,7 @@ public record MessageSubscriptionFilter(
     private List<Operation<Integer>> processDefinitionVersionOperations;
     private List<Operation<String>> toolNameOperations;
     private List<Operation<String>> inboundConnectorTypeOperations;
+    private List<Operation<String>> businessIdOperations;
 
     public Builder messageSubscriptionKeys(final Long value, final Long... values) {
       return messageSubscriptionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
@@ -299,6 +301,21 @@ public record MessageSubscriptionFilter(
       return this;
     }
 
+    public Builder businessIds(final String value, final String... values) {
+      return businessIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder businessIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return businessIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder businessIdOperations(final List<Operation<String>> operations) {
+      businessIdOperations = addValuesToList(businessIdOperations, operations);
+      return this;
+    }
+
     @Override
     public MessageSubscriptionFilter build() {
       return new MessageSubscriptionFilter(
@@ -317,7 +334,8 @@ public record MessageSubscriptionFilter(
           Objects.requireNonNullElse(processDefinitionNameOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),
           Objects.requireNonNullElse(toolNameOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(inboundConnectorTypeOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(inboundConnectorTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(businessIdOperations, Collections.emptyList()));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
@@ -102,6 +102,11 @@ public record MessageSubscriptionSort(List<FieldSorting> orderings) implements S
       return this;
     }
 
+    public Builder businessId() {
+      currentOrdering = new FieldSorting("businessId", null);
+      return this;
+    }
+
     @Override
     protected MessageSubscriptionSort.Builder self() {
       return this;

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
@@ -41,6 +41,7 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   private Map<String, String> toolProperties;
   private String toolName;
   private String inboundConnectorType;
+  private String businessId;
 
   @Override
   public Long getMessageSubscriptionKey() {
@@ -130,6 +131,11 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   @Override
   public String getInboundConnectorType() {
     return inboundConnectorType;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessId;
   }
 
   public MessageSubscriptionBuilder setToolProperties(final Map<String, String> toolProperties) {
@@ -222,6 +228,11 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
 
   public MessageSubscriptionBuilder setInboundConnectorType(final String inboundConnectorType) {
     this.inboundConnectorType = inboundConnectorType;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setBusinessId(final String businessId) {
+    this.businessId = businessId;
     return this;
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -112,6 +112,7 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
   public static final String MESSAGE_SUBSCRIPTION_TYPE = "messageSubscriptionType";
   public static final String TOOL_NAME = "toolName";
   public static final String INBOUND_CONNECTOR_TYPE = "inboundConnectorType";
+  public static final String BUSINESS_ID = "businessId";
 
   public MessageSubscriptionTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -72,6 +72,9 @@ public class MessageSubscriptionEntity
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String inboundConnectorType;
 
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String businessId;
+
   /**
    * @deprecated since 8.9
    */
@@ -275,6 +278,15 @@ public class MessageSubscriptionEntity
     return this;
   }
 
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  public MessageSubscriptionEntity setBusinessId(final String businessId) {
+    this.businessId = businessId;
+    return this;
+  }
+
   /**
    * @deprecated since 8.9
    */
@@ -369,7 +381,8 @@ public class MessageSubscriptionEntity
         toolProperties,
         messageSubscriptionType,
         toolName,
-        inboundConnectorType);
+        inboundConnectorType,
+        businessId);
   }
 
   @Override
@@ -405,6 +418,7 @@ public class MessageSubscriptionEntity
         && Objects.equals(toolProperties, that.toolProperties)
         && Objects.equals(messageSubscriptionType, that.messageSubscriptionType)
         && Objects.equals(toolName, that.toolName)
-        && Objects.equals(inboundConnectorType, that.inboundConnectorType);
+        && Objects.equals(inboundConnectorType, that.inboundConnectorType)
+        && Objects.equals(businessId, that.businessId);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -112,6 +112,9 @@
       },
       "inboundConnectorType": {
         "type": "keyword"
+      },
+      "businessId": {
+        "type": "keyword"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
@@ -112,6 +112,9 @@
       },
       "inboundConnectorType": {
         "type": "keyword"
+      },
+      "businessId": {
+        "type": "keyword"
       }
 		}
 	}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.exporter.utils.ExporterUtil.emptyToNull;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.ExporterMetadata;
@@ -93,6 +94,7 @@ public class MessageSubscriptionFromProcessMessageSubscriptionHandler
         .setFlowNodeId(elementId)
         .setTenantId(tenantOrDefault(recordValue.getTenantId()))
         .setPositionProcessMessageSubscription(record.getPosition())
+        .setBusinessId(emptyToNull(recordValue.getBusinessId()))
         .setMessageSubscriptionType("PROCESS_EVENT");
 
     final MessageSubscriptionMetadataEntity eventMetadata = new MessageSubscriptionMetadataEntity();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -252,6 +252,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     final String tenantId = "tenantId";
     final String messageName = "messageName";
     final String correlationKey = "correlationKey";
+    final String businessId = "businessId";
     final Intent intent = ProcessMessageSubscriptionIntent.CREATED;
     final var recordValue =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -264,6 +265,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
             .withTenantId(tenantId)
             .withMessageName(messageName)
             .withCorrelationKey(correlationKey)
+            .withBusinessId(businessId)
             .build();
     final Record<ProcessMessageSubscriptionRecordValue> record =
         factory.generateRecord(
@@ -297,7 +299,41 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     assertThat(entity.getPositionProcessMessageSubscription()).isEqualTo(position);
     assertThat(entity.getMetadata().getMessageName()).isEqualTo(messageName);
     assertThat(entity.getMetadata().getCorrelationKey()).isEqualTo(correlationKey);
+    assertThat(entity.getBusinessId()).isEqualTo(businessId);
     assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+  }
+
+  @Test
+  public void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final long recordKey = 789;
+    final var recordValue =
+        ImmutableProcessMessageSubscriptionRecordValue.builder()
+            .withProcessInstanceKey(123)
+            .withElementInstanceKey(456)
+            .withProcessDefinitionKey(555)
+            .withElementId("elementId")
+            .withBpmnProcessId("bpmnProcessId")
+            .withTenantId("tenantId")
+            .withMessageName("messageName")
+            .withCorrelationKey("correlationKey")
+            .withBusinessId("")
+            .build();
+    final Record<ProcessMessageSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+            r ->
+                r.withIntent(ProcessMessageSubscriptionIntent.CREATED)
+                    .withKey(recordKey)
+                    .withValue(recordValue));
+
+    // when
+    final var ids = underTest.generateIds(record);
+    final MessageSubscriptionEntity entity = underTest.createNewEntity(ids.getFirst());
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getBusinessId()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.rdbms.handlers;
 
 import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
+import static io.camunda.exporter.rdbms.utils.ExportUtil.emptyToNull;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
@@ -93,6 +94,7 @@ public class MessageSubscriptionExportHandler
         .dateTime(toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
         .messageName(value.getMessageName())
         .correlationKey(value.getCorrelationKey())
+        .businessId(emptyToNull(value.getBusinessId()))
         .tenantId(value.getTenantId())
         .partitionId(record.getPartitionId())
         .processDefinitionName(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -141,6 +141,7 @@ final class MessageSubscriptionExportHandlerTest {
     final String tenantId = "tenant-1";
     final String processName = "Process One";
     final int processVersion = 2;
+    final String businessId = "order-100";
     final Map<String, String> extProps =
         Map.of("io.camunda.tool:name", "myTool", "inbound.type", "io.camunda:http-webhook:1");
 
@@ -155,6 +156,7 @@ final class MessageSubscriptionExportHandlerTest {
             .withRootProcessInstanceKey(rootProcessInstanceKey)
             .withElementInstanceKey(flowNodeInstanceKey)
             .withTenantId(tenantId)
+            .withBusinessId(businessId)
             .build();
 
     final Record<ProcessMessageSubscriptionRecordValue> record =
@@ -191,6 +193,7 @@ final class MessageSubscriptionExportHandlerTest {
     assertThat(model.messageSubscriptionType()).isEqualTo(MessageSubscriptionType.PROCESS_EVENT);
     assertThat(model.messageName()).isEqualTo(messageName);
     assertThat(model.correlationKey()).isEqualTo(correlationKey);
+    assertThat(model.businessId()).isEqualTo(businessId);
     assertThat(model.tenantId()).isEqualTo(tenantId);
     assertThat(model.partitionId()).isEqualTo(partitionId);
     assertThat(model.dateTime())
@@ -250,5 +253,37 @@ final class MessageSubscriptionExportHandlerTest {
     assertThat(model.toolProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isNull();
     assertThat(model.inboundConnectorType()).isNull();
+  }
+
+  @Test
+  void shouldMapEmptyBusinessIdToNull() {
+    // given
+    final long pdKey = 300L;
+    final var recordValue =
+        ImmutableProcessMessageSubscriptionRecordValue.builder()
+            .withProcessDefinitionKey(pdKey)
+            .withBpmnProcessId("proc")
+            .withElementId("catch")
+            .withMessageName("msg")
+            .withCorrelationKey("key")
+            .withProcessInstanceKey(1L)
+            .withRootProcessInstanceKey(1L)
+            .withElementInstanceKey(2L)
+            .withBusinessId("")
+            .withVariables(Map.of())
+            .build();
+    final Record<ProcessMessageSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+            r -> r.withIntent(ProcessMessageSubscriptionIntent.CREATED).withValue(recordValue));
+    when(processCache.get(pdKey)).thenReturn(Optional.empty());
+
+    // when
+    underTest.export(record);
+
+    // then
+    final var captor = ArgumentCaptor.forClass(MessageSubscriptionDbModel.class);
+    verify(writer).create(captor.capture());
+    assertThat(captor.getValue().businessId()).isNull();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -318,6 +318,7 @@ components:
     MessageSubscriptionResult:
       type: object
       required:
+        - businessId
         - rootProcessInstanceKey
         - correlationKey
         - elementId
@@ -337,6 +338,14 @@ components:
         - tenantId
         - toolName
       properties:
+        businessId:
+          description: |
+            The business id inherited from the subscribing process instance when this message
+            subscription was opened. It is `null` when the process instance has no business id, and
+            for message start event subscriptions, which are not tied to a process instance.
+          nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
         messageSubscriptionKey:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKey'
@@ -437,6 +446,8 @@ components:
           addedInVersion: "8.10"
         - propertyName: inboundConnectorType
           addedInVersion: "8.10"
+        - propertyName: businessId
+          addedInVersion: "8.10"
 
     MessageSubscriptionSearchQuerySortRequest:
       type: object
@@ -445,6 +456,7 @@ components:
           description: The field to sort by.
           type: string
           enum:
+            - businessId
             - messageSubscriptionKey
             - processDefinitionId
             - processDefinitionName
@@ -485,6 +497,13 @@ components:
       description: Message subscription search filter.
       type: object
       properties:
+        businessId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: |
+            Filter by the business id inherited from the subscribing process instance when the
+            subscription was opened. Supports advanced string filtering, including `$like` with
+            `*`/`?` wildcards.
         messageSubscriptionKey:
           allOf:
             - $ref: '#/components/schemas/MessageSubscriptionKeyFilterProperty'
@@ -584,6 +603,8 @@ components:
         - propertyName: toolName
           addedInVersion: "8.10"
         - propertyName: inboundConnectorType
+          addedInVersion: "8.10"
+        - propertyName: businessId
           addedInVersion: "8.10"
 
     CorrelatedMessageSubscriptionSearchQueryResult:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -56,7 +56,8 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   "processDefinitionName": null,
                   "processDefinitionVersion": null,
                   "toolName": null,
-                  "inboundConnectorType": null
+                  "inboundConnectorType": null,
+                  "businessId": null
                 }
             ],
             "page": {


### PR DESCRIPTION
## Description

`POST /v2/message-subscriptions/search` had a read/search-path gap for `businessId`: it was silently dropped from response items, ignored as a filter, and rejected as a sort criterion with HTTP 400, even though the engine already
stamps the subscribing process instance's `businessId` onto message-subscription records. 
Correlated message subscriptions (`CorrelatedMessageSubscription`) already had full `businessId` support; this PR closes the same gap for the standard message-subscription search path.

The change wires `businessId` end-to-end through the read path:

- **API schema & Java client contract** — adds `businessId` to the response item and search query model.
- **Read model** — carries `businessId` through the internal message-subscription domain object.
- **Filter** — applies `businessId` equals / like-wildcard filtering in both Elasticsearch/OpenSearch and RDBMS query builders.
- **Sort** — adds `businessId` as a valid sort field in both Elasticsearch/OpenSearch and RDBMS.
- **ES/OS exporter** — populates `businessId` when indexing message-subscription records.
- **RDBMS storage** — populates `businessId` when persisting message-subscription records.

## Related issues

closes #59444
relates to #51687