### PR TITLE
ci: add nightly QA workflows for stable/8.10

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -50,9 +50,9 @@ jobs:
           BRANCH: ${{ github.event.inputs.branch }}
         run: |
           echo "Detecting base branch for input branch: $BRANCH"
-          git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 main "$BRANCH"
+          git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 stable/8.10 main "$BRANCH"
           base="main"
-          for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 main; do
+          for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 stable/8.10 main; do
             if git merge-base --is-ancestor origin/$candidate "origin/$BRANCH"; then
               base="$candidate"
               break

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -91,6 +91,8 @@ jobs:
             base="stable/8.8"
           elif [[ "$major_minor" == "8.9" ]]; then
             base="stable/8.9"
+          elif [[ "$major_minor" == "8.10" ]]; then
+            base="stable/8.10"
           else
             base="main"
           fi

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-es.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-es.yml
@@ -1,0 +1,34 @@
+# description: Nightly Elasticsearch API tests for stable/8.10
+# test location: /qa/c8-orchestration-cluster-e2e-test-suite
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: C8 Orchestration Cluster Nightly 8.10 - API Tests (ES)
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-api-tests-es:
+    uses: ./.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+    with:
+      branch: stable/8.10
+    secrets: inherit
+
+  nightly-api-tests-es-all-in-one:
+    uses: ./.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+    with:
+      branch: stable/8.10
+      camunda_mode: all-in-one
+    secrets: inherit
+
+  nightly-analytics-exporter-tests:
+    uses: ./.github/workflows/c8-orchestration-cluster-reusable-analytics-exporter-tests.yml
+    with:
+      branch: stable/8.10
+    secrets: inherit

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-rdbms.yml
@@ -1,0 +1,66 @@
+# description: Nightly RDBMS API tests for stable/8.10 — builds the Camunda distribution
+#              and runs the full database matrix (Postgres, MySQL, MariaDB, MSSQL, Oracle).
+# test location: /qa/c8-orchestration-cluster-e2e-test-suite
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: C8 Orchestration Cluster Nightly 8.10 - API Tests (RDBMS)
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-api-tests-rdbms:
+    uses: ./.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+    with:
+      branch: stable/8.10
+    secrets: inherit
+
+  nightly-api-tests-rdbms-all-in-one:
+    uses: ./.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+    with:
+      branch: stable/8.10
+      camunda_mode: all-in-one
+    secrets: inherit
+
+  # Auto-retry when a matrix leg failed because its self-hosted runner was
+  # terminated mid-job (spot preemption / autoscaler scale-down / node eviction)
+  # rather than a real test failure. The reusable action only re-runs the failed
+  # jobs when one of the runner-shutdown messages is present in the run logs, so
+  # genuine test failures are never masked. Capped at two retries via run_attempt.
+  rerun-failed-jobs:
+    needs:
+      - nightly-api-tests-rdbms
+      - nightly-api-tests-rdbms-all-in-one
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
+        with:
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.10-e2e.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.10-e2e.yml
@@ -1,0 +1,22 @@
+# description: Nightly E2E tests for stable/8.10 (Tasklist V2 only — V1 is not present on 8.10).
+# test location: /qa/c8-orchestration-cluster-e2e-test-suite
+# type: CI
+# owner: @camunda/test-automation-team
+---
+name: C8 Orchestration Cluster Nightly 8.10 - E2E Tests
+
+on:
+  schedule:
+    - cron: "15 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-e2e-tests-v2:
+    uses: ./.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+    with:
+      branch: stable/8.10
+      tasklist_mode: v2
+    secrets: inherit

--- a/.github/workflows/c8-orchestration-cluster-nightly-metrics-report.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-metrics-report.yml
@@ -118,6 +118,7 @@ jobs:
             "8.7|c8-orchestration-cluster-nightly-8.7-api-es.yml" \
             "8.8|c8-orchestration-cluster-nightly-8.8-api-es.yml" \
             "8.9|c8-orchestration-cluster-nightly-8.9-api-es.yml" \
+            "8.10|c8-orchestration-cluster-nightly-8.10-api-es.yml" \
             "main|c8-orchestration-cluster-nightly-main-api-es.yml"; do
             build_line "${entry%%|*}" "${entry#*|}"
             api_es_lines+="${BUILD_LINE_RESULT}"$'\n'
@@ -129,6 +130,7 @@ jobs:
           api_rdbms_success=0; api_rdbms_total=0; api_rdbms_lines=""
           for entry in \
             "8.9|c8-orchestration-cluster-nightly-8.9-api-rdbms.yml" \
+            "8.10|c8-orchestration-cluster-nightly-8.10-api-rdbms.yml" \
             "main|c8-orchestration-cluster-nightly-main-api-rdbms.yml"; do
             build_line "${entry%%|*}" "${entry#*|}"
             api_rdbms_lines+="${BUILD_LINE_RESULT}"$'\n'
@@ -142,6 +144,7 @@ jobs:
             "8.7|c8-orchestration-cluster-nightly-8.7-e2e.yml" \
             "8.8|c8-orchestration-cluster-nightly-8.8-e2e.yml" \
             "8.9|c8-orchestration-cluster-nightly-8.9-e2e.yml" \
+            "8.10|c8-orchestration-cluster-nightly-8.10-e2e.yml" \
             "main|c8-orchestration-cluster-nightly-main-e2e.yml"; do
             build_line "${entry%%|*}" "${entry#*|}"
             e2e_es_lines+="${BUILD_LINE_RESULT}"$'\n'


### PR DESCRIPTION
`stable/8.10` was cut and protected today, so the QA workflows need to know about it. This turned out to be **five separate places**, not the two originally reported.

## 1. New nightly workflows (3 files)

| Workflow | Cron (UTC) |
|---|---|
| `c8-orchestration-cluster-nightly-8.10-api-es.yml` | `0 2` |
| `c8-orchestration-cluster-nightly-8.10-api-rdbms.yml` | `0 2` |
| `c8-orchestration-cluster-nightly-8.10-e2e.yml` | `15 2` |

**Mirrored from `main`, not 8.9.** The request asked for "the 8.10 equivalents mirroring the existing 8.9 ones", but `stable/8.10` was cut from main and differs from 8.9 in two ways that would have produced broken workflows:

**E2E is Tasklist V2 only.** 8.9 runs both modes and its `playwright.config.ts` carries `tasklist-v1-e2e` *and* `tasklist-v2-e2e`. On `stable/8.10` there is a single `tasklist-e2e` project and no v1 variant — matching main, whose header states *"V1 is removed from main"*. Copying 8.9 would have added a `tasklist_mode: v1` job with nothing to run.

```
8.9  projects: … tasklist-v1-e2e  tasklist-v2-e2e  identity-e2e  operate-e2e …
8.10 projects: … tasklist-e2e     identity-e2e     operate-e2e   optimize-default-config
                 optimize-startup  analytics-exporter-isolated …
```

**`api-es` needs the analytics-exporter job.** `stable/8.10` has `zeebe/exporters/analytics-exporter` and an `analytics-exporter-isolated` project. 8.9 has neither and its `api-es` workflow has no such job — mirroring 8.9 would have silently dropped that coverage.

**Three workflows, not two.** The request named only `-api-es` and `-e2e`, but 8.9 and main both also carry `-api-rdbms`. Without it 8.10 loses the entire Postgres/MySQL/MariaDB/MSSQL/Oracle matrix.

Cron slots continue the existing 15-minute cadence with no collisions — 8.7 `0:00/0:15`, 8.8 `0:30/0:45`, 8.9 `1:00/1:15`, main `1:30/1:45`, so 8.10 takes `2:00/2:15`. As on 8.9 and main, `api-es` and `api-rdbms` share the branch slot. The rdbms file is a verbatim copy of main's apart from description, name, cron and the two `branch` inputs, so the runner-shutdown auto-retry and build-status observation carry over unchanged.

## 2. Nightly metrics report (3 list entries)

Adding workflow files is not sufficient. `c8-orchestration-cluster-nightly-metrics-report.yml` does **not** discover workflows — it iterates three hardcoded lists of `"<version>|<workflow file>"` pairs (API/ES, API/RDBMS, E2E/ES). Without registration the 8.10 nightlies would have run and posted to Slack individually but been **absent from the daily report**, with every category's success ratio still counting four branches instead of five.

8.10 added to all three lists, between 8.9 and main to preserve the documented "versions ASC" ordering.

## 3. Release workflow

`c8-orchestration-cluster-e2e-tests-release.yml` maps a release version to a base branch:

```bash
elif [[ "$major_minor" == "8.9" ]]; then base="stable/8.9"
else base="main"          # ← 8.10 landed here
```

Validating an `8.10.x` release resolved `base="main"` — now 8.11. The RDBMS gate happens to allow `main`, so it would have *looked* fine, but per the file's own comment `base` drives "which test directories to run, `NON_STANDALONE` for 8.6/8.7, RDBMS matrix gating". All of it would have reasoned about 8.11 while testing an 8.10 release. Added the `8.10` arm.

## 4. On-demand workflow

`c8-orchestration-cluster-e2e-tests-on-demand.yml` never fetched or considered `stable/8.10`:

```bash
git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 main "$BRANCH"
for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 main; do
```

A branch cut from `stable/8.10` matches no candidate — `main` is not an ancestor once the lines diverged — so detection defaulted to `main`. Added `stable/8.10` to both, ascending before `main`.

This one fails *quietly and plausibly*: the mode and RDBMS gates key off `stable/8.9 || main`, so a mislabelled 8.10 branch still gets both camunda modes and RDBMS. Right behaviour, wrong reason — and it would have kept reporting `Detected base branch: main` for 8.10 work indefinitely.

## Verified as already correct — deliberately unchanged

- **`forward-compatibility-tests.yml`** discovers stable branches via the `list-maintained-branches` action (`min-version: '8.8'`) and builds consecutive pairs; its own comment cites `8.9→8.10`. Picks up 8.10 automatically.
- **The three reusable workflows** (`reusable-api-tests`, `reusable-e2e-tests`, `reusable-rdbms-api-tests`) only special-case `stable/8.7` for the single-services legacy path. 8.10 takes the modern default.

## Verification

- All five files parse as YAML; new workflow job names confirmed.
- All four referenced reusable workflows exist on main: `reusable-api-tests`, `reusable-e2e-tests`, `reusable-rdbms-api-tests`, `reusable-analytics-exporter-tests`.
- The modified `run:` steps in metrics-report, release and on-demand are `bash -n` clean (GHA expressions stubbed).
- No stray `main` references in the new nightly files; `stable/8.10` confirmed to exist and be protected.
- Diffs to existing files are minimal: metrics-report +3 lines, release +2, on-demand 2 changed.

Schedules can only really be proven by the first nightly; each new workflow also has `workflow_dispatch` if you'd rather trigger one now than wait for 02:00 UTC.

## Follow-up worth doing separately

This PR touches **four hand-maintained branch enumerations** (metrics ×3 lists, release ×1 mapping, on-demand ×2 lines), none of which has a test that catches an omission, and all of which fail quietly by defaulting to `main`. `forward-compatibility-tests.yml` already solves this properly by deriving branches from `list-maintained-branches`. Applying that pattern to the other four would make the 8.11 cut a no-op — suggest a follow-up rather than expanding scope here.

Also flagged for other teams: a repo-wide sweep for `stable/8.9` in `.github/workflows` additionally hit `c8run-release-rc.yaml`, `zeebe-release-stable-dry-run.yml`, `data-layer-nightly-tests.yml`, `optimize-*-nightly.yml`, `camunda-*-compatibility-trigger.yml` and `alwaysgreen-*.yml`. Those are other teams' and unaudited — their owners should check for hardcoded branch lists after this cut.

Requested by @Lilian Cavalet in #ask-test-automation following the `stable/8.10` cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
