### PR TITLE
ci: route push-triggered CI failures to their owning teams

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -24,6 +24,7 @@ on:
 
 env:
   GO_VERSION: ">= 1.23.1"
+  TEST_OWNER: '@camunda/distribution'
 
 permissions:
   actions: write

--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   GCS_BUILD_CACHE_BUCKET: camunda-monorepo-ci-artifacts
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   build-distball:

--- a/.github/workflows/ci-client-components.yml
+++ b/.github/workflows/ci-client-components.yml
@@ -2,7 +2,7 @@
 # test location: /client-components
 # called by: ci.yml
 # type: CI
-# owner: @camunda/engineering-operations
+# owner: @camunda/core-features
 name: Client Components Jobs
 
 on:
@@ -11,6 +11,7 @@ on:
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
   CLIENT_DIR: client-components
+  TEST_OWNER: '@camunda/core-features'
 
 jobs:
   lint:

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -45,6 +45,10 @@ on:
         description: "CI runner type for the tests"
         default: gcp-core-32-default
         type: string
+      test-owner:
+        description: "Canonical GitHub team handle owning these tests, propagated to CI Analytics for alert routing"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -54,6 +58,7 @@ defaults:
 
 # Define environment variable for concurrency
 env:
+  TEST_OWNER: ${{ inputs.test-owner }}
   BRANCH_NAME: ${{ inputs.branch }}
   LIMITS_CPU: ${{ inputs.forkCount }}  # consumed by `maven-surefire-plugin` & `maven-failsafe-plugin` plugins defined in main `pom.xml` file
   GHA_BEST_PRACTICES_LINTER: enabled

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -61,6 +61,7 @@ jobs:
       command: ./mvnw -f operate/qa/integration-tests verify -P operateCoreFeaturesIT -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Core Features ITs
       runner-type: gcp-core-32-default
+      test-owner: '@camunda/core-features'
 
   run-data-layer-opensearch-tests:
     name: "Integration"
@@ -71,3 +72,4 @@ jobs:
       command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Opensearch ITs
       runner-type: gcp-core-32-default
+      test-owner: '@camunda/data-layer'

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -36,6 +36,9 @@ concurrency:
   cancel-in-progress: true
   group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
 
+env:
+  TEST_OWNER: '@camunda/core-features'
+
 jobs:
   # does not meet the 10 minute runtime as required by the unified CI
   integration-tests:

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -40,6 +40,7 @@ defaults:
 
 # Define environment variable for concurrency
 env:
+  TEST_OWNER: '@camunda/core-features'
   LIMITS_CPU: ${{ inputs.forkCount }}  # consumed by `maven-surefire-plugin` & `maven-failsafe-plugin` plugins defined in main `pom.xml` file
 
 jobs:


### PR DESCRIPTION
## Problem

Six workflows reachable from an `on: push` trigger call the `observe-build-status` action with no `TEST_OWNER` in scope. They submit an empty `user_description` to CI Analytics, so incidents opened from their failures carry no owning team and alert routing cannot pick a team medic — each one has to be attributed by hand.

Two of them (`c8run-build`, `operate-docker-tests`) never declared the variable. The other four are reusable workflows, where the cause is easier to miss: **`env` declared in a calling workflow does not cross a `workflow_call` boundary.** Declaring the handle in `operate-ci.yml` or `tasklist-ci.yml` has no effect on the workflow that actually runs the observe step — it looks like coverage while providing none.

## Changes

| Workflow | Reached via | Handle |
|---|---|---|
| `c8run-build.yaml` | direct `on: push` | `@camunda/distribution` |
| `operate-docker-tests.yml` | direct `on: push` | `@camunda/core-features` |
| `ci-build-distball-reusable.yml` | `ci.yml` | `@camunda/engineering-operations` |
| `ci-client-components.yml` | `ci.yml` | `@camunda/core-features` |
| `tasklist-ci-test-reusable.yml` | `tasklist-ci.yml` | `@camunda/core-features` |
| `operate-ci-test-reusable.yml` | `operate-ci.yml` | threaded per call site |

`operate-ci-test-reusable` needed different treatment because it is shared by two teams — `operate-ci.yml` calls it once for Core Features ITs and once for Data Layer Opensearch ITs. A single workflow-level handle would misattribute one team's failures to the other, which is worse than no attribution, so the handle is threaded in as a `test-owner` input supplied per call site. The input is **required** rather than defaulted so actionlint rejects any future caller that omits it; a default would let the gap reappear silently, which is how the original gap survived this long.

This also corrects `ci-client-components.yml`'s owner comment, which claimed `@camunda/engineering-operations` while `.codeowners` maps both that workflow ([L228](https://github.com/camunda/camunda/blob/256d8a8f3451cbf35149bc8f480782ba46ced7ea/.codeowners#L228)) and `/client-components/` ([L201](https://github.com/camunda/camunda/blob/256d8a8f3451cbf35149bc8f480782ba46ced7ea/.codeowners#L201)) to `@camunda/core-features`. The comment was wrong from creation rather than drifting: the workflow was added naming `@camunda/monorepo-devops-team`, and the later rename of that team propagated the mistake mechanically. Handles otherwise come from `.codeowners`, documented in `docs/monorepo-docs/ci.md` as the source of truth; `ci-build-distball-reusable` has no `.codeowners` rule, so its handle comes from its own owner comment.

## Validation

- `actionlint` clean on all changed files (only the repo-wide pre-existing `[runner-label]` noise for self-hosted labels).
- `conftest` against `.github/*.rego`: 0 failures. The 3 warnings are byte-identical to a baseline run against the pre-change versions of the same files.
- Negative check on the new required input, via throwaway callers: omitting `test-owner` gives `input "test-owner" is required by ... [workflow-call]`; typo'ing it as `test_owner` is flagged as both missing and undefined; the correct form is clean. The enforcement runs in `ci.yml`'s actionlint step on every PR.
- No spotless run: the diff is entirely `.github/workflows/*.y*ml`, and spotless covers only markdown, Java, and POMs.

## Note on sequencing

`main` has the identical gap in all six files, and this PR targets `stable/8.9` only. Since backport automation runs `main` → `stable/*` and not the reverse, `main` needs its own PR — otherwise the next branch cut from it reintroduces the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
