### PR TITLE
Recovery mode dashboard visibility

### DIFF
--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -3467,6 +3467,21 @@
               "legendFormat": "Unhealthy",
               "range": false,
               "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "count(\n(\n  min(zeebe_health{camunda_region=~\"$region\", namespace=~\"$namespace\"})\n  by (namespace)\n  == 2\n)\n* on(namespace)\ngroup_left(\n  label_cloud_camunda_io_generation,\n  label_cloud_camunda_io_sales_plan_type\n)\nmax(\n  kube_namespace_labels{\n    label_cloud_camunda_io_generation=~\"$generation\",\n    label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n  }\n) by (\n  namespace\n))",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Recovering",
+              "range": false,
+              "refId": "C"
             }
           ],
           "title": "Engine Health Overview",
@@ -3583,7 +3598,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg by (namespace) (\n  zeebe_health{camunda_region=~\"$region\", namespace=~\"$namespace\"}\n)\n* on(namespace)\ngroup_left(\n  label_cloud_camunda_io_generation,\n  label_cloud_camunda_io_sales_plan_type\n)\nmax(\n  kube_namespace_labels{\n    label_cloud_camunda_io_generation=~\"$generation\",\n    label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n  }\n) by (\n  namespace\n)",
+              "expr": "min by (namespace) (\n  zeebe_health{camunda_region=~\"$region\", namespace=~\"$namespace\"}\n)\n* on(namespace)\ngroup_left(\n  label_cloud_camunda_io_generation,\n  label_cloud_camunda_io_sales_plan_type\n)\nmax(\n  kube_namespace_labels{\n    label_cloud_camunda_io_generation=~\"$generation\",\n    label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n  }\n) by (\n  namespace\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "Partition {{partition}}",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -477,6 +477,9 @@
                     },
                     "1": {
                       "text": "Healthy"
+                    },
+                    "2": {
+                      "text": "Recovering"
                     }
                   },
                   "type": "value"
@@ -496,6 +499,10 @@
                   {
                     "color": "green",
                     "value": 1
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 2
                   }
                 ]
               }
@@ -1804,6 +1811,11 @@
                       "color": "dark-red",
                       "index": 3,
                       "text": "DEAD"
+                    },
+                    "2": {
+                      "color": "blue",
+                      "index": 4,
+                      "text": "RECOVERING"
                     }
                   },
                   "type": "value"

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -126,6 +126,7 @@ public interface PartitionManager {
         brokerStartupContext.getMeterRegistry(),
         brokerStartupContext.getGatewayBrokerTransport(),
         brokerStartupContext.getExportedPositionSupplier(physicalTenantId),
-        topologyManager);
+        topologyManager,
+        brokerStartupContext.getHealthCheckService().componentName());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartition.java
@@ -13,6 +13,8 @@ import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PHYSICAL_TENANT;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.partitioning.startup.steps.recovery.RecoveryBackupApiRequestHandlerStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.recovery.RecoveryBackupServiceStep;
+import io.camunda.zeebe.broker.partitioning.startup.steps.recovery.RecoveryMetricsStep;
+import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcess;
 import java.util.List;
@@ -45,6 +47,7 @@ public final class RecoveryPartition {
                 partitionId.group()),
             LOGGER,
             List.of(
+                new RecoveryMetricsStep(partitionId),
                 new RecoveryBackupServiceStep(partitionId),
                 new RecoveryBackupApiRequestHandlerStep(partitionId))));
   }
@@ -89,5 +92,9 @@ public final class RecoveryPartition {
 
   PartitionId partitionId() {
     return context.partitionId();
+  }
+
+  HealthMetrics healthMetrics() {
+    return context.getHealthMetrics();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -114,6 +114,7 @@ public final class RecoveryPartitionManager
   private final BrokerInfo brokerInfo;
   private final AtomixServerTransport gatewayBrokerTransport;
   private final @Nullable IntFunction<Long> exportedPositionSupplier;
+  private final String brokerComponentName;
   private @Nullable BackupStore backupStore;
   private @Nullable ExecutorService restoreExecutor;
 
@@ -128,7 +129,9 @@ public final class RecoveryPartitionManager
       final MeterRegistry meterRegistry,
       final AtomixServerTransport gatewayBrokerTransport,
       final @Nullable IntFunction<Long> exportedPositionSupplier,
-      final TopologyManagerImpl topologyManager) {
+      final TopologyManagerImpl topologyManager,
+      final String brokerComponentName) {
+    this.brokerComponentName = brokerComponentName;
     this.partitionGroup = partitionGroup;
     this.concurrencyControl = concurrencyControl;
     actorSchedulingService = schedulingService;
@@ -239,9 +242,11 @@ public final class RecoveryPartitionManager
                 // reported once the partition is registered as INACTIVE above, since
                 // onHealthChanged is a no-op for a partition the topology doesn't know about yet
                 recoveryPartitions.forEach(
-                    p ->
-                        topologyManager.onHealthChanged(
-                            p.partitionId().number(), HealthStatus.HEALTHY));
+                    p -> {
+                      topologyManager.onHealthChanged(
+                          p.partitionId().number(), HealthStatus.HEALTHY);
+                      p.healthMetrics().setRecovering();
+                    });
                 failedPartitionIds.forEach(
                     id -> topologyManager.onHealthChanged(id, HealthStatus.DEAD));
                 if (recoveryPartitions.isEmpty()) {
@@ -280,7 +285,8 @@ public final class RecoveryPartitionManager
         brokerCfg,
         brokerInfo,
         gatewayBrokerTransport,
-        backupStore);
+        backupStore,
+        brokerComponentName);
   }
 
   private void stopInternal(final ActorFuture<Void> result) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionStartupContext.java
@@ -12,12 +12,15 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.management.ReadOnlyBackupService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
+import io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics;
 import io.camunda.zeebe.broker.transport.backupapi.ReadOnlyBackupApiRequestHandler;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.nio.file.Path;
 import org.jspecify.annotations.Nullable;
 
@@ -34,8 +37,12 @@ public final class RecoveryPartitionStartupContext {
   private final BrokerInfo brokerInfo;
   private final AtomixServerTransport gatewayBrokerTransport;
   private final @Nullable BackupStore backupStore;
+  private final String brokerComponentName;
   private ReadOnlyBackupService backupService;
   private ReadOnlyBackupApiRequestHandler backupApiRequestHandler;
+  private CompositeMeterRegistry partitionMeterRegistry;
+  private HealthMetrics healthMetrics;
+  private HealthTreeMetrics healthTreeMetrics;
 
   public RecoveryPartitionStartupContext(
       final PartitionId partitionId,
@@ -47,7 +54,9 @@ public final class RecoveryPartitionStartupContext {
       final BrokerCfg brokerCfg,
       final BrokerInfo brokerInfo,
       final AtomixServerTransport gatewayBrokerTransport,
-      final @Nullable BackupStore backupStore) {
+      final @Nullable BackupStore backupStore,
+      final String brokerComponentName) {
+    this.brokerComponentName = brokerComponentName;
     this.partitionId = partitionId;
     this.partitionDirectory = partitionDirectory;
     this.schedulingService = schedulingService;
@@ -122,6 +131,39 @@ public final class RecoveryPartitionStartupContext {
   public RecoveryPartitionStartupContext setBackupApiRequestHandler(
       final ReadOnlyBackupApiRequestHandler backupApiRequestHandler) {
     this.backupApiRequestHandler = backupApiRequestHandler;
+    return this;
+  }
+
+  public CompositeMeterRegistry getPartitionMeterRegistry() {
+    return partitionMeterRegistry;
+  }
+
+  public RecoveryPartitionStartupContext setPartitionMeterRegistry(
+      final CompositeMeterRegistry partitionMeterRegistry) {
+    this.partitionMeterRegistry = partitionMeterRegistry;
+    return this;
+  }
+
+  public String brokerComponentName() {
+    return brokerComponentName;
+  }
+
+  public HealthTreeMetrics getHealthTreeMetrics() {
+    return healthTreeMetrics;
+  }
+
+  public RecoveryPartitionStartupContext setHealthTreeMetrics(
+      final HealthTreeMetrics healthTreeMetrics) {
+    this.healthTreeMetrics = healthTreeMetrics;
+    return this;
+  }
+
+  public HealthMetrics getHealthMetrics() {
+    return healthMetrics;
+  }
+
+  public RecoveryPartitionStartupContext setHealthMetrics(final HealthMetrics healthMetrics) {
+    this.healthMetrics = healthMetrics;
     return this;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/recovery/RecoveryMetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/recovery/RecoveryMetricsStep.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.startup.steps.recovery;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.partitioning.RecoveryPartitionStartupContext;
+import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
+import io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.startup.StartupStep;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+
+/**
+ * Wraps the broker meter registry with this partition's tags and registers the {@code zeebe.health}
+ * gauge plus a recovering node in the component health tree for the duration of recovery mode,
+ * mirroring {@link io.camunda.zeebe.broker.partitioning.startup.steps.MetricsStep} for the normal
+ * partition pipeline. Must run first on startup and last on shutdown so the gauges are unregistered
+ * before the partition manager stops - otherwise a partition that later starts processing again
+ * would register new gauges under the same names and tags, which Micrometer silently ignores in
+ * favor of the stale ones left behind here.
+ */
+public record RecoveryMetricsStep(PartitionId partitionId)
+    implements StartupStep<RecoveryPartitionStartupContext> {
+
+  @Override
+  public String getName() {
+    return "Recovery Partition %d - Metrics".formatted(partitionId.number());
+  }
+
+  @Override
+  public ActorFuture<RecoveryPartitionStartupContext> startup(
+      final RecoveryPartitionStartupContext context) {
+    final var partitionRegistry =
+        MicrometerUtil.wrap(context.meterRegistry(), PartitionKeyNames.tags(partitionId));
+    final var healthMetrics = new HealthMetrics(partitionRegistry);
+
+    // Reuse the component name and parent of the normal ZeebePartition so the partition keeps its
+    // row in the component health tree while it is recovering, instead of vanishing from it.
+    final var healthTreeMetrics = new HealthTreeMetrics(partitionRegistry);
+    final var componentName = ZeebePartition.componentName(partitionId);
+    healthTreeMetrics.registerRelationship(componentName, context.brokerComponentName());
+    healthTreeMetrics.registerRecoveringNode(componentName);
+
+    return CompletableActorFuture.completed(
+        context
+            .setPartitionMeterRegistry(partitionRegistry)
+            .setHealthMetrics(healthMetrics)
+            .setHealthTreeMetrics(healthTreeMetrics));
+  }
+
+  @Override
+  public ActorFuture<RecoveryPartitionStartupContext> shutdown(
+      final RecoveryPartitionStartupContext context) {
+    final var healthTreeMetrics = context.getHealthTreeMetrics();
+    if (healthTreeMetrics != null) {
+      healthTreeMetrics.close();
+    }
+    MicrometerUtil.close(context.getPartitionMeterRegistry());
+    return CompletableActorFuture.completed(
+        context.setPartitionMeterRegistry(null).setHealthMetrics(null).setHealthTreeMetrics(null));
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
@@ -32,4 +32,8 @@ public final class HealthMetrics {
   public void setDead() {
     health.set(-1);
   }
+
+  public void setRecovering() {
+    health.set(2);
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetricsDoc.java
@@ -28,7 +28,8 @@ public enum HealthMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public String getDescription() {
-      return "Shows current health of the partition (1 = healthy, 0 = unhealthy, -1 = dead)";
+      return "Shows current health of the partition (1 = healthy, 0 = unhealthy, -1 = dead,"
+          + " 2 = recovering)";
     }
 
     @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetrics.java
@@ -18,16 +18,21 @@ import io.micrometer.core.instrument.Tags;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class HealthTreeMetrics implements ComponentTreeListener {
+  public static final int RECOVERING_VALUE = 2;
   private static final Logger LOG = LoggerFactory.getLogger(HealthTreeMetrics.class);
   private static final int MAX_PATH_ITERATIONS = 8;
   private final MeterRegistry meterRegistry;
   private final Map<String, Meter.Id> meters = new HashMap<>();
   // Map of child -> parent: a child only has 1 parent
   private final Map<String, String> relationships = new HashMap<>();
+  // Holds the value suppliers of recovering nodes: Micrometer keeps only a weak reference to the
+  // object a gauge reads from, so without this the gauge would start reporting NaN once collected
+  private final Map<String, AtomicInteger> recoveringValues = new HashMap<>();
   private final Tags extraTags;
 
   public HealthTreeMetrics(final MeterRegistry meterRegistry) {
@@ -78,12 +83,37 @@ public final class HealthTreeMetrics implements ComponentTreeListener {
     }
   }
 
+  /**
+   * Registers a node that constantly reports {@link #RECOVERING_VALUE}, for a component that exists
+   * only while its partition is in recovery mode. Such a component has no {@link
+   * io.camunda.zeebe.util.health.HealthReport} of its own, so {@link
+   * #registerNode(HealthMonitorable)} cannot be used; register any relationship first so the
+   * reported path matches the one the normal component uses.
+   */
+  public void registerRecoveringNode(final String componentName) {
+    final var value = new AtomicInteger(RECOVERING_VALUE);
+    final var meterDoc = HealthMetricsDoc.NODES;
+    final var builder =
+        Gauge.builder(meterDoc.getName(), value, AtomicInteger::intValue)
+            .description(meterDoc.getDescription())
+            .tag(NodesKeyNames.ID.asString(), componentName)
+            .tag(NodesKeyNames.PATH.asString(), pathOf(componentName));
+
+    if (extraTags != null) {
+      builder.tags(extraTags);
+    }
+
+    recoveringValues.put(componentName, value);
+    meters.put(componentName, builder.register(meterRegistry).getId());
+  }
+
   @Override
   public void close() {
     for (final var id : meters.values()) {
       meterRegistry.remove(id);
     }
     meters.clear();
+    recoveringValues.clear();
   }
 
   private Gauge buildNodeGauge(final HealthMonitorable component) {
@@ -119,6 +149,7 @@ public final class HealthTreeMetrics implements ComponentTreeListener {
 
   private void removeFromRegistry(final String metricName) {
     final var meterId = meters.remove(metricName);
+    recoveringValues.remove(metricName);
     if (meterId != null) {
       meterRegistry.remove(meterId);
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
@@ -158,7 +158,8 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
             new SimpleMeterRegistry(),
             transport,
             (ignored) -> 0L,
-            topologyManager);
+            topologyManager,
+            "Broker-0");
 
     // exit manager: a lightweight fake standing in for a real Raft-based PartitionManagerImpl -
     // it just marks both local partitions LEADER on start, matching what PartitionModeHandlerTest

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -58,6 +58,7 @@ final class RecoveryPartitionManagerTest {
   private static final String GROUP = PartitionManagerImpl.DEFAULT_GROUP_NAME;
   private static final int PARTITION_ID = 1;
   private static final int PARTITION_ID_2 = 2;
+  private static final String BROKER_COMPONENT_NAME = "Broker-0";
 
   private ActorScheduler actorScheduler;
   private Actor controlActor;
@@ -69,6 +70,7 @@ final class RecoveryPartitionManagerTest {
   private TopologyManagerImpl topologyManager;
   private BrokerInfo brokerInfo;
   private AtomixServerTransport transport;
+  private SimpleMeterRegistry meterRegistry;
 
   @BeforeEach
   void setUp() {
@@ -104,6 +106,7 @@ final class RecoveryPartitionManagerTest {
         .thenReturn(CompletableActorFuture.completed(null));
     when(transport.unsubscribe(any(), any())).thenReturn(CompletableActorFuture.completed(null));
 
+    meterRegistry = new SimpleMeterRegistry();
     partitionManager = buildManager(new BrokerCfg(), actorScheduler);
   }
 
@@ -117,10 +120,11 @@ final class RecoveryPartitionManagerTest {
         clusterConfigurationService,
         clusterServices.getMembershipService(),
         schedulingService,
-        new SimpleMeterRegistry(),
+        meterRegistry,
         transport,
         null,
-        topologyManager);
+        topologyManager,
+        BROKER_COMPONENT_NAME);
   }
 
   private PartitionMetadata localPartitionMetadata(final int partitionId) {
@@ -246,6 +250,95 @@ final class RecoveryPartitionManagerTest {
                               .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
                               .containsEntry(PARTITION_ID_2, PartitionHealthStatus.HEALTHY));
             });
+  }
+
+  @Test
+  void shouldReportRecoveringHealthMetricAfterStartCompletes() {
+    // when
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - each successfully recovered partition's zeebe.health gauge reports the recovering
+    // code (distinct from 1=healthy/0=unhealthy/-1=dead), since these partitions are inactive and
+    // not yet processing, just kept alive for read-only backup access during broker restore
+    assertThat(healthGaugeValue(PARTITION_ID)).isEqualTo(2);
+    assertThat(healthGaugeValue(PARTITION_ID_2)).isEqualTo(2);
+  }
+
+  @Test
+  void shouldRemoveHealthGaugeOnStop() {
+    // given - the gauge exists once recovery has started
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(healthGaugeValue(PARTITION_ID)).isEqualTo(2);
+
+    // when
+    assertThat(partitionManager.stop()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - the gauge is fully unregistered rather than left stale; Micrometer's
+    // Gauge.builder(...).register() silently ignores a re-registration under the same name+tags,
+    // so leaving it behind would make the next HealthMetrics registered for this partition (e.g.
+    // by the normal ZeebePartition once the cluster exits recovery mode) permanently stuck at 2
+    assertThat(
+            meterRegistry
+                .find("zeebe.health")
+                .tags("physicalTenant", GROUP, "partition", String.valueOf(PARTITION_ID))
+                .gauge())
+        .isNull();
+  }
+
+  @Test
+  void shouldReportRecoveringInHealthTreeAfterStartCompletes() {
+    // when
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - the partition also appears as a node in the component health tree that feeds the
+    // "Health status timeline" panel, under the same id and path the normal ZeebePartition uses,
+    // so the row stays in place across the mode switch instead of disappearing during recovery
+    assertThat(healthTreeGaugeValue(PARTITION_ID)).isEqualTo(2);
+    assertThat(healthTreeGaugeValue(PARTITION_ID_2)).isEqualTo(2);
+  }
+
+  @Test
+  void shouldRemoveHealthTreeNodeOnStop() {
+    // given
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(healthTreeGaugeValue(PARTITION_ID)).isEqualTo(2);
+
+    // when
+    assertThat(partitionManager.stop()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - the node is unregistered, so the normal ZeebePartition can claim the same id/path
+    // once the cluster leaves recovery mode
+    assertThat(
+            meterRegistry
+                .find("zeebe.broker.health.nodes")
+                .tags("physicalTenant", GROUP, "partition", String.valueOf(PARTITION_ID))
+                .gauge())
+        .isNull();
+  }
+
+  private double healthTreeGaugeValue(final int partitionId) {
+    final var componentName = "Partition-%s-%d".formatted(GROUP, partitionId);
+    return meterRegistry
+        .get("zeebe.broker.health.nodes")
+        .tags(
+            "physicalTenant",
+            GROUP,
+            "partition",
+            String.valueOf(partitionId),
+            "id",
+            componentName,
+            "path",
+            BROKER_COMPONENT_NAME + "/" + componentName)
+        .gauge()
+        .value();
+  }
+
+  private double healthGaugeValue(final int partitionId) {
+    return meterRegistry
+        .get("zeebe.health")
+        .tags("physicalTenant", GROUP, "partition", String.valueOf(partitionId))
+        .gauge()
+        .value();
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthMetricsTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthMetricsTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+final class HealthMetricsTest {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final HealthMetrics healthMetrics = new HealthMetrics(registry);
+
+  @Test
+  void shouldReportRecoveringAsTwo() {
+    // when
+    healthMetrics.setRecovering();
+
+    // then
+    assertThat(registry.get("zeebe.health").gauge().value()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Provide visibility in Grafana in terms of the partition's mode state. 

<img width="956" height="119" alt="image" src="https://github.com/user-attachments/assets/7651d14b-b828-4845-841b-e1e6fa4c2acc" />

<img width="860" height="417" alt="image" src="https://github.com/user-attachments/assets/6bdf4fdf-9065-4c51-826a-a7db01fa7e0a" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #56005 
