### PR TITLE
fix: disable incident retry on a suspended process instance

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
@@ -89,6 +89,7 @@ type IncidentsTableProps = {
   incidents: EnhancedIncident[];
   decisionInstancesByElementKey?: DecisionInstanceLookup;
   childInstanceWithIncident?: ChildInstanceWithIncident;
+  isProcessInstanceSuspended?: boolean;
   state: React.ComponentProps<typeof SortableTable>['state'];
   onVerticalScrollStartReach?: React.ComponentProps<
     typeof SortableTable
@@ -105,6 +106,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
     processInstanceKey,
     decisionInstancesByElementKey,
     childInstanceWithIncident,
+    isProcessInstanceSuspended = false,
     onVerticalScrollEndReach,
     onVerticalScrollStartReach,
   }) {
@@ -279,6 +281,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
                 <IncidentOperation
                   incidentKey={incident.incidentKey}
                   jobKey={incident.jobKey}
+                  disabled={isProcessInstanceSuspended}
                 />
               ) : undefined,
             };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -221,10 +221,24 @@ describe('IncidentsTable', () => {
 
     expect(
       await firstIncidentRow.findByRole('button', {name: 'Retry Incident'}),
-    ).toBeInTheDocument();
+    ).toBeEnabled();
     expect(
       secondIncidentRow.queryByRole('button', {name: 'Retry Incident'}),
     ).not.toBeInTheDocument();
+  });
+
+  it('should disable retry when the process instance is suspended', () => {
+    render(
+      <IncidentsTable
+        state="content"
+        processInstanceKey="1"
+        isProcessInstanceSuspended
+        incidents={[{...firstIncident, processInstanceKey: '1'}]}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(screen.getByRole('button', {name: 'Retry Incident'})).toBeDisabled();
   });
 
   it('should provide a link to root cause decision instance for DECISION_EVALUATION_ERROR', () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
@@ -9,6 +9,7 @@
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
@@ -231,5 +232,53 @@ describe('IncidentsTab', () => {
         'There are no incidents matching this filter set',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should enable retry when the process instance is active', async () => {
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([
+        createIncident({
+          processInstanceKey: PROCESS_INSTANCE_ID,
+        }),
+      ]),
+    );
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: 'Retry Incident'}),
+      ).toBeEnabled();
+    });
+  });
+
+  it('should disable retry when the process instance is suspended', async () => {
+    mockFetchProcessInstance().withSuccess({
+      ...mockProcessInstance,
+      state: 'SUSPENDED',
+    });
+    mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
+      searchResult([
+        createIncident({
+          processInstanceKey: PROCESS_INSTANCE_ID,
+        }),
+      ]),
+    );
+
+    render(<IncidentsTab />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('data-table-skeleton'),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: 'Retry Incident'}),
+      ).toBeDisabled();
+    });
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -19,7 +19,7 @@ import {useGetIncidentsByProcessInstancePaginated} from 'modules/queries/inciden
 import {useGetIncidentsByElementInstancePaginated} from 'modules/queries/incidents/useGetIncidentsByElementInstancePaginated';
 import {incidentsPanelFiltersStore} from 'modules/stores/incidentsPanelFiltersStore';
 import {getIncidentsSearchFilter} from 'modules/utils/incidents';
-import {isInstanceRunning} from 'modules/utils/instance';
+import {isInstanceRunning, isInstanceSuspended} from 'modules/utils/instance';
 import {modificationsStore} from 'modules/stores/modifications';
 import {IncidentsFilter} from './IncidentsFilter';
 import {IncidentsTable} from './IncidentsTable';
@@ -189,6 +189,9 @@ const IncidentsTab: React.FC = observer(() => {
         onVerticalScrollEndReach={handleScrollEndReach}
         processInstanceKey={processInstanceId}
         incidents={enhancedIncidents}
+        isProcessInstanceSuspended={
+          processInstance !== undefined && isInstanceSuspended(processInstance)
+        }
         decisionInstancesByElementKey={decisionInstancesByElementKey}
         childInstanceWithIncident={childInstanceWithIncident}
       />

--- a/operate/client/src/modules/components/IncidentOperation/index.test.tsx
+++ b/operate/client/src/modules/components/IncidentOperation/index.test.tsx
@@ -45,6 +45,14 @@ describe('IncidentOperation', () => {
     mockGetIncident().withSuccess(createIncident({state: 'RESOLVED'}));
   });
 
+  it('should disable retry when disabled is true', () => {
+    render(<IncidentOperation incidentKey="123" jobKey={null} disabled />, {
+      wrapper: Wrapper,
+    });
+
+    expect(retryButton()).toBeDisabled();
+  });
+
   it('should display an notification when retrying an incident fails', async () => {
     mockResolveIncident().withServerError(500);
     const {user} = render(

--- a/operate/client/src/modules/components/IncidentOperation/index.tsx
+++ b/operate/client/src/modules/components/IncidentOperation/index.tsx
@@ -18,6 +18,7 @@ import {useResolveIncident} from 'modules/mutations/incidents/useResolveIncident
 type IncidentOperationProps = {
   incidentKey: string;
   jobKey: string | null;
+  disabled?: boolean;
 };
 
 const IncidentOperation: React.FC<IncidentOperationProps> = (props) => {
@@ -50,7 +51,7 @@ const IncidentOperation: React.FC<IncidentOperationProps> = (props) => {
           onClick={handleClick}
           data-testid="retry-incident"
           title="Retry Incident"
-          disabled={isPending}
+          disabled={isPending || props.disabled}
           size="sm"
         />
       </OperationItems>

--- a/operate/client/src/modules/utils/instance/index.ts
+++ b/operate/client/src/modules/utils/instance/index.ts
@@ -12,8 +12,12 @@ const isInstanceRunning = (processInstance: ProcessInstance): boolean => {
   return processInstance.state === 'ACTIVE' || processInstance.hasIncident;
 };
 
+const isInstanceSuspended = (processInstance: ProcessInstance): boolean => {
+  return processInstance.state === 'SUSPENDED';
+};
+
 const getProcessDefinitionName = (instance: ProcessInstance) => {
   return instance.processDefinitionName ?? instance.processDefinitionId;
 };
 
-export {getProcessDefinitionName, isInstanceRunning};
+export {getProcessDefinitionName, isInstanceRunning, isInstanceSuspended};


### PR DESCRIPTION
## Description

On a suspended process instance that still has an incident, Operate left the incidents table Retry control enabled. Clicking it always showed "Operation could not be created" and dropped the engine `INVALID_STATE` reason.

This change disables Retry Incident when the process instance is suspended. The instance header and process list already hide retry for this state.

Closes #60721

## Test plan

- [ ] Open a process instance that has an incident
- [ ] Confirm Retry Incident is enabled on the Incidents tab
- [ ] Suspend the instance
- [ ] Confirm Retry Incident is disabled
- [ ] Resume the instance
- [ ] Confirm Retry Incident is enabled again