### PR TITLE
fix: disable Operate Design System navigation by default

### DIFF
--- a/operate/client/e2e-playwright/mocks/clientConfig.ts
+++ b/operate/client/e2e-playwright/mocks/clientConfig.ts
@@ -19,6 +19,7 @@ const clientConfigMock = `window.clientConfig = ${JSON.stringify({
   tasklistUrl: null,
   resourcePermissionsEnabled: false,
   multiTenancyEnabled: false,
+  isNavV2Enabled: true,
 })};`;
 
 export {clientConfigMock};

--- a/operate/client/e2e-playwright/pages/Common.ts
+++ b/operate/client/e2e-playwright/pages/Common.ts
@@ -35,6 +35,7 @@ type ClientConfig = {
   tasklistUrl?: null | string;
   resourcePermissionsEnabled?: boolean;
   multiTenancyEnabled?: boolean;
+  isNavV2Enabled?: boolean;
 };
 
 export class Common {
@@ -243,6 +244,7 @@ export class Common {
       stage: null,
       mixpanelToken: null,
       mixpanelAPIHost: null,
+      isNavV2Enabled: true,
     };
 
     return context.route('**/client-config.js', (route) =>
@@ -253,7 +255,7 @@ export class Common {
         },
         body: `window.clientConfig = ${JSON.stringify({
           ...defaultConfig,
-          config,
+          ...config,
         })};`,
       }),
     );

--- a/operate/client/src/modules/utils/getClientConfig.ts
+++ b/operate/client/src/modules/utils/getClientConfig.ts
@@ -23,7 +23,7 @@ const ClientConfigSchema = z.object({
   multiTenancyEnabled: z.boolean().optional().default(false),
   databaseType: z.string().optional().default('document-store'),
   waitStatesEnabled: z.boolean().optional().default(true),
-  isNavV2Enabled: z.boolean().optional().default(true),
+  isNavV2Enabled: z.boolean().optional().default(false),
 });
 
 const DEFAULT_CLIENT_CONFIG = ClientConfigSchema.safeParse({}).data!;

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -39,7 +39,7 @@ public class OperateProperties {
 
   private boolean enterprise = false;
 
-  private boolean navV2Enabled = true;
+  private boolean navV2Enabled = false;
 
   private String tasklistUrl = null;
 


### PR DESCRIPTION
## Description

Disables the Operate Design System navigation by default while preserving runtime configuration-based opt-in. Playwright client configuration explicitly enables navigation V2 so existing visual, accessibility, and documentation screenshot baselines remain unchanged.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None.