### PR TITLE
test: disable web session restart IT that stalls the rdbms CI job

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Bean;
@@ -117,6 +118,9 @@ class PhysicalTenantWebSessionIsolationIT {
   }
 
   @Test
+  @Disabled(
+      "Blocks for ~600s inside the full rdbms suite and times out CI. Re-enable with the fix: "
+          + "https://github.com/camunda/camunda/issues/61009")
   void shouldSurviveRestartInCorrectPhysicalTenantStore() {
     // given — write via app1's tenant A store
     final String id = UUID.randomUUID().toString();


### PR DESCRIPTION
## Why

`PhysicalTenantWebSessionIsolationIT#shouldSurviveRestartInCorrectPhysicalTenantStore` blocks for almost exactly 600 s inside the full `rdbms` suite. It passes, but it burns a third of the 30-minute budget of `CI: rdbms-integration-tests`, which then hits its flat timeout and is cancelled — taking the merge queue to `main` to a ~60% failure rate and blocking all merges (L2 incident).

It is deterministic, not flaky:

| Run | Duration |
|---|---|
| [32813946108](https://github.com/camunda/camunda/actions/runs/32813946108) | 602.1 s |
| [32813156447](https://github.com/camunda/camunda/actions/runs/32813156447) | 605.0 s (class total) |
| [32809723272](https://github.com/camunda/camunda/actions/runs/32809723272) | 603.8 s (class total) |

Next-slowest class in the suite: 192 s. The failsafe report has `failures=0 errors=0 flakes=0` and no rerun markers despite `failsafe.rerunFailingTestsCount=7`, so it is one 600 s execution, not eight retried attempts. A spread under 1.5 s means a hard timeout, not a race.

## What

`@Disabled` on the single offending method.

Not the whole class — `shouldIsolateSessionsAcrossPhysicalTenants` (~1.8 s) is unaffected and keeps cross-tenant session isolation under test. Only the restart path loses coverage. This is the smallest change that removes the timeout.

## Alternatives considered

Fixing the root cause directly, which would obviously be better. It isn't possible yet: the method completes in under 7 s when the class runs in isolation, so the stall depends on the accumulated JVM/Testcontainers state of the full suite (`forkCount=1`), and CI captures no application log for it (the failsafe XML has no `<system-out>`). Identifying what is being waited on needs an instrumented CI run. Given the queue is blocked, unblocking first and diagnosing behind the issue is the right order.

## Verification

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS
```

`./mvnw verify -pl qa/acceptance-tests -Prdbms -Dit.test=PhysicalTenantWebSessionIsolationIT -DskipTests=false -DskipUTs -Dquickly`

## ⚠️ Temporary

This `@Disabled` must be reverted. #61009 tracks root-causing it and says so explicitly; it must not be closed until the annotation is gone.

Related to #61009