### PR TITLE
test: isolate UnifiedConfigurationHelper's static environment between test classes

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperResetListener.java
+++ b/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperResetListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+/**
+ * Resets {@link UnifiedConfigurationHelper}'s static {@code environment} reference after every
+ * Spring test class (including {@code @Nested} classes, which each get their own {@link
+ * TestContext}).
+ *
+ * <p>{@link UnifiedConfigurationHelper} pins the {@code Environment} of whichever
+ * ApplicationContext last constructed it into a static field, used as a legacy-configuration
+ * fallback. Spring caches and reuses test contexts, so that reference otherwise survives past the
+ * test class that created it and leaks into whichever test runs next in the same JVM — including
+ * plain-POJO tests that build a {@link Camunda} without any Spring context at all, silently
+ * corrupting their legacy-property fallback with a stale environment from an unrelated test.
+ */
+public class UnifiedConfigurationHelperResetListener extends AbstractTestExecutionListener {
+
+  @Override
+  public void afterTestClass(final TestContext testContext) {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/RdbmsExporterPhysicalTenantConfigTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/RdbmsExporterPhysicalTenantConfigTest.java
@@ -11,10 +11,13 @@ import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.exporter.rdbms.ExporterConfiguration;
 import java.time.Duration;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -29,14 +32,26 @@ class RdbmsExporterPhysicalTenantConfigTest {
   private static final String TENANT_A = "tenanta";
   private static final String TENANT_B = "tenantb";
 
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
   @Test
   void shouldResolveExporterConfigurationPerPhysicalTenant() {
     // given three physical tenants (the default plus two named) each with its own rdbms settings
-    final MockEnvironment environment = new MockEnvironment();
     environment.setProperty("camunda.data.secondary-storage.type", "rdbms");
-    configureTenant(environment, DEFAULT_PHYSICAL_TENANT_ID, "10", "PT1S");
-    configureTenant(environment, TENANT_A, "100", "PT2S");
-    configureTenant(environment, TENANT_B, "500", "PT9S");
+    configureTenant(DEFAULT_PHYSICAL_TENANT_ID, "10", "PT1S");
+    configureTenant(TENANT_A, "100", "PT2S");
+    configureTenant(TENANT_B, "500", "PT9S");
 
     final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, new Camunda());
 
@@ -62,11 +77,8 @@ class RdbmsExporterPhysicalTenantConfigTest {
         .isEqualTo(Duration.ofSeconds(1));
   }
 
-  private static void configureTenant(
-      final MockEnvironment environment,
-      final String tenantId,
-      final String queueSize,
-      final String flushInterval) {
+  private void configureTenant(
+      final String tenantId, final String queueSize, final String flushInterval) {
     final String base = "camunda.physical-tenants." + tenantId + ".";
     // A distinct storage location per tenant satisfies the secondary-storage isolation validation.
     environment.setProperty(

--- a/configuration/src/test/resources/META-INF/spring.factories
+++ b/configuration/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.test.context.TestExecutionListener=\
+io.camunda.configuration.UnifiedConfigurationHelperResetListener


### PR DESCRIPTION
## Summary

`RdbmsExporterPhysicalTenantConfigTest` is flaky in CI, failing with a false "physical tenants share the same backup location" error depending on which test ran before it. Example failing job: https://github.com/camunda/camunda/actions/runs/32743395201/job/97483168792

## Root cause

`UnifiedConfigurationHelper.environment` is a `static` field, overwritten as a side effect whenever a `UnifiedConfigurationHelper` Spring bean is constructed. Many test classes in the `configuration` module use `@SpringJUnitConfig({..., UnifiedConfigurationHelper.class})` with their own `@TestPropertySource` values, and none reset this static field afterward. Whichever such test runs last leaves its `Environment` pinned globally, so an unrelated test that never touches Spring at all (like `RdbmsExporterPhysicalTenantConfigTest`, which builds a plain `Camunda` POJO) can silently inherit stale legacy configuration through it.

Concretely: `DataBackupBrokerPropertiesTest$WithNewAndLegacySet` (which sets the legacy `camunda.data.backup.store=azure` property) runs before `RdbmsExporterPhysicalTenantConfigTest` and leaves the static environment pointing at its context. `PrimaryStorageBackup.getStore()` reads that leaked environment via `UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(...)`, finds the legacy AZURE key set with no new key present, and falls back to `AZURE` for every physical tenant's backup store — collapsing all tenants onto the same default Azure location and tripping `PrimaryStorageBackupIsolationValidation`'s collision check.

## Fix

Added a Spring `TestExecutionListener`, auto-registered via `META-INF/spring.factories` in test resources, that resets `UnifiedConfigurationHelper`'s static environment after every Spring test class (and `@Nested` class) finishes. This requires no changes to the many existing `@SpringJUnitConfig` test files and only affects the test classpath.