### PR TITLE
feat: strip cached process definition XML from reports on deletion

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
@@ -74,6 +74,35 @@ public class PublicApiProcessDefinitionDeletionIT extends AbstractCCSMIT {
   }
 
   @Test
+  public void shouldReturn202AndQueueJobForAlreadySoftDeletedDefinition() {
+    // given
+    final String processDefinitionKey = "100000000000007";
+    seedProcessDefinition(processDefinitionKey);
+    embeddedOptimizeExtension
+        .getBean(ProcessDefinitionWriter.class)
+        .markDefinitionAsDeleted(processDefinitionKey);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildDeleteProcessDefinitionDataRequest(processDefinitionKey)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.ACCEPTED.value());
+    final JobRegistryEntryDto entry =
+        embeddedOptimizeExtension
+            .getBean(JobRegistryReader.class)
+            .findLastByJobTypeAndEntityId(
+                JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionKey)
+            .orElseThrow();
+    assertThat(entry.getStatus()).isEqualTo(JobStatus.QUEUED);
+  }
+
+  @Test
   public void shouldReturn400WhenKeyIsNotNumeric() {
     // when
     final Response response =

--- a/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.rest;
 
+import static io.camunda.optimize.service.util.configuration.ConfigurationServiceConstants.CCSM_PROFILE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractCCSMIT;
@@ -20,6 +21,7 @@ import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,8 +32,15 @@ public class PublicApiProcessDefinitionDeletionIT extends AbstractCCSMIT {
 
   private static final String TEST_ACCESS_TOKEN = "test-access-token";
 
+  @Override
+  protected void startAndUseNewOptimizeInstance() {
+    // see PublicApiVariableLabelsIT for rationale for pinning cslEnabled=false here
+    startAndUseNewOptimizeInstance(Map.of("optimize.security.csl.enabled", "false"), CCSM_PROFILE);
+  }
+
   @BeforeEach
   public void configurePublicApiToken() {
+    startAndUseNewOptimizeInstance();
     embeddedOptimizeExtension
         .getConfigurationService()
         .getOptimizeApiConfiguration()

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
@@ -20,11 +21,17 @@ import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobStatus;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.reader.ProcessOverviewReader;
+import io.camunda.optimize.service.db.reader.ReportReader;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.db.writer.ProcessOverviewWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,6 +45,9 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
   private ProcessDefinitionReader processDefinitionReader;
   private ProcessOverviewReader processOverviewReader;
   private ProcessOverviewWriter processOverviewWriter;
+  private ReportReader reportReader;
+  private ReportWriter reportWriter;
+  private DefinitionService definitionService;
   private JobRegistryWriter jobRegistryWriter;
   private JobDispatcher jobDispatcher;
 
@@ -47,6 +57,9 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     processDefinitionReader = embeddedOptimizeExtension.getBean(ProcessDefinitionReader.class);
     processOverviewReader = embeddedOptimizeExtension.getBean(ProcessOverviewReader.class);
     processOverviewWriter = embeddedOptimizeExtension.getBean(ProcessOverviewWriter.class);
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+    reportWriter = embeddedOptimizeExtension.getBean(ReportWriter.class);
+    definitionService = embeddedOptimizeExtension.getBean(DefinitionService.class);
     jobRegistryWriter = embeddedOptimizeExtension.getBean(JobRegistryWriter.class);
     jobDispatcher = embeddedOptimizeExtension.getBean(JobDispatcher.class);
   }
@@ -72,11 +85,11 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     persistProcessInstances(Stream.concat(instancesV1.stream(), instancesV2.stream()).toList());
 
     processOverviewWriter.updateProcessOwnerIfNotSet(bpmnProcessId, "owner-1");
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     // when
     handler.handle(job(definitionIdV1));
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     // then
     assertThat(getProcessDefinition(definitionIdV1)).isEmpty();
@@ -101,15 +114,127 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
     persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
     processOverviewWriter.updateProcessOwnerIfNotSet(bpmnProcessId, "owner-1");
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     // when
     handler.handle(job(definitionId));
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     // then
     assertThat(getProcessDefinition(definitionId)).isEmpty();
     assertThat(processOverviewReader.getProcessOverviewByKey(bpmnProcessId)).isPresent();
+  }
+
+  @Test
+  void shouldClearCachedXmlOnReportsWhenLastVersionDeleted() {
+    // given -- a single version of bpmnProcessId, so this deletion removes its last version
+    final String bpmnProcessId = "definition-deletion-clear-xml-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+    final String reportId = createSingleProcessReportWithCachedXml(bpmnProcessId);
+    refreshAllIndices();
+
+    // when
+    handler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getCachedXml(reportId)).isNull();
+  }
+
+  @Test
+  void shouldLeaveCachedXmlUntouchedWhenOtherVersionsRemain() {
+    // given
+    final String bpmnProcessId = "definition-deletion-keep-xml-test-" + UUID.randomUUID();
+    final String definitionIdV1 = bpmnProcessId + ":1:" + UUID.randomUUID();
+    final String definitionIdV2 = bpmnProcessId + ":2:" + UUID.randomUUID();
+    persistProcessInstances(
+        List.of(
+            instanceFor(bpmnProcessId, definitionIdV1, "1"),
+            instanceFor(bpmnProcessId, definitionIdV2, "2")));
+    final String reportId = createSingleProcessReportWithCachedXml(bpmnProcessId);
+    refreshAllIndices();
+
+    // when -- only one of the two versions is deleted, so bpmnProcessId still has a version left
+    handler.handle(job(definitionIdV1));
+    refreshAllIndices();
+
+    // then
+    assertThat(getCachedXml(reportId)).isEqualTo("<definitions>cached</definitions>");
+  }
+
+  @Test
+  void shouldClearCachedXmlOnComparisonReportWhereKeyIsFirstDefinition() {
+    // given -- a comparison report referencing bpmnProcessId as its first of two definitions
+    final String bpmnProcessId = "definition-deletion-comparison-first-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+
+    final ProcessReportDataDto comparisonData = new ProcessReportDataDto();
+    comparisonData.setProcessDefinitionKey(bpmnProcessId);
+    comparisonData.getDefinitions().add(new ReportDataDefinitionDto("some-other-process"));
+    comparisonData.getConfiguration().setXml("<definitions>cached</definitions>");
+    final String reportId =
+        reportWriter
+            .createNewSingleProcessReport("demo", comparisonData, "Comparison Report", null, null)
+            .getId();
+    refreshAllIndices();
+
+    // when
+    handler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getCachedXml(reportId)).isNull();
+  }
+
+  @Test
+  void shouldLeaveCachedXmlUntouchedOnComparisonReportWhereKeyIsNotFirstDefinition() {
+    // given -- a comparison report referencing bpmnProcessId only as its second definition
+    final String bpmnProcessId = "definition-deletion-not-first-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+
+    final ProcessReportDataDto comparisonData = new ProcessReportDataDto();
+    comparisonData.setProcessDefinitionKey("some-other-process");
+    comparisonData.getDefinitions().add(new ReportDataDefinitionDto(bpmnProcessId));
+    comparisonData.getConfiguration().setXml("<definitions>cached</definitions>");
+    final String reportId =
+        reportWriter
+            .createNewSingleProcessReport("demo", comparisonData, "Comparison Report", null, null)
+            .getId();
+    refreshAllIndices();
+
+    // when
+    handler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getCachedXml(reportId)).isEqualTo("<definitions>cached</definitions>");
+  }
+
+  @Test
+  void shouldEvictDefinitionFromCacheAfterDeletion() {
+    // given
+    final String bpmnProcessId = "definition-deletion-cache-evict-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessDefinitions(List.of(definitionFor(bpmnProcessId, definitionId, "1")));
+    refreshAllIndices();
+    // populate the cache before deletion
+    definitionService.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, bpmnProcessId);
+
+    // when
+    handler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then -- a fresh cache fetch no longer returns the deleted definition
+    assertThat(
+            definitionService.getCachedTenantToLatestDefinitionMap(
+                DefinitionType.PROCESS, bpmnProcessId))
+        .isEmpty();
   }
 
   @Test
@@ -123,7 +248,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
     // when / then
     assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
     assertThat(getProcessDefinition(definitionId)).isEmpty();
   }
 
@@ -133,10 +258,10 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     final String bpmnProcessId = "definition-deletion-idempotency-test-" + UUID.randomUUID();
     final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
     persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     handler.handle(job(definitionId));
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
     assertThat(getProcessDefinition(definitionId)).isEmpty();
 
     // when / then -- re-invoking against already-deleted data is a no-op, not an exception
@@ -149,7 +274,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     final String bpmnProcessId = "definition-deletion-dispatch-test-" + UUID.randomUUID();
     final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
     persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     final JobRegistryEntryDto queued =
         jobRegistryWriter.createJobEntry(
@@ -157,7 +282,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
     // when
     jobDispatcher.dispatchNextBatch();
-    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    refreshAllIndices();
 
     // then
     assertThat(getProcessDefinition(definitionId)).isEmpty();
@@ -173,6 +298,20 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
   private Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(final String definitionId) {
     return processDefinitionReader.getProcessDefinition(definitionId, false);
+  }
+
+  private String createSingleProcessReportWithCachedXml(final String bpmnProcessId) {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setProcessDefinitionKey(bpmnProcessId);
+    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
+    return reportWriter
+        .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
+        .getId();
+  }
+
+  private String getCachedXml(final String reportId) {
+    final ReportDefinitionDto<?> report = reportReader.getReport(reportId).orElseThrow();
+    return ((ProcessReportDataDto) report.getData()).getConfiguration().getXml();
   }
 
   private JobRegistryEntryDto job(final String definitionId) {
@@ -199,5 +338,9 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
         .tenantId(ZEEBE_DEFAULT_TENANT_ID)
         .bpmn20Xml("<definitions/>")
         .build();
+  }
+
+  private static void refreshAllIndices() {
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -11,6 +11,10 @@ import static io.camunda.optimize.service.util.InstanceIndexUtil.getProcessInsta
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
 import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
@@ -26,13 +30,17 @@ import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.reader.DefinitionReader;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.reader.ProcessOverviewReader;
 import io.camunda.optimize.service.db.reader.ReportReader;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
 import io.camunda.optimize.service.db.writer.ProcessOverviewWriter;
 import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.report.ReportService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -401,6 +409,57 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
     // when / then -- re-invoking against already-deleted data is a no-op, not an exception
     assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldLeaveDefinitionResumableAfterATerminalFailureAndCompleteCleanupOnRetry() {
+    // given -- the deletion job will fail terminally right after the definition instances are
+    // deleted, before the remaining-versions check, XML clear, cache eviction, and hard-delete run
+    final String bpmnProcessId = "definition-deletion-resume-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+    final String reportId = createSingleProcessReportWithCachedXml(bpmnProcessId);
+    refreshAllIndices();
+
+    final ProcessInstanceWriter realProcessInstanceWriter =
+        embeddedOptimizeExtension.getBean(ProcessInstanceWriter.class);
+    final ProcessInstanceWriter failOnceThenDelegateWriter = mock(ProcessInstanceWriter.class);
+    doThrow(new IllegalStateException("simulated terminal failure"))
+        .doAnswer(
+            invocation -> {
+              realProcessInstanceWriter.deleteInstancesByDefinitionId(
+                  invocation.getArgument(0), invocation.getArgument(1));
+              return null;
+            })
+        .when(failOnceThenDelegateWriter)
+        .deleteInstancesByDefinitionId(anyString(), anyString());
+    final ProcessDefinitionDeletionJobHandler resumableHandler =
+        new ProcessDefinitionDeletionJobHandler(
+            processDefinitionReader,
+            failOnceThenDelegateWriter,
+            embeddedOptimizeExtension.getBean(ProcessDefinitionWriter.class),
+            embeddedOptimizeExtension.getBean(DefinitionReader.class),
+            embeddedOptimizeExtension.getBean(ReportService.class),
+            definitionService);
+
+    // when -- the first attempt fails terminally
+    assertThatThrownBy(() -> resumableHandler.handle(job(definitionId)))
+        .isInstanceOf(IllegalStateException.class);
+    refreshAllIndices();
+
+    // then -- the definition is soft-deleted, so a retry can still find and finish it
+    final ProcessDefinitionOptimizeDto softDeleted =
+        getProcessDefinition(definitionId).orElseThrow();
+    assertThat(softDeleted.isDeleted()).isTrue();
+    assertThat(getCachedXml(reportId)).isEqualTo("<definitions>cached</definitions>");
+
+    // when -- the job is retried; this time the instance deletion succeeds
+    resumableHandler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then -- the remainder of the cleanup tail, including the final hard-delete, now completes
+    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(getCachedXml(reportId)).isNull();
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
@@ -32,7 +33,9 @@ import io.camunda.optimize.service.db.reader.ReportReader;
 import io.camunda.optimize.service.db.writer.JobRegistryWriter;
 import io.camunda.optimize.service.db.writer.ProcessOverviewWriter;
 import io.camunda.optimize.service.db.writer.ReportWriter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -178,14 +181,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
     // the report is scoped to tenant A specifically, i.e. the tenant whose data is about to
     // become entirely gone, even though the bpmnProcessId still lives on under tenant B
-    final ProcessReportDataDto reportData = new ProcessReportDataDto();
-    reportData.setProcessDefinitionKey(bpmnProcessId);
-    reportData.setTenantIds(List.of(ZEEBE_DEFAULT_TENANT_ID));
-    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
-    final String reportId =
-        reportWriter
-            .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
-            .getId();
+    final String reportId = createReport(bpmnProcessId, List.of(ZEEBE_DEFAULT_TENANT_ID));
     refreshAllIndices();
 
     // when -- only tenant A's (only) version is deleted
@@ -209,14 +205,8 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
             definitionFor(bpmnProcessId, definitionIdTenantA, "1", ZEEBE_DEFAULT_TENANT_ID),
             definitionFor(bpmnProcessId, definitionIdTenantB, "1", "tenant-b")));
 
-    final ProcessReportDataDto reportData = new ProcessReportDataDto();
-    reportData.setProcessDefinitionKey(bpmnProcessId);
-    reportData.setTenantIds(List.of(ZEEBE_DEFAULT_TENANT_ID, "tenant-b"));
-    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
     final String reportId =
-        reportWriter
-            .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
-            .getId();
+        createReport(bpmnProcessId, List.of(ZEEBE_DEFAULT_TENANT_ID, "tenant-b"));
     refreshAllIndices();
 
     // when -- only tenant A's (only) version is deleted; tenant B's version is untouched
@@ -230,6 +220,34 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
   }
 
   @Test
+  void shouldLeaveCachedXmlUntouchedOnReportScopedToADifferentTenant() {
+    // given -- the report only covers tenant B; tenant A's (only) version is what gets deleted
+    final String bpmnProcessId = "definition-deletion-other-tenant-test-" + UUID.randomUUID();
+    final String definitionIdTenantA = bpmnProcessId + ":1:tenant-a:" + UUID.randomUUID();
+    final String definitionIdTenantB = bpmnProcessId + ":1:tenant-b:" + UUID.randomUUID();
+    persistProcessDefinitions(
+        List.of(
+            definitionFor(bpmnProcessId, definitionIdTenantA, "1", ZEEBE_DEFAULT_TENANT_ID),
+            definitionFor(bpmnProcessId, definitionIdTenantB, "1", "tenant-b")));
+
+    final String reportIdTenantA = createReport(bpmnProcessId, List.of(ZEEBE_DEFAULT_TENANT_ID));
+    final String reportIdTenantB = createReport(bpmnProcessId, List.of("tenant-b"));
+
+    refreshAllIndices();
+
+    // when -- only tenant A's (only) version is deleted; tenant B's version, and this report's
+    // tenant, are untouched
+    handler.handle(job(definitionIdTenantA));
+    refreshAllIndices();
+
+    // then
+    assertThat(getProcessDefinition(definitionIdTenantA)).isEmpty();
+    assertThat(getProcessDefinition(definitionIdTenantB)).isPresent();
+    assertThat(getCachedXml(reportIdTenantA)).isNull();
+    assertThat(getCachedXml(reportIdTenantB)).isEqualTo("<definitions>cached</definitions>");
+  }
+
+  @Test
   void shouldClearCachedXmlOnComparisonReportWhereKeyIsFirstDefinition() {
     // given -- a comparison report referencing bpmnProcessId as its first of two definitions
     final String bpmnProcessId = "definition-deletion-comparison-first-test-" + UUID.randomUUID();
@@ -238,6 +256,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
     final ProcessReportDataDto comparisonData = new ProcessReportDataDto();
     comparisonData.setProcessDefinitionKey(bpmnProcessId);
+    comparisonData.setTenantIds(new ArrayList<>(List.of(ZEEBE_DEFAULT_TENANT_ID)));
     comparisonData.getDefinitions().add(new ReportDataDefinitionDto("some-other-process"));
     comparisonData.getConfiguration().setXml("<definitions>cached</definitions>");
     final String reportId =
@@ -300,6 +319,57 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
             definitionService.getCachedTenantToLatestDefinitionMap(
                 DefinitionType.PROCESS, bpmnProcessId))
         .isEmpty();
+  }
+
+  @Test
+  void shouldStillReportCorrectCachedLatestWhenDeletingANonLatestVersion() {
+    // given -- two versions exist; version 2 is the cached latest
+    final String bpmnProcessId = "definition-deletion-keep-cache-test-" + UUID.randomUUID();
+    final String definitionIdV1 = bpmnProcessId + ":1:" + UUID.randomUUID();
+    final String definitionIdV2 = bpmnProcessId + ":2:" + UUID.randomUUID();
+    persistProcessDefinitions(
+        List.of(
+            definitionFor(bpmnProcessId, definitionIdV1, "1"),
+            definitionFor(bpmnProcessId, definitionIdV2, "2")));
+    refreshAllIndices();
+    final Map<String, DefinitionOptimizeResponseDto> cachedBeforeDeletion =
+        definitionService.getCachedTenantToLatestDefinitionMap(
+            DefinitionType.PROCESS, bpmnProcessId);
+
+    // when -- the older, non-latest version is deleted; version 2 remains the true latest
+    handler.handle(job(definitionIdV1));
+    refreshAllIndices();
+
+    // then -- content is unaffected
+    assertThat(
+            definitionService.getCachedTenantToLatestDefinitionMap(
+                DefinitionType.PROCESS, bpmnProcessId))
+        .isEqualTo(cachedBeforeDeletion);
+  }
+
+  @Test
+  void shouldEvictCacheWhenDeletedVersionIsTheTenantsCachedLatest() {
+    // given -- two versions exist; version 2 is the cached latest
+    final String bpmnProcessId = "definition-deletion-evict-cache-test-" + UUID.randomUUID();
+    final String definitionIdV1 = bpmnProcessId + ":1:" + UUID.randomUUID();
+    final String definitionIdV2 = bpmnProcessId + ":2:" + UUID.randomUUID();
+    persistProcessDefinitions(
+        List.of(
+            definitionFor(bpmnProcessId, definitionIdV1, "1"),
+            definitionFor(bpmnProcessId, definitionIdV2, "2")));
+    refreshAllIndices();
+    // populate the cache with the stale (pre-deletion) latest, version 2
+    definitionService.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, bpmnProcessId);
+
+    // when -- the cached latest version is deleted, leaving version 1 as the new latest
+    handler.handle(job(definitionIdV2));
+    refreshAllIndices();
+
+    // then -- a fresh cache fetch returns the new latest, version 1
+    final Map<String, DefinitionOptimizeResponseDto> cachedAfterDeletion =
+        definitionService.getCachedTenantToLatestDefinitionMap(
+            DefinitionType.PROCESS, bpmnProcessId);
+    assertThat(cachedAfterDeletion.get(ZEEBE_DEFAULT_TENANT_ID).getVersion()).isEqualTo("1");
   }
 
   @Test
@@ -368,6 +438,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
   private String createSingleProcessReportWithCachedXml(final String bpmnProcessId) {
     final ProcessReportDataDto reportData = new ProcessReportDataDto();
     reportData.setProcessDefinitionKey(bpmnProcessId);
+    reportData.setTenantIds(new ArrayList<>(List.of(ZEEBE_DEFAULT_TENANT_ID)));
     reportData.getConfiguration().setXml("<definitions>cached</definitions>");
     return reportWriter
         .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
@@ -411,6 +482,16 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
         .tenantId(tenantId)
         .bpmn20Xml("<definitions/>")
         .build();
+  }
+
+  private String createReport(final String bpmnProcessId, final List<String> tenantIds) {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setProcessDefinitionKey(bpmnProcessId);
+    reportData.setTenantIds(new ArrayList<>(tenantIds));
+    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
+    return reportWriter
+        .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
+        .getId();
   }
 
   private static void refreshAllIndices() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -412,6 +412,29 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
   }
 
   @Test
+  void shouldNotClearXmlWhenReportsFirstDefinitionNoLongerMatchesAtWriteTime() {
+    // given
+    final String bpmnProcessId = "definition-deletion-race-test-" + UUID.randomUUID();
+    final String reportId = createSingleProcessReportWithCachedXml(bpmnProcessId);
+    refreshAllIndices();
+
+    // when -- simulates a concurrent edit landing between candidate selection and the write
+    final ProcessReportDataDto changedData = new ProcessReportDataDto();
+    changedData.setProcessDefinitionKey("a-different-process");
+    changedData.getConfiguration().setXml("<definitions>cached</definitions>");
+    reportWriter.createOrUpdateSingleProcessReport(
+        reportId, "demo", changedData, "Test Report", null, null);
+    refreshAllIndices();
+
+    reportWriter.clearReportDefinitionXmlForReportIds(
+        List.of(reportId), bpmnProcessId, ZEEBE_DEFAULT_TENANT_ID);
+    refreshAllIndices();
+
+    // then -- the write re-checks the report's current state and declines
+    assertThat(getCachedXml(reportId)).isEqualTo("<definitions>cached</definitions>");
+  }
+
+  @Test
   void shouldLeaveDefinitionResumableAfterATerminalFailureAndCompleteCleanupOnRetry() {
     // given -- the deletion job will fail terminally right after the definition instances are
     // deleted, before the remaining-versions check, XML clear, cache eviction, and hard-delete run

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -165,6 +165,71 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
   }
 
   @Test
+  void
+      shouldClearCachedXmlWhenLastVersionForThisTenantIsDeletedEvenIfOtherTenantsStillHaveVersions() {
+    // given the same bpmnProcessId has one version under tenant A and one under tenant B
+    final String bpmnProcessId = "definition-deletion-multi-tenant-test-" + UUID.randomUUID();
+    final String definitionIdTenantA = bpmnProcessId + ":1:tenant-a:" + UUID.randomUUID();
+    final String definitionIdTenantB = bpmnProcessId + ":1:tenant-b:" + UUID.randomUUID();
+    persistProcessDefinitions(
+        List.of(
+            definitionFor(bpmnProcessId, definitionIdTenantA, "1", ZEEBE_DEFAULT_TENANT_ID),
+            definitionFor(bpmnProcessId, definitionIdTenantB, "1", "tenant-b")));
+
+    // the report is scoped to tenant A specifically, i.e. the tenant whose data is about to
+    // become entirely gone, even though the bpmnProcessId still lives on under tenant B
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setProcessDefinitionKey(bpmnProcessId);
+    reportData.setTenantIds(List.of(ZEEBE_DEFAULT_TENANT_ID));
+    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
+    final String reportId =
+        reportWriter
+            .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
+            .getId();
+    refreshAllIndices();
+
+    // when -- only tenant A's (only) version is deleted
+    handler.handle(job(definitionIdTenantA));
+    refreshAllIndices();
+
+    // then
+    assertThat(getProcessDefinition(definitionIdTenantA)).isEmpty();
+    assertThat(getProcessDefinition(definitionIdTenantB)).isPresent();
+    assertThat(getCachedXml(reportId)).isNull();
+  }
+
+  @Test
+  void shouldClearCachedXmlOnReportSharedAcrossTenantsWhenOnlyOneOfItsTenantsIsDeleted() {
+    // given a report spanning both tenants, but only tenant A's (only) version is deleted
+    final String bpmnProcessId = "definition-deletion-shared-report-test-" + UUID.randomUUID();
+    final String definitionIdTenantA = bpmnProcessId + ":1:tenant-a:" + UUID.randomUUID();
+    final String definitionIdTenantB = bpmnProcessId + ":1:tenant-b:" + UUID.randomUUID();
+    persistProcessDefinitions(
+        List.of(
+            definitionFor(bpmnProcessId, definitionIdTenantA, "1", ZEEBE_DEFAULT_TENANT_ID),
+            definitionFor(bpmnProcessId, definitionIdTenantB, "1", "tenant-b")));
+
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setProcessDefinitionKey(bpmnProcessId);
+    reportData.setTenantIds(List.of(ZEEBE_DEFAULT_TENANT_ID, "tenant-b"));
+    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
+    final String reportId =
+        reportWriter
+            .createNewSingleProcessReport("demo", reportData, "Test Report", null, null)
+            .getId();
+    refreshAllIndices();
+
+    // when -- only tenant A's (only) version is deleted; tenant B's version is untouched
+    handler.handle(job(definitionIdTenantA));
+    refreshAllIndices();
+
+    // then
+    assertThat(getProcessDefinition(definitionIdTenantA)).isEmpty();
+    assertThat(getProcessDefinition(definitionIdTenantB)).isPresent();
+    assertThat(getCachedXml(reportId)).isNull();
+  }
+
+  @Test
   void shouldClearCachedXmlOnComparisonReportWhereKeyIsFirstDefinition() {
     // given -- a comparison report referencing bpmnProcessId as its first of two definitions
     final String bpmnProcessId = "definition-deletion-comparison-first-test-" + UUID.randomUUID();
@@ -329,13 +394,21 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
   private ProcessDefinitionOptimizeDto definitionFor(
       final String bpmnProcessId, final String definitionId, final String version) {
+    return definitionFor(bpmnProcessId, definitionId, version, ZEEBE_DEFAULT_TENANT_ID);
+  }
+
+  private ProcessDefinitionOptimizeDto definitionFor(
+      final String bpmnProcessId,
+      final String definitionId,
+      final String version,
+      final String tenantId) {
     return ProcessDefinitionOptimizeDto.builder()
         .id(definitionId)
         .key(bpmnProcessId)
         .version(version)
         .name(bpmnProcessId)
         .dataSource(new ZeebeDataSourceDto("test-source", 1))
-        .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+        .tenantId(tenantId)
         .bpmn20Xml("<definitions/>")
         .build();
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/DefinitionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/DefinitionService.java
@@ -103,8 +103,13 @@ public class DefinitionService implements ConfigurationReloadable {
     latestDecisionDefinitionCache.invalidateAll();
   }
 
-  public void invalidateProcessDefinition(final String key) {
-    latestProcessDefinitionCache.invalidate(key);
+  public void invalidateProcessDefinitionIfLatest(
+      final String key, final String tenantId, final String version) {
+    final DefinitionOptimizeResponseDto cachedLatest =
+        getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, key).get(tenantId);
+    if (cachedLatest != null && version.equals(cachedLatest.getVersion())) {
+      latestProcessDefinitionCache.invalidate(key);
+    }
   }
 
   public String getLatestVersionToKey(final DefinitionType type, final String key) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/DefinitionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/DefinitionService.java
@@ -103,6 +103,10 @@ public class DefinitionService implements ConfigurationReloadable {
     latestDecisionDefinitionCache.invalidateAll();
   }
 
+  public void invalidateProcessDefinition(final String key) {
+    latestProcessDefinitionCache.invalidate(key);
+  }
+
   public String getLatestVersionToKey(final DefinitionType type, final String key) {
     return definitionReader.getLatestVersionToKey(type, key);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -16,6 +16,7 @@ import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionInde
 import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_KEY;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch._types.ScriptLanguage;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
@@ -102,9 +103,13 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
   public void deleteDefinition(final String definitionId) {
     LOG.debug("Deleting process definition with ID {}", definitionId);
     try {
+      // Refresh immediately: callers rely on a subsequent search seeing this delete right away
       esClient.delete(
           OptimizeDeleteRequestBuilderES.of(
-              d -> d.optimizeIndex(esClient, PROCESS_DEFINITION_INDEX_NAME).id(definitionId)));
+              d ->
+                  d.optimizeIndex(esClient, PROCESS_DEFINITION_INDEX_NAME)
+                      .id(definitionId)
+                      .refresh(Refresh.True)));
     } catch (final IOException e) {
       throw new OptimizeRuntimeException(
           String.format(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -82,12 +82,14 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
   public void markDefinitionAsDeleted(final String definitionId) {
     LOG.debug("Marking process definition with ID {} as deleted", definitionId);
     try {
+      // Refresh immediately: callers rely on a subsequent search seeing this update right away
       esClient.update(
           new OptimizeUpdateRequestBuilderES<>()
               .optimizeIndex(esClient, PROCESS_DEFINITION_INDEX_NAME)
               .id(definitionId)
               .script(MARK_AS_DELETED_SCRIPT)
               .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+              .refresh(Refresh.True)
               .build(),
           Object.class);
     } catch (final Exception e) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
@@ -56,6 +56,7 @@ import jakarta.json.JsonValue;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -299,6 +300,30 @@ public class ReportWriterES implements ReportWriter {
         updateItem,
         updateDefinitionXmlScript,
         Query.of(q -> q.term(t -> t.field(PROCESS_DEFINITION_PROPERTY).value(definitionKey))),
+        SINGLE_PROCESS_REPORT_INDEX_NAME);
+  }
+
+  @Override
+  public void clearReportDefinitionXmlForReportIds(final List<String> reportIds) {
+    if (reportIds.isEmpty()) {
+      return;
+    }
+    final String updateItem =
+        String.format("%d report(s) with cleared definition XML", reportIds.size());
+    LOG.debug("Clearing definition XML for {} in Elasticsearch", updateItem);
+
+    final Script clearDefinitionXmlScript =
+        Script.of(
+            s ->
+                s.lang(ScriptLanguage.Painless)
+                    // this script is deliberately not updating the modified date as this is
+                    // not a user operation
+                    .source("ctx._source.data.configuration.xml = null;"));
+
+    taskRepositoryES.tryUpdateByQueryRequest(
+        updateItem,
+        clearDefinitionXmlScript,
+        Query.of(q -> q.ids(i -> i.values(reportIds))),
         SINGLE_PROCESS_REPORT_INDEX_NAME);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
@@ -56,6 +56,7 @@ import jakarta.json.JsonValue;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -68,6 +69,7 @@ import org.springframework.stereotype.Component;
 public class ReportWriterES implements ReportWriter {
 
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ReportWriterES.class);
+
   private final ObjectMapper objectMapper;
   private final OptimizeElasticsearchClient esClient;
   private final TaskRepositoryES taskRepositoryES;
@@ -304,7 +306,8 @@ public class ReportWriterES implements ReportWriter {
   }
 
   @Override
-  public void clearReportDefinitionXmlForReportIds(final List<String> reportIds) {
+  public void clearReportDefinitionXmlForReportIds(
+      final List<String> reportIds, final String processDefinitionKey, final String tenantId) {
     if (reportIds.isEmpty()) {
       return;
     }
@@ -312,13 +315,17 @@ public class ReportWriterES implements ReportWriter {
         String.format("%d report(s) with cleared definition XML", reportIds.size());
     LOG.debug("Clearing definition XML for {} in Elasticsearch", updateItem);
 
+    final Map<String, JsonData> scriptParams = new HashMap<>();
+    scriptParams.put("key", JsonData.of(processDefinitionKey));
+    scriptParams.put("tenantId", JsonData.of(tenantId));
     final Script clearDefinitionXmlScript =
         Script.of(
             s ->
                 s.lang(ScriptLanguage.Painless)
                     // this script is deliberately not updating the modified date as this is
                     // not a user operation
-                    .source("ctx._source.data.configuration.xml = null;"));
+                    .source(ReportWriter.CLEAR_DEFINITION_XML_IF_STILL_MATCHING_SCRIPT)
+                    .params(scriptParams));
 
     taskRepositoryES.tryUpdateByQueryRequest(
         updateItem,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportWriterES.java
@@ -327,10 +327,13 @@ public class ReportWriterES implements ReportWriter {
                     .source(ReportWriter.CLEAR_DEFINITION_XML_IF_STILL_MATCHING_SCRIPT)
                     .params(scriptParams));
 
+    // Abort on version conflicts so a report edited concurrently with this write can be retried by
+    // the caller instead of keeping stale XML.
     taskRepositoryES.tryUpdateByQueryRequest(
         updateItem,
         clearDefinitionXmlScript,
         Query.of(q -> q.ids(i -> i.values(reportIds))),
+        true,
         SINGLE_PROCESS_REPORT_INDEX_NAME);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
@@ -28,8 +28,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch.core.DeleteRequest;
 import org.opensearch.client.opensearch.core.UpdateRequest;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
@@ -91,7 +93,17 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
   @Override
   public void deleteDefinition(final String definitionId) {
     LOG.debug("Deleting process definition with ID {}", definitionId);
-    osClient.delete(PROCESS_DEFINITION_INDEX_NAME, definitionId);
+    // Refresh immediately: callers rely on a subsequent search seeing this delete right away
+    final DeleteRequest.Builder request =
+        new DeleteRequest.Builder()
+            .index(PROCESS_DEFINITION_INDEX_NAME)
+            .id(definitionId)
+            .refresh(Refresh.True);
+    osClient.delete(
+        request,
+        String.format(
+            "There was a problem when trying to delete process definition with ID %s",
+            definitionId));
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
@@ -77,12 +77,14 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
   @Override
   public void markDefinitionAsDeleted(final String definitionId) {
     LOG.debug("Marking process definition with ID {} as deleted", definitionId);
+    // Refresh immediately: callers rely on a subsequent search seeing this delete right away
     final UpdateRequest.Builder updateReqBuilder =
         new UpdateRequest.Builder<>()
             .index(PROCESS_DEFINITION_INDEX_NAME)
             .id(definitionId)
             .script(MARK_AS_DELETED_SCRIPT)
-            .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT);
+            .retryOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+            .refresh(Refresh.True);
     final String errorMessage =
         String.format(
             "There was a problem when trying to mark process definition with ID %s as deleted",

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
@@ -299,8 +299,10 @@ public class ReportWriterOS implements ReportWriter {
         OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams(
             CLEAR_DEFINITION_XML_IF_STILL_MATCHING_SCRIPT, scriptParams);
 
+    // Abort on version conflicts so a report edited concurrently with this write can be retried by
+    // the caller instead of keeping stale XML.
     osClient.updateByQuery(
-        SINGLE_PROCESS_REPORT_INDEX_NAME, QueryDSL.ids(reportIds), clearDefinitionXmlScript);
+        SINGLE_PROCESS_REPORT_INDEX_NAME, QueryDSL.ids(reportIds), clearDefinitionXmlScript, true);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
@@ -41,6 +41,7 @@ import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondit
 import jakarta.json.JsonValue;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -277,6 +278,22 @@ public class ReportWriterOS implements ReportWriter {
         SINGLE_PROCESS_REPORT_INDEX_NAME,
         QueryDSL.term(PROCESS_DEFINITION_PROPERTY, definitionKey),
         updateDefinitionXmlScript);
+  }
+
+  @Override
+  public void clearReportDefinitionXmlForReportIds(final List<String> reportIds) {
+    if (reportIds.isEmpty()) {
+      return;
+    }
+    final String updateItem =
+        String.format("%d report(s) with cleared definition XML", reportIds.size());
+    LOG.debug("Clearing definition XML for {} in OpenSearch", updateItem);
+
+    final Script clearDefinitionXmlScript =
+        OpenSearchWriterUtil.createDefaultScript("ctx._source.data.configuration.xml = null;");
+
+    osClient.updateByQuery(
+        SINGLE_PROCESS_REPORT_INDEX_NAME, QueryDSL.ids(reportIds), clearDefinitionXmlScript);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportWriterOS.java
@@ -41,6 +41,7 @@ import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondit
 import jakarta.json.JsonValue;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.opensearch.client.json.JsonData;
@@ -65,6 +66,7 @@ import org.springframework.stereotype.Component;
 public class ReportWriterOS implements ReportWriter {
 
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ReportWriterOS.class);
+
   private final ObjectMapper objectMapper;
   private final OptimizeOpenSearchClient osClient;
 
@@ -281,7 +283,8 @@ public class ReportWriterOS implements ReportWriter {
   }
 
   @Override
-  public void clearReportDefinitionXmlForReportIds(final List<String> reportIds) {
+  public void clearReportDefinitionXmlForReportIds(
+      final List<String> reportIds, final String processDefinitionKey, final String tenantId) {
     if (reportIds.isEmpty()) {
       return;
     }
@@ -289,8 +292,12 @@ public class ReportWriterOS implements ReportWriter {
         String.format("%d report(s) with cleared definition XML", reportIds.size());
     LOG.debug("Clearing definition XML for {} in OpenSearch", updateItem);
 
+    final Map<String, JsonData> scriptParams = new HashMap<>();
+    scriptParams.put("key", JsonData.of(processDefinitionKey));
+    scriptParams.put("tenantId", JsonData.of(tenantId));
     final Script clearDefinitionXmlScript =
-        OpenSearchWriterUtil.createDefaultScript("ctx._source.data.configuration.xml = null;");
+        OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams(
+            CLEAR_DEFINITION_XML_IF_STILL_MATCHING_SCRIPT, scriptParams);
 
     osClient.updateByQuery(
         SINGLE_PROCESS_REPORT_INDEX_NAME, QueryDSL.ids(reportIds), clearDefinitionXmlScript);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/reader/ProcessDefinitionReader.java
@@ -32,6 +32,10 @@ public interface ProcessDefinitionReader {
   Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(
       final String definitionId, final boolean includeXml);
 
+  /**
+   * Checks if a process definition with the given definitionId exists in the database regardless of
+   * whether it is soft-deleted or not.
+   */
   boolean processDefinitionExists(final String definitionId);
 
   Set<String> getAllNonOnboardedProcessDefinitionKeys();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/TaskRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/TaskRepositoryES.java
@@ -85,6 +85,15 @@ public class TaskRepositoryES extends TaskRepository {
       final Script updateScript,
       final Query filterQuery,
       final String... indices) {
+    return tryUpdateByQueryRequest(updateItemIdentifier, updateScript, filterQuery, false, indices);
+  }
+
+  public boolean tryUpdateByQueryRequest(
+      final String updateItemIdentifier,
+      final Script updateScript,
+      final Query filterQuery,
+      final boolean failOnVersionConflicts,
+      final String... indices) {
     LOG.debug("Updating {}", updateItemIdentifier);
     final boolean clusterTaskCheckingEnabled =
         configurationService
@@ -97,7 +106,7 @@ public class TaskRepositoryES extends TaskRepository {
             b ->
                 b.index(esClient.addPrefixesToIndices(indices))
                     .query(filterQuery)
-                    .conflicts(Conflicts.Proceed)
+                    .conflicts(failOnVersionConflicts ? Conflicts.Abort : Conflicts.Proceed)
                     .script(updateScript)
                     .waitForCompletion(!clusterTaskCheckingEnabled)
                     .refresh(true));

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
 import io.camunda.optimize.service.db.reader.JobRegistryReader;
 import io.camunda.optimize.service.util.configuration.CacheConfiguration;
+import io.camunda.optimize.service.util.configuration.ConfigurationReloadable;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.time.Duration;
 import java.util.Collection;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,7 +36,7 @@ import org.springframework.stereotype.Component;
  * that expires after a configurable TTL and is re-fetched wholesale on the next lookup.
  */
 @Component
-public class DeletedProcessDefinitionFilter {
+public class DeletedProcessDefinitionFilter implements ConfigurationReloadable {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeletedProcessDefinitionFilter.class);
   private static final String SUPPRESSED_IDS_CACHE_KEY = "suppressedProcessDefinitionIds";
@@ -64,6 +66,11 @@ public class DeletedProcessDefinitionFilter {
             .expireAfterWrite(Duration.ofMillis(cacheConfig.getDefaultTtlMillis()))
             .ticker(ticker)
             .build();
+  }
+
+  @Override
+  public void reloadConfiguration(final ApplicationContext context) {
+    cache.invalidateAll();
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/DeletedProcessDefinitionFilter.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,6 +43,7 @@ public class DeletedProcessDefinitionFilter {
   private final int maxSize;
   private final Cache<String, Set<String>> cache;
 
+  @Autowired
   public DeletedProcessDefinitionFilter(
       final JobRegistryReader jobRegistryReader, final ConfigurationService configurationService) {
     this(jobRegistryReader, configurationService, Ticker.systemTicker());

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportWriter.java
@@ -27,6 +27,7 @@ import io.camunda.optimize.dto.optimize.query.report.single.decision.DecisionRep
 import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecisionReportDefinitionUpdateDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionUpdateDto;
+import java.util.List;
 import java.util.Set;
 
 public interface ReportWriter {
@@ -84,6 +85,8 @@ public interface ReportWriter {
 
   void updateProcessDefinitionXmlForProcessReportsWithKey(
       final String definitionKey, final String definitionXml);
+
+  void clearReportDefinitionXmlForReportIds(final List<String> reportIds);
 
   void deleteAllManagementReports();
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportWriter.java
@@ -48,6 +48,17 @@ public interface ReportWriter {
       String.join(
           ".", DATA, SingleReportDataDto.Fields.definitions, ReportDataDefinitionDto.Fields.key);
 
+  // Re-checks the report's current first definition/tenants to make sure the wrong XML is not
+  // cleared if other writes have altered the report since the last read.
+  String CLEAR_DEFINITION_XML_IF_STILL_MATCHING_SCRIPT =
+      "def defs = ctx._source.data.definitions;"
+          + "if (defs != null && defs.size() > 0 && defs[0].key == params.key) {"
+          + "  def tenantIds = defs[0].tenantIds;"
+          + "  if (tenantIds == null || tenantIds.contains(params.tenantId)) {"
+          + "    ctx._source.data.configuration.xml = null;"
+          + "  }"
+          + "}";
+
   IdResponseDto createNewCombinedReport(
       final String userId,
       final CombinedReportDataDto reportData,
@@ -86,7 +97,14 @@ public interface ReportWriter {
   void updateProcessDefinitionXmlForProcessReportsWithKey(
       final String definitionKey, final String definitionXml);
 
-  void clearReportDefinitionXmlForReportIds(final List<String> reportIds);
+  /**
+   * Clears the cached XML for the given report IDs, but only for a report whose first-listed
+   * definition still matches {@code processDefinitionKey}/{@code tenantId} at write time. The
+   * caller selects candidate {@code reportIds} from a point-in-time read, so a concurrent edit to a
+   * report's first definition or tenants between that read and this write must not blank the XML.
+   */
+  void clearReportDefinitionXmlForReportIds(
+      final List<String> reportIds, final String processDefinitionKey, final String tenantId);
 
   void deleteAllManagementReports();
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -156,11 +156,11 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
         () -> processDefinitionWriter.deleteDefinition(definitionId));
   }
 
-  private void withRetry(final String description, final Runnable deletion) {
+  private void withRetry(final String description, final Runnable runnable) {
     withRetry(
         description,
         () -> {
-          deletion.run();
+          runnable.run();
           return null;
         });
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -113,16 +113,6 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
       return;
     }
     final String bpmnProcessId = definition.get().getKey();
-    final String version = definition.get().getVersion();
-
-    final boolean isLastRemainingVersion =
-        withRetry(
-                "check remaining versions of process definition " + bpmnProcessId,
-                () ->
-                    definitionReader.getDefinitionVersions(
-                        DefinitionType.PROCESS, bpmnProcessId, Set.of()))
-            .stream()
-            .allMatch(v -> version.equals(v.getVersion()));
 
     deleteWithRetry(
         "delete process instances for definition " + definitionId,
@@ -130,6 +120,14 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
     deleteWithRetry(
         "delete process definition " + definitionId,
         () -> processDefinitionWriter.deleteDefinition(definitionId));
+
+    final boolean isLastRemainingVersion =
+        withRetry(
+                "check remaining versions of process definition " + bpmnProcessId,
+                () ->
+                    definitionReader.getDefinitionVersions(
+                        DefinitionType.PROCESS, bpmnProcessId, Set.of()))
+            .isEmpty();
 
     if (isLastRemainingVersion) {
       deleteWithRetry(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -135,12 +135,20 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
                         DefinitionType.PROCESS, bpmnProcessId, Collections.singleton(tenantId)))
             .isEmpty();
 
+    // Invalidate before clearing XML: otherwise a report evaluation that already read the
+    // stale cached "latest" definition could write its BPMN XML back into a report right
+    // after we clear it.
+    withRetry(
+        "invalidate cached process definition " + bpmnProcessId,
+        () ->
+            definitionService.invalidateProcessDefinitionIfLatest(
+                bpmnProcessId, tenantId, version));
+
     if (isLastRemainingVersion) {
       withRetry(
           "clear cached XML for reports referencing " + bpmnProcessId,
           () -> reportService.clearCachedReportXml(bpmnProcessId, tenantId));
     }
-    definitionService.invalidateProcessDefinitionIfLatest(bpmnProcessId, tenantId, version);
 
     // Hard-delete last
     withRetry(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -8,19 +8,24 @@
 package io.camunda.optimize.service.job;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.reader.DefinitionReader;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
 import io.camunda.optimize.service.exceptions.OptimizeByQueryFailureException;
+import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.BackoffCalculator;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
@@ -46,24 +51,43 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessInstanceWriter processInstanceWriter;
   private final ProcessDefinitionWriter processDefinitionWriter;
+  private final DefinitionReader definitionReader;
+  private final ReportService reportService;
+  private final DefinitionService definitionService;
   private final Sleeper sleeper;
 
   @Autowired
   public ProcessDefinitionDeletionJobHandler(
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceWriter processInstanceWriter,
-      final ProcessDefinitionWriter processDefinitionWriter) {
-    this(processDefinitionReader, processInstanceWriter, processDefinitionWriter, Thread::sleep);
+      final ProcessDefinitionWriter processDefinitionWriter,
+      final DefinitionReader definitionReader,
+      final ReportService reportService,
+      final DefinitionService definitionService) {
+    this(
+        processDefinitionReader,
+        processInstanceWriter,
+        processDefinitionWriter,
+        definitionReader,
+        reportService,
+        definitionService,
+        Thread::sleep);
   }
 
   ProcessDefinitionDeletionJobHandler(
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceWriter processInstanceWriter,
       final ProcessDefinitionWriter processDefinitionWriter,
+      final DefinitionReader definitionReader,
+      final ReportService reportService,
+      final DefinitionService definitionService,
       final Sleeper sleeper) {
     this.processDefinitionReader = processDefinitionReader;
     this.processInstanceWriter = processInstanceWriter;
     this.processDefinitionWriter = processDefinitionWriter;
+    this.definitionReader = definitionReader;
+    this.reportService = reportService;
+    this.definitionService = definitionService;
     this.sleeper = sleeper;
   }
 
@@ -89,12 +113,30 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
       return;
     }
     final String bpmnProcessId = definition.get().getKey();
+    final String version = definition.get().getVersion();
+
+    final boolean isLastRemainingVersion =
+        withRetry(
+                "check remaining versions of process definition " + bpmnProcessId,
+                () ->
+                    definitionReader.getDefinitionVersions(
+                        DefinitionType.PROCESS, bpmnProcessId, Set.of()))
+            .stream()
+            .allMatch(v -> version.equals(v.getVersion()));
+
     deleteWithRetry(
         "delete process instances for definition " + definitionId,
         () -> processInstanceWriter.deleteInstancesByDefinitionId(bpmnProcessId, definitionId));
     deleteWithRetry(
         "delete process definition " + definitionId,
         () -> processDefinitionWriter.deleteDefinition(definitionId));
+
+    if (isLastRemainingVersion) {
+      deleteWithRetry(
+          "clear cached XML for reports referencing " + bpmnProcessId,
+          () -> reportService.clearCachedReportXml(bpmnProcessId));
+    }
+    definitionService.invalidateProcessDefinition(bpmnProcessId);
   }
 
   private void deleteWithRetry(final String description, final Runnable deletion) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -113,6 +113,8 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
       return;
     }
     final String bpmnProcessId = definition.get().getKey();
+    final String tenantId = definition.get().getTenantId();
+    final String version = definition.get().getVersion();
 
     deleteWithRetry(
         "delete process instances for definition " + definitionId,
@@ -129,17 +131,15 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
                 "check remaining versions of process definition " + bpmnProcessId,
                 () ->
                     definitionReader.getDefinitionVersions(
-                        DefinitionType.PROCESS,
-                        bpmnProcessId,
-                        Collections.singleton(definition.get().getTenantId())))
+                        DefinitionType.PROCESS, bpmnProcessId, Collections.singleton(tenantId)))
             .isEmpty();
 
     if (isLastRemainingVersion) {
       deleteWithRetry(
           "clear cached XML for reports referencing " + bpmnProcessId,
-          () -> reportService.clearCachedReportXml(bpmnProcessId));
+          () -> reportService.clearCachedReportXml(bpmnProcessId, tenantId));
     }
-    definitionService.invalidateProcessDefinition(bpmnProcessId);
+    definitionService.invalidateProcessDefinitionIfLatest(bpmnProcessId, tenantId, version);
   }
 
   private void deleteWithRetry(final String description, final Runnable deletion) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -23,9 +23,9 @@ import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.BackoffCalculator;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
@@ -121,12 +121,17 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
         "delete process definition " + definitionId,
         () -> processDefinitionWriter.deleteDefinition(definitionId));
 
+    // Scoped to this definition's own tenant: a bpmnProcessId can exist independently per
+    // tenant, so a version still live under a different tenant must not block clearing the
+    // cached XML for reports whose data is, for this tenant, now entirely gone.
     final boolean isLastRemainingVersion =
         withRetry(
                 "check remaining versions of process definition " + bpmnProcessId,
                 () ->
                     definitionReader.getDefinitionVersions(
-                        DefinitionType.PROCESS, bpmnProcessId, Set.of()))
+                        DefinitionType.PROCESS,
+                        bpmnProcessId,
+                        Collections.singleton(definition.get().getTenantId())))
             .isEmpty();
 
     if (isLastRemainingVersion) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -116,12 +116,13 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
     final String tenantId = definition.get().getTenantId();
     final String version = definition.get().getVersion();
 
-    deleteWithRetry(
+    // Soft-delete first so a terminal failure anywhere below leaves the deletion retriable
+    withRetry(
+        "mark process definition as deleted " + definitionId,
+        () -> processDefinitionWriter.markDefinitionAsDeleted(definitionId));
+    withRetry(
         "delete process instances for definition " + definitionId,
         () -> processInstanceWriter.deleteInstancesByDefinitionId(bpmnProcessId, definitionId));
-    deleteWithRetry(
-        "delete process definition " + definitionId,
-        () -> processDefinitionWriter.deleteDefinition(definitionId));
 
     // Scoped to this definition's own tenant: a bpmnProcessId can exist independently per
     // tenant, so a version still live under a different tenant must not block clearing the
@@ -135,14 +136,19 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
             .isEmpty();
 
     if (isLastRemainingVersion) {
-      deleteWithRetry(
+      withRetry(
           "clear cached XML for reports referencing " + bpmnProcessId,
           () -> reportService.clearCachedReportXml(bpmnProcessId, tenantId));
     }
     definitionService.invalidateProcessDefinitionIfLatest(bpmnProcessId, tenantId, version);
+
+    // Hard-delete last
+    withRetry(
+        "delete process definition " + definitionId,
+        () -> processDefinitionWriter.deleteDefinition(definitionId));
   }
 
-  private void deleteWithRetry(final String description, final Runnable deletion) {
+  private void withRetry(final String description, final Runnable deletion) {
     withRetry(
         description,
         () -> {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
@@ -464,7 +464,8 @@ public class ReportService implements CollectionReferencingService {
             .map(ReportDefinitionDto::getId)
             .toList();
     if (!reportIdsToClear.isEmpty()) {
-      reportWriter.clearReportDefinitionXmlForReportIds(reportIdsToClear);
+      reportWriter.clearReportDefinitionXmlForReportIds(
+          reportIdsToClear, processDefinitionKey, tenantId);
     }
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
@@ -31,6 +31,7 @@ import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportData
 import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportItemDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.SingleReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.decision.DecisionReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecisionReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.single.decision.SingleDecisionReportDefinitionUpdateDto;
@@ -447,6 +448,27 @@ public class ReportService implements CollectionReferencingService {
   public void updateDefinitionXmlOfProcessReports(
       final String definitionKey, final String definitionXml) {
     reportWriter.updateProcessDefinitionXmlForProcessReportsWithKey(definitionKey, definitionXml);
+  }
+
+  /**
+   * Clears the cached BPMN XML ({@code data.configuration.xml}) on every single-process report
+   * whose first-listed definition is {@code processDefinitionKey}.
+   */
+  public void clearCachedReportXml(final String processDefinitionKey) {
+    final List<String> reportIdsToClear =
+        getAllReportsForProcessDefinitionKeyOmitXml(processDefinitionKey).stream()
+            .filter(report -> isFirstDefinition(report, processDefinitionKey))
+            .map(ReportDefinitionDto::getId)
+            .toList();
+    if (!reportIdsToClear.isEmpty()) {
+      reportWriter.clearReportDefinitionXmlForReportIds(reportIdsToClear);
+    }
+  }
+
+  private boolean isFirstDefinition(
+      final ReportDefinitionDto<?> report, final String processDefinitionKey) {
+    return report.getData() instanceof final SingleReportDataDto singleReportData
+        && processDefinitionKey.equals(singleReportData.getDefinitionKey());
   }
 
   public void updateSingleDecisionReport(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/report/ReportService.java
@@ -452,12 +452,15 @@ public class ReportService implements CollectionReferencingService {
 
   /**
    * Clears the cached BPMN XML ({@code data.configuration.xml}) on every single-process report
-   * whose first-listed definition is {@code processDefinitionKey}.
+   * whose first-listed definition is {@code processDefinitionKey} and whose tenants include {@code
+   * tenantId}. A report scoped to other tenants only is left untouched, since its cached XML still
+   * reflects data that is unaffected by this tenant's deletion.
    */
-  public void clearCachedReportXml(final String processDefinitionKey) {
+  public void clearCachedReportXml(final String processDefinitionKey, final String tenantId) {
     final List<String> reportIdsToClear =
         getAllReportsForProcessDefinitionKeyOmitXml(processDefinitionKey).stream()
-            .filter(report -> isFirstDefinition(report, processDefinitionKey))
+            .filter(
+                report -> matchesFirstDefinitionAndTenant(report, processDefinitionKey, tenantId))
             .map(ReportDefinitionDto::getId)
             .toList();
     if (!reportIdsToClear.isEmpty()) {
@@ -465,10 +468,18 @@ public class ReportService implements CollectionReferencingService {
     }
   }
 
-  private boolean isFirstDefinition(
-      final ReportDefinitionDto<?> report, final String processDefinitionKey) {
-    return report.getData() instanceof final SingleReportDataDto singleReportData
-        && processDefinitionKey.equals(singleReportData.getDefinitionKey());
+  private boolean matchesFirstDefinitionAndTenant(
+      final ReportDefinitionDto<?> report,
+      final String processDefinitionKey,
+      final String tenantId) {
+    if (!(report.getData() instanceof final SingleReportDataDto singleReportData)
+        || !processDefinitionKey.equals(singleReportData.getDefinitionKey())) {
+      return false;
+    }
+    // getTenantIds() is null when the underlying definition's tenant list is itself null. Treat it
+    // as "unknown, always matches"
+    final List<String> tenantIds = singleReportData.getTenantIds();
+    return tenantIds == null || tenantIds.contains(tenantId);
   }
 
   public void updateSingleDecisionReport(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/DefinitionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/DefinitionServiceTest.java
@@ -79,24 +79,72 @@ class DefinitionServiceTest {
   }
 
   @Test
-  void shouldEvictProcessDefinitionFromCacheOnInvalidation() {
+  void shouldEvictWhenDeletedVersionIsTheCachedLatestForTenant() {
     // given
     final String definitionKey = "invoice-process";
     final ProcessDefinitionOptimizeDto definition = new ProcessDefinitionOptimizeDto();
     definition.setKey(definitionKey);
-    definition.setTenantId(null);
+    definition.setTenantId("tenant-a");
+    definition.setVersion("3");
     when(definitionReader.getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
             DefinitionType.PROCESS, definitionKey))
         .thenReturn(List.of(definition));
-    // populate the cache
+    // populate the cache with tenant-a's latest at version 3
     underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
 
-    // when
-    underTest.invalidateProcessDefinition(definitionKey);
+    // when -- the deleted definition is version 3, the tenant's cached latest
+    underTest.invalidateProcessDefinitionIfLatest(definitionKey, "tenant-a", "3");
     underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
 
     // then -- the loader had to be called again since the entry was evicted
     verify(definitionReader, times(2))
+        .getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
+            DefinitionType.PROCESS, definitionKey);
+  }
+
+  @Test
+  void shouldNotEvictWhenDeletedVersionIsNotTheCachedLatestForTenant() {
+    // given
+    final String definitionKey = "invoice-process";
+    final ProcessDefinitionOptimizeDto definition = new ProcessDefinitionOptimizeDto();
+    definition.setKey(definitionKey);
+    definition.setTenantId("tenant-a");
+    definition.setVersion("3");
+    when(definitionReader.getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
+            DefinitionType.PROCESS, definitionKey))
+        .thenReturn(List.of(definition));
+    // populate the cache with tenant-a's latest at version 3
+    underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
+
+    // when -- an older version than the cached latest was deleted
+    underTest.invalidateProcessDefinitionIfLatest(definitionKey, "tenant-a", "2");
+    underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
+
+    // then -- the cache entry is untouched, so the loader is not called again
+    verify(definitionReader, times(1))
+        .getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
+            DefinitionType.PROCESS, definitionKey);
+  }
+
+  @Test
+  void shouldNotEvictWhenTenantHasNoCachedLatestDefinition() {
+    // given -- the cache only holds a latest definition for tenant-a
+    final String definitionKey = "invoice-process";
+    final ProcessDefinitionOptimizeDto definition = new ProcessDefinitionOptimizeDto();
+    definition.setKey(definitionKey);
+    definition.setTenantId("tenant-a");
+    definition.setVersion("3");
+    when(definitionReader.getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
+            DefinitionType.PROCESS, definitionKey))
+        .thenReturn(List.of(definition));
+    underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
+
+    // when -- a definition for a different, uncached tenant was deleted
+    underTest.invalidateProcessDefinitionIfLatest(definitionKey, "tenant-b", "1");
+    underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
+
+    // then -- nothing to invalidate, so the loader is not called again
+    verify(definitionReader, times(1))
         .getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
             DefinitionType.PROCESS, definitionKey);
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/DefinitionServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/DefinitionServiceTest.java
@@ -8,8 +8,12 @@
 package io.camunda.optimize.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.service.db.reader.DefinitionReader;
 import io.camunda.optimize.service.security.util.definition.DataSourceDefinitionAuthorizationService;
@@ -72,5 +76,28 @@ class DefinitionServiceTest {
 
     // then
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldEvictProcessDefinitionFromCacheOnInvalidation() {
+    // given
+    final String definitionKey = "invoice-process";
+    final ProcessDefinitionOptimizeDto definition = new ProcessDefinitionOptimizeDto();
+    definition.setKey(definitionKey);
+    definition.setTenantId(null);
+    when(definitionReader.getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
+            DefinitionType.PROCESS, definitionKey))
+        .thenReturn(List.of(definition));
+    // populate the cache
+    underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
+
+    // when
+    underTest.invalidateProcessDefinition(definitionKey);
+    underTest.getCachedTenantToLatestDefinitionMap(DefinitionType.PROCESS, definitionKey);
+
+    // then -- the loader had to be called again since the entry was evicted
+    verify(definitionReader, times(2))
+        .getLatestFullyImportedDefinitionsFromTenantsIfAvailable(
+            DefinitionType.PROCESS, definitionKey);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/es/TaskRepositoryESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/es/TaskRepositoryESTest.java
@@ -16,9 +16,12 @@ import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.BulkIndexByScrollFailure;
 import co.elastic.clients.elasticsearch._types.Conflicts;
+import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.core.UpdateByQueryRequest;
+import co.elastic.clients.elasticsearch.core.UpdateByQueryResponse;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.exceptions.OptimizeByQueryFailureException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -101,6 +104,65 @@ class TaskRepositoryESTest {
             () ->
                 taskRepositoryES.tryDeleteByQueryRequest(
                     Query.of(q -> q.matchAll(m -> m)), "test instances", true, true, "test-index"))
+        .isInstanceOf(OptimizeByQueryFailureException.class);
+  }
+
+  @Test
+  void shouldUseProceedConflictsModeByDefaultForUpdate() throws IOException {
+    // given
+    final ArgumentCaptor<UpdateByQueryRequest> requestCaptor =
+        ArgumentCaptor.forClass(UpdateByQueryRequest.class);
+    when(esClient.submitUpdateTask(requestCaptor.capture()))
+        .thenReturn(UpdateByQueryResponse.of(b -> b.updated(1L).timedOut(false)));
+
+    // when
+    taskRepositoryES.tryUpdateByQueryRequest(
+        "test reports", mock(Script.class), Query.of(q -> q.matchAll(m -> m)), "test-index");
+
+    // then -- unrelated callers keep skipping (rather than failing on) version conflicts
+    assertThat(requestCaptor.getValue().conflicts()).isEqualTo(Conflicts.Proceed);
+  }
+
+  @Test
+  void shouldUseAbortConflictsModeWhenFailOnVersionConflictsIsRequestedForUpdate()
+      throws IOException {
+    // given
+    final ArgumentCaptor<UpdateByQueryRequest> requestCaptor =
+        ArgumentCaptor.forClass(UpdateByQueryRequest.class);
+    when(esClient.submitUpdateTask(requestCaptor.capture()))
+        .thenReturn(UpdateByQueryResponse.of(b -> b.updated(1L).timedOut(false)));
+
+    // when
+    taskRepositoryES.tryUpdateByQueryRequest(
+        "test reports", mock(Script.class), Query.of(q -> q.matchAll(m -> m)), true, "test-index");
+
+    // then
+    assertThat(requestCaptor.getValue().conflicts()).isEqualTo(Conflicts.Abort);
+  }
+
+  @Test
+  void shouldThrowWhenAbortedUpdateReportsAVersionConflictFailure() throws IOException {
+    // given
+    final BulkIndexByScrollFailure conflictFailure =
+        BulkIndexByScrollFailure.of(
+            f ->
+                f.id("report-1")
+                    .index("test-index")
+                    .cause(c -> c.type("version_conflict_engine_exception").reason("conflict"))
+                    .status(409));
+    when(esClient.submitUpdateTask(any(UpdateByQueryRequest.class)))
+        .thenReturn(
+            UpdateByQueryResponse.of(b -> b.updated(0L).timedOut(false).failures(conflictFailure)));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                taskRepositoryES.tryUpdateByQueryRequest(
+                    "test reports",
+                    mock(co.elastic.clients.elasticsearch._types.Script.class),
+                    Query.of(q -> q.matchAll(m -> m)),
+                    true,
+                    "test-index"))
         .isInstanceOf(OptimizeByQueryFailureException.class);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
@@ -104,8 +105,27 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
+    verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
     verify(processInstanceWriter).deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
     verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+  }
+
+  @Test
+  void shouldMarkDefinitionAsDeletedBeforeDeletingInstancesAndHardDeletingLast() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+
+    // when
+    handler.handle(job());
+
+    // then
+    final var order = inOrder(processDefinitionWriter, processInstanceWriter);
+    order.verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
+    order
+        .verify(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -118,11 +138,30 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
+    verify(processDefinitionWriter, never()).markDefinitionAsDeleted(anyString());
     verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
     verify(processDefinitionWriter, never()).deleteDefinition(anyString());
     verify(reportService, never()).clearCachedReportXml(anyString(), any());
     verify(definitionService, never())
         .invalidateProcessDefinitionIfLatest(anyString(), any(), anyString());
+  }
+
+  @Test
+  void shouldRetryOnRetryableErrorWhenMarkingDefinitionAsDeleted() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
+        .doNothing()
+        .when(processDefinitionWriter)
+        .markDefinitionAsDeleted(DEFINITION_ID);
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(processDefinitionWriter, times(2)).markDefinitionAsDeleted(DEFINITION_ID);
+    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -202,7 +241,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
   }
 
   @Test
-  void shouldCheckRemainingVersionsAfterDeletingSoAConcurrentSiblingDeleteIsNeverMissed() {
+  void shouldCheckRemainingVersionsAfterMarkingThisOneAsDeletedSoItIsNeverCountedAsRemaining() {
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     when(definitionReader.getDefinitionVersions(
@@ -214,10 +253,11 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
     // then
     final var order = inOrder(definitionReader, processDefinitionWriter);
-    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+    order.verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
     order
         .verify(definitionReader)
         .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID));
+    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -339,6 +379,33 @@ class ProcessDefinitionDeletionJobHandlerTest {
     verify(processInstanceWriter, times(1))
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
     verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+  }
+
+  @Test
+  void shouldResumeCleanupOnANewHandleCallAfterAPriorTerminalFailure() {
+    // given -- the first attempt fails terminally right after the definition was marked deleted, so
+    // nothing else in the cleanup tail ran
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    doThrow(new IllegalStateException("not retryable"))
+        .when(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(IllegalStateException.class);
+    verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
+    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+
+    // when -- the job is retried: the definition lookup still finds the soft-deleted definition
+    // and this time the instance deletion succeeds
+    doNothing()
+        .when(processInstanceWriter)
+        .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
+    handler.handle(job());
+
+    // then -- the remainder of the cleanup tail, including the final hard-delete, now completes
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID, TENANT_ID);
+    verify(definitionService)
+        .invalidateProcessDefinitionIfLatest(BPMN_PROCESS_ID, TENANT_ID, VERSION);
+    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   private JobRegistryEntryDto job() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -66,10 +66,13 @@ class ProcessDefinitionDeletionJobHandlerTest {
     definitionReader = mock(DefinitionReader.class);
     reportService = mock(ReportService.class);
     definitionService = mock(DefinitionService.class);
+    // default: after deletion, no other version is left (i.e. this was the last remaining
+    // version); individual tests override this when they need to assert the "other versions
+    // remain" behavior
     lenient()
         .when(
             definitionReader.getDefinitionVersions(eq(DefinitionType.PROCESS), anyString(), any()))
-        .thenReturn(List.of(new DefinitionVersionResponseDto("1", null)));
+        .thenReturn(List.of());
     handler =
         new ProcessDefinitionDeletionJobHandler(
             processDefinitionReader,
@@ -120,11 +123,11 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
   @Test
   void shouldClearCachedXmlAndInvalidateCacheWhenDeletingTheOnlyRemainingVersion() {
-    // given -- pre-delete query sees only the version being deleted
+    // given -- post-delete query finds no other version left
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
-        .thenReturn(List.of(new DefinitionVersionResponseDto("1", null)));
+        .thenReturn(List.of());
 
     // when
     handler.handle(job());
@@ -136,25 +139,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
   @Test
   void shouldNotClearCachedXmlWhenOtherVersionsRemainAfterDeletion() {
-    // given -- pre-delete query sees this version plus another sibling version
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
-        .thenReturn(Optional.of(definition()));
-    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
-        .thenReturn(
-            List.of(
-                new DefinitionVersionResponseDto("1", null),
-                new DefinitionVersionResponseDto("2", null)));
-
-    // when
-    handler.handle(job());
-
-    // then
-    verify(reportService, never()).clearCachedReportXml(anyString());
-  }
-
-  @Test
-  void shouldNotClearCachedXmlWhenTheSingleReturnedVersionIsNotTheOneBeingDeleted() {
-    // given
+    // given -- post-delete query still finds a sibling version
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
@@ -173,10 +158,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
-        .thenReturn(
-            List.of(
-                new DefinitionVersionResponseDto("1", null),
-                new DefinitionVersionResponseDto("2", null)));
+        .thenReturn(List.of(new DefinitionVersionResponseDto("2", null)));
 
     // when
     handler.handle(job());
@@ -186,24 +168,21 @@ class ProcessDefinitionDeletionJobHandlerTest {
   }
 
   @Test
-  void shouldCheckRemainingVersionsBeforeDeletingSoALastVersionDeleteIsNeverMissed() {
-    // given -- deleteDefinition() does not force a refresh, so checking remaining versions
-    // AFTER deleting could still see the stale (not-yet-refreshed) document and wrongly
-    // conclude other versions remain; checking beforehand avoids that read-after-write gap
+  void shouldCheckRemainingVersionsAfterDeletingSoAConcurrentSiblingDeleteIsNeverMissed() {
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
-        .thenReturn(List.of(new DefinitionVersionResponseDto("1", null)));
+        .thenReturn(List.of());
 
     // when
     handler.handle(job());
 
     // then
     final var order = inOrder(definitionReader, processDefinitionWriter);
+    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
     order
         .verify(definitionReader)
         .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of());
-    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -51,6 +51,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
   private static final String DEFINITION_ID = "definition-1";
   private static final String BPMN_PROCESS_ID = "invoice-process";
   private static final String TENANT_ID = "tenant-1";
+  private static final String VERSION = "1";
 
   private ProcessDefinitionReader processDefinitionReader;
   private ProcessInstanceWriter processInstanceWriter;
@@ -119,12 +120,13 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
     verify(processDefinitionWriter, never()).deleteDefinition(anyString());
-    verify(reportService, never()).clearCachedReportXml(anyString());
-    verify(definitionService, never()).invalidateProcessDefinition(anyString());
+    verify(reportService, never()).clearCachedReportXml(anyString(), any());
+    verify(definitionService, never())
+        .invalidateProcessDefinitionIfLatest(anyString(), any(), anyString());
   }
 
   @Test
-  void shouldClearCachedXmlAndInvalidateCacheWhenDeletingTheOnlyRemainingVersion() {
+  void shouldClearCachedXmlAndDelegateCacheInvalidationWhenDeletingTheOnlyRemainingVersion() {
     // given -- post-delete query finds no other version left
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
@@ -136,8 +138,9 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
-    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID);
-    verify(definitionService).invalidateProcessDefinition(BPMN_PROCESS_ID);
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID, TENANT_ID);
+    verify(definitionService)
+        .invalidateProcessDefinitionIfLatest(BPMN_PROCESS_ID, TENANT_ID, VERSION);
   }
 
   @Test
@@ -153,23 +156,9 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
-    verify(reportService, never()).clearCachedReportXml(anyString());
-  }
-
-  @Test
-  void shouldInvalidateDefinitionCacheEvenWhenOtherVersionsRemain() {
-    // given
-    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
-        .thenReturn(Optional.of(definition()));
-    when(definitionReader.getDefinitionVersions(
-            DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID)))
-        .thenReturn(List.of(new DefinitionVersionResponseDto("2", null)));
-
-    // when
-    handler.handle(job());
-
-    // then
-    verify(definitionService).invalidateProcessDefinition(BPMN_PROCESS_ID);
+    verify(reportService, never()).clearCachedReportXml(anyString(), any());
+    verify(definitionService)
+        .invalidateProcessDefinitionIfLatest(BPMN_PROCESS_ID, TENANT_ID, VERSION);
   }
 
   @Test
@@ -187,7 +176,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(definitionReader, never())
         .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of());
-    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID);
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID, TENANT_ID);
   }
 
   @Test
@@ -205,7 +194,11 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
-    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID);
+    verify(definitionReader)
+        .getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Collections.singleton(null));
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID, null);
+    verify(definitionService).invalidateProcessDefinitionIfLatest(BPMN_PROCESS_ID, null, VERSION);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -9,25 +9,36 @@ package io.camunda.optimize.service.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.job.EntityType;
 import io.camunda.optimize.dto.optimize.query.job.JobRegistryEntryDto;
 import io.camunda.optimize.dto.optimize.query.job.JobType;
+import io.camunda.optimize.dto.optimize.rest.DefinitionVersionResponseDto;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.reader.DefinitionReader;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
 import io.camunda.optimize.service.exceptions.OptimizeByQueryFailureException;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.report.ReportService;
 import java.net.SocketTimeoutException;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +53,9 @@ class ProcessDefinitionDeletionJobHandlerTest {
   private ProcessDefinitionReader processDefinitionReader;
   private ProcessInstanceWriter processInstanceWriter;
   private ProcessDefinitionWriter processDefinitionWriter;
+  private DefinitionReader definitionReader;
+  private ReportService reportService;
+  private DefinitionService definitionService;
   private ProcessDefinitionDeletionJobHandler handler;
 
   @BeforeEach
@@ -49,9 +63,22 @@ class ProcessDefinitionDeletionJobHandlerTest {
     processDefinitionReader = mock(ProcessDefinitionReader.class);
     processInstanceWriter = mock(ProcessInstanceWriter.class);
     processDefinitionWriter = mock(ProcessDefinitionWriter.class);
+    definitionReader = mock(DefinitionReader.class);
+    reportService = mock(ReportService.class);
+    definitionService = mock(DefinitionService.class);
+    lenient()
+        .when(
+            definitionReader.getDefinitionVersions(eq(DefinitionType.PROCESS), anyString(), any()))
+        .thenReturn(List.of(new DefinitionVersionResponseDto("1", null)));
     handler =
         new ProcessDefinitionDeletionJobHandler(
-            processDefinitionReader, processInstanceWriter, processDefinitionWriter, millis -> {});
+            processDefinitionReader,
+            processInstanceWriter,
+            processDefinitionWriter,
+            definitionReader,
+            reportService,
+            definitionService,
+            millis -> {});
   }
 
   @Test
@@ -87,6 +114,96 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
     verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+    verify(reportService, never()).clearCachedReportXml(anyString());
+    verify(definitionService, never()).invalidateProcessDefinition(anyString());
+  }
+
+  @Test
+  void shouldClearCachedXmlAndInvalidateCacheWhenDeletingTheOnlyRemainingVersion() {
+    // given -- pre-delete query sees only the version being deleted
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+        .thenReturn(List.of(new DefinitionVersionResponseDto("1", null)));
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID);
+    verify(definitionService).invalidateProcessDefinition(BPMN_PROCESS_ID);
+  }
+
+  @Test
+  void shouldNotClearCachedXmlWhenOtherVersionsRemainAfterDeletion() {
+    // given -- pre-delete query sees this version plus another sibling version
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+        .thenReturn(
+            List.of(
+                new DefinitionVersionResponseDto("1", null),
+                new DefinitionVersionResponseDto("2", null)));
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(reportService, never()).clearCachedReportXml(anyString());
+  }
+
+  @Test
+  void shouldNotClearCachedXmlWhenTheSingleReturnedVersionIsNotTheOneBeingDeleted() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+        .thenReturn(List.of(new DefinitionVersionResponseDto("2", null)));
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(reportService, never()).clearCachedReportXml(anyString());
+  }
+
+  @Test
+  void shouldInvalidateDefinitionCacheEvenWhenOtherVersionsRemain() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+        .thenReturn(
+            List.of(
+                new DefinitionVersionResponseDto("1", null),
+                new DefinitionVersionResponseDto("2", null)));
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(definitionService).invalidateProcessDefinition(BPMN_PROCESS_ID);
+  }
+
+  @Test
+  void shouldCheckRemainingVersionsBeforeDeletingSoALastVersionDeleteIsNeverMissed() {
+    // given -- deleteDefinition() does not force a refresh, so checking remaining versions
+    // AFTER deleting could still see the stale (not-yet-refreshed) document and wrongly
+    // conclude other versions remain; checking beforehand avoids that read-after-write gap
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+        .thenReturn(List.of(new DefinitionVersionResponseDto("1", null)));
+
+    // when
+    handler.handle(job());
+
+    // then
+    final var order = inOrder(definitionReader, processDefinitionWriter);
+    order
+        .verify(definitionReader)
+        .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of());
+    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -218,6 +335,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
     final ProcessDefinitionOptimizeDto definition = new ProcessDefinitionOptimizeDto();
     definition.setId(DEFINITION_ID);
     definition.setKey(BPMN_PROCESS_ID);
+    definition.setVersion("1");
     return definition;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -36,6 +36,7 @@ import io.camunda.optimize.service.exceptions.OptimizeByQueryFailureException;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.report.ReportService;
 import java.net.SocketTimeoutException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -49,6 +50,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
   private static final String DEFINITION_ID = "definition-1";
   private static final String BPMN_PROCESS_ID = "invoice-process";
+  private static final String TENANT_ID = "tenant-1";
 
   private ProcessDefinitionReader processDefinitionReader;
   private ProcessInstanceWriter processInstanceWriter;
@@ -126,7 +128,8 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // given -- post-delete query finds no other version left
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
-    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+    when(definitionReader.getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID)))
         .thenReturn(List.of());
 
     // when
@@ -142,7 +145,8 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // given -- post-delete query still finds a sibling version
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
-    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+    when(definitionReader.getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID)))
         .thenReturn(List.of(new DefinitionVersionResponseDto("2", null)));
 
     // when
@@ -157,7 +161,8 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // given
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
-    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+    when(definitionReader.getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID)))
         .thenReturn(List.of(new DefinitionVersionResponseDto("2", null)));
 
     // when
@@ -168,10 +173,47 @@ class ProcessDefinitionDeletionJobHandlerTest {
   }
 
   @Test
+  void shouldScopeRemainingVersionsLookupToTheDeletedDefinitionsTenantNotAllTenants() {
+    // given
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definition()));
+    when(definitionReader.getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID)))
+        .thenReturn(List.of());
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(definitionReader, never())
+        .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of());
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID);
+  }
+
+  @Test
+  void shouldCheckRemainingVersionsScopedToTheDeletedDefinitionsTenantWhenTenantIsNull() {
+    // given -- single-tenant setups store a null tenantId; the scoped lookup must tolerate that
+    final ProcessDefinitionOptimizeDto definitionWithNullTenant = definition();
+    definitionWithNullTenant.setTenantId(null);
+    when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
+        .thenReturn(Optional.of(definitionWithNullTenant));
+    when(definitionReader.getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Collections.singleton(null)))
+        .thenReturn(List.of());
+
+    // when
+    handler.handle(job());
+
+    // then
+    verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID);
+  }
+
+  @Test
   void shouldCheckRemainingVersionsAfterDeletingSoAConcurrentSiblingDeleteIsNeverMissed() {
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
-    when(definitionReader.getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of()))
+    when(definitionReader.getDefinitionVersions(
+            DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID)))
         .thenReturn(List.of());
 
     // when
@@ -182,7 +224,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
     order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
     order
         .verify(definitionReader)
-        .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of());
+        .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID));
   }
 
   @Test
@@ -315,6 +357,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
     definition.setId(DEFINITION_ID);
     definition.setKey(BPMN_PROCESS_ID);
     definition.setVersion("1");
+    definition.setTenantId(TENANT_ID);
     return definition;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.report;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.report.combined.CombinedReportDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.reader.ReportReader;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import io.camunda.optimize.service.identity.AbstractIdentityService;
+import io.camunda.optimize.service.relations.ReportRelationService;
+import io.camunda.optimize.service.security.AuthorizedCollectionService;
+import io.camunda.optimize.service.security.ReportAuthorizationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+  private static final String BPMN_PROCESS_ID = "invoice-process";
+  private static final String OTHER_BPMN_PROCESS_ID = "shipping-process";
+
+  private ReportReader reportReader;
+  private ReportWriter reportWriter;
+  private ReportService reportService;
+
+  @BeforeEach
+  void init() {
+    reportReader = mock(ReportReader.class);
+    reportWriter = mock(ReportWriter.class);
+    reportService =
+        new ReportService(
+            reportWriter,
+            reportReader,
+            mock(ReportAuthorizationService.class),
+            mock(ReportRelationService.class),
+            mock(AuthorizedCollectionService.class),
+            mock(AbstractIdentityService.class),
+            mock(DefinitionService.class),
+            mock(ConfigurationService.class));
+  }
+
+  @Test
+  void shouldClearXmlForSingleDefinitionReport() {
+    // given
+    final SingleProcessReportDefinitionRequestDto report =
+        singleProcessReport("report-1", BPMN_PROCESS_ID);
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(report));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+
+    // then
+    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-1"));
+  }
+
+  @Test
+  void shouldClearXmlForComparisonReportWhereKeyIsFirstListedDefinition() {
+    // given -- a comparison report referencing BPMN_PROCESS_ID as its first of two definitions
+    final ProcessReportDataDto comparisonData = new ProcessReportDataDto();
+    comparisonData.setProcessDefinitionKey(BPMN_PROCESS_ID);
+    comparisonData.getDefinitions().add(new ReportDataDefinitionDto(OTHER_BPMN_PROCESS_ID));
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto(comparisonData);
+    report.setId("report-3");
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(report));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+
+    // then
+    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-3"));
+  }
+
+  @Test
+  void shouldNotClearXmlForReportWhereKeyIsNotFirstListedDefinition() {
+    // given -- a comparison report referencing BPMN_PROCESS_ID only as its second definition
+    final ProcessReportDataDto comparisonData = new ProcessReportDataDto();
+    comparisonData.setProcessDefinitionKey(OTHER_BPMN_PROCESS_ID);
+    comparisonData.getDefinitions().add(new ReportDataDefinitionDto(BPMN_PROCESS_ID));
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto(comparisonData);
+    report.setId("report-2");
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(report));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+
+    // then
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+  }
+
+  @Test
+  void shouldIgnoreCombinedReportsAndNotClearXml() {
+    // given
+    final CombinedReportDefinitionRequestDto combinedReport =
+        new CombinedReportDefinitionRequestDto();
+    combinedReport.setId("combined-1");
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(combinedReport));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+
+    // then
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+  }
+
+  @Test
+  void shouldNotCallWriterWhenNoCandidatesFound() {
+    // given
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of());
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+
+    // then
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+  }
+
+  private SingleProcessReportDefinitionRequestDto singleProcessReport(
+      final String reportId, final String definitionKey) {
+    final ProcessReportDataDto data = new ProcessReportDataDto();
+    data.setProcessDefinitionKey(definitionKey);
+    final SingleProcessReportDefinitionRequestDto report =
+        new SingleProcessReportDefinitionRequestDto(data);
+    report.setId(reportId);
+    return report;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.report;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -70,7 +71,8 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
-    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-1"));
+    verify(reportWriter)
+        .clearReportDefinitionXmlForReportIds(List.of("report-1"), BPMN_PROCESS_ID, null);
   }
 
   @Test
@@ -89,7 +91,8 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
-    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-3"));
+    verify(reportWriter)
+        .clearReportDefinitionXmlForReportIds(List.of("report-3"), BPMN_PROCESS_ID, null);
   }
 
   @Test
@@ -108,7 +111,7 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
-    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList(), any(), any());
   }
 
   @Test
@@ -124,7 +127,7 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
-    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList(), any(), any());
   }
 
   @Test
@@ -140,7 +143,7 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, "tenant-a");
 
     // then
-    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList(), any(), any());
   }
 
   @Test
@@ -156,7 +159,8 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, "tenant-a");
 
     // then
-    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-5"));
+    verify(reportWriter)
+        .clearReportDefinitionXmlForReportIds(List.of("report-5"), BPMN_PROCESS_ID, "tenant-a");
   }
 
   @Test
@@ -172,7 +176,8 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, "tenant-a");
 
     // then
-    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-6"));
+    verify(reportWriter)
+        .clearReportDefinitionXmlForReportIds(List.of("report-6"), BPMN_PROCESS_ID, "tenant-a");
   }
 
   @Test
@@ -185,7 +190,7 @@ class ReportServiceTest {
     reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
-    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList(), any(), any());
   }
 
   private SingleProcessReportDefinitionRequestDto singleProcessReport(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/report/ReportServiceTest.java
@@ -25,6 +25,7 @@ import io.camunda.optimize.service.relations.ReportRelationService;
 import io.camunda.optimize.service.security.AuthorizedCollectionService;
 import io.camunda.optimize.service.security.ReportAuthorizationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,7 @@ class ReportServiceTest {
         .thenReturn(List.of(report));
 
     // when
-    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
     verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-1"));
@@ -85,7 +86,7 @@ class ReportServiceTest {
         .thenReturn(List.of(report));
 
     // when
-    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
     verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-3"));
@@ -104,7 +105,7 @@ class ReportServiceTest {
         .thenReturn(List.of(report));
 
     // when
-    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
     verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
@@ -120,10 +121,58 @@ class ReportServiceTest {
         .thenReturn(List.of(combinedReport));
 
     // when
-    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
     verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+  }
+
+  @Test
+  void shouldNotClearXmlWhenReportIsScopedToADifferentTenant() {
+    // given -- the report only covers tenant B; tenant A's data is what was deleted
+    final SingleProcessReportDefinitionRequestDto report =
+        singleProcessReport("report-4", BPMN_PROCESS_ID);
+    report.getData().setTenantIds(new ArrayList<>(List.of("tenant-b")));
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(report));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, "tenant-a");
+
+    // then
+    verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());
+  }
+
+  @Test
+  void shouldClearXmlWhenReportIncludesTheAffectedTenantAmongMultiple() {
+    // given -- the report spans both tenants, one of which was just deleted
+    final SingleProcessReportDefinitionRequestDto report =
+        singleProcessReport("report-5", BPMN_PROCESS_ID);
+    report.getData().setTenantIds(new ArrayList<>(List.of("tenant-a", "tenant-b")));
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(report));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, "tenant-a");
+
+    // then
+    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-5"));
+  }
+
+  @Test
+  void shouldClearXmlWhenReportsTenantIdsIsNull() {
+    // given -- a report has a null tenantIds list on its first definition
+    final SingleProcessReportDefinitionRequestDto report =
+        singleProcessReport("report-6", BPMN_PROCESS_ID);
+    report.getData().setTenantIds(null);
+    when(reportReader.getAllReportsForProcessDefinitionKeyOmitXml(BPMN_PROCESS_ID))
+        .thenReturn(List.of(report));
+
+    // when
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, "tenant-a");
+
+    // then
+    verify(reportWriter).clearReportDefinitionXmlForReportIds(List.of("report-6"));
   }
 
   @Test
@@ -133,7 +182,7 @@ class ReportServiceTest {
         .thenReturn(List.of());
 
     // when
-    reportService.clearCachedReportXml(BPMN_PROCESS_ID);
+    reportService.clearCachedReportXml(BPMN_PROCESS_ID, null);
 
     // then
     verify(reportWriter, never()).clearReportDefinitionXmlForReportIds(anyList());

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -308,6 +308,14 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
     return richOpenSearchClient.doc().updateByQuery(index, query, script);
   }
 
+  public long updateByQuery(
+      final String index,
+      final Query query,
+      final Script script,
+      final boolean failOnVersionConflicts) {
+    return richOpenSearchClient.doc().updateByQuery(index, query, script, failOnVersionConflicts);
+  }
+
   public final <T> IndexResponse index(final IndexRequest.Builder<T> indexRequest) {
     return richOpenSearchClient.doc().index(indexRequest);
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -20,6 +20,7 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
 import io.camunda.optimize.service.db.os.client.dsl.RequestDSL;
 import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.exceptions.OptimizeByQueryFailureException;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -402,16 +404,30 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
   }
 
   public long updateByQuery(final String index, final Query query, final Script script) {
+    return updateByQuery(index, query, script, false);
+  }
+
+  public long updateByQuery(
+      final String index,
+      final Query query,
+      final Script script,
+      final boolean failOnVersionConflicts) {
     final UpdateByQueryRequest request =
         applyIndexPrefix(updateByQueryRequestBuilder(List.of(index)))
             .query(query)
             .refresh(Refresh.True)
+            .conflicts(failOnVersionConflicts ? Conflicts.Abort : Conflicts.Proceed)
             .script(script)
             .build();
     final UpdateByQueryResponse response;
     Long status;
     try {
       response = openSearchClient.updateByQuery(request);
+      if (failOnVersionConflicts && response.failures() != null && !response.failures().isEmpty()) {
+        final String message = "update by query contained failures: " + response.failures();
+        LOG.error(message);
+        throw new OptimizeByQueryFailureException(message);
+      }
       status = response.updated();
     } catch (final IOException e) {
       status = null;

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperationsTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperationsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.client.sync;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.exceptions.OptimizeByQueryFailureException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.BulkByScrollFailure;
+import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.UpdateByQueryRequest;
+import org.opensearch.client.opensearch.core.UpdateByQueryResponse;
+
+@ExtendWith(MockitoExtension.class)
+class OpenSearchDocumentOperationsTest {
+
+  private OpenSearchClient openSearchClient;
+  private OpenSearchDocumentOperations documentOperations;
+
+  @BeforeEach
+  void init() {
+    openSearchClient = mock(OpenSearchClient.class);
+    final OptimizeIndexNameService indexNameService = mock(OptimizeIndexNameService.class);
+    when(indexNameService.getOptimizeIndexAliasForIndex(any(String.class)))
+        .thenAnswer(i -> i.getArgument(0));
+    documentOperations = new OpenSearchDocumentOperations(openSearchClient, indexNameService);
+  }
+
+  @Test
+  void shouldNotFailWhenVersionConflictsAreProceededByDefault() throws IOException {
+    // given
+    when(openSearchClient.updateByQuery(any(UpdateByQueryRequest.class)))
+        .thenReturn(UpdateByQueryResponse.of(b -> b.updated(0L).timedOut(false)));
+    final Query query = Query.of(q -> q.matchAll(m -> m));
+    final Script script = mock(Script.class);
+
+    // when / then
+    documentOperations.updateByQuery("test-index", query, script);
+  }
+
+  @Test
+  void shouldThrowWhenAbortedUpdateReportsAVersionConflictFailure() throws IOException {
+    // given
+    final BulkByScrollFailure conflictFailure =
+        BulkByScrollFailure.of(
+            f ->
+                f.id("report-1")
+                    .index("test-index")
+                    .cause(c -> c.type("version_conflict_engine_exception").reason("conflict"))
+                    .status(409));
+    when(openSearchClient.updateByQuery(any(UpdateByQueryRequest.class)))
+        .thenReturn(
+            UpdateByQueryResponse.of(b -> b.updated(0L).timedOut(false).failures(conflictFailure)));
+    final Query query = Query.of(q -> q.matchAll(m -> m));
+    final Script script = mock(Script.class);
+
+    // when / then
+    assertThatThrownBy(() -> documentOperations.updateByQuery("test-index", query, script, true))
+        .isInstanceOf(OptimizeByQueryFailureException.class);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`ProcessDefinitionDeletionJobHandler` deletes a process definition's instances and definition document, but left one thing behind: any report caching that definition's BPMN XML (`data.configuration.xml`). Once the last version of a `bpmnProcessId` is deleted, nothing was ever going to clear that cached XML.

- Before deleting anything, the handler checks whether the version being deleted is the last remaining version for its `bpmnProcessId` and tenant.  When it is the last version, `ReportService.clearCachedReportXml` clears `configuration.xml `on every report whose first-listed definition matches the key (and the tenant).
- `DefinitionService's` in-JVM cache entry for the deleted key is invalidated when the deletion renders the cache stale.
- Conflict errors during updates lead to retries to make sure XMLs are eventually cleared.
- The process definition is soft-deleted at first. When all other dependent operations are done then the process definition is hard-deleted. This is to ensure a new deletion is resumable.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59927
