### PR TITLE
fix: honor unified-config connection pool limits in camunda-exporter

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -70,6 +70,16 @@ public final class CamundaExporterConfigurationApplier {
         source.getConnectionTimeout() != null
             ? Math.toIntExact(source.getConnectionTimeout().toMillis())
             : null);
+    // Only override when set: unset unified values must not wipe the values bound through the
+    // legacy 'zeebe.broker.exporters.camundaexporter.args.connect' path.
+    final var maxConnections = source.getMaxConnections();
+    if (maxConnections != null) {
+      target.setMaxConnections(maxConnections);
+    }
+    final var maxConnectionsPerRoute = source.getMaxConnectionsPerRoute();
+    if (maxConnectionsPerRoute != null) {
+      target.setMaxConnectionsPerRoute(maxConnectionsPerRoute);
+    }
     target.setUsername(source.getUsername());
     target.setPassword(source.getPassword());
     target.setIndexPrefix(source.getIndexPrefix());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -70,8 +70,10 @@ public final class CamundaExporterConfigurationApplier {
         source.getConnectionTimeout() != null
             ? Math.toIntExact(source.getConnectionTimeout().toMillis())
             : null);
-    // Only override when set: unset unified values must not wipe the values bound through the
-    // legacy 'zeebe.broker.exporters.camundaexporter.args.connect' path.
+    // Unlike the fields above, these two register no legacy property on their source getter:
+    // they were born with the unified property, so there is no pre-unified path to migrate from.
+    // 'zeebe.broker.exporters.camundaexporter.args.connect.maxConnections[PerRoute]' still binds
+    // onto this same target, so copy only when set — an unset unified value must not wipe it.
     final var maxConnections = source.getMaxConnections();
     if (maxConnections != null) {
       target.setMaxConnections(maxConnections);

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -282,6 +282,10 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(exporterConfiguration.getConnect().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(exporterConfiguration.getConnect().getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
 
       assertThat(exporterConfiguration.getConnect().getClusterName())
           .isEqualTo(EXPECTED_CLUSTER_NAME);
@@ -648,6 +652,10 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(exporterConfiguration.getConnect().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(exporterConfiguration.getConnect().getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
 
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);
@@ -736,6 +744,45 @@ public class SecondaryStorageElasticsearchTest {
       final ExporterConfiguration exporterConfiguration =
           UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
       assertThat(exporterConfiguration.getConnect().getUrl()).isEqualTo("http://matching-url:4321");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
+        "zeebe.broker.exporters.camundaexporter.class-name=io.camunda.exporter.CamundaExporter",
+        "zeebe.broker.exporters.camundaexporter.args.connect.maxConnections="
+            + EXPECTED_MAX_CONNECTIONS,
+        "zeebe.broker.exporters.camundaexporter.args.connect.maxConnectionsPerRoute="
+            + EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
+      })
+  class WithOnlyLegacyExporterConnectionPoolSet {
+    final BrokerBasedProperties brokerBasedProperties;
+
+    WithOnlyLegacyExporterConnectionPoolSet(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+    }
+
+    @Test
+    void shouldKeepLegacyConnectionPoolWhenUnifiedConfigIsUnset() {
+      // given
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      // when
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+
+      // then
+      assertThat(exporterConfiguration.getConnect().getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(exporterConfiguration.getConnect().getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -278,6 +278,10 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(exporterConfiguration.getConnect().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(exporterConfiguration.getConnect().getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
       assertThat(exporterConfiguration.getConnect().isAwsEnabled()).isEqualTo(EXPECTED_AWS_ENABLED);
 
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
@@ -638,6 +642,10 @@ public class SecondaryStorageOpensearchTest {
           .isEqualTo(EXPECTED_SOCKET_TIMEOUT);
       assertThat(exporterConfiguration.getConnect().getConnectTimeout())
           .isEqualTo(EXPECTED_CONNECTION_TIMEOUT);
+      assertThat(exporterConfiguration.getConnect().getMaxConnections())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS);
+      assertThat(exporterConfiguration.getConnect().getMaxConnectionsPerRoute())
+          .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
 
       assertThat(exporterConfiguration.getIndex().getNumberOfShards())
           .isEqualTo(EXPECTED_NUMBER_OF_SHARDS);


### PR DESCRIPTION
## Description

`CamundaExporterConfigurationApplier.applyConnect()` copies the document-based secondary-storage settings onto the exporter's legacy `ConnectConfiguration`, but never copied `maxConnections` / `maxConnectionsPerRoute`. Anything set via `camunda.data.secondary-storage.<db>.max-connections[-per-route]` was silently ignored, and the exporter's ES/OS client kept the provider-default pool sizing.

Both fields are now copied, guarded on non-null. The guard matters: they are unset by default in unified configuration, and `BrokerBasedPropertiesOverride.populateCamundaExporter()` loads the legacy `zeebe.broker.exporters.camundaexporter.args.connect` args map before the applier runs — an unconditional copy would push `null` over values bound through the legacy path, which is exactly the workaround users have been pointed at for this bug. `SearchEngineConnectPropertiesOverride` already null-guards the same two fields, so both consumers of the unified source now behave alike.

Closes #58238