### PR TITLE
ci: load-test: schedule release load test for 8.10

### DIFF
--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -59,6 +59,14 @@ jobs:
       name: schedule-release-8-9-x
       tag: '8.9.16'
 
+  release-load-test-8-10:
+    name: Release load test (stable/8.10)
+    uses: camunda/camunda/.github/workflows/camunda-release-load-test.yaml@stable/8.10
+    secrets: inherit
+    with:
+      name: schedule-release-8-10-x
+      tag: '8.10.0-alpha4'
+
   release-load-test-main:
     name: Release load test (main)
     uses: ./.github/workflows/camunda-release-load-test.yaml
@@ -99,6 +107,15 @@ jobs:
     with:
       namespace: c8-schedule-release-8-9-x
 
+  verify-and-cleanup-8-10:
+    name: Verify and cleanup (stable/8.10)
+    needs: [release-load-test-8-10]
+    if: always()
+    uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
+    secrets: inherit
+    with:
+      namespace: c8-schedule-release-8-10-x
+
   verify-and-cleanup-main:
     name: Verify and cleanup (main)
     needs: [release-load-test-main]
@@ -111,12 +128,18 @@ jobs:
   notify-on-success:
     name: Notify on success
     runs-on: ubuntu-latest
-    needs: [verify-and-cleanup-8-7, verify-and-cleanup-8-8, verify-and-cleanup-8-9, verify-and-cleanup-main]
+    needs:
+      - verify-and-cleanup-8-7
+      - verify-and-cleanup-8-8
+      - verify-and-cleanup-8-9
+      - verify-and-cleanup-8-10
+      - verify-and-cleanup-main
     if: >-
       always() &&
       needs.verify-and-cleanup-8-7.result == 'success' &&
       needs.verify-and-cleanup-8-8.result == 'success' &&
       needs.verify-and-cleanup-8-9.result == 'success' &&
+      needs.verify-and-cleanup-8-10.result == 'success' &&
       needs.verify-and-cleanup-main.result == 'success'
     timeout-minutes: 5
     permissions: {}
@@ -155,6 +178,7 @@ jobs:
                     • stable/8.7: `8.7.37` (${{ needs.verify-and-cleanup-8-7.result }})
                     • stable/8.8: `8.8.35` (${{ needs.verify-and-cleanup-8-8.result }})
                     • stable/8.9: `8.9.16` (${{ needs.verify-and-cleanup-8-9.result }})
+                    • stable/8.10: `8.10.0-alpha4` (${{ needs.verify-and-cleanup-8-10.result }})
                     • main: `8.10.0-alpha4` (${{ needs.verify-and-cleanup-main.result }})
 
               - type: context
@@ -175,12 +199,18 @@ jobs:
   notify-on-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [verify-and-cleanup-8-7, verify-and-cleanup-8-8, verify-and-cleanup-8-9, verify-and-cleanup-main]
+    needs:
+      - verify-and-cleanup-8-7
+      - verify-and-cleanup-8-8
+      - verify-and-cleanup-8-9
+      - verify-and-cleanup-8-10
+      - verify-and-cleanup-main
     if: >-
       always() &&
       (needs.verify-and-cleanup-8-7.result == 'failure' ||
       needs.verify-and-cleanup-8-8.result == 'failure' ||
       needs.verify-and-cleanup-8-9.result == 'failure' ||
+      needs.verify-and-cleanup-8-10.result == 'failure' ||
       needs.verify-and-cleanup-main.result == 'failure')
     timeout-minutes: 5
     permissions: {}
@@ -219,6 +249,7 @@ jobs:
                     • stable/8.7: ${{ needs.verify-and-cleanup-8-7.result }}
                     • stable/8.8: ${{ needs.verify-and-cleanup-8-8.result }}
                     • stable/8.9: ${{ needs.verify-and-cleanup-8-9.result }}
+                    • stable/8.10: ${{ needs.verify-and-cleanup-8-10.result }}
                     • main: ${{ needs.verify-and-cleanup-main.result }}
 
               - type: section

--- a/load-tests/setup/stable-810/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-defaults.yaml
@@ -152,7 +152,7 @@ orchestration:
   image:
     registry: docker.io
     repository: camunda/camunda
-    tag: "SNAPSHOT"
+    tag: 8.10.0-alpha4
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   ## @param core.partitionCount defines how many partitions are set up in the cluster

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-release.yaml
@@ -47,26 +47,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-elasticsearch-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-elasticsearch-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-release.yaml
@@ -47,26 +47,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-elasticsearch:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-elasticsearch:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-release.yaml
@@ -35,26 +35,26 @@ data:
         metrics: http://identity.c8-golden-stable-810-none-optimize:82/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-none-optimize:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-release.yaml
@@ -35,26 +35,26 @@ data:
         metrics: http://identity.c8-golden-stable-810-none:82/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-none:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-release.yaml
@@ -47,26 +47,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-opensearch-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-opensearch-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-release.yaml
@@ -47,26 +47,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-opensearch:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-opensearch:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-release.yaml
@@ -47,26 +47,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-rdbms-optimize:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms-optimize:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-release.yaml
@@ -41,26 +41,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-rdbms-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-release.yaml
@@ -41,26 +41,26 @@ data:
         metrics: http://connectors.c8-golden-stable-810-rdbms:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus
       - name: Orchestration Admin
         id: admin
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         url: http://localhost:8080/admin
         readiness: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-810-rdbms:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: SNAPSHOT
+        version: 8.10.0-alpha4
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:SNAPSHOT
+          image: docker.io/camunda/camunda:8.10.0-alpha4
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
## Description

Same as the other versions but for 8.10

Needs:
* https://github.com/camunda/camunda/pull/60997

Closes: https://github.com/camunda/camunda/issues/60971

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/60971
* https://github.com/camunda/camunda/pull/60997