### PR TITLE
feat: enable new redesign in Admin

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@camunda/camunda-api-zod-schemas": "0.0.90",
         "@camunda/camunda-composite-components": "0.25.4",
-        "@camunda/design-system": "0.47.0",
+        "@camunda/design-system": "0.48.0",
         "@camunda/session-heartbeat": "0.0.1",
         "@carbon/elements": "11.95.0",
         "@carbon/react": "1.112.0",
@@ -361,9 +361,9 @@
       }
     },
     "node_modules/@camunda/design-system": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.47.0.tgz",
-      "integrity": "sha512-W1Kr7Mr3DtL0n/m7hVPB9kAab3WkrhYAJzjxWnqwJ+MFI/+1uU32Zv+YBDkTYKZh0JAmDVb1zZZU3PnxgEPhaA==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.48.0.tgz",
+      "integrity": "sha512-ffCaGZOYfrWggY8kt2MdDTnc5ARMRdLDI9SOtXO7ugCx4FKPitAav5M2x6K97Pc626lWOz+IhAG30gaaZj72yQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-table": "^8.20.5",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@camunda/camunda-api-zod-schemas": "0.0.90",
     "@camunda/camunda-composite-components": "0.25.4",
-    "@camunda/design-system": "0.47.0",
+    "@camunda/design-system": "0.48.0",
     "@camunda/session-heartbeat": "0.0.1",
     "@carbon/elements": "11.95.0",
     "@carbon/react": "1.112.0",

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -8,5 +8,5 @@
 
 export const featureFlags = [];
 
-export const IS_NEW_DESIGN_SYSTEM_ENABLED = false;
+export const IS_NEW_DESIGN_SYSTEM_ENABLED = true;
 export const IS_NAV_V2_ENABLED = IS_NEW_DESIGN_SYSTEM_ENABLED;

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -6,7 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import { isSaaS } from "./configuration";
+
 export const featureFlags = [];
 
-export const IS_NEW_DESIGN_SYSTEM_ENABLED = true;
+export const IS_NEW_DESIGN_SYSTEM_ENABLED = isSaaS ? false : true;
 export const IS_NAV_V2_ENABLED = IS_NEW_DESIGN_SYSTEM_ENABLED;


### PR DESCRIPTION
## Description

This PR enables the new redesign to Camunda design system in Admin. The redesign is WIP but should already be enabled in Alpha 5.

**[Q]:** Does it need further backport labels to reach Alpha 5?

Depends on https://github.com/camunda/camunda/pull/60858, which might need further backport labels as well.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

