### PR TITLE
deps: upgrade micrometer to 1.16.7 to remediate CVE-2026-59296 (stable/8.7)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,7 +85,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.31.1</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.15.12</version.micrometer>
+    <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
> **Note:** branch name still says `1.15.13` for history continuity; the change now targets **1.16.7** (see below).

## What

Bumps `io.micrometer` from **1.15.12 → 1.16.7** (public OSS fix) on `stable/8.7` to remediate **CVE-2026-59296**.

## Why

CVE-2026-59296 (CWE-74, CVSS 5.9 Medium): `micrometer-core` / `micrometer-registry-statsd` do not sanitise line terminators (`\n`, `\r`) in metric names, tag keys, or tag values, enabling metric/log line-injection via the StatsD (Datadog/Etsy) registry or `LoggingMeterRegistry`.

- **Exploitability here: Not Affected.** The vulnerable sinks are unused — `micrometer-registry-statsd` is not a dependency, and `LoggingMeterRegistry` is never configured. Only Prometheus and OTLP registries are used. This PR is **scanner hygiene**, not an active-exposure fix.
- **Version choice:** the 1.15 line has **no OSS fix** (1.15.13 is HeroDevs-NES enterprise-only and 404s on Maven Central, so it cannot resolve in CI). The lowest **public** OSS fix is **1.16.7**.

## ⚠️ Compatibility risk — CI must validate

This bumps micrometer **one minor ahead** of the Spring Boot 3.5 baseline this branch pins (SB 3.5 manages micrometer 1.15.x; cf. #59640). The risk is runtime incompatibility in actuator/observability autoconfiguration.

- [ ] All CI green, **especially `Spring-Boot-Compatibility 3.5.x`** and the actuator/observability ITs.
- If the compatibility jobs fail → **close this PR** and keep the CVE registry disposition as **Not Affected** for `stable/8.7` (the finding is not exploitable regardless).

## Related

- CVE-2026-59296 — https://nvd.nist.gov/vuln/detail/CVE-2026-59296
- Companion PR for `stable/8.7` (same change).
