### PR TITLE
ci: install Java 25 alongside Java 21 for c8run RDBMS regression tests

### DIFF
--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -67,6 +67,16 @@ jobs:
         with:
           go-version: '>=1.23.1'
 
+      # c8run on this branch resolves its own JVM from JAVA_HOME at runtime, so the default
+      # (last-listed) version here is what actually launches c8run/Camunda under test. Java 25
+      # is installed alongside only so the pinned ijhttp CLI below has a JVM new enough to load.
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: 'temurin'
+          java-version: |
+            25
+            21
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
@@ -113,7 +123,7 @@ jobs:
         run: |
           curl -f -L -o ijhttp.zip "https://download.jetbrains.com/resources/intellij/http-client/262.7132.23/intellij-http-client.zip"
           unzip ijhttp.zip
-          ijhttp/ijhttp qa/http/c8run-tests/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
+          JAVA_HOME="$JAVA_HOME_25_X64" ijhttp/ijhttp qa/http/c8run-tests/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
 
       - name: Cleanup
         shell: bash

--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -56,26 +56,22 @@ jobs:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
 
+      # c8run on this branch resolves its own JVM from JAVA_HOME at runtime, so the default
+      # (last-listed) java-version is what actually launches c8run/Camunda under test. Java 25
+      # is installed alongside only so the pinned ijhttp CLI below has a JVM new enough to load.
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          java-version: |
+            25
+            21
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.23.1'
-
-      # c8run on this branch resolves its own JVM from JAVA_HOME at runtime, so the default
-      # (last-listed) version here is what actually launches c8run/Camunda under test. Java 25
-      # is installed alongside only so the pinned ijhttp CLI below has a JVM new enough to load.
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          distribution: 'temurin'
-          java-version: |
-            25
-            21
 
       - name: Import Secrets
         id: secrets
@@ -123,7 +119,7 @@ jobs:
         run: |
           curl -f -L -o ijhttp.zip "https://download.jetbrains.com/resources/intellij/http-client/262.7132.23/intellij-http-client.zip"
           unzip ijhttp.zip
-          JAVA_HOME="$JAVA_HOME_25_X64" ijhttp/ijhttp qa/http/c8run-tests/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
+          JAVA_HOME="${JAVA_HOME_25_X64:?ijhttp 262.x needs Java 25, check the setup-build step}" ijhttp/ijhttp qa/http/c8run-tests/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
 
       - name: Cleanup
         shell: bash


### PR DESCRIPTION
## Summary

- `c8run-rdbms-regression-test.yml` on `stable/8.9` had no `setup-java` step, so it fell back to the runner's default Java 21. The pinned IntelliJ HTTP Client CLI (`ijhttp` 262.7132.23) used to run the `.http` regression tests requires Java 25+ to load, so every run of this workflow on `stable/8.9` has been failing with `UnsupportedClassVersionError` since the ijhttp URL was pinned on 2026-08-05 (`b309ab0601a`).
- `main` doesn't hit this because it separately installs Java 25 as part of the jlink/bundled-JRE feature — which is intentionally main-only and not meant for `stable/8.9`.
- c8run on `stable/8.9` resolves its own JVM from `JAVA_HOME` at runtime (no bundled JRE), so the default JDK on the runner is also what launches the actual c8run/Camunda process under test. Simply bumping the whole job to Java 25 would silently start testing Camunda 8.9 under a Java version it doesn't ship with.
- Fix: install both Java 21 and Java 25 via `setup-java` (`21` listed last, so it stays the default `JAVA_HOME`/`PATH` for the build/package/run-c8run steps), and only point the `ijhttp` invocation at `JAVA_HOME_25_X64`.
- Verified by applying the identical change on top of #60878 (`c8run-release-8.9.17`) — both `build_and_test_c8run` matrix legs passed (previously failing). Reverted that verification commit off #60878 since this PR is the actual fix.

## Test plan

- [x] `actionlint` clean
- [x] Verified fix on PR #60878 CI (both `build_and_test_c8run` legs passed)
- [ ] CI green on this PR