### PR TITLE
test: use a real MeterRegistry in RdbmsTestConfiguration instead of a mock

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
@@ -13,8 +13,8 @@ import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.application.commons.rdbms.RdbmsDataSources;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import javax.sql.DataSource;
-import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +42,6 @@ public class RdbmsTestConfiguration {
 
   @Bean
   public MeterRegistry meterRegistry() {
-    return Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS);
+    return new SimpleMeterRegistry();
   }
 }


### PR DESCRIPTION
## Summary

`LiquibaseMultiTenantIT` intermittently failed in CI with:

```
java.lang.ClassCastException: class io.micrometer.core.instrument.Timer$MockitoMock$... cannot be cast to class io.micrometer.core.instrument.Counter
```

thrown from Hikari's `MicrometerMetricsTracker` while registering its connection-pool metrics.

https://github.com/camunda/camunda/actions/runs/32761222914/job/97542078449
https://github.com/camunda/camunda/actions/runs/32753459617/job/97517755494

### Root cause

`RdbmsTestConfiguration` provided its `MeterRegistry` bean as `Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS)`. Because `management.metrics.use-global-registry` defaults to `true` and is never overridden in these tests, Spring Boot adds this mock as a permanent child of the JVM-wide `Metrics.globalRegistry` on every context start, and it is never removed on teardown.

With `forkCount=1`, all tests in the module share one JVM, so these mock registries accumulate across the whole run. When Hikari later registers its own pool metrics into a composite registry built on top of this bean, it can collide with a mocked meter left behind by an earlier, unrelated test under the same meter name, causing the type mismatch above.

### Fix

Replace the mocked `MeterRegistry` with a real `SimpleMeterRegistry`. No test relies on mock-specific behavior of this bean.