### PR TITLE
ci: route 8.10 in the release and on-demand QA workflows

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -50,9 +50,9 @@ jobs:
           BRANCH: ${{ github.event.inputs.branch }}
         run: |
           echo "Detecting base branch for input branch: $BRANCH"
-          git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 main "$BRANCH"
+          git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 stable/8.10 main "$BRANCH"
           base="main"
-          for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 main; do
+          for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 stable/8.10 main; do
             if git merge-base --is-ancestor origin/$candidate "origin/$BRANCH"; then
               base="$candidate"
               break

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -91,6 +91,8 @@ jobs:
             base="stable/8.8"
           elif [[ "$major_minor" == "8.9" ]]; then
             base="stable/8.9"
+          elif [[ "$major_minor" == "8.10" ]]; then
+            base="stable/8.10"
           else
             base="main"
           fi


### PR DESCRIPTION
Follow-up to the `stable/8.10` cut, split out from #61000 because it touches the release path and deserves its own review.

Both workflows resolve a base branch from a hardcoded list that stops at 8.9, so **8.10 silently falls through to `main`** — which is now 8.11.

## Release workflow

`c8-orchestration-cluster-e2e-tests-release.yml` maps the release version to a base branch:

```bash
elif [[ "$major_minor" == "8.9" ]]; then base="stable/8.9"
else base="main"          # ← 8.10 landed here
```

Validating an `8.10.x` release resolved `base="main"`. The RDBMS gate happens to allow `main`, so this would have *looked* fine — but per the file's own comment `base` drives "which test directories to run, `NON_STANDALONE` for 8.6/8.7, RDBMS matrix gating". All of that would have reasoned about **8.11** while testing an **8.10** release.

Added the `8.10` arm.

## On-demand workflow

`c8-orchestration-cluster-e2e-tests-on-demand.yml` never fetched or considered `stable/8.10`:

```bash
git fetch origin stable/8.6 stable/8.7 stable/8.8 stable/8.9 main "$BRANCH"
for candidate in stable/8.6 stable/8.7 stable/8.8 stable/8.9 main; do
```

A branch cut from `stable/8.10` matches no candidate — `main` isn't an ancestor once the two lines diverged — so base detection defaulted to `main`. Added `stable/8.10` to both, in ascending order before `main`.

Worth noting this one fails *quietly and plausibly*: the mode and RDBMS gates at lines 73 and 303 key off `stable/8.9 || main`, so an 8.10 branch mislabelled as `main` still gets both camunda modes and RDBMS. Right behaviour, wrong reason — and it would have kept reporting `Detected base branch: main` for 8.10 work indefinitely.

## Verified as already correct — no change needed

- **`forward-compatibility-tests.yml`** discovers stable branches via the `list-maintained-branches` action (`min-version: '8.8'`) and builds consecutive pairs; its own comment cites `8.9→8.10`. Picks up 8.10 automatically.
- **The three reusable workflows** (`reusable-api-tests`, `reusable-e2e-tests`, `reusable-rdbms-api-tests`) only special-case `stable/8.7` for the single-services legacy path. 8.10 takes the modern default.

## Verification

Both files parse as YAML, and the two modified `run:` steps are `bash -n` clean with GHA expressions stubbed. Diff is 2 added lines in the release file and 2 changed lines in on-demand — nothing else.

## Pattern worth fixing properly

This is the same class of bug as the nightly metrics report in #61000: a central list enumerating branches that needs a manual entry per release cut, with no test that catches the omission. Between the two PRs that's **four** such lists (metrics ×3, release ×1, on-demand ×2 lines). Deriving them from `list-maintained-branches` — the way `forward-compatibility-tests.yml` already does — would make the 8.11 cut a no-op. Suggest raising that as a follow-up rather than doing it here.

## Out of scope but flagged

A repo-wide sweep for `stable/8.9` in `.github/workflows` also hit `c8run-release-rc.yaml`, `zeebe-release-stable-dry-run.yml`, `data-layer-nightly-tests.yml`, `optimize-*-nightly.yml`, `camunda-*-compatibility-trigger.yml` and `alwaysgreen-*.yml`. Those belong to other teams and I haven't audited them — their owners should check for hardcoded branch lists after this cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
