### PR TITLE
feat: load-test: enable `stable-810` profile

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -7,7 +7,7 @@ ROOT_DIR="$SCRIPT_DIR"
 
 . "${SCRIPT_DIR}/utils.sh"
 
-AVAILABLE_VERSIONS=(main stable-87 stable-88 stable-89)
+AVAILABLE_VERSIONS=(main stable-87 stable-88 stable-89 stable-810)
 
 # Internal plumbing hook for the golden-file test harness: lets callers enumerate versions without
 # duplicating AVAILABLE_VERSIONS.
@@ -60,6 +60,12 @@ case "$target_version" in
   stable-89)
     # renovate: version=camunda-platform-8.9
     camunda_platform_helm_chart_version="14.8.4"
+    allowed_storage=(elasticsearch opensearch postgresql mysql mariadb mssql oracle none)
+    elasticsearch_version="8.18.0"
+    ;;
+  stable-810)
+    # renovate: version=camunda-platform-8.10
+    camunda_platform_helm_chart_version="15.0.0-alpha4"
     allowed_storage=(elasticsearch opensearch postgresql mysql mariadb mssql oracle none)
     elasticsearch_version="8.18.0"
     ;;

--- a/load-tests/setup/stable-810/Makefile
+++ b/load-tests/setup/stable-810/Makefile
@@ -1,0 +1,5 @@
+namespace ?= __NAMESPACE__
+secondary_storage ?= __STORAGE_TYPE__
+enable_optimize ?= __ENABLE_OPTIMIZE__
+
+include ../common.mk

--- a/load-tests/setup/stable-810/databases/mssql.yaml
+++ b/load-tests/setup/stable-810/databases/mssql.yaml
@@ -1,0 +1,148 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+# mssql.yaml — Plain Kubernetes manifests for Microsoft SQL Server 2022.
+#
+# The ClusterIP Service is named "mssql" to match the JDBC URL in
+# camunda-platform-values-mssql.yaml:
+#   jdbc:sqlserver://mssql:1433;Encrypt=false
+
+---
+# SA password – referenced by the StatefulSet container.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mssql-secret
+  labels:
+    app.kubernetes.io/name: mssql
+type: Opaque
+stringData:
+  SA_PASSWORD: "Camunda#8_demo"
+
+
+---
+# ClusterIP Service — "mssql" resolves to this service inside the namespace.
+# JDBC URL: jdbc:sqlserver://mssql:1433;Encrypt=false
+apiVersion: v1
+kind: Service
+metadata:
+  name: mssql
+  labels:
+    app.kubernetes.io/name: mssql
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mssql
+  ports:
+    - name: mssql
+      port: 1433
+      targetPort: 1433
+      protocol: TCP
+
+---
+# StatefulSet — single replica with a 128 Gi SSD PVC.
+# The volumeClaimTemplate creates a PVC named "mssql-data-mssql-0";
+# this PVC is NOT removed automatically when the StatefulSet is deleted
+# (see the clean target in the Makefile for explicit PVC cleanup).
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mssql
+  labels:
+    app.kubernetes.io/name: mssql
+spec:
+  serviceName: mssql
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mssql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mssql
+    spec:
+      # fsGroup 10001 ensures the mounted volume is writable by the mssql user
+      # inside the Microsoft SQL Server container image.
+      securityContext:
+        fsGroup: 10001
+
+      nodeSelector:
+        component: benchmark-n2-standard-8
+        topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+      tolerations:
+        - key: nodepool
+          operator: Equal
+          value: n2-standard-8
+          effect: NoSchedule
+
+      containers:
+        - name: mssql
+          image: mcr.microsoft.com/mssql/server:2022-latest
+          env:
+            - name: ACCEPT_EULA
+              value: "Y"
+            - name: MSSQL_SA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mssql-secret
+                  key: SA_PASSWORD
+          ports:
+            - name: mssql
+              containerPort: 1433
+              protocol: TCP
+          resources:
+            requests:
+              memory: 8Gi
+              cpu: "3000m"
+            limits:
+              memory: 12Gi
+              cpu: "3000m"
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - >-
+                  /opt/mssql-tools18/bin/sqlcmd
+                  -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C
+                  -Q "SELECT 1"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - >-
+                  /opt/mssql-tools18/bin/sqlcmd
+                  -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C
+                  -Q "SELECT 1"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: mssql-data
+              mountPath: /var/opt/mssql
+
+  # PVC template — creates "mssql-data-mssql-0" on first deployment.
+  # storageClass "ssd" provisions a 128 Gi SSD-backed volume.
+  volumeClaimTemplates:
+    - metadata:
+        name: mssql-data
+        labels:
+          app.kubernetes.io/name: mssql
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: 512Gi
+

--- a/load-tests/setup/stable-810/databases/oracle.yaml
+++ b/load-tests/setup/stable-810/databases/oracle.yaml
@@ -1,0 +1,194 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+# oracle.yaml — Plain Kubernetes manifests for Oracle Database Free 23c.
+
+# Current limitations
+# - the currently used Oracle free image only supports up to 12GB of tablespace.
+#     This currently fills up with audit logs and undo logs even with an aggressive history TTL
+#
+#
+# Uses the gvenzl/oracle-free image (same as db/docker-compose.yml) which runs
+# Oracle Database Free 23c. The plain slim variant is used instead of
+# slim-faststart because the faststart image copies a pre-built database from
+# the image layer on first start. In Kubernetes that copy fails with
+# ORA-00205 (cannot identify control file), which leaves Oracle in a half-
+# started state; the subsequent restart then sees its own lock file and fails
+# with ORA-01081. The slim image avoids this by creating the database from
+# scratch via dbca, which is slower (~20-30 min on first run) but reliable.
+# The startupProbe below gives a 30-minute window to cover that first run;
+# subsequent pod restarts reuse the PVC and start in seconds.
+# Using the default entrypoint without modification keeps behaviour identical to
+# Docker Compose, letting runOracle.sh handle startup the same way in both
+# environments.
+#
+# /dev/shm: Kubernetes pods default to 64 MB of shared memory, which is far too
+# small for Oracle's Automatic Memory Management (AMM). Oracle Free's SGA alone
+# is ~2 GB. Without a sufficiently large /dev/shm Oracle fails to allocate the
+# SGA, crashes mid-startup, and on the next attempt sees its own partially-
+# created lock file → ORA-01081. The dshm emptyDir (medium: Memory) below
+# removes this limit, mirroring what Docker (and Docker Compose) provide on a
+# typical host.
+#
+# The ClusterIP Service is named "oracle" to match the JDBC URL in
+# camunda-platform-values-oracle.yaml:
+#   jdbc:oracle:thin:@//oracle:1521/FREEPDB1
+
+---
+# Passwords — referenced by the StatefulSet container.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oracle-secret
+  labels:
+    app.kubernetes.io/name: oracle
+type: Opaque
+stringData:
+  ORACLE_PASSWORD: "sys_user_password"
+  APP_USER_PASSWORD: "camunda"
+
+
+---
+# ClusterIP Service — "oracle" resolves to this service inside the namespace.
+# JDBC URL: jdbc:oracle:thin:@//oracle:1521/FREEPDB1
+apiVersion: v1
+kind: Service
+metadata:
+  name: oracle
+  labels:
+    app.kubernetes.io/name: oracle
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: oracle
+  ports:
+    - name: oracle
+      port: 1521
+      targetPort: 1521
+      protocol: TCP
+
+---
+# StatefulSet — single replica with a 128 Gi SSD PVC.
+# The volumeClaimTemplate creates a PVC named "oracle-data-oracle-0";
+# this PVC is NOT removed automatically when the StatefulSet is deleted
+# (see the clean target in the Makefile for explicit PVC cleanup).
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: oracle
+  labels:
+    app.kubernetes.io/name: oracle
+spec:
+  serviceName: oracle
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oracle
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: oracle
+    spec:
+      # fsGroup 54321 ensures the mounted PVC is writable by the oracle user
+      # (UID/GID 54321) inside the gvenzl/oracle-free container image.
+      securityContext:
+        fsGroup: 54321
+
+      nodeSelector:
+        component: benchmark-n2-standard-8
+        topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+      tolerations:
+        - key: nodepool
+          operator: Equal
+          value: n2-standard-8
+          effect: NoSchedule
+
+      containers:
+        - name: oracle
+          image: gvenzl/oracle-free:23-slim
+          # No command override — use the image's default entrypoint (runOracle.sh)
+          # exactly as Docker Compose does.
+          env:
+            - name: ORACLE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oracle-secret
+                  key: ORACLE_PASSWORD
+            - name: APP_USER
+              value: "camunda"
+            - name: APP_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oracle-secret
+                  key: APP_USER_PASSWORD
+          ports:
+            - name: oracle
+              containerPort: 1521
+              protocol: TCP
+          resources:
+            requests:
+              memory: 8Gi
+              cpu: "3000m"
+            limits:
+              memory: 12Gi
+              cpu: "3000m"
+          # startupProbe gates liveness/readiness until Oracle is fully open.
+          # On first run the slim image creates the database from scratch (~20-30
+          # minutes). failureThreshold * periodSeconds gives a 30-minute window.
+          # Subsequent restarts reuse the PVC and finish within the initial delay.
+          startupProbe:
+            exec:
+              command:
+                - healthcheck.sh
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 60   # 60 × 30 s = 1800 s ≈ 30 minutes
+          readinessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - healthcheck.sh
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: oracle-data
+              mountPath: /opt/oracle/oradata
+            - name: dshm
+              mountPath: /dev/shm
+
+      # Provide Oracle with a /dev/shm large enough for its SGA.
+      # The default Kubernetes /dev/shm is 64 MB; Oracle AMM needs ~2 GB.
+      # medium: Memory makes this an in-memory tmpfs; its size is bounded by
+      # the pod's memory limit rather than needing a separate sizeLimit.
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+
+  # PVC template — creates "oracle-data-oracle-0" on first deployment.
+  # storageClass "ssd" provisions a 128 Gi SSD-backed volume.
+  volumeClaimTemplates:
+    - metadata:
+        name: oracle-data
+        labels:
+          app.kubernetes.io/name: oracle
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: 128Gi
+

--- a/load-tests/setup/stable-810/values/camunda-platform-override-values.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-override-values.yaml
@@ -1,0 +1,5 @@
+# Consistency check overrides for the max stress scenario.
+# This file is injected as application-override.yml (loaded after and overrides application.yml)
+# when scenario=max, to disable checks that would add overhead during maximum-load tests.
+zeebe.broker.experimental.consistencyChecks.enablePreconditions: "false"
+zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "false"

--- a/load-tests/setup/stable-810/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml
@@ -1,0 +1,77 @@
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+# Variant of camunda-platform-values-rdbms.yaml that additionally declares a second
+# physical tenant (testfoo) on the same shared RDBMS, isolated by table prefix.
+# Selected by the Makefile when `physical_tenants=true` (rdbms secondary storage only).
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+    rdbms:
+      enabled: true
+  data:
+    secondaryStorage:
+      type: rdbms
+      rdbms:
+        username: camunda
+        secret:
+          inlineSecret: camunda
+
+  # Overriding the extraConfiguration for the Platform chart
+  # to disable Camunda Exporter usage and make use of the RDBMS exporter instead, as well as to set some additional configuration for Camunda application
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+        # History cleanup adjust batch sizes
+        camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+        camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+        # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+        camunda.data.secondary-storage.rdbms.queue-size: 2001
+        camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+        camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+        camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+        # Physical tenants: shared RDBMS database, isolated by table prefix.
+        # The default tenant uses the DEFAULT_ prefix; testfoo uses the TESTFOO_ prefix.
+        camunda.data.secondary-storage.rdbms.prefix: DEFAULT_
+        camunda.physical-tenants.testfoo.data.secondary-storage.rdbms.prefix: TESTFOO_
+        # testfoo tenant: grant the orchestration client the same permissions as the default tenant
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].ownerType: CLIENT
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].ownerId: orchestration
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].resourceType: RESOURCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].resourceId: "*"
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].permissions[0]: CREATE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].ownerType: CLIENT
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].ownerId: orchestration
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].resourceType: PROCESS_DEFINITION
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].resourceId: "*"
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[0]: CREATE_PROCESS_INSTANCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[1]: UPDATE_PROCESS_INSTANCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[2]: READ_PROCESS_INSTANCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[3]: READ_PROCESS_DEFINITION
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].ownerType: CLIENT
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].ownerId: orchestration
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].resourceType: MESSAGE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].resourceId: "*"
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].permissions[0]: CREATE
+        # testfoo tenant: assign the default OIDC provider (Keycloak) so this tenant can authenticate
+        camunda.physical-tenants.testfoo.security.authentication.providers.assigned[0]: oidc
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"

--- a/load-tests/setup/stable-810/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-defaults.yaml
@@ -1,0 +1,289 @@
+# Default load test values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+# Per default we run with the Orchestration Cluster, Optimize, Connectors, and Identity
+# Keycloak as identity provider with OIDC authentication, but you can easily
+# switch to other configurations by changing the values in this file or by overriding them via the
+# command line when installing the chart.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  commonLabels:
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
+
+  # Disable global ingress
+  ingress:
+    enabled: false
+  image:
+    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    pullPolicy: Always
+    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets:
+      - name: harbor-registry
+
+  # Default node configuration for all the components, unless specific
+  # reconfigured.
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  identity:
+    auth:
+      enabled: true
+
+    keycloak:
+      auth:
+        adminUser: admin
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-keycloak-admin-password
+
+      # The address of the Keycloak deployed via the Keycloak Operator.
+      # Note that this instance of Keycloak **runs in a different namespace**
+      # than the namespace of the load test. This is on purpose, due to a
+      # limitation in how the Keycloak Operator works.
+      url:
+        protocol: http
+        host: __NAMESPACE__.keycloak-operator.svc
+        port: '18080'
+
+  security:
+    authentication:
+      type: oidc
+
+identity:
+  enabled: true
+  fullnameOverride: identity # we override the names for simplicity of the deployment
+  firstUser:
+    secret:
+      existingSecret: camunda-credentials
+      existingSecretKey: identity-firstuser-password
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
+    - name: IDENTITY_LOG_APPENDER
+      value: Stackdriver
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+connectors:
+  enabled: true
+  fullnameOverride: connectors # we override the names for simplicity of the deployment
+  security:
+    authentication:
+      method: oidc
+      oidc:
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: connectors-security-authentication-oidc-secret
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/connectors/connectors-configuration/#google-stackdriver-json-logging
+    - name: CONNECTORS_LOG_APPENDER
+      value: stackdriver
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+webModeler:
+  enabled: false
+
+postgresql:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  security:
+    authentication:
+      method: oidc
+      unprotectedApi: false
+      oidc:
+        secret:
+          ## @param orchestration.security.authentication.oidc.secret.existingSecret can be used to reference an existing Kubernetes Secret containing the client secret.
+          existingSecret: camunda-credentials
+          ## @param orchestration.security.authentication.oidc.secret.existingSecretKey defines the key within the existing secret object.
+          existingSecretKey: orchestration-security-authentication-oidc-secret
+
+    authorizations:
+      enabled: true
+    initialization:
+      authorizations:
+        # Grant the orchestration client (load tester) permission to create resources (BPMN/DMN)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: RESOURCE
+          resourceId: "*"
+          permissions:
+            - CREATE
+        # Grant the orchestration client permissions to manage and observe process instances
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: PROCESS_DEFINITION
+          resourceId: "*"
+          permissions:
+            - CREATE_PROCESS_INSTANCE
+            - UPDATE_PROCESS_INSTANCE
+            - READ_PROCESS_INSTANCE
+            - READ_PROCESS_DEFINITION
+        # Grant the orchestration client permission to publish messages
+        # (required by realistic benchmark workers: customer_notification,
+        # dispute_process_request_proof_from_vendor)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: MESSAGE
+          resourceId: "*"
+          permissions:
+            - CREATE
+  # For simplicity of the deployment, we override the names to camunda
+  # This means we will have pods like: camunda-0, camunda-1, camunda-2
+  fullnameOverride: camunda
+  image:
+    registry: docker.io
+    repository: camunda/camunda
+    tag: "SNAPSHOT"
+  ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
+  clusterSize: "3"
+  ## @param core.partitionCount defines how many partitions are set up in the cluster
+  partitionCount: "3"
+  ## @param core.replicationFactor defines how each partition is replicated, the value defines the number of nodes
+  replicationFactor: "3"
+  ## @param core.cpuThreadCount defines how many threads can be used for the processing on each broker pod
+  cpuThreadCount: "3"
+  ## @param core.ioThreadCount defines how many threads can be used for the exporting on each broker pod
+  ioThreadCount: "3"
+  # Resources of the orchestration cluster
+  resources:
+    requests:
+      cpu: 3000m
+      memory: 2Gi
+    limits:
+      cpu: 3000m
+      memory: 2Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  ## @param core.pvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
+  pvcSize: "64Gi"
+  ## @param core.pvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim.
+  # It is recommended to use a storage class, which is backed with a SSD. Set to "-" to disable use of default storage class.
+  pvcStorageClassName: benchmark-ssd-zonal-v1
+  # @extra core.containerSecurityContext defines the security options the container should be run with
+  containerSecurityContext:
+    ## @param core.containerSecurityContext.allowPrivilegeEscalation
+    allowPrivilegeEscalation: true
+    ## @param core.containerSecurityContext.privileged
+    privileged: true
+    ## @param core.containerSecurityContext.runAsNonRoot
+    runAsNonRoot: true
+    ## @param core.containerSecurityContext.runAsUser
+    runAsUser: 1000
+    capabilities:
+      add: ["NET_ADMIN"]
+  javaOpts: >-
+    -XX:MaxRAMPercentage=25.0
+    -XX:+ExitOnOutOfMemoryError
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/usr/local/camunda/data
+    -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log
+    -XX:NativeMemoryTracking=summary
+    -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M
+
+  # We set extra configuration to configure additional settings for Camunda application, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+
+        # Camunda Exporter configuration
+        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+        zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"
+
+  # Zeebe config
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+  ## @param core.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/camunda/logs
+  # Retention for the ES Exporter indices - legacy Zeebe indices
+  retention:
+    enabled: true
+    minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
+  # Retention for the Camunda Exporter
+  history:
+    retention:
+      ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
+      enabled: true
+      ## @param core.history.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
+      minimumAge: 1d
+      policyName: "camunda-retention-policy"
+  # @param core.env can be used to set extra environment variables in each broker container
+  env:
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+# Change these settings to configure a different way to collect metrics
+prometheusServiceMonitor:
+  enabled: true
+  labels:
+    release: monitoring
+  scrapeInterval: 30s

--- a/load-tests/setup/stable-810/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-elasticsearch.yaml
@@ -1,0 +1,38 @@
+# Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used for Optimize AND as the Camunda secondary storage.
+#
+# If you want to configure Elasticsearch only for Optimize and use another
+# secondary storage option for Camunda, see
+# the "camunda-platform-values-optimize-elasticsearch.yaml" file.
+# If you make changes to this file or the
+# "camunda-platform-values-optimize-elasticsearch.yaml" file, make sure to keep
+# the other file in sync (minus the secondary storage-only options).
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to ELS
+  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
+  data:
+    secondaryStorage:
+      type: elasticsearch
+      elasticsearch:
+        # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
+        # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
+        # See resources/elasticsearch.yaml for the resource definition.
+        url: http://elasticsearch-es-http:9200
+
+########################################################################################
+################################################### Optimize datastore configuration
+########################################################################################
+# Optimize and the legacy Zeebe exporter resolve the Elasticsearch connection from
+# this component-scoped block (global.elasticsearch was removed in camunda-platform 15.x).
+optimize:
+  database:
+    elasticsearch:
+      enabled: true
+      url:
+        host: elasticsearch-es-http

--- a/load-tests/setup/stable-810/values/camunda-platform-values-mariadb.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-mariadb.yaml
@@ -1,0 +1,113 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # needed to allow the pass-through-cache for Bitnami images
+  security:
+    allowInsecureImages: true
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:mariadb://mariadb:3306/camunda
+
+###########################################################################
+#
+#    MARIA DB
+#
+###########################################################################
+# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
+image:
+  registry: europe-west1-docker.pkg.dev
+  repository: camunda-benchmark/dockerhub/bitnamilegacy/mariadb
+  tag: "latest"
+
+auth:
+  rootPassword: camunda
+  database: camunda
+  username: camunda
+  password: camunda
+  rootHost: "%"
+
+primary:
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: 3000m
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-8
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-8
+      effect: NoSchedule
+
+  persistence:
+    size: 512Gi
+    storageClass: "benchmark-ssd-zonal-v1"
+
+  configuration: |-
+    [mysqld]
+    # ---- Bitnami required paths -----------------------------------------------
+    # primary.configuration replaces the ENTIRE my.cnf. Bitnami's init script
+    # normally injects these at runtime, so they must be included explicitly here.
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mariadb
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    datadir=/bitnami/mariadb/data
+    tmpdir=/opt/bitnami/mariadb/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+    log-error=/opt/bitnami/mariadb/logs/mysqld.log
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_uca1400_ai_ci
+
+    # ---- Performance tuning ---------------------------------------------------
+    innodb_log_buffer_size         = 128M      # default 64MB; doubled to reduce redo flush frequency
+    innodb_flush_log_at_trx_commit = 2         # default 1 (full fsync per commit); flush once/sec instead
+    innodb_flush_method            = O_DIRECT  # default on Linux; explicit for clarity
+
+    # Buffer pool (default: 128MB)
+    innodb_buffer_pool_size        = 6G        # ~50% of 12Gi limit
+
+    # Write I/O (not a dynamic variable — must live in my.cnf, cannot SET GLOBAL)
+    innodb_write_io_threads        = 8         # default 4; doubled for write-heavy workload
+
+    # MVCC Purge safety valves (defaults: 0 = unlimited)
+    innodb_max_purge_lag           = 10000000  # throttle DML if unpurged rows exceed this
+    innodb_max_purge_lag_delay     = 300000    # cap the imposed delay at 300ms
+
+    # Monitoring
+    slow_query_log                 = ON        # default OFF
+    long_query_time                = 1         # default 10s
+    log_queries_not_using_indexes  = ON        # default OFF
+    min_examined_row_limit         = 100       # suppress noise from single-row writes
+
+    [client]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    default-character-set=utf8mb4
+
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid

--- a/load-tests/setup/stable-810/values/camunda-platform-values-mssql.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-mssql.yaml
@@ -1,0 +1,23 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # Load-test only: intra-cluster traffic is within the same namespace.
+        # Encryption is disabled to match the standard MSSQL test configuration
+        # used across the QA module (application-rdbmsMSSQL.yaml, docker-compose.yml).
+        url: "jdbc:sqlserver://mssql:1433;Encrypt=false"
+        username: sa
+        # Load-test only: credentials are hardcoded inline, consistent with the
+        # MySQL and PostgreSQL load-test values files (e.g. inlineSecret: camunda).
+        # Do not use these credentials in production environments.
+        secret:
+          inlineSecret: "Camunda#8_demo"

--- a/load-tests/setup/stable-810/values/camunda-platform-values-mysql.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-mysql.yaml
@@ -1,0 +1,148 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  # needed to allow the pass-through-cache for mysql images
+  security:
+    allowInsecureImages: true
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        url: jdbc:mysql://mysql:3306/camunda
+
+  ####
+  #### MySQL manually mounted driver
+  ####
+  extraVolumeMounts:
+    - name: jdbcdrivers
+      mountPath: /driver-lib
+  extraVolumes:
+    - name: jdbcdrivers
+      emptyDir: {}
+  initContainers:
+    - name: fetch-jdbc-drivers
+      image: alpine:3.24
+      imagePullPolicy: Always
+      command:
+        - sh
+        - -c
+        - >
+          wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.7.0/mysql-connector-j-9.7.0.jar
+          -O /driver-lib/mysql-driver.jar
+      volumeMounts:
+        - name: jdbcdrivers
+          mountPath: /driver-lib
+      securityContext:
+        runAsUser: 1001
+
+###########################################################################
+#
+#    #     # #     #  #####   #####  #
+#    ##   ## #     # #     # #     # #
+#    # # # # #     # #       #     # #
+#    #  #  # #     #  #####  #     # #
+#    #     #  #   #       # #  ## ## #
+#    #     #   # #  #     #  #    ## #
+#    #     #    #    #####    #### ## ######
+#
+###########################################################################
+# Use the internal registry mirror to avoid Docker Hub rate limiting in the benchmark cluster
+image:
+  registry: europe-west1-docker.pkg.dev
+  repository: camunda-benchmark/dockerhub/bitnamilegacy/mysql
+  tag: "latest"
+
+auth:
+  rootPassword: camunda
+  database: camunda
+  username: camunda
+  password: camunda
+  rootHost: "%"
+
+primary:
+  resources:
+    requests:
+      memory: 8Gi
+      cpu: 3000m
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
+  persistence:
+    size: 512Gi
+    storageClass: "benchmark-ssd-zonal-v1"
+
+  configuration: |-
+    [mysqld]
+    # ---- Bitnami required paths -----------------------------------------------
+    # primary.configuration replaces the ENTIRE my.cnf. Bitnami's init script
+    # normally injects these at runtime, so they must be included explicitly here.
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mysql
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
+    tmpdir=/opt/bitnami/mysql/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    log-error=/opt/bitnami/mysql/logs/mysqld.log
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_general_ci
+
+    # ---- Performance tuning ---------------------------------------------------
+    # InnoDB Redo Log (default: 100MB — far too small for write-heavy)
+    innodb_log_buffer_size         = 128M      # default 64MB; doubled to reduce redo flush frequency
+    innodb_redo_log_capacity       = 4G        # default 100MB; like max_wal_size in PostgreSQL
+    innodb_flush_log_at_trx_commit = 2         # default 1 (full fsync per commit); flush once/sec instead
+    innodb_flush_method            = O_DIRECT  # default on Linux; explicit for clarity
+
+    # Buffer pool (default: 128MB)
+    innodb_buffer_pool_size        = 6G        # ~50% of 12Gi limit
+
+    # Write I/O (not a dynamic variable — must live in my.cnf, cannot SET GLOBAL)
+    innodb_write_io_threads        = 8         # default 4; doubled for write-heavy workload
+
+    # MVCC Purge safety valves (defaults: 0 = unlimited)
+    innodb_max_purge_lag           = 10000000  # throttle DML if unpurged rows exceed this
+    innodb_max_purge_lag_delay     = 300000    # cap the imposed delay at 300ms
+
+    # Monitoring
+    slow_query_log                 = ON        # default OFF
+    long_query_time                = 1         # default 10s
+    log_queries_not_using_indexes  = ON        # default OFF
+    min_examined_row_limit         = 100       # suppress noise from single-row writes
+
+    [client]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    default-character-set=utf8mb4
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid

--- a/load-tests/setup/stable-810/values/camunda-platform-values-none.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-none.yaml
@@ -1,0 +1,59 @@
+# Values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This file is used to override the default values of the chart.
+# The values are optimized for running the load tests with a Camunda cluster on GKE.
+#
+# This is a YAML-formatted file.
+
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  noSecondaryStorage: true
+
+optimize:
+  enabled: false
+
+connectors:
+  enabled: false
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+  # No secondary storage backend — pairs with `global.noSecondaryStorage: true` above.
+  data:
+    secondaryStorage:
+      type: none
+  # We set extra configuration to configure additional settings for Camunda application, that are part
+  # of the orchestration cluster.
+  # This allows adding configurations without the need of overwriting all environment variables from the Platform chart.
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"
+  history:
+    retention:
+      enabled: false

--- a/load-tests/setup/stable-810/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-opensearch.yaml
@@ -1,0 +1,25 @@
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to OpenSearch
+  # overriding the default value of elasticsearch
+  data:
+    secondaryStorage:
+      type: opensearch
+      opensearch:
+        url: http://opensearch:9200
+
+########################################################################################
+################################################### Optimize datastore configuration
+########################################################################################
+# Optimize and the legacy Zeebe exporter resolve the OpenSearch connection from
+# this component-scoped block (global.opensearch was removed in camunda-platform 15.x).
+optimize:
+  database:
+    opensearch:
+      enabled: true
+      url:
+        protocol: http
+        host: "opensearch"
+        port: 9200

--- a/load-tests/setup/stable-810/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,0 +1,59 @@
+# Optimize Elasticsearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures Elasticsearch when it's used for Optimize.
+#
+# For the Elasticsearch as secondary storage configuration, see the
+# "camunda-platform-values-elasticsearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# sure to keep the other file in sync (minus the secondary storage-only options).
+
+orchestration:
+  data:
+    secondary-storage:
+      elasticsearch:
+        url: http://elasticsearch-es-http:9200
+
+  # Secondary storage configuration is not configured here, but in the
+  # Elasticsearch/OpenSearch/RDBMS-specific values file.
+  env:
+    # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
+    # otherwise it is vulnerable to node restarts
+    # ES/OS exporter configuration is bound to the Optimize usage
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+##########################################################################
+################################################### Optimize configuration
+##########################################################################
+optimize:
+  database:
+    elasticsearch:
+      enabled: true
+      url:
+        # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
+        # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
+        # See load-tests/setup/default/resources/elasticsearch.yaml for the resource definition.
+        host: elasticsearch-es-http

--- a/load-tests/setup/stable-810/values/camunda-platform-values-optimize-opensearch.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-optimize-opensearch.yaml
@@ -1,0 +1,56 @@
+# Optimize OpenSearch values for Camunda Platform Chart.
+# https://github.com/camunda/camunda-platform-helm
+#
+# This configures OpenSearch when it's used for Optimize.
+#
+# For the OpenSearch as secondary storage configuration, see the
+# "camunda-platform-values-opensearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-opensearch.yaml" file, make
+# sure to keep the other file in sync (minus the secondary storage-only options).
+
+orchestration:
+  data:
+    secondary-storage:
+      opensearch:
+        url: http://opensearch:9200
+
+  # Secondary storage configuration is not configured here, but in the
+  # Elasticsearch/OpenSearch/RDBMS-specific values file.
+  env:
+    # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
+    # otherwise it is vulnerable to node restarts
+    # ES/OS exporter configuration is bound to the Optimize usage
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+##########################################################################
+################################################### Optimize configuration
+##########################################################################
+optimize:
+  database:
+    opensearch:
+      enabled: true
+      url:
+        host: opensearch

--- a/load-tests/setup/stable-810/values/camunda-platform-values-optimize.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-optimize.yaml
@@ -1,0 +1,68 @@
+global:
+  # Identity authentication is enabled for Optimize
+  identity:
+    auth:
+      optimize:
+        clientId: optimize
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-optimize-client-token
+
+identity:
+  # Dedicated M2M Keycloak client for the load-tester's Optimize meter, with `write:*` on optimize-api.
+  clients:
+    - id: optimize-loadtest
+      name: Optimize Load Tester
+      type: m2m
+      secret:
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-optimize-loadtest-client-secret
+      permissions:
+        - resourceServerId: optimize-api
+          definition: write:*
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        historyCleanup:
+          cronTrigger: '*/30 * * * *'
+          ttl: 'P1D'
+          processDataCleanup:
+            enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
+    # Bearer-token (JWT) auth for /api/** (camunda/camunda#46878); consumed by the load-tester meter.
+    - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+      value: "true"
+    - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+      value: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+

--- a/load-tests/setup/stable-810/values/camunda-platform-values-oracle.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-oracle.yaml
@@ -1,0 +1,48 @@
+# -------
+#
+# owner: @data-layer
+#
+# -------
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # Load-test only: intra-cluster traffic is within the same namespace.
+        # Connects to the pluggable database FREEPDB1, which is the default PDB
+        # created by the gvenzl/oracle-free image (see databases/oracle.yaml).
+        url: "jdbc:oracle:thin:@//oracle:1521/FREEPDB1"
+        username: camunda
+        # Load-test only: credentials are hardcoded inline, consistent with the
+        # MySQL and PostgreSQL load-test values files (e.g. inlineSecret: camunda).
+        # Do not use these credentials in production environments.
+        secret:
+          inlineSecret: "camunda"
+
+  ####
+  #### Oracle manually mounted driver
+  ####
+  extraVolumeMounts:
+    - name: jdbcdrivers
+      mountPath: /driver-lib
+  extraVolumes:
+    - name: jdbcdrivers
+      emptyDir: {}
+  initContainers:
+    - name: fetch-jdbc-drivers
+      image: alpine:3.24
+      imagePullPolicy: Always
+      command:
+        - sh
+        - -c
+        - >
+          wget https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/23.6.0.24.10/ojdbc11-23.6.0.24.10.jar
+          -O /driver-lib/oracle-driver.jar
+      volumeMounts:
+        - name: jdbcdrivers
+          mountPath: /driver-lib
+      securityContext:
+        runAsUser: 1001

--- a/load-tests/setup/stable-810/values/camunda-platform-values-postgresql.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-postgresql.yaml
@@ -1,0 +1,10 @@
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  data:
+    secondaryStorage:
+      rdbms:
+        # The hostname depends on the name of the PostgreSQL cluster deployed
+        # by the load-test-setup Helm Chart.
+        url: jdbc:postgresql://postgresql-rw:5432/camunda

--- a/load-tests/setup/stable-810/values/camunda-platform-values-rdbms.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-rdbms.yaml
@@ -1,0 +1,51 @@
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+    rdbms:
+      enabled: true
+  data:
+    secondaryStorage:
+      type: rdbms
+      rdbms:
+        # The username is the same for all the underlying RDBMS databases.
+        username: camunda
+        secret:
+          # The password is the same for all the underlying RDBMS databases.
+          inlineSecret: camunda
+
+  # Overriding the extraConfiguration for the Platform chart
+  # to disable Camunda Exporter usage and make use of the RDBMS exporter instead, as well as to set some additional configuration for Camunda application
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+        # History cleanup adjust batch sizes
+        camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+        camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+        # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+        camunda.data.secondary-storage.rdbms.queue-size: 2001
+        camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+        camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+        camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"

--- a/load-tests/setup/stable-810/values/values-stable.yaml
+++ b/load-tests/setup/stable-810/values/values-stable.yaml
@@ -1,0 +1,15 @@
+# Additional values file to run on stable VMs
+# Scheduling on stable VMs is useful to observe long-term behavior, such as memory leaks, etc.
+# https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
+orchestration:
+  # Require n2-standard-2 to ensure the broker is the only application running on its node
+  # However, that node does not have the required cpu/memory capacity
+  nodeSelector:
+    component: benchmark-n2-standard-4-stable
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-4-stable
+    effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-chaos-killer
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://elasticsearch-es-http:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-d

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-chaos-killer
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-chaos-killer
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-chaos-killer
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Wosp3]DocdWawe"
+  identity-admin-client-token: "Fara4~HoxsPanr"
+  identity-firstuser-password: "NadoLife1/Kiwj"
+  identity-keycloak-admin-password: "GisnZoyk6)Tana"
+  identity-optimize-client-token: "Liso6'MuylCate"
+  identity-optimize-loadtest-client-secret: "WijuRukaXafu1."
+  identity-postgresql-admin-password: "RequBupxCido4]"
+  identity-postgresql-user-password: "FilfGaxaRado2="
+  orchestration-security-authentication-oidc-secret: "KatoRovu6;Cofq"

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/chaos-killer.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/chaos-killer.yaml
@@ -1,0 +1,101 @@
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-stable-810-chaos-killer
+
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-stable-810-chaos-killer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-stable-810-chaos-killer
+subjects:
+  - kind: ServiceAccount
+    name: chaos-killer
+    namespace: c8-golden-stable-810-chaos-killer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chaos-killer
+
+---
+# Source: load-test-setup/templates/chaos-killer.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: chaos-killer
+  namespace: c8-golden-stable-810-chaos-killer
+spec:
+  schedule: "0 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: chaos-killer
+          restartPolicy: OnFailure
+          containers:
+            - name: chaos-killer
+              image: bitnami/kubectl:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: CHAOS_TARGET_PATTERNS
+                  value: "camunda-* elastic-* postgresql-*"
+              command:
+                - /bin/sh
+                - -ceu
+                - |-
+                  if [ -z "$CHAOS_TARGET_PATTERNS" ]; then
+                    echo "No chaos target patterns configured."
+                    exit 1
+                  fi
+
+                  all_pods="$(kubectl get pods --namespace c8-golden-stable-810-chaos-killer -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+                  if [ -z "$all_pods" ]; then
+                    echo "No pods found in namespace c8-golden-stable-810-chaos-killer."
+                    exit 1
+                  fi
+
+                  matched_pods="$({
+                    for pattern in $CHAOS_TARGET_PATTERNS; do
+                      for pod in $all_pods; do
+                        case "$pod" in
+                          $pattern) printf '%s\n' "$pod" ;;
+                        esac
+                      done
+                    done
+                  } | awk 'NF && !seen[$0]++')"
+
+                  if [ -z "$matched_pods" ]; then
+                    echo "No pods matched patterns: $CHAOS_TARGET_PATTERNS"
+                    exit 1
+                  fi
+
+                  selected_pod="$(printf '%s\n' "$matched_pods" | awk 'BEGIN { srand(); } { pods[NR] = $0 } END { if (NR > 0) print pods[int(rand() * NR) + 1] }')"
+                  if [ -z "$selected_pod" ]; then
+                    echo "Failed to choose a pod from the matched set."
+                    exit 1
+                  fi
+
+                  echo "Matched pods:"
+                  printf ' - %s\n' $matched_pods
+                  echo "Deleting pod $selected_pod in namespace c8-golden-stable-810-chaos-killer"
+                  kubectl delete pod "$selected_pod" --namespace c8-golden-stable-810-chaos-killer --ignore-not-found=true --wait=false

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-d"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 256Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-chaos-killer-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-chaos-killer"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "R2lzblpveWs2KVRhbmE="

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-chaos-killer
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-chaos-killer"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-chaos-killer-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-chaos-killer/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-chaos-killer-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-chaos-killer-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-chaos-killer"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-chaos-killer-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "TmVzZkdlYmUyJlhheWM="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-chaos-killer-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-chaos-killer/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-chaos-killer"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "TmVzZkdlYmUyJlhheWM="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "KatoRovu6;Cofq"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-chaos-killer.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-chaos-killer"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,283 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-elasticsearch-no-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-elasticsearch-no-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-elasticsearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-elasticsearch-stable
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://elasticsearch-es-http:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-c

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-elasticsearch-stable
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-elasticsearch-stable
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-elasticsearch-stable
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Behp5.PemoHilq"
+  identity-admin-client-token: "ZepuXati5?Honf"
+  identity-firstuser-password: "Gale9/SusjKayz"
+  identity-keycloak-admin-password: "FosfYaxzGola7#"
+  identity-optimize-client-token: "ZojbHiroPoml1."
+  identity-optimize-loadtest-client-secret: "HacxDokuZubl5]"
+  identity-postgresql-admin-password: "ReweZewu9;Jipu"
+  identity-postgresql-user-password: "FiduSusl4!Liqa"
+  orchestration-security-authentication-oidc-secret: "Moze6:YigqVary"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-c"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 256Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-elasticsearch-stable-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-elasticsearch-stable"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "Rm9zZllheHpHb2xhNyM="

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-elasticsearch-stable
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-elasticsearch-stable"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-elasticsearch-stable-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-elasticsearch-stable/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-elasticsearch-stable-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-elasticsearch-stable-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-elasticsearch-stable"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-c"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-elasticsearch-stable-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "Q3VnZVNvd2g4Lkd1Y3k="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-elasticsearch-stable-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-elasticsearch-stable/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-elasticsearch-stable"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "Q3VnZVNvd2g4Lkd1Y3k="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Moze6:YigqVary"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-elasticsearch-stable"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,74 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-elasticsearch-stable
+      namespace: c8-golden-stable-810-elasticsearch-stable
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-elasticsearch-stable:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-elasticsearch-stable:82/actuator/prometheus
+      - name: Optimize
+        id: optimize
+        version: 8.10.0-alpha4
+        url: http://localhost:8083
+        readiness: http://optimize.c8-golden-stable-810-elasticsearch-stable:80/api/readyz
+        metrics: http://optimize.c8-golden-stable-810-elasticsearch-stable:8092/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-elasticsearch-stable:8080
+        readiness: http://connectors.c8-golden-stable-810-elasticsearch-stable:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-elasticsearch-stable:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,54 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/configmap.yaml
@@ -1,0 +1,220 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        optimize:
+          applications:
+            - name: Optimize
+              id: ${CAMUNDA_OPTIMIZE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}}
+              type: confidential
+              secret: ${CAMUNDA_OPTIMIZE_SECRET:${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+          apis:
+            - name: Optimize API
+              audience: "optimize-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Optimize"
+              description: "Grants full access to Optimize"
+              permissions:
+                - audience: "optimize-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        optimize:
+          secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Optimize
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -1,0 +1,155 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: CAMUNDA_OPTIMIZE_CLIENT_ID
+              value: "optimize"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/configmap.yaml
@@ -1,0 +1,61 @@
+---
+# Source: camunda-platform/templates/optimize/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: optimize-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+apiVersion: v1
+data:
+  environment-config.yaml: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "elasticsearch-es-http"
+            httpPort: 9200
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+  application-ccsm.yaml: |
+    spring:
+      config:
+        import: optional:file:/optimize/config/application.yml
+    camunda:
+      identity:
+        clientId: "optimize"
+        audience: "optimize-api"
+        issuer: ""
+        issuerBackendUrl: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+  application.yml: |
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -1,0 +1,209 @@
+---
+# Source: camunda-platform/templates/optimize/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: optimize
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: optimize
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        - name: migration
+          image: camunda/optimize:8.10.0-alpha4
+          command: ['./upgrade/upgrade.sh', '--skip-warning']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "elasticsearch-es-http"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      containers:
+        - name: optimize
+          image: camunda/optimize:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "elasticsearch-es-http"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ccsm"
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: OPTIMIZE_LOG_LEVEL
+              value: "info"
+            - name: UPGRADE_LOG_LEVEL
+              value: "info"
+            - name: ES_LOG_LEVEL
+              value: "warn"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          ports:
+            - containerPort: 8090
+              name: http
+              protocol: TCP
+            - containerPort: 8092
+              name: management
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              scheme: HTTP
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+        - name: environment-config
+          configMap:
+            name: optimize-configuration
+            defaultMode: 492
+      serviceAccountName: optimize
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/optimize/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8090
+      protocol: TCP
+    - port: 8092
+      name: management
+      targetPort: 8092
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: optimize

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/optimize/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: optimize
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-elasticsearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-elasticsearch-stable-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          elasticsearch:
+            className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            args:
+              url: "http://elasticsearch-es-http:9200"
+              index:
+                prefix: "zeebe-record"
+                numberOfReplicas: "1"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4-stable
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4-stable
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/optimize-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/optimize-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/optimize-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-elasticsearch-stable-camunda-platform-optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: optimize
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-elasticsearch
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://elasticsearch-es-http:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-d

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-elasticsearch
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-elasticsearch
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-elasticsearch
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "XovlLeyb4@Wese"
+  identity-admin-client-token: "Fesx9%MizoZedu"
+  identity-firstuser-password: "Mafx8%CifoLeso"
+  identity-keycloak-admin-password: "KiyiSanf7#Payi"
+  identity-optimize-client-token: "KezwGizaBihc5?"
+  identity-optimize-loadtest-client-secret: "MujaNovuPewe4!"
+  identity-postgresql-admin-password: "Copj1;CupePapy"
+  identity-postgresql-user-password: "Cahz1=CaqrVoqa"
+  orchestration-security-authentication-oidc-secret: "FayiXayh3,Totc"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-d"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 256Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-elasticsearch-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-elasticsearch"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "S2l5aVNhbmY3I1BheWk="

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-elasticsearch
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-elasticsearch"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-elasticsearch-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-elasticsearch/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-elasticsearch-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-elasticsearch-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-elasticsearch"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-elasticsearch-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "Rm95aVNvdGUxP1BhY2k="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-elasticsearch-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-elasticsearch/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-elasticsearch"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "Rm95aVNvdGUxP1BhY2k="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "FayiXayh3,Totc"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-elasticsearch"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,74 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-elasticsearch
+      namespace: c8-golden-stable-810-elasticsearch
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-elasticsearch:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-elasticsearch:82/actuator/prometheus
+      - name: Optimize
+        id: optimize
+        version: 8.10.0-alpha4
+        url: http://localhost:8083
+        readiness: http://optimize.c8-golden-stable-810-elasticsearch:80/api/readyz
+        metrics: http://optimize.c8-golden-stable-810-elasticsearch:8092/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-elasticsearch:8080
+        readiness: http://connectors.c8-golden-stable-810-elasticsearch:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-elasticsearch:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,54 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/configmap.yaml
@@ -1,0 +1,220 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        optimize:
+          applications:
+            - name: Optimize
+              id: ${CAMUNDA_OPTIMIZE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}}
+              type: confidential
+              secret: ${CAMUNDA_OPTIMIZE_SECRET:${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+          apis:
+            - name: Optimize API
+              audience: "optimize-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Optimize"
+              description: "Grants full access to Optimize"
+              permissions:
+                - audience: "optimize-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        optimize:
+          secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Optimize
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/deployment.yaml
@@ -1,0 +1,155 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: CAMUNDA_OPTIMIZE_CLIENT_ID
+              value: "optimize"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/configmap.yaml
@@ -1,0 +1,61 @@
+---
+# Source: camunda-platform/templates/optimize/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: optimize-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+apiVersion: v1
+data:
+  environment-config.yaml: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "elasticsearch-es-http"
+            httpPort: 9200
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+  application-ccsm.yaml: |
+    spring:
+      config:
+        import: optional:file:/optimize/config/application.yml
+    camunda:
+      identity:
+        clientId: "optimize"
+        audience: "optimize-api"
+        issuer: ""
+        issuerBackendUrl: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+  application.yml: |
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -1,0 +1,209 @@
+---
+# Source: camunda-platform/templates/optimize/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: optimize
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: optimize
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        - name: migration
+          image: camunda/optimize:8.10.0-alpha4
+          command: ['./upgrade/upgrade.sh', '--skip-warning']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "elasticsearch-es-http"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      containers:
+        - name: optimize
+          image: camunda/optimize:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "elasticsearch-es-http"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ccsm"
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: OPTIMIZE_LOG_LEVEL
+              value: "info"
+            - name: UPGRADE_LOG_LEVEL
+              value: "info"
+            - name: ES_LOG_LEVEL
+              value: "warn"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          ports:
+            - containerPort: 8090
+              name: http
+              protocol: TCP
+            - containerPort: 8092
+              name: management
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              scheme: HTTP
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+        - name: environment-config
+          configMap:
+            name: optimize-configuration
+            defaultMode: 492
+      serviceAccountName: optimize
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/optimize/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8090
+      protocol: TCP
+    - port: 8092
+      name: management
+      targetPort: 8092
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: optimize

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/optimize/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/optimize/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: optimize
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-elasticsearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-elasticsearch-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          elasticsearch:
+            className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            args:
+              url: "http://elasticsearch-es-http:9200"
+              index:
+                prefix: "zeebe-record"
+                numberOfReplicas: "1"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-elasticsearch-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/optimize-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/optimize-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/optimize-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-elasticsearch-camunda-platform-optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: optimize
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-elasticsearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=300
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "300"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-max
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://elasticsearch-es-http:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-c

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-max
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-max
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-max
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Bidi5^HomvZodi"
+  identity-admin-client-token: "GasuFaku2.Rowo"
+  identity-firstuser-password: "YofjPexu2~Dubz"
+  identity-keycloak-admin-password: "RigsGula9;Coqo"
+  identity-optimize-client-token: "BefeKibl6/Kidr"
+  identity-optimize-loadtest-client-secret: "FodaMixqZack8#"
+  identity-postgresql-admin-password: "TomoXowa7&Jayu"
+  identity-postgresql-user-password: "WensJaye5$Qifk"
+  orchestration-security-authentication-oidc-secret: "Bofo8?ZolaSexn"

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-c"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 256Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-max-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-max"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "Umlnc0d1bGE5O0NvcW8="

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-max
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-max"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-max-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-max/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-max-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-max-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-max"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-c"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-max-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "U2lrb1NlcGpUZXRpNT8="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-max-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-max/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-max"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "U2lrb1NlcGpUZXRpNT8="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Bofo8?ZolaSexn"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-max.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-max"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    load-tester:
+      monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,149 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,148 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "FagrZanl6:Caza"
+  identity-admin-client-token: "Tiji3!JikaMipa"
+  identity-firstuser-password: "HiqiHusrHije3!"
+  identity-keycloak-admin-password: "Fosa4^PiziBowd"
+  identity-optimize-client-token: "MohdVeyuZefe8'"
+  identity-optimize-loadtest-client-secret: "BimiNewm2_Suhf"
+  identity-postgresql-admin-password: "Dosi1,GarnYowi"
+  identity-postgresql-user-password: "YiqzColh2$Wefi"
+  orchestration-security-authentication-oidc-secret: "Tont5*NokuVeti"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-none-optimize-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-none-optimize"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "Rm9zYTReUGl6aUJvd2Q="

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-none-optimize
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-none-optimize"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-none-optimize-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-none-optimize/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-none-optimize-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-none-optimize-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-none-optimize"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-b"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-none-optimize-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "TmV2aVRlcXM2X0tvc2M="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-none-optimize-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-none-optimize/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-none-optimize"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "TmV2aVRlcXM2X0tvc2M="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-b"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Tont5*NokuVeti"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-none-optimize.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-none-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-none-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,62 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-none-optimize
+      namespace: c8-golden-stable-810-none-optimize
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-none-optimize.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-none-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-none-optimize:82/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,54 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-optimize-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.exporters.camunda.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,174 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-none-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-none-optimize.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,136 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,244 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "none"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-none-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-none-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: false
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-none-optimize-zeebe
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-none-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-none-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    load-tester:
+      monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,149 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,148 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "DilaPope9.Nujo"
+  identity-admin-client-token: "Goyz7]NadqPami"
+  identity-firstuser-password: "VaheJitd1_Dazi"
+  identity-keycloak-admin-password: "YedbPuwuPawp2;"
+  identity-optimize-client-token: "Kepl7#CigiGiye"
+  identity-optimize-loadtest-client-secret: "QavoTikpLuki1#"
+  identity-postgresql-admin-password: "Welt1!TagoXesk"
+  identity-postgresql-user-password: "YisuVixxHeci1("
+  orchestration-security-authentication-oidc-secret: "JeneRezq0?Minf"

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-none-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-none"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "WWVkYlB1d3VQYXdwMjs="

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-none
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-none"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-none-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-none/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-none-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-none-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-none"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-none-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "V2ljdldvdGExK0dlcmc="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-none-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-none/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-none"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "V2ljdldvdGExK0dlcmc="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "JeneRezq0?Minf"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-none.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-none"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-none.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,62 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-none
+      namespace: c8-golden-stable-810-none
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-none.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-none:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-none:82/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,54 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-none-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.exporters.camunda.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/configmap.yaml
@@ -1,0 +1,174 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-none.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-none.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/deployment.yaml
@@ -1,0 +1,136 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-none
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-none
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,244 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "none"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-none.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-none.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: false
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-none-zeebe
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-none
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-none
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-none-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-none-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-none
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,283 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-opensearch-no-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-opensearch-no-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-opensearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/configmap.yaml
@@ -1,0 +1,29 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opensearch-master-config
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+data:
+  log4j2.properties: |
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.layout.type = OpenSearchJsonLayout
+    appender.console.layout.type_name = json_logger
+    
+    rootLogger.level = info
+    rootLogger.appenderRef.console.ref = console
+    
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins.security.disabled: true
+    # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
+    logger.org.opensearch.deprecation: "OFF"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/poddisruptionbudget.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "opensearch-master-pdb"
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/service.yaml
@@ -1,0 +1,60 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: opensearch
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+  - name: metrics
+    protocol: TCP
+    port: 9600
+
+---
+# Source: load-test-setup/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: opensearch-headless
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: opensearch-master
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+  annotations:
+    majorVersion: "2.19.0"
+spec:
+  serviceName: opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: load-test-setup
+  replicas: 3
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: opensearch-master
+    spec:
+      accessModes:
+      - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: "256Gi"
+      storageClassName: "benchmark-ssd-zonal-v1"
+  template:
+    metadata:
+      name: "opensearch-master"
+      labels:
+
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: opensearch-master
+      annotations:
+        configchecksum: de7a39ce3cfcc4c5bdf245fdb96bea2840f03518f66b3dbbf63cc31c614c004
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-8
+      nodeSelector:
+        component: benchmark-n2-standard-8
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - load-test-setup
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - opensearch
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: opensearch-master-config
+      - emptyDir: {}
+        name: config-emptydir
+      enableServiceLinks: true
+      initContainers:
+      - name: fsgroup-volume
+        image: "busybox:latest"
+        imagePullPolicy: "IfNotPresent"
+        command: ['sh', '-c']
+        args:
+          - 'chown -R 1000:1000 /usr/share/opensearch/data'
+        securityContext:
+          runAsUser: 0
+        resources:
+          {}
+        volumeMounts:
+          - name: "opensearch-master"
+            mountPath: /usr/share/opensearch/data
+      - name: sysctl
+        image: "busybox:latest"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - sh
+        - -c
+        - |
+          set -xe
+          DESIRED="262144"
+          CURRENT=$(sysctl -n vm.max_map_count)
+          if [ "$DESIRED" -gt "$CURRENT" ]; then
+            sysctl -w vm.max_map_count=$DESIRED
+          fi
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        resources:
+          {}
+      - name: configfile
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - sh
+        - -c
+        - |
+          #!/usr/bin/env bash
+          cp -r /tmp/configfolder/*  /tmp/config/
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+        resources:
+          {}
+        volumeMounts:
+          - mountPath: /tmp/config/
+            name: config-emptydir
+          - name: config
+            mountPath: /tmp/configfolder/log4j2.properties
+            subPath: log4j2.properties
+          - name: config
+            mountPath: /tmp/configfolder/opensearch.yml
+            subPath: opensearch.yml
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          limits:
+            cpu: 7000m
+            memory: 8Gi
+          requests:
+            cpu: 7000m
+            memory: 8Gi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: cluster.initial_master_nodes
+          value: "opensearch-master-0,opensearch-master-1,opensearch-master-2,"
+        - name: discovery.seed_hosts
+          value: "opensearch-headless"
+        - name: cluster.name
+          value: "opensearch"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms3g -Xmx3g"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+          value: yourStrongPassword123!
+        volumeMounts:
+        - name: "opensearch-master"
+          mountPath: /usr/share/opensearch/data
+        - name: config-emptydir
+          mountPath: /usr/share/opensearch/config/log4j2.properties
+          subPath: log4j2.properties
+        - name: config-emptydir
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-opensearch-stable
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://opensearch:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-c

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-opensearch-stable
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-opensearch-stable
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-opensearch-stable
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Gage3:TogmCiqu"
+  identity-admin-client-token: "Dupo9+LujvZupi"
+  identity-firstuser-password: "NuheGedcLera5+"
+  identity-keycloak-admin-password: "Qiku9)CuxoJedr"
+  identity-optimize-client-token: "ZomfQoxu7+Risu"
+  identity-optimize-loadtest-client-secret: "XecoJatnZudo4!"
+  identity-postgresql-admin-password: "Ruzu9;WuxoVunu"
+  identity-postgresql-user-password: "MeboJicpGofr7@"
+  orchestration-security-authentication-oidc-secret: "Mufs0=KawaHopu"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-opensearch-stable-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-opensearch-stable"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "UWlrdTkpQ3V4b0plZHI="

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-opensearch-stable
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-opensearch-stable"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-opensearch-stable-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-opensearch-stable/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-opensearch-stable-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-opensearch-stable-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-opensearch-stable"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-c"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-opensearch-stable-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "VG9jbzQ6WW9rb1BveGE="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-opensearch-stable-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-opensearch-stable/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-opensearch-stable"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "VG9jbzQ6WW9rb1BveGE="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Mufs0=KawaHopu"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://opensearch:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-opensearch-stable"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,74 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-opensearch-stable
+      namespace: c8-golden-stable-810-opensearch-stable
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-opensearch-stable:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-opensearch-stable:82/actuator/prometheus
+      - name: Optimize
+        id: optimize
+        version: 8.10.0-alpha4
+        url: http://localhost:8083
+        readiness: http://optimize.c8-golden-stable-810-opensearch-stable:80/api/readyz
+        metrics: http://optimize.c8-golden-stable-810-opensearch-stable:8092/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-opensearch-stable:8080
+        readiness: http://connectors.c8-golden-stable-810-opensearch-stable:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-opensearch-stable:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,54 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-stable-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/configmap.yaml
@@ -1,0 +1,220 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        optimize:
+          applications:
+            - name: Optimize
+              id: ${CAMUNDA_OPTIMIZE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}}
+              type: confidential
+              secret: ${CAMUNDA_OPTIMIZE_SECRET:${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+          apis:
+            - name: Optimize API
+              audience: "optimize-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Optimize"
+              description: "Grants full access to Optimize"
+              permissions:
+                - audience: "optimize-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        optimize:
+          secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Optimize
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/deployment.yaml
@@ -1,0 +1,155 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: CAMUNDA_OPTIMIZE_CLIENT_ID
+              value: "optimize"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/configmap.yaml
@@ -1,0 +1,61 @@
+---
+# Source: camunda-platform/templates/optimize/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: optimize-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+apiVersion: v1
+data:
+  environment-config.yaml: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "opensearch"
+            httpPort: 9200
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+  application-ccsm.yaml: |
+    spring:
+      config:
+        import: optional:file:/optimize/config/application.yml
+    camunda:
+      identity:
+        clientId: "optimize"
+        audience: "optimize-api"
+        issuer: ""
+        issuerBackendUrl: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+  application.yml: |
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/templates/optimize/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: optimize
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: optimize
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        - name: migration
+          image: camunda/optimize:8.10.0-alpha4
+          command: ['./upgrade/upgrade.sh', '--skip-warning']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: CAMUNDA_OPTIMIZE_DATABASE
+              value: opensearch
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT
+              value: "9200"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
+              value: "opensearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "c8-golden-stable-810-opensearch-stable-elasticsearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      containers:
+        - name: optimize
+          image: camunda/optimize:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: CAMUNDA_OPTIMIZE_DATABASE
+              value: opensearch
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT
+              value: "9200"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
+              value: "opensearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "c8-golden-stable-810-opensearch-stable-elasticsearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ccsm"
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: OPTIMIZE_LOG_LEVEL
+              value: "info"
+            - name: UPGRADE_LOG_LEVEL
+              value: "info"
+            - name: ES_LOG_LEVEL
+              value: "warn"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-stable-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-stable-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          ports:
+            - containerPort: 8090
+              name: http
+              protocol: TCP
+            - containerPort: 8092
+              name: management
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              scheme: HTTP
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+        - name: environment-config
+          configMap:
+            name: optimize-configuration
+            defaultMode: 492
+      serviceAccountName: optimize
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/optimize/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8090
+      protocol: TCP
+    - port: 8092
+      name: management
+      targetPort: 8092
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: optimize

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/optimize/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: optimize
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,297 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-opensearch-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-opensearch-stable-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          opensearch:
+            className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
+            args:
+              authentication:
+                username: ""
+                password: "${VALUES_OPENSEARCH_PASSWORD:}"
+              url: "http://opensearch:9200"
+              index:
+                prefix: "zeebe-record"
+                numberOfReplicas: "1"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-stable-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4-stable
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4-stable
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/optimize-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/optimize-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/optimize-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-opensearch-stable-camunda-platform-optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: optimize
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/configmap.yaml
@@ -1,0 +1,29 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opensearch-master-config
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+data:
+  log4j2.properties: |
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.layout.type = OpenSearchJsonLayout
+    appender.console.layout.type_name = json_logger
+    
+    rootLogger.level = info
+    rootLogger.appenderRef.console.ref = console
+    
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins.security.disabled: true
+    # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
+    logger.org.opensearch.deprecation: "OFF"

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/poddisruptionbudget.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: "opensearch-master-pdb"
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/service.yaml
@@ -1,0 +1,60 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: opensearch
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+  ports:
+  - name: http
+    protocol: TCP
+    port: 9200
+  - name: transport
+    protocol: TCP
+    port: 9300
+  - name: metrics
+    protocol: TCP
+    port: 9600
+
+---
+# Source: load-test-setup/charts/opensearch/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: opensearch-headless
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None # This is needed for statefulset hostnames like opensearch-0 to resolve
+  # Create endpoints also if the related pod isn't ready
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+  ports:
+  - name: http
+    port: 9200
+  - name: transport
+    port: 9300
+  - name: metrics
+    port: 9600

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: load-test-setup/charts/opensearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: opensearch-master
+  labels:
+
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-master
+  annotations:
+    majorVersion: "2.19.0"
+spec:
+  serviceName: opensearch-headless
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: load-test-setup
+  replicas: 3
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: opensearch-master
+    spec:
+      accessModes:
+      - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: "256Gi"
+      storageClassName: "benchmark-ssd-zonal-v1"
+  template:
+    metadata:
+      name: "opensearch-master"
+      labels:
+
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: opensearch-master
+      annotations:
+        configchecksum: de7a39ce3cfcc4c5bdf245fdb96bea2840f03518f66b3dbbf63cc31c614c004
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      automountServiceAccountToken: false
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-8
+      nodeSelector:
+        component: benchmark-n2-standard-8
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - load-test-setup
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - opensearch
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - name: config
+        configMap:
+          name: opensearch-master-config
+      - emptyDir: {}
+        name: config-emptydir
+      enableServiceLinks: true
+      initContainers:
+      - name: fsgroup-volume
+        image: "busybox:latest"
+        imagePullPolicy: "IfNotPresent"
+        command: ['sh', '-c']
+        args:
+          - 'chown -R 1000:1000 /usr/share/opensearch/data'
+        securityContext:
+          runAsUser: 0
+        resources:
+          {}
+        volumeMounts:
+          - name: "opensearch-master"
+            mountPath: /usr/share/opensearch/data
+      - name: sysctl
+        image: "busybox:latest"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - sh
+        - -c
+        - |
+          set -xe
+          DESIRED="262144"
+          CURRENT=$(sysctl -n vm.max_map_count)
+          if [ "$DESIRED" -gt "$CURRENT" ]; then
+            sysctl -w vm.max_map_count=$DESIRED
+          fi
+        securityContext:
+          runAsUser: 0
+          privileged: true
+        resources:
+          {}
+      - name: configfile
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - sh
+        - -c
+        - |
+          #!/usr/bin/env bash
+          cp -r /tmp/configfolder/*  /tmp/config/
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+        resources:
+          {}
+        volumeMounts:
+          - mountPath: /tmp/config/
+            name: config-emptydir
+          - name: config
+            mountPath: /tmp/configfolder/log4j2.properties
+            subPath: log4j2.properties
+          - name: config
+            mountPath: /tmp/configfolder/opensearch.yml
+            subPath: opensearch.yml
+      containers:
+      - name: "opensearch"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1000
+
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        ports:
+        - name: http
+          containerPort: 9200
+        - name: transport
+          containerPort: 9300
+        - name: metrics
+          containerPort: 9600
+        resources:
+          limits:
+            cpu: 7000m
+            memory: 8Gi
+          requests:
+            cpu: 7000m
+            memory: 8Gi
+        env:
+        - name: node.name
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: cluster.initial_master_nodes
+          value: "opensearch-master-0,opensearch-master-1,opensearch-master-2,"
+        - name: discovery.seed_hosts
+          value: "opensearch-headless"
+        - name: cluster.name
+          value: "opensearch"
+        - name: network.host
+          value: "0.0.0.0"
+        - name: OPENSEARCH_JAVA_OPTS
+          value: "-Xms3g -Xmx3g"
+        - name: node.roles
+          value: "master,ingest,data,remote_cluster_client,"
+        - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+          value: yourStrongPassword123!
+        volumeMounts:
+        - name: "opensearch-master"
+          mountPath: /usr/share/opensearch/data
+        - name: config-emptydir
+          mountPath: /usr/share/opensearch/config/log4j2.properties
+          subPath: log4j2.properties
+        - name: config-emptydir
+          mountPath: /usr/share/opensearch/config/opensearch.yml
+          subPath: opensearch.yml

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-opensearch
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://opensearch:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-b

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-opensearch
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-opensearch
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-opensearch
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "CahjVahzPile6."
+  identity-admin-client-token: "ZeleJedlTalk8&"
+  identity-firstuser-password: "Vatq9.XaroQube"
+  identity-keycloak-admin-password: "Wovf7:PopeZetx"
+  identity-optimize-client-token: "Cext0*LimoBiym"
+  identity-optimize-loadtest-client-secret: "DelaDiks7^Hijh"
+  identity-postgresql-admin-password: "HiyePogqXaxr6:"
+  identity-postgresql-user-password: "VeyiLaji6;Gawa"
+  orchestration-security-authentication-oidc-secret: "BizuMixaZohp3."

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-opensearch-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-opensearch"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "V292Zjc6UG9wZVpldHg="

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-opensearch
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-opensearch"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-opensearch-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-opensearch/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-opensearch-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-opensearch-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-opensearch"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-b"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-opensearch-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "WWlzaDYjTGl3dk1pY2U="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-opensearch-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-opensearch/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-opensearch"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "WWlzaDYjTGl3dk1pY2U="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-b"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "BizuMixaZohp3."
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://opensearch:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-b"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-opensearch"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,74 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-opensearch
+      namespace: c8-golden-stable-810-opensearch
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-opensearch:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-opensearch:82/actuator/prometheus
+      - name: Optimize
+        id: optimize
+        version: 8.10.0-alpha4
+        url: http://localhost:8083
+        readiness: http://optimize.c8-golden-stable-810-opensearch:80/api/readyz
+        metrics: http://optimize.c8-golden-stable-810-opensearch:8092/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-opensearch:8080
+        readiness: http://connectors.c8-golden-stable-810-opensearch:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-opensearch:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,54 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/configmap.yaml
@@ -1,0 +1,220 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        optimize:
+          applications:
+            - name: Optimize
+              id: ${CAMUNDA_OPTIMIZE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}}
+              type: confidential
+              secret: ${CAMUNDA_OPTIMIZE_SECRET:${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+          apis:
+            - name: Optimize API
+              audience: "optimize-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Optimize"
+              description: "Grants full access to Optimize"
+              permissions:
+                - audience: "optimize-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        optimize:
+          secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Optimize
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/deployment.yaml
@@ -1,0 +1,155 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: CAMUNDA_OPTIMIZE_CLIENT_ID
+              value: "optimize"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/configmap.yaml
@@ -1,0 +1,61 @@
+---
+# Source: camunda-platform/templates/optimize/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: optimize-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+apiVersion: v1
+data:
+  environment-config.yaml: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "opensearch"
+            httpPort: 9200
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+  application-ccsm.yaml: |
+    spring:
+      config:
+        import: optional:file:/optimize/config/application.yml
+    camunda:
+      identity:
+        clientId: "optimize"
+        audience: "optimize-api"
+        issuer: ""
+        issuerBackendUrl: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+  application.yml: |
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/deployment.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/templates/optimize/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: optimize
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: optimize
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        - name: migration
+          image: camunda/optimize:8.10.0-alpha4
+          command: ['./upgrade/upgrade.sh', '--skip-warning']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: CAMUNDA_OPTIMIZE_DATABASE
+              value: opensearch
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT
+              value: "9200"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
+              value: "opensearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "c8-golden-stable-810-opensearch-elasticsearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      containers:
+        - name: optimize
+          image: camunda/optimize:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: CAMUNDA_OPTIMIZE_DATABASE
+              value: opensearch
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT
+              value: "9200"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
+              value: "opensearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "c8-golden-stable-810-opensearch-elasticsearch"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ccsm"
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: OPTIMIZE_LOG_LEVEL
+              value: "info"
+            - name: UPGRADE_LOG_LEVEL
+              value: "info"
+            - name: ES_LOG_LEVEL
+              value: "warn"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          ports:
+            - containerPort: 8090
+              name: http
+              protocol: TCP
+            - containerPort: 8092
+              name: management
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              scheme: HTTP
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+        - name: environment-config
+          configMap:
+            name: optimize-configuration
+            defaultMode: 492
+      serviceAccountName: optimize
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/optimize/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8090
+      protocol: TCP
+    - port: 8092
+      name: management
+      targetPort: 8092
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: optimize

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/optimize/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/optimize/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: optimize
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,297 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-opensearch.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-opensearch-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          opensearch:
+            className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
+            args:
+              authentication:
+                username: ""
+                password: "${VALUES_OPENSEARCH_PASSWORD:}"
+              url: "http://opensearch:9200"
+              index:
+                prefix: "zeebe-record"
+                numberOfReplicas: "1"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-opensearch-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/optimize-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/optimize-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/optimize-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-opensearch-camunda-platform-optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: optimize
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-opensearch
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-rdbms-optimize
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://elasticsearch-es-http:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-d

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-rdbms-optimize
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-rdbms-optimize
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-rdbms-optimize
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "GuqsZikfNohu1~"
+  identity-admin-client-token: "CohkPamoNozw6="
+  identity-firstuser-password: "WumyGeneLejk9)"
+  identity-keycloak-admin-password: "Yibg5^FaffXeqa"
+  identity-optimize-client-token: "Reyg0?YozmCoye"
+  identity-optimize-loadtest-client-secret: "Zerz9=FameYica"
+  identity-postgresql-admin-password: "DovoJeym5;Yubu"
+  identity-postgresql-user-password: "QeqmBilu9=Xezu"
+  orchestration-security-authentication-oidc-secret: "Jikq9%MapuWobs"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-d"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 256Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-optimize-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-optimize"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "WWliZzVeRmFmZlhlcWE="

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-rdbms-optimize
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-optimize"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-rdbms-optimize-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-rdbms-optimize/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-rdbms-optimize-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-rdbms-optimize-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-rdbms-optimize"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-rdbms-optimize-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "TWFkYVZlY3BYaXN4MF0="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-optimize-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-rdbms-optimize/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-optimize"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "TWFkYVZlY3BYaXN4MF0="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Jikq9%MapuWobs"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-rdbms-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+---
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  description: PostgreSQL cluster for Camunda secondary storage
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
+
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+    requests:
+      cpu: 3000m
+      memory: 8Gi
+
+  storage:
+    size: 256Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
+    # The PostgreSQL configuration flags.
+    parameters:
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
+
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Camunda to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: camunda
+      owner: camunda
+      secret:
+        name: postgresql-camunda-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,74 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-rdbms-optimize
+      namespace: c8-golden-stable-810-rdbms-optimize
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-rdbms-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-rdbms-optimize:82/actuator/prometheus
+      - name: Optimize
+        id: optimize
+        version: 8.10.0-alpha4
+        url: http://localhost:8083
+        readiness: http://optimize.c8-golden-stable-810-rdbms-optimize:80/api/readyz
+        metrics: http://optimize.c8-golden-stable-810-rdbms-optimize:8092/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-rdbms-optimize:8080
+        readiness: http://connectors.c8-golden-stable-810-rdbms-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-rdbms-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,76 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] SECURITY: inlineSecret is set in: [orchestration]. This stores secrets as plain-text in the Helm values and is NOT suitable for production use. For production environments, please use Kubernetes Secrets with 'secret.existingSecret' instead.
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.exporters.camunda.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-optimize-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,220 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        optimize:
+          applications:
+            - name: Optimize
+              id: ${CAMUNDA_OPTIMIZE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}}
+              type: confidential
+              secret: ${CAMUNDA_OPTIMIZE_SECRET:${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+          apis:
+            - name: Optimize API
+              audience: "optimize-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Optimize"
+              description: "Grants full access to Optimize"
+              permissions:
+                - audience: "optimize-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        optimize:
+          secret: ${VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Optimize
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,155 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_INIT_OPTIMIZE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: CAMUNDA_OPTIMIZE_CLIENT_ID
+              value: "optimize"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/configmap.yaml
@@ -1,0 +1,61 @@
+---
+# Source: camunda-platform/templates/optimize/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: optimize-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+apiVersion: v1
+data:
+  environment-config.yaml: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "elasticsearch-es-http"
+            httpPort: 9200
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+  application-ccsm.yaml: |
+    spring:
+      config:
+        import: optional:file:/optimize/config/application.yml
+    camunda:
+      identity:
+        clientId: "optimize"
+        audience: "optimize-api"
+        issuer: ""
+        issuerBackendUrl: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+  application.yml: |
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -1,0 +1,209 @@
+---
+# Source: camunda-platform/templates/optimize/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: optimize
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: optimize
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        - name: migration
+          image: camunda/optimize:8.10.0-alpha4
+          command: ['./upgrade/upgrade.sh', '--skip-warning']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "elasticsearch-es-http"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      containers:
+        - name: optimize
+          image: camunda/optimize:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: OPTIMIZE_ELASTICSEARCH_HOST
+              value: "elasticsearch-es-http"
+            - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+              value: "9200"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ccsm"
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-client-token
+            - name: OPTIMIZE_LOG_LEVEL
+              value: "info"
+            - name: UPGRADE_LOG_LEVEL
+              value: "info"
+            - name: ES_LOG_LEVEL
+              value: "warn"
+            - name: OPTIMIZE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+              value: "true"
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs
+            - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+              value: "3"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+              value: "1000"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          ports:
+            - containerPort: 8090
+              name: http
+              protocol: TCP
+            - containerPort: 8092
+              name: management
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/readyz
+              scheme: HTTP
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+            - mountPath: /optimize/config/environment-config.yaml
+              subPath: environment-config.yaml
+              name: environment-config
+            - mountPath: /optimize/config/application-ccsm.yaml
+              subPath: application-ccsm.yaml
+              name: environment-config
+            - name: environment-config
+              mountPath: /optimize/config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+        - name: environment-config
+          configMap:
+            name: optimize-configuration
+            defaultMode: 492
+      serviceAccountName: optimize
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/optimize/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: optimize
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8090
+      protocol: TCP
+    - port: 8092
+      name: management
+      targetPort: 8092
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: optimize

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/optimize/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: optimize
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,289 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "rdbms"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+          rdbms:
+            aws-enabled: false
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
+            username: "camunda"
+            password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-rdbms-optimize.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-rdbms-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          elasticsearch:
+            className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            args:
+              url: "http://elasticsearch-es-http:9200"
+              index:
+                prefix: "zeebe-record"
+                numberOfReplicas: "1"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # History cleanup adjust batch sizes
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+    # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+    camunda.data.secondary-storage.rdbms.queue-size: 2001
+    camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+    camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+    camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,212 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            - name: VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
+              value: "camunda"
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/optimize-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/optimize-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/optimize-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-optimize-camunda-platform-optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: optimize
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Yoru5+FoceHikq"
+  identity-admin-client-token: "Puvu4/GeyoVons"
+  identity-firstuser-password: "SawoGazq8#Faxr"
+  identity-keycloak-admin-password: "LequHake3!Fuju"
+  identity-optimize-client-token: "Xuza1(KavjDede"
+  identity-optimize-loadtest-client-secret: "FipoDicq6!Zatf"
+  identity-postgresql-admin-password: "Gale0^YoklSotz"
+  identity-postgresql-user-password: "ZubiLege6~Coga"
+  orchestration-security-authentication-oidc-secret: "JeduQijc5+Xuqa"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-stable-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-stable"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "TGVxdUhha2UzIUZ1anU="

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-rdbms-stable
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-stable"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-rdbms-stable-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-rdbms-stable/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-rdbms-stable-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-rdbms-stable-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-rdbms-stable"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-b"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-rdbms-stable-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "WnV5c1FvbmE0JlNpdmk="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-stable-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-rdbms-stable/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-stable"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "WnV5c1FvbmE0JlNpdmk="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-b"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "JeduQijc5+Xuqa"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-rdbms-stable"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+---
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  description: PostgreSQL cluster for Camunda secondary storage
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
+
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+    requests:
+      cpu: 3000m
+      memory: 8Gi
+
+  storage:
+    size: 256Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-b"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
+    # The PostgreSQL configuration flags.
+    parameters:
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
+
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Camunda to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: camunda
+      owner: camunda
+      secret:
+        name: postgresql-camunda-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-stable-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-stable-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,68 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-stable-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-rdbms-stable
+      namespace: c8-golden-stable-810-rdbms-stable
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-rdbms-stable:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-rdbms-stable:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-rdbms-stable:8080
+        readiness: http://connectors.c8-golden-stable-810-rdbms-stable:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-rdbms-stable:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,76 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-stable-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] SECURITY: inlineSecret is set in: [orchestration]. This stores secrets as plain-text in the Helm values and is NOT suitable for production use. For production environments, please use Kubernetes Secrets with 'secret.existingSecret' instead.
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.exporters.camunda.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-stable-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/configmap.yaml
@@ -1,0 +1,185 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/deployment.yaml
@@ -1,0 +1,143 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,266 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "rdbms"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          rdbms:
+            aws-enabled: false
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
+            username: "camunda"
+            password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-rdbms-stable.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-rdbms-stable-zeebe
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # History cleanup adjust batch sizes
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+    # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+    camunda.data.secondary-storage.rdbms.queue-size: 2001
+    camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+    camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+    camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            - name: VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
+              value: "camunda"
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-stable-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4-stable
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4-stable
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-stable-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-stable-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms-stable
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "QunoPezaMizn0^"
+  identity-admin-client-token: "Josn6@LewaKaha"
+  identity-firstuser-password: "PahsBifo6%Befw"
+  identity-keycloak-admin-password: "YezoMayaWuvy8,"
+  identity-optimize-client-token: "TicoSogvTuwi3'"
+  identity-optimize-loadtest-client-secret: "Garq9-TirhNebe"
+  identity-postgresql-admin-password: "LogkRoqeWizi8!"
+  identity-postgresql-user-password: "BecuLasiSeha2+"
+  orchestration-security-authentication-oidc-secret: "BudtNete6@Mehi"

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "WWV6b01heWFXdXZ5OCw="

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-rdbms
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-rdbms-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-rdbms/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-rdbms-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-rdbms-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-rdbms"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-c"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-rdbms-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "QmlnYVBlZmpXdXZpMic="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-rdbms/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "QmlnYVBlZmpXdXZpMic="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "BudtNete6@Mehi"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-rdbms.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-rdbms"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+---
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  description: PostgreSQL cluster for Camunda secondary storage
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
+
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+    requests:
+      cpu: 3000m
+      memory: 8Gi
+
+  storage:
+    size: 256Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
+    # The PostgreSQL configuration flags.
+    parameters:
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
+
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Camunda to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: camunda
+      owner: camunda
+      secret:
+        name: postgresql-camunda-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: ""
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,68 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-810-rdbms
+      namespace: c8-golden-stable-810-rdbms
+      version: 15.0.0-alpha4
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        url: http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha4.2
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-810-rdbms:82/actuator/health
+        metrics: http://identity.c8-golden-stable-810-rdbms:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha4
+        url: http://connectors.c8-golden-stable-810-rdbms:8080
+        readiness: http://connectors.c8-golden-stable-810-rdbms:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-810-rdbms:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: admin
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-warnings.yaml
@@ -1,0 +1,76 @@
+---
+# Source: camunda-platform/templates/common/configmap-warnings.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-810-rdbms-camunda-platform-warnings
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  warnings: |-
+    [camunda][warning] SECURITY: inlineSecret is set in: [orchestration]. This stores secrets as plain-text in the Helm values and is NOT suitable for production use. For production environments, please use Kubernetes Secrets with 'secret.existingSecret' instead.
+    
+      
+    
+      
+    
+      
+    
+      
+    
+      
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.retention.policyName" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.retention.minimumAge" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.security.initialization.authorizations" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+        
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.exporters.camunda.enabled" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,124 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha4
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-camunda-platform-identity-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/configmap.yaml
@@ -1,0 +1,185 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: ""
+        backend-url: "http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/deployment.yaml
@@ -1,0 +1,143 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha4.2
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: CAMUNDA_CONNECTORS_CLIENT_ID
+              value: "connectors"
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: CAMUNDA_ORCHESTRATION_CLIENT_ID
+              value: "orchestration"
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,266 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "rdbms"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          rdbms:
+            aws-enabled: false
+            url: "jdbc:postgresql://postgresql-rw:5432/camunda"
+            username: "camunda"
+            password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "/protocol/openid-connect/auth"
+            jwk-set-uri: "http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://c8-golden-stable-810-rdbms.keycloak-operator.svc:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-810-rdbms-zeebe
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # History cleanup adjust batch sizes
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+    # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+    camunda.data.secondary-storage.rdbms.queue-size: 2001
+    camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+    camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+    camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/service.yaml
@@ -1,0 +1,38 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            - name: VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
+              value: "camunda"
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-810-rdbms-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-810-rdbms-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-810-rdbms
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,143 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=1
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="bankDisputeHandling"
+                -Dapp.starter.bpmnXmlPath="bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn"
+                -Dapp.starter.extraBpmnModels.0="bpmn/realistic/refundingProcess.bpmn"
+                -Dapp.starter.extraBpmnModels.1="bpmn/realistic/determineFraudRatingConfidence.dmn"
+                -Dapp.starter.businessKey="customerId"
+                -Dapp.starter.payloadPath="bpmn/realistic/realisticPayload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "1"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "bankDisputeHandling"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn"
+            - name: LOAD_TESTER_STARTER_EXTRA_BPMN_MODELS_0_
+              value: "bpmn/realistic/refundingProcess.bpmn"
+            - name: LOAD_TESTER_STARTER_EXTRA_BPMN_MODELS_1_
+              value: "bpmn/realistic/determineFraudRatingConfidence.dmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "customerId"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/realistic/realisticPayload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,827 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: customer-notification
+  labels:
+    app: customer-notification
+spec:
+  selector:
+    matchLabels:
+      app: customer-notification
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: customer-notification
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: customer-notification
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=30
+                -Dapp.worker.completionDelay=300ms
+                -Dapp.worker.workerName="customer-notification"
+                -Dapp.worker.jobType="customer_notification"
+                -Dapp.worker.payloadPath="bpmn/emptyPayload.json"
+                -Dapp.worker.sendMessage=true
+                -Dapp.worker.messageName="dispute_process_receive_documents"
+                -Dapp.worker.correlationKeyVariableName="correlationKey"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "30"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "300ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "customer-notification"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "customer_notification"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/emptyPayload.json"
+            - name: LOAD_TESTER_WORKER_SEND_MESSAGE
+              value: "true"
+            - name: LOAD_TESTER_WORKER_MESSAGE_NAME
+              value: "dispute_process_receive_documents"
+            - name: LOAD_TESTER_WORKER_CORRELATION_KEY_VARIABLE_NAME
+              value: "correlationKey"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispute-process-request-get-vendor-info
+  labels:
+    app: dispute-process-request-get-vendor-info
+spec:
+  selector:
+    matchLabels:
+      app: dispute-process-request-get-vendor-info
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: dispute-process-request-get-vendor-info
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: dispute-process-request-get-vendor-info
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=30
+                -Dapp.worker.completionDelay=10ms
+                -Dapp.worker.workerName="dispute-process-request-get-vendor-info"
+                -Dapp.worker.jobType="dispute_process_request_get_vendor_info"
+                -Dapp.worker.payloadPath="bpmn/emptyPayload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "30"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "10ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "dispute-process-request-get-vendor-info"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "dispute_process_request_get_vendor_info"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/emptyPayload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dispute-process-request-proof-from-vendor
+  labels:
+    app: dispute-process-request-proof-from-vendor
+spec:
+  selector:
+    matchLabels:
+      app: dispute-process-request-proof-from-vendor
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: dispute-process-request-proof-from-vendor
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: dispute-process-request-proof-from-vendor
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=30
+                -Dapp.worker.completionDelay=300ms
+                -Dapp.worker.workerName="dispute-process-request-proof-from-vendor"
+                -Dapp.worker.jobType="dispute_process_request_proof_from_vendor"
+                -Dapp.worker.payloadPath="bpmn/emptyPayload.json"
+                -Dapp.worker.sendMessage=true
+                -Dapp.worker.messageName="dispute_process_refund_approved"
+                -Dapp.worker.correlationKeyVariableName="correlationKey"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "30"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "300ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "dispute-process-request-proof-from-vendor"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "dispute_process_request_proof_from_vendor"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/emptyPayload.json"
+            - name: LOAD_TESTER_WORKER_SEND_MESSAGE
+              value: "true"
+            - name: LOAD_TESTER_WORKER_MESSAGE_NAME
+              value: "dispute_process_refund_approved"
+            - name: LOAD_TESTER_WORKER_CORRELATION_KEY_VARIABLE_NAME
+              value: "correlationKey"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: extract-data-from-document
+  labels:
+    app: extract-data-from-document
+spec:
+  selector:
+    matchLabels:
+      app: extract-data-from-document
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: extract-data-from-document
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: extract-data-from-document
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=30
+                -Dapp.worker.completionDelay=300ms
+                -Dapp.worker.workerName="extract-data-from-document"
+                -Dapp.worker.jobType="extract_data_from_document"
+                -Dapp.worker.payloadPath="bpmn/emptyPayload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "30"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "300ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "extract-data-from-document"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "extract_data_from_document"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/emptyPayload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inform-about-successful-claim
+  labels:
+    app: inform-about-successful-claim
+spec:
+  selector:
+    matchLabels:
+      app: inform-about-successful-claim
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: inform-about-successful-claim
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: inform-about-successful-claim
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=30
+                -Dapp.worker.completionDelay=300ms
+                -Dapp.worker.workerName="inform-about-successful-claim"
+                -Dapp.worker.jobType="inform_about_successful_claim"
+                -Dapp.worker.payloadPath="bpmn/emptyPayload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "30"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "300ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "inform-about-successful-claim"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "inform_about_successful_claim"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/emptyPayload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: refunding
+  labels:
+    app: refunding
+spec:
+  selector:
+    matchLabels:
+      app: refunding
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: refunding
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: refunding
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=30
+                -Dapp.worker.threads=30
+                -Dapp.worker.completionDelay=300ms
+                -Dapp.worker.workerName="refunding"
+                -Dapp.worker.jobType="refunding"
+                -Dapp.worker.payloadPath="bpmn/emptyPayload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "30"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "30"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "300ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "refunding"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "refunding"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/emptyPayload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -1,0 +1,93 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-realistic
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+
+        app.kubernetes.io/name: prometheus-elasticsearch-exporter
+        app.kubernetes.io/instance: load-test-setup
+
+        app.kubernetes.io/managed-by: Helm
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+    spec:
+      serviceAccountName: default
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter:v1.11.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=json",
+                    "--log.level=info",
+                    "--es.uri=http://elasticsearch-es-http:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--no-es.aliases",
+                    "--es.shards",
+                    "--collector.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "20"]
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-d

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/service.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-realistic
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9108
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+---
+# Source: load-test-setup/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prom-els-exporter
+  namespace: c8-golden-stable-810-realistic
+  labels:
+
+    app.kubernetes.io/name: prometheus-elasticsearch-exporter
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: elasticsearch-exporter
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-elasticsearch-exporter
+      app.kubernetes.io/instance: load-test-setup
+  namespaceSelector:
+    matchNames:
+      - c8-golden-stable-810-realistic
+  sampleLimit: 0

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Viqo3)MunxYifp"
+  identity-admin-client-token: "QokeRuheWujg6!"
+  identity-firstuser-password: "Yoko5~PoyfJuni"
+  identity-keycloak-admin-password: "LapaKiboGuqo8~"
+  identity-optimize-client-token: "XanuFuyu6]Hink"
+  identity-optimize-loadtest-client-secret: "Yako6&BubaNufb"
+  identity-postgresql-admin-password: "TutoLuji6+Poca"
+  identity-postgresql-user-password: "VeveTuli6,Caqa"
+  orchestration-security-authentication-oidc-secret: "WihwNebo8=Wuly"

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-d"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 256Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-realistic-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-realistic"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "TGFwYUtpYm9HdXFvOH4="

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-realistic
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-realistic"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-realistic-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-realistic/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-realistic-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-realistic-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-realistic"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-realistic-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "SGF2aTMsS2VzbkplbW4="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-realistic-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-realistic/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-realistic"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "SGF2aTMsS2VzbkplbW4="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "WihwNebo8=Wuly"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-realistic.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,73 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-realistic"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -116,6 +116,7 @@ var defaultScenarios = []scenario{
 // to generate its golden files, then commit them. No other code change is needed.
 var versions = []string{
 	"main",
+	"stable-810",
 	"stable-89",
 	"stable-88",
 	"stable-87",


### PR DESCRIPTION
## Description

First part of https://github.com/camunda/camunda/issues/60969: enables the `stable-810` version profile, copied from `main`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/60969
