### PR TITLE
test: add blackbox integration test for rebalance endpoint

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceForwardingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceForwardingIT.java
@@ -9,21 +9,19 @@ package io.camunda.zeebe.it.cluster.clustering;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import feign.Response;
+import feign.Util;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
 final class ClusterRebalanceForwardingIT {
 
-  private static final String REBALANCE_PATH = "cluster/v2/rebalance";
-
   @AutoClose private TestCluster cluster;
-  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
   @Test
   void shouldForwardARequestFromANonCoordinatorToTheCoordinator() throws Exception {
@@ -41,16 +39,23 @@ final class ClusterRebalanceForwardingIT {
     final var nonCoordinator = cluster.brokers().get(MemberId.from("1"));
 
     // when
-    final var fromNonCoordinator = getRebalance(nonCoordinator.restAddress());
+    final var nonCoordinatorClient = ClusterRebalanceRestClient.of(nonCoordinator.restAddress());
+    final var coordinatorClient = ClusterRebalanceRestClient.of(coordinator.restAddress());
 
     // then
-    assertThat(fromNonCoordinator.statusCode()).isEqualTo(200);
-    final var fromCoordinator = getRebalance(coordinator.restAddress());
-    assertThat(fromNonCoordinator.body()).isEqualTo(fromCoordinator.body());
+    try (final var fromNonCoordinator = nonCoordinatorClient.getRebalance();
+        final var fromCoordinator = coordinatorClient.getRebalance()) {
+      assertThat(fromNonCoordinator.status()).isEqualTo(200);
+      final var nonCoordinatorBody = readBody(fromNonCoordinator);
+      final var coordinatorBody = readBody(fromCoordinator);
+      assertThat(nonCoordinatorBody).isEqualTo(coordinatorBody);
+    }
   }
 
-  private HttpResponse<String> getRebalance(final URI restAddress) throws Exception {
-    final var request = HttpRequest.newBuilder(restAddress.resolve(REBALANCE_PATH)).GET().build();
-    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+  private static String readBody(final Response response) throws IOException {
+    if (response.body() == null) {
+      return "";
+    }
+    return Util.toString(response.body().asReader(StandardCharsets.UTF_8));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertThatAllJobsCanBeCompleted;
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.atomix.cluster.MemberId;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Black-box coverage for {@code POST /cluster/v2/rebalance}. */
+@ZeebeIntegration
+final class ClusterRebalanceIT {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterRebalanceIT.class);
+  private static final String REBALANCE_PATH = "cluster/v2/rebalance";
+  private static final String JOB_TYPE = "rebalance-test";
+  private static final int PARTITION_COUNT = 3;
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withEmbeddedGateway(true)
+          .withBrokersCount(3)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withReplicationFactor(3)
+          .build();
+
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+  @AutoClose private CamundaClient client;
+
+  @BeforeEach
+  void setup() {
+    // broker 1 is stopped/restarted to force an imbalance, so use another broker's client
+    client = cluster.brokers().get(MemberId.from("0")).newClientBuilder().build();
+  }
+
+  @Test
+  void shouldRebalanceLeadershipAndResumeProcessing() {
+    // given
+    forceBadLeaderDistribution();
+    assertThat(hasBadLeaderDistribution()).isTrue();
+    final var processInstanceKeys =
+        createInstanceWithAJobOnAllPartitions(client, JOB_TYPE, PARTITION_COUNT);
+
+    // when
+    assertAccepted(triggerRebalance());
+
+    // then
+    awaitCompletedRebalance();
+    awaitBalancedTopology();
+    assertThatAllJobsCanBeCompleted(processInstanceKeys, client, JOB_TYPE);
+  }
+
+  private void assertAccepted(final HttpResponse<String> response) {
+    assertThat(response.statusCode())
+        .as("rebalance response: %s", response.body())
+        .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+  }
+
+  private HttpResponse<String> triggerRebalance() {
+    final URI uri = rebalanceUri();
+    final HttpRequest request = HttpRequest.newBuilder(uri).POST(BodyPublishers.noBody()).build();
+    return sendHttp(request);
+  }
+
+  private HttpResponse<String> getRebalance() {
+    final URI uri = rebalanceUri();
+    final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+    return sendHttp(request);
+  }
+
+  private URI rebalanceUri() {
+    final URI restAddress = cluster.availableGateway().restAddress();
+    final String path = restAddress.getPath();
+    final URI baseWithTrailingSlash =
+        path.endsWith("/") ? restAddress : URI.create(restAddress + "/");
+    return baseWithTrailingSlash.resolve(REBALANCE_PATH);
+  }
+
+  private HttpResponse<String> sendHttp(final HttpRequest request) {
+    try {
+      return httpClient.send(request, BodyHandlers.ofString());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void awaitCompletedRebalance() {
+    Awaitility.await("the rebalance completes with at least one transferred partition")
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(
+            () -> {
+              final var response = getRebalance();
+              assertThat(response.statusCode())
+                  .as("rebalance status response: %s", response.body())
+                  .isEqualTo(HttpURLConnection.HTTP_OK);
+
+              final JsonNode body = JSON.readTree(response.body());
+              assertThat(body.has("runningRebalance"))
+                  .as("runningRebalance field present: %s", response.body())
+                  .isTrue();
+              assertThat(body.get("runningRebalance").isNull())
+                  .as("no rebalance still running: %s", response.body())
+                  .isTrue();
+
+              final JsonNode lastCompleted = body.get("lastCompletedRebalance");
+              assertThat(lastCompleted)
+                  .as("a completed rebalance is present: %s", response.body())
+                  .isNotNull();
+              assertThat(lastCompleted.isNull())
+                  .as("a completed rebalance is present: %s", response.body())
+                  .isFalse();
+
+              assertThat(lastCompleted.path("result").asText())
+                  .as("rebalance result: %s", response.body())
+                  .isEqualTo("COMPLETED");
+
+              final var partitions = lastCompleted.path("partitions");
+              assertThat(partitions.isArray() && partitions.size() > 0)
+                  .as("rebalance partitions present: %s", response.body())
+                  .isTrue();
+              final boolean anyTransferred =
+                  StreamSupport.stream(partitions.spliterator(), false)
+                      .anyMatch(
+                          partition -> "TRANSFERRED".equals(partition.path("result").asText()));
+              assertThat(anyTransferred)
+                  .as("at least one partition was transferred: %s", response.body())
+                  .isTrue();
+            });
+  }
+
+  private void awaitBalancedTopology() {
+    Awaitility.await("the final leader distribution is round-robin across brokers 0, 1, and 2")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var topology = client.newTopologyRequest().send().join();
+              TopologyAssert.assertThat(topology)
+                  .hasLeaderForPartition(1, 0)
+                  .hasLeaderForPartition(2, 1)
+                  .hasLeaderForPartition(3, 2);
+            });
+  }
+
+  @SuppressWarnings("resource")
+  private void forceBadLeaderDistribution() {
+    if (hasGoodLeaderDistribution()) {
+      final var brokerId = MemberId.from("1");
+      final var stoppedBroker = cluster.brokers().get(brokerId).stop();
+      LOG.debug("Broker stopped");
+      waitForBadLeaderDistribution();
+      LOG.debug("Bad distribution of partition: waiting for the broker to be ready");
+      stoppedBroker.start().await(TestHealthProbe.READY);
+
+      stoppedBroker.awaitCompleteTopology(
+          cluster.brokers().size(),
+          cluster.partitionsCount(),
+          cluster.replicationFactor(),
+          Duration.ofMinutes(1));
+    }
+  }
+
+  private void waitForBadLeaderDistribution() {
+    Awaitility.await("at least one broker is leader for more than one partition")
+        .timeout(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(this::hasBadLeaderDistribution);
+  }
+
+  private boolean hasBadLeaderDistribution() {
+    return client.newTopologyRequest().send().join().getBrokers().stream()
+        .anyMatch(
+            brokerInfo ->
+                brokerInfo.getPartitions().stream().filter(PartitionInfo::isLeader).count() > 1);
+  }
+
+  private boolean hasGoodLeaderDistribution() {
+    return client.newTopologyRequest().send().join().getBrokers().stream()
+        .allMatch(
+            brokerInfo ->
+                brokerInfo.getPartitions().stream().filter(PartitionInfo::isLeader).count() == 1);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.PartitionInfo;
@@ -20,14 +21,12 @@ import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.stream.StreamSupport;
 import org.awaitility.Awaitility;
@@ -41,7 +40,6 @@ import org.slf4j.LoggerFactory;
 @ZeebeIntegration
 final class ClusterRebalanceIT {
   private static final Logger LOG = LoggerFactory.getLogger(ClusterRebalanceIT.class);
-  private static final String REBALANCE_PATH = "cluster/v2/rebalance";
   private static final String JOB_TYPE = "rebalance-test";
   private static final int PARTITION_COUNT = 3;
   private static final ObjectMapper JSON = new ObjectMapper();
@@ -55,13 +53,14 @@ final class ClusterRebalanceIT {
           .withReplicationFactor(3)
           .build();
 
-  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
   @AutoClose private CamundaClient client;
+  private ClusterRebalanceRestClient rebalanceClient;
 
   @BeforeEach
   void setup() {
     // broker 1 is stopped/restarted to force an imbalance, so use another broker's client
     client = cluster.brokers().get(MemberId.from("0")).newClientBuilder().build();
+    rebalanceClient = ClusterRebalanceRestClient.of(cluster.availableGateway());
   }
 
   @Test
@@ -81,40 +80,30 @@ final class ClusterRebalanceIT {
     assertThatAllJobsCanBeCompleted(processInstanceKeys, client, JOB_TYPE);
   }
 
-  private void assertAccepted(final HttpResponse<String> response) {
-    assertThat(response.statusCode())
-        .as("rebalance response: %s", response.body())
+  private void assertAccepted(final Response response) {
+    final String body = readBody(response);
+    assertThat(response.status())
+        .as("rebalance response: %s", body)
         .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
   }
 
-  private HttpResponse<String> triggerRebalance() {
-    final URI uri = rebalanceUri();
-    final HttpRequest request = HttpRequest.newBuilder(uri).POST(BodyPublishers.noBody()).build();
-    return sendHttp(request);
+  private Response triggerRebalance() {
+    return rebalanceClient.triggerRebalance();
   }
 
-  private HttpResponse<String> getRebalance() {
-    final URI uri = rebalanceUri();
-    final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
-    return sendHttp(request);
+  private Response getRebalance() {
+    return rebalanceClient.getRebalance();
   }
 
-  private URI rebalanceUri() {
-    final URI restAddress = cluster.availableGateway().restAddress();
-    final String path = restAddress.getPath();
-    final URI baseWithTrailingSlash =
-        path.endsWith("/") ? restAddress : URI.create(restAddress + "/");
-    return baseWithTrailingSlash.resolve(REBALANCE_PATH);
-  }
-
-  private HttpResponse<String> sendHttp(final HttpRequest request) {
-    try {
-      return httpClient.send(request, BodyHandlers.ofString());
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
+  private static String readBody(final Response response) {
+    try (response) {
+      final var body = response.body();
+      if (body == null) {
+        return "";
+      }
+      return new String(body.asInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -124,40 +113,41 @@ final class ClusterRebalanceIT {
         .untilAsserted(
             () -> {
               final var response = getRebalance();
-              assertThat(response.statusCode())
-                  .as("rebalance status response: %s", response.body())
+              final String responseBody = readBody(response);
+              assertThat(response.status())
+                  .as("rebalance status response: %s", responseBody)
                   .isEqualTo(HttpURLConnection.HTTP_OK);
 
-              final JsonNode body = JSON.readTree(response.body());
+              final JsonNode body = JSON.readTree(responseBody);
               assertThat(body.has("runningRebalance"))
-                  .as("runningRebalance field present: %s", response.body())
+                  .as("runningRebalance field present: %s", responseBody)
                   .isTrue();
               assertThat(body.get("runningRebalance").isNull())
-                  .as("no rebalance still running: %s", response.body())
+                  .as("no rebalance still running: %s", responseBody)
                   .isTrue();
 
               final JsonNode lastCompleted = body.get("lastCompletedRebalance");
               assertThat(lastCompleted)
-                  .as("a completed rebalance is present: %s", response.body())
+                  .as("a completed rebalance is present: %s", responseBody)
                   .isNotNull();
               assertThat(lastCompleted.isNull())
-                  .as("a completed rebalance is present: %s", response.body())
+                  .as("a completed rebalance is present: %s", responseBody)
                   .isFalse();
 
               assertThat(lastCompleted.path("result").asText())
-                  .as("rebalance result: %s", response.body())
+                  .as("rebalance result: %s", responseBody)
                   .isEqualTo("COMPLETED");
 
               final var partitions = lastCompleted.path("partitions");
               assertThat(partitions.isArray() && partitions.size() > 0)
-                  .as("rebalance partitions present: %s", response.body())
+                  .as("rebalance partitions present: %s", responseBody)
                   .isTrue();
               final boolean anyTransferred =
                   StreamSupport.stream(partitions.spliterator(), false)
                       .anyMatch(
                           partition -> "TRANSFERRED".equals(partition.path("result").asText()));
               assertThat(anyTransferred)
-                  .as("at least one partition was transferred: %s", response.body())
+                  .as("at least one partition was transferred: %s", responseBody)
                   .isTrue();
             });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/Utils.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/Utils.java
@@ -64,7 +64,7 @@ public final class Utils {
         .isNotEqualTo(response.getCurrentTopology());
   }
 
-  static void assertThatAllJobsCanBeCompleted(
+  public static void assertThatAllJobsCanBeCompleted(
       final List<Long> processInstanceKeys,
       final CamundaClient camundaClient,
       final String jobType) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
@@ -22,7 +22,10 @@ import java.net.URI;
  */
 public interface ClusterRebalanceRestClient {
   static ClusterRebalanceRestClient of(final TestGateway<?> gateway) {
-    final URI restAddress = gateway.restAddress();
+    return of(gateway.restAddress());
+  }
+
+  static ClusterRebalanceRestClient of(final URI restAddress) {
     final var path = restAddress.getPath();
     final var baseWithTrailingSlash =
         path.endsWith("/") ? restAddress : URI.create(restAddress + "/");

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.restapi;
+
+import feign.Feign;
+import feign.Headers;
+import feign.RequestLine;
+import feign.Response;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import java.net.URI;
+
+/**
+ * Java interface for the cluster's {@code cluster/v2/rebalance} REST endpoint. To instantiate this
+ * interface, you can use {@link Feign}; see {@link #of(TestGateway)} as an example.
+ */
+public interface ClusterRebalanceRestClient {
+  static ClusterRebalanceRestClient of(final TestGateway<?> gateway) {
+    final URI restAddress = gateway.restAddress();
+    final var path = restAddress.getPath();
+    final var baseWithTrailingSlash =
+        path.endsWith("/") ? restAddress : URI.create(restAddress + "/");
+    final var endpoint = baseWithTrailingSlash.resolve("cluster/v2/rebalance").toString();
+    final var target = new HardCodedTarget<>(ClusterRebalanceRestClient.class, endpoint);
+    return Feign.builder().retryer(Retryer.NEVER_RETRY).target(target);
+  }
+
+  /** Triggers a rebalance of the cluster's leadership. */
+  @RequestLine("POST")
+  @Headers("Accept: application/json")
+  Response triggerRebalance();
+
+  /** Returns the status of the cluster's rebalance. */
+  @RequestLine("GET")
+  @Headers("Accept: application/json")
+  Response getRebalance();
+}


### PR DESCRIPTION
Tests coordinated leadership transfer end-to-end via the REST `/cluster/v2/rebalance` endpoint. This is just a basic scenario (force unbalanced cluster, trigger rebalance, verify cluster is balanced and functional) - for more complex scenarios we have lower-level tests, and I'll be looking at adding some chaos testing scenarios separately too.