### PR TITLE
deps: bump openjre-base-compat:21-dev to JDK 21.0.12.1 (stable/optimize-8.7)

### DIFF
--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -4,13 +4,13 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:a99ec526ee35aff020694da8a4067cacda5e19a0958e0f106521eb5d120f3ac7"
+ARG BASE_DIGEST="sha256:728ccf1d6dd2dc032e2e9f864f5ed29e324d459dc07569f8881f65d84b99b451"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
 ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:ca397720325ceefe39ce397f186759fc87d9efafb2dc4ce53315980844c2f4f2"
+ARG BASE_DIGEST_PUBLIC="sha256:96975602e131485862eb8cd32927face8a06d7591a5e865944b634a701d9df72"
 ARG BASE="hardened"
 
 # set to "build" to build camunda from scratch instead of using a distball

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:a99ec526ee35aff020694da8a4067cacda5e19a0958e0f106521eb5d120f3ac7"
+ARG BASE_DIGEST="sha256:728ccf1d6dd2dc032e2e9f864f5ed29e324d459dc07569f8881f65d84b99b451"
 ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
 # If you don't have access to Minimus hardened base images, you can use public


### PR DESCRIPTION
## Summary

Bumps pinned base image digests in both `optimize.Dockerfile` and `camunda.Dockerfile` to builds shipping **JDK 21.0.12**, addressing CVE-2026-46968.

| File | Image | Old digest | New digest | JDK version |
|------|-------|-----------|-----------|-------------|
| `optimize.Dockerfile` | `openjre-base-compat:21-dev` | `a99ec526` | `728ccf1d` | 21.0.12.1 (2026-08-18) |
| `camunda.Dockerfile` | `openjre-base-compat:21-dev` | `a99ec526` | `728ccf1d` | 21.0.12.1 (2026-08-18) |
| `camunda.Dockerfile` | `eclipse-temurin:21-jre-noble` | `ca397720` | `96975602` | 21.0.12_8 (2026-08-21) |

## Context

CVE-2026-46968 is a JSSE vulnerability in Oracle Java SE that allows an unauthenticated attacker with network access via TLS to modify data in transit (CVSS 3.1 Base Score 5.9, \`AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N\`). JDK 21.0.11 is explicitly listed as an affected version. Optimize makes TLS connections to Elasticsearch/OpenSearch and accepts HTTPS connections, so the vulnerable code path is active.

Closes 