### PR TITLE
test: add regression tests for object-variable flattening default (product-hub#3785)

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -517,6 +517,144 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   }
 
   @Test
+  public void zeebeVariableImport_flattensDeeplyNestedObjectVariableAtEachLevel() {
+    // Regression for epic camunda/product-hub#3785 (case 6): with flattening enabled (see the
+    // @BeforeEach setup), a multi-level nested object must flatten correctly at each level with the
+    // correct types preserved, not just one level deep.
+    // given
+    final Map<String, Object> geo = new HashMap<>();
+    geo.put("lat", 52.52);
+    geo.put("lon", 13.405);
+    final Map<String, Object> address = new HashMap<>();
+    address.put("city", "Berlin");
+    address.put("geo", geo);
+    final Map<String, Object> user = new HashMap<>();
+    user.put("firstName", "Ada");
+    user.put("lastName", "Lovelace");
+    user.put("address", address);
+    final Map<String, Object> variables = Map.of("user", user);
+
+    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    final long processInstanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            deployedProcess.getBpmnProcessId(), variables);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+    // then the object is flattened at every level (String at each string level, Double for the
+    // numeric coordinates) and the raw value is stored
+    assertThat(instance.getVariables())
+        .extracting(
+            SimpleProcessVariableDto::getName,
+            SimpleProcessVariableDto::getType,
+            SimpleProcessVariableDto::getValue)
+        .containsExactlyInAnyOrder(
+            Tuple.tuple(
+                "user",
+                OBJECT.getId(),
+                Collections.singletonList(
+                    variablesClient.createMapJsonObjectVariableDto(user).getValue())),
+            Tuple.tuple("user.firstName", STRING.getId(), Collections.singletonList("Ada")),
+            Tuple.tuple("user.lastName", STRING.getId(), Collections.singletonList("Lovelace")),
+            Tuple.tuple("user.address.city", STRING.getId(), Collections.singletonList("Berlin")),
+            Tuple.tuple("user.address.geo.lat", DOUBLE.getId(), Collections.singletonList("52.52")),
+            Tuple.tuple(
+                "user.address.geo.lon", DOUBLE.getId(), Collections.singletonList("13.405")));
+  }
+
+  @Test
+  public void zeebeVariableImport_handlesTopLevelAndNestedArrayVariablesConsistently() {
+    // Regression for epic camunda/product-hub#3785 (case 7): both a plain top-level array variable
+    // and an array nested inside an object variable must be handled consistently (each as a
+    // multi-value variable with a _listSize indicator), with no crash either way. A top-level
+    // primitive array stores no raw object value, whereas the enclosing object variable does store
+    // its raw value. Flattening is enabled via the @BeforeEach setup.
+    // given
+    final Map<String, Object> objectWithArray = new HashMap<>();
+    objectWithArray.put("tags", List.of("a", "b", "c"));
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("topLevelArray", List.of("x", "y"));
+    variables.put("objectWithArray", objectWithArray);
+
+    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    final long processInstanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            deployedProcess.getBpmnProcessId(), variables);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, processInstanceKey);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+    // then
+    assertThat(instance.getVariables())
+        .extracting(
+            SimpleProcessVariableDto::getName,
+            SimpleProcessVariableDto::getType,
+            SimpleProcessVariableDto::getValue)
+        .containsExactlyInAnyOrder(
+            Tuple.tuple("topLevelArray", STRING.getId(), List.of("x", "y")),
+            Tuple.tuple("topLevelArray._listSize", LONG.getId(), Collections.singletonList("2")),
+            Tuple.tuple(
+                "objectWithArray",
+                OBJECT.getId(),
+                Collections.singletonList(
+                    variablesClient.createMapJsonObjectVariableDto(objectWithArray).getValue())),
+            Tuple.tuple("objectWithArray.tags", STRING.getId(), List.of("a", "b", "c")),
+            Tuple.tuple(
+                "objectWithArray.tags._listSize", LONG.getId(), Collections.singletonList("3")));
+  }
+
+  @Test
+  public void zeebeVariableImport_importsEmptyObjectAndOmitsNullValuedVariable() {
+    // Characterization for epic camunda/product-hub#3785 (case 8), flagged during manual QA as
+    // worth a second look. Flattening is enabled via the @BeforeEach setup.
+    //  - An empty object ({}) imports without error and is stored as an OBJECT variable with no
+    //    flattened sub-fields.
+    //  - A null-valued variable does NOT cause an error and is OMITTED entirely (it is neither
+    //    flattened nor stored as null). This matches the behavior already verified by
+    //    zeebeVariableImport_unsupportedTypesGetIgnored. Asserted here as the current behavior so a
+    //    reviewer can decide whether null-valued variables should instead be stored explicitly.
+    // given
+    final Map<String, Object> emptyObject = Map.of();
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("emptyObjectVar", emptyObject);
+    variables.put("nullVar", null);
+    variables.put("controlVar", "keep");
+
+    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    final long processInstanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            deployedProcess.getBpmnProcessId(), variables);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(3, processInstanceKey);
+
+    // when
+    importAllZeebeEntitiesFromScratch();
+    final ProcessInstanceDto instance = getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+    // then the empty object is stored as a raw OBJECT value with no flattened sub-fields, and the
+    // null-valued variable is omitted
+    assertThat(instance.getVariables())
+        .extracting(
+            SimpleProcessVariableDto::getName,
+            SimpleProcessVariableDto::getType,
+            SimpleProcessVariableDto::getValue)
+        .containsExactlyInAnyOrder(
+            Tuple.tuple(
+                "emptyObjectVar",
+                OBJECT.getId(),
+                Collections.singletonList(
+                    variablesClient.createMapJsonObjectVariableDto(emptyObject).getValue())),
+            Tuple.tuple("controlVar", STRING_TYPE, Collections.singletonList("keep")));
+  }
+
+  @Test
   public void zeebeVariableImport_importVariablesInBatches() {
     // given
     embeddedOptimizeExtension

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
@@ -425,6 +425,64 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
             Tuple.tuple("objectVar.likes._listSize", LONG.getId(), Collections.singletonList("3")));
   }
 
+  @Test
+  public void zeebeVariableImport_objectVariableIsFlattenedRetroactivelyAfterEnablingFlag() {
+    // Regression for epic camunda/product-hub#3785 (case 5, recovery via reimport): an object
+    // variable imported while the flag was false (so no flattening happened) must get correctly
+    // flattened retroactively once the flag is switched to true and the importer reimports the
+    // underlying Zeebe records. The raw Zeebe record always preserves the full object regardless of
+    // the flag - only Optimize's own import behavior is gated by it.
+    // given the flag is off and the object variable is imported (and therefore skipped)
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getConfiguredZeebe()
+        .setIncludeObjectVariableValue(false);
+    final Map<String, Object> objectVar = new HashMap<>();
+    objectVar.put("firstName", "Ada");
+    objectVar.put("lastName", "Lovelace");
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("user", objectVar);
+    variables.put("plainVar", "keep");
+    final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(variables);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
+    importAllZeebeEntitiesFromScratch();
+
+    // then only the plain variable is stored; the object variable is absent (not flattened, raw not
+    // stored)
+    final ProcessInstanceDto beforeReimport =
+        getProcessInstanceForId(String.valueOf(processInstanceKey));
+    assertThat(beforeReimport.getVariables())
+        .extracting(SimpleProcessVariableDto::getName, SimpleProcessVariableDto::getType)
+        .containsExactly(Tuple.tuple("plainVar", STRING_TYPE));
+
+    // when the flag is switched on and the same Zeebe records are reimported from scratch
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getConfiguredZeebe()
+        .setIncludeObjectVariableValue(true);
+    importAllZeebeEntitiesFromScratch();
+
+    // then the object variable is now flattened into report-usable sub-fields and its raw value is
+    // stored
+    final ProcessInstanceDto afterReimport =
+        getProcessInstanceForId(String.valueOf(processInstanceKey));
+    assertThat(afterReimport.getVariables())
+        .extracting(
+            SimpleProcessVariableDto::getName,
+            SimpleProcessVariableDto::getType,
+            SimpleProcessVariableDto::getValue)
+        .containsExactlyInAnyOrder(
+            Tuple.tuple("plainVar", STRING_TYPE, Collections.singletonList("keep")),
+            Tuple.tuple(
+                "user",
+                OBJECT.getId(),
+                Collections.singletonList(
+                    variablesClient.createMapJsonObjectVariableDto(objectVar).getValue())),
+            Tuple.tuple("user.firstName", STRING.getId(), Collections.singletonList("Ada")),
+            Tuple.tuple("user.lastName", STRING.getId(), Collections.singletonList("Lovelace")));
+  }
+
   private Map<String, Object> generateVariables() {
     return Map.of("var1", "someValue", "var2", false, "var3", 123, "var4", 123.3, "var5", "");
   }

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceTest.java
@@ -587,6 +587,67 @@ public class ConfigurationServiceTest {
     }
   }
 
+  // Regression tests for epic camunda/product-hub#3785 (implemented in camunda/camunda#60587):
+  // Optimize object-variable flattening is disabled by default on Self-Managed via
+  // zeebe.includeObjectVariableValue (env CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE). The
+  // default (unset) resolving to false is already covered by
+  // assertThatPlaceholderDefaultValuesAreResolved; the tests below cover explicit overrides and
+  // config-source precedence.
+
+  @Test
+  public void includeObjectVariableValueResolvesToFalseWhenExplicitlyConfiguredFalse() {
+    // given the property is explicitly set to false (as opposed to relying on the default)
+    environmentVariablesExtension.set("CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE", "false");
+
+    // when
+    final ConfigurationService underTest = createDefaultConfiguration();
+
+    // then
+    // Characterization for epic camunda/product-hub#3785 (case 4, config-resolution half): an
+    // explicit `false` and a defaulted `false` both resolve to the same effective value. Nothing
+    // downstream (e.g. ConfigurationValidator) can tell them apart. Sub-issue camunda/camunda#60583
+    // confirms this is intentional: the startup WARN fires unconditionally whenever the effective
+    // (resolved) value is false, regardless of whether it was defaulted or explicitly configured.
+    // So no distinction is expected here. Flagged during manual QA as worth a second look; per the
+    // ticket, the current behavior is correct.
+    assertThat(underTest.getConfiguredZeebe().isIncludeObjectVariableValue()).isFalse();
+  }
+
+  @Test
+  public void includeObjectVariableValueResolvesToTrueWhenExplicitlyConfiguredTrue() {
+    // given the operator opts back in to object-variable flattening
+    environmentVariablesExtension.set("CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE", "true");
+
+    // when
+    final ConfigurationService underTest = createDefaultConfiguration();
+
+    // then
+    assertThat(underTest.getConfiguredZeebe().isIncludeObjectVariableValue()).isTrue();
+  }
+
+  @Test
+  public void includeObjectVariableValueSystemPropertyTakesPrecedenceOverEnvironmentVariable() {
+    // given the property is set via BOTH a JVM system property and an environment variable, with
+    // conflicting values
+    environmentVariablesExtension.set("CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE", "true");
+    System.setProperty("CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE", "false");
+
+    // when
+    final ConfigurationService underTest = createDefaultConfiguration();
+
+    // then
+    // Characterization for epic camunda/product-hub#3785 (case 9). ConfigurationParser resolves
+    // placeholders via `System.getProperty(name)` first, falling back to `System.getenv(name)`
+    // (see ConfigurationParser#resolveVariablePlaceholders), so the JVM SYSTEM PROPERTY wins over
+    // the ENVIRONMENT VARIABLE. This was flagged during manual QA, whose note assumed the env var
+    // wins; the code shows the system property wins. A system property outranking an env var is
+    // actually consistent with Spring Boot's own property-source ordering. Note this resolution
+    // path is Optimize-specific (ConfigurationParser), not Spring's Environment. Left as a
+    // characterization of current behavior so a reviewer can decide whether the precedence (or the
+    // QA note) should be revisited.
+    assertThat(underTest.getConfiguredZeebe().isIncludeObjectVariableValue()).isFalse();
+  }
+
   private ConfigurationService createConfiguration(final String... locations) {
     return ConfigurationServiceBuilder.createConfiguration()
         .loadConfigurationFrom(locations)


### PR DESCRIPTION
## What

Adds **regression tests** for epic camunda/product-hub#3785 (*disable Optimize object-variable flattening by default for Self-Managed*), implemented in camunda/camunda#60587. That PR flipped `zeebe.includeObjectVariableValue` (env `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE`) from `true` → `false` in `service-config.yaml` and added a startup `WARN` in `ConfigurationValidator`.

Changes are **additive only** (288 insertions, 0 deletions) and follow the existing test conventions/base classes already used in these files (`AbstractCCSMIT` integration tests + the mock-based `ConfigurationValidatorTest` / builder-based `ConfigurationServiceTest`). No new helpers, fixtures, or styles introduced.

## Existing coverage found (checked first, not duplicated)

`#60587` already added baseline tests, so these cases are **already covered** and were **not** duplicated:

- **Default → not flattened / raw not stored** — `ZeebeVariableCreationImportIT.zeebeVariableImport_importObjectVariablesWhenObjectVariablesAreExcludedInConfiguration` + `ConfigurationServiceTest.assertThatPlaceholderDefaultValuesAreResolved` (default resolves `false`).
- **Opt-in (`true`) → flattened + raw stored** — `ZeebeVariableCreationImportIT.zeebeVariableImport_importObjectVariables` and `ZeebeVariableUpdateImportIT.zeebeVariableImport_updateObjectVariable`.
- **Startup WARN when unset** — `ConfigurationValidatorTest.validateShouldWarnWhenObjectVariableValuesAreNotImported` (+ no-warn variants).

## What the new tests add (the gaps)

**`ZeebeVariableCreationImportIT`**
- `zeebeVariableImport_flattensDeeplyNestedObjectVariableAtEachLevel` — multi-level object (`firstName`, `address.city`, `address.geo.lat/lon`) flattens at every level with correct types (String/Double) preserved, plus raw value stored. *(case 6)*
- `zeebeVariableImport_handlesTopLevelAndNestedArrayVariablesConsistently` — a plain top-level array and an array nested in an object are both handled as a multi-value variable + `_listSize`, no crash either way. *(case 7)*
- `zeebeVariableImport_importsEmptyObjectAndOmitsNullValuedVariable` — characterization: empty `{}` imports as an OBJECT var with no sub-fields; a null-valued variable is **omitted entirely** (not stored as null). *(case 8)*

**`ZeebeVariableUpdateImportIT`**
- `zeebeVariableImport_objectVariableIsFlattenedRetroactivelyAfterEnablingFlag` — imported while the flag was `false` (skipped), then the flag is enabled and the same Zeebe records are reimported from scratch → the object is flattened retroactively and its raw value stored. The raw Zeebe record preserves the full object regardless of the flag. *(case 5)*

**`ConfigurationServiceTest`**
- `includeObjectVariableValueResolvesToFalseWhenExplicitlyConfiguredFalse` / `...TrueWhenExplicitlyConfiguredTrue` — explicit env override resolution.
- `includeObjectVariableValueSystemPropertyTakesPrecedenceOverEnvironmentVariable` — config-source precedence. *(case 9)*

**`ConfigurationValidatorTest`**
- `validateWarnsForEffectiveFalseRegardlessOfWhetherDefaultedOrExplicitlyConfigured` — characterization of the WARN. *(case 4)*

## Items flagged during manual QA (reviewer decision points)

These are written as **characterization tests** of current behavior, clearly commented so a reviewer can decide whether to fix the behavior or keep the test:

- **Case 4 (WARN for explicit `false` vs default):** the validator only sees the resolved boolean, so defaulted-`false` and explicit-`false` are indistinguishable and both warn. **Checked the linked ticket:** sub-issue camunda/camunda#60583 explicitly requires the WARN to fire *"unconditional whenever the effective (resolved) value is false regardless of whether that came from the default or an explicit customer override"* — so this is **intentional**, not an oversight. Documented in the test; no change needed.
- **Case 8 (null-valued variable):** confirmed against the code (`ZeebeVariableImportService.getVariableTypeFromJsonNode` returns empty for JSON `null` → the record is filtered out) — null-valued variables are **omitted entirely** rather than stored as null. Asserted to match reality; flagged for a second look.
- **Case 9 (precedence):** the QA note assumed the **environment variable** wins, but `ConfigurationParser` resolves `System.getProperty(name)` first and falls back to `System.getenv(name)`, so the **JVM system property wins** — the reverse of the QA assumption, and also the reverse of Spring Boot's usual ordering (this resolution path is Optimize-specific, not Spring's `Environment`). The test asserts actual behavior with a comment so the precedence (or the QA note) can be revisited.

## Testing

The integration tests (`src/it/java`) run in CI against Elasticsearch/OpenSearch + Zeebe testcontainers; the unit tests run in the standard `optimize-commons` test job. They were not executed locally (the workspace is a partial/sparse checkout without the full Optimize reactor).
