### PR TITLE
refactor: migrate users page to new design system

### DIFF
--- a/identity/client/src/components/entityDetailV2/EntityDetail.tsx
+++ b/identity/client/src/components/entityDetailV2/EntityDetail.tsx
@@ -7,12 +7,6 @@
  */
 
 import { FC, ReactNode } from "react";
-import {
-  Loading,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListWrapper,
-} from "@carbon/react";
 import { Cell, HeadCell } from "./components";
 import Skeleton from "./Skeleton";
 
@@ -33,22 +27,22 @@ const EntityDetail: FC<EntityDetailProps> = ({
   const entries = data.length;
   const isDataMissing = data.some(({ value }) => !value);
 
-  return loading && isDataMissing ? (
-    <Skeleton entries={entries} />
-  ) : (
-    <StructuredListWrapper aria-label={listLabel}>
-      {loading && <Loading />}
-      <StructuredListBody>
-        {data?.map(({ label, value }, idx) => (
-          <StructuredListRow key={`${label}-${idx}`}>
-            <HeadCell head noWrap>
-              {label}
-            </HeadCell>
-            <Cell>{value}</Cell>
-          </StructuredListRow>
-        ))}
-      </StructuredListBody>
-    </StructuredListWrapper>
+  if (loading || isDataMissing) {
+    return <Skeleton entries={entries} />;
+  }
+
+  return (
+    <dl aria-label={listLabel} className="m-0 flex flex-col">
+      {data?.map(({ label, value }, idx) => (
+        <div
+          key={`${label}-${idx}`}
+          className="flex gap-4 py-3 shadow-[inset_0_-1px_0_var(--border)]"
+        >
+          <HeadCell>{label}</HeadCell>
+          <Cell>{value}</Cell>
+        </div>
+      ))}
+    </dl>
   );
 };
 

--- a/identity/client/src/components/entityDetailV2/EntityDetail.tsx
+++ b/identity/client/src/components/entityDetailV2/EntityDetail.tsx
@@ -25,7 +25,9 @@ const EntityDetail: FC<EntityDetailProps> = ({
   loading,
 }) => {
   const entries = data.length;
-  const isDataMissing = data.some(({ value }) => !value);
+  const isDataMissing = data.some(
+    ({ value }) => value === undefined || value === null,
+  );
 
   if (loading || isDataMissing) {
     return <Skeleton entries={entries} />;

--- a/identity/client/src/components/entityDetailV2/Skeleton.tsx
+++ b/identity/client/src/components/entityDetailV2/Skeleton.tsx
@@ -7,13 +7,7 @@
  */
 
 import { FC } from "react";
-import {
-  SkeletonText,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListWrapper,
-} from "@carbon/react";
-import { cssSize } from "src/utility/style";
+import { Skeleton as SkeletonBlock } from "@camunda/design-system";
 import { Cell, HeadCell } from "./components";
 
 type SkeletonProps = {
@@ -21,20 +15,21 @@ type SkeletonProps = {
 };
 
 const Skeleton: FC<SkeletonProps> = ({ entries = 2 }) => (
-  <StructuredListWrapper>
-    <StructuredListBody>
-      {new Array(entries).fill(undefined).map((_, i) => (
-        <StructuredListRow key={`list-skeleton-row-${i}`}>
-          <HeadCell head noWrap>
-            <SkeletonText heading width={cssSize(20)} />
-          </HeadCell>
-          <Cell>
-            <SkeletonText />
-          </Cell>
-        </StructuredListRow>
-      ))}
-    </StructuredListBody>
-  </StructuredListWrapper>
+  <dl className="m-0 flex flex-col">
+    {new Array(entries).fill(undefined).map((_, i) => (
+      <div
+        key={`list-skeleton-row-${i}`}
+        className="flex gap-4 py-3 shadow-[inset_0_-1px_0_var(--border)]"
+      >
+        <HeadCell>
+          <SkeletonBlock className="h-3 w-48" />
+        </HeadCell>
+        <Cell>
+          <SkeletonBlock className="h-3 w-full" />
+        </Cell>
+      </div>
+    ))}
+  </dl>
 );
 
 export default Skeleton;

--- a/identity/client/src/components/entityDetailV2/components.tsx
+++ b/identity/client/src/components/entityDetailV2/components.tsx
@@ -6,14 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import styled from "styled-components";
-import { StructuredListCell } from "@carbon/react";
-import { cssSize } from "src/utility/style";
+import { FC, ReactNode } from "react";
 
-export const Cell = styled(StructuredListCell)`
-  border-top: 0 none;
-`;
+type CellProps = { children: ReactNode };
 
-export const HeadCell = styled(StructuredListCell)`
-  width: ${cssSize(32)};
-`;
+export const Cell: FC<CellProps> = ({ children }) => (
+  <dd className="m-0 flex-1">{children}</dd>
+);
+
+export const HeadCell: FC<CellProps> = ({ children }) => (
+  <dt className="w-64 shrink-0 whitespace-nowrap font-medium text-neutral-foreground-strong">
+    {children}
+  </dt>
+);

--- a/identity/client/src/components/globalV2/ErrorPage.tsx
+++ b/identity/client/src/components/globalV2/ErrorPage.tsx
@@ -6,20 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import styled from "styled-components";
 import { FC, ReactNode } from "react";
 import Failmunda from "src/assets/images/failmunda.svg";
-// TODO: Replace with Tailwind classes
-import Flex from "src/components/layout/Flex";
-import { cssSize } from "src/utility/style.ts";
 import Page from "src/components/layoutV2/Page";
-
-const CenterWrapper = styled(Flex)`
-  margin: ${cssSize(10)} auto;
-  max-width: ${cssSize(50)};
-  align-items: start;
-  flex-direction: column;
-`;
 
 type ErrorPageProps = {
   title: ReactNode;
@@ -28,11 +17,11 @@ type ErrorPageProps = {
 
 const ErrorPage: FC<ErrorPageProps> = ({ title, children }) => (
   <Page>
-    <CenterWrapper>
+    <div className="mx-auto my-20 flex max-w-100 flex-col items-start gap-3">
       <Failmunda />
       <h1>{title}</h1>
       {children}
-    </CenterWrapper>
+    </div>
   </Page>
 );
 

--- a/identity/client/src/components/layoutV2/Page.tsx
+++ b/identity/client/src/components/layoutV2/Page.tsx
@@ -12,6 +12,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
+  BreadcrumbPage,
   BreadcrumbSeparator,
   PageHeader as DSPageHeader,
   PageLayout,
@@ -55,7 +56,8 @@ export const PageHeader: FC<PageHeaderProps> = ({
 
 type BreadcrumbsProps = {
   items: {
-    href: string;
+    // Omit `href` for the current page — it renders as non-interactive text.
+    href?: string;
     title: ReactNode;
   }[];
 };
@@ -64,12 +66,16 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ items }) => (
   <Breadcrumb>
     <BreadcrumbList>
       {items.map(({ href, title }, index) => (
-        <Fragment key={href}>
+        <Fragment key={href ?? index}>
           {index > 0 && <BreadcrumbSeparator />}
           <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to={href}>{title}</Link>
-            </BreadcrumbLink>
+            {href ? (
+              <BreadcrumbLink asChild>
+                <Link to={href}>{title}</Link>
+              </BreadcrumbLink>
+            ) : (
+              <BreadcrumbPage>{title}</BreadcrumbPage>
+            )}
           </BreadcrumbItem>
         </Fragment>
       ))}

--- a/identity/client/src/components/layoutV2/PageHeadline.tsx
+++ b/identity/client/src/components/layoutV2/PageHeadline.tsx
@@ -8,7 +8,7 @@
 
 import styled from "styled-components";
 
-// TODO: Replace with Design system heading and Tailwind component
+/** @deprecated Use `PageHeader` from `@camunda/design-system` instead. */
 const PageHeadline = styled.h1`
   min-width: 0;
   overflow: hidden;

--- a/identity/client/src/components/tabsV2/index.tsx
+++ b/identity/client/src/components/tabsV2/index.tsx
@@ -8,15 +8,13 @@
 
 import { ReactNode, useEffect } from "react";
 import {
-  Tab,
-  TabList,
-  TabPanel as CarbonTabPanel,
-  TabPanels,
-  Tabs as CarbonTabs,
-} from "@carbon/react";
+  Tabs as DSTabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { useNavigate } from "react-router-dom";
-import styled from "styled-components";
 
 export type TabsProps<
   T extends { key: string; label: string; content: ReactNode },
@@ -25,11 +23,6 @@ export type TabsProps<
   tabs: readonly T[];
   selectedTabKey: string;
 };
-
-const TabPanel = styled(CarbonTabPanel)`
-  padding-left: 0;
-  padding-right: 0;
-`;
 
 const Tabs = <T extends { key: string; label: string; content: ReactNode }>({
   path,
@@ -40,6 +33,7 @@ const Tabs = <T extends { key: string; label: string; content: ReactNode }>({
   const { t } = useTranslate("components");
 
   const selectedTabIndex = tabs.findIndex(({ key }) => key === selectedTabKey);
+  const activeTabKey = selectedTabIndex > -1 ? selectedTabKey : tabs[0].key;
 
   useEffect(() => {
     if (selectedTabIndex === -1) {
@@ -48,23 +42,25 @@ const Tabs = <T extends { key: string; label: string; content: ReactNode }>({
   }, [navigate, path, selectedTabIndex, tabs]);
 
   return (
-    <CarbonTabs
-      selectedIndex={selectedTabIndex > -1 ? selectedTabIndex : 0}
-      onChange={({ selectedIndex }: { selectedIndex: number }) =>
-        navigate(`${path}/${tabs[selectedIndex].key}`)
-      }
+    <DSTabs
+      value={activeTabKey}
+      onValueChange={(key) => {
+        void navigate(`${path}/${key}`);
+      }}
     >
-      <TabList aria-label={t("Tabs")}>
+      <TabsList variant="line" aria-label={t("Tabs")}>
         {tabs.map(({ key, label }) => (
-          <Tab key={`tab-${key}`}>{label}</Tab>
+          <TabsTrigger key={`tab-${key}`} value={key}>
+            {label}
+          </TabsTrigger>
         ))}
-      </TabList>
-      <TabPanels>
-        {tabs.map(({ key, content }) => (
-          <TabPanel key={`tab-panel-${key}`}>{content}</TabPanel>
-        ))}
-      </TabPanels>
-    </CarbonTabs>
+      </TabsList>
+      {tabs.map(({ key, content }) => (
+        <TabsContent key={`tab-panel-${key}`} value={key}>
+          {content}
+        </TabsContent>
+      ))}
+    </DSTabs>
   );
 };
 

--- a/identity/client/src/components/tabsV2/index.tsx
+++ b/identity/client/src/components/tabsV2/index.tsx
@@ -6,31 +6,66 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { ReactNode, useEffect } from "react";
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
 import {
   Tabs as DSTabs,
-  TabsContent,
+  TabsContent as DSTabsContent,
   TabsList,
   TabsTrigger,
 } from "@camunda/design-system";
-import useTranslate from "src/utility/localization";
 import { useNavigate } from "react-router-dom";
+import useTranslate from "src/utility/localization";
 
-export type TabsProps<
-  T extends { key: string; label: string; content: ReactNode },
-> = {
-  path: string;
-  tabs: readonly T[];
-  selectedTabKey: string;
+export type TabItem = {
+  key: string;
+  label: string;
+  content: ReactNode;
 };
 
-const Tabs = <T extends { key: string; label: string; content: ReactNode }>({
+type TabsContextValue = {
+  tabs: readonly TabItem[];
+  activeTabKey: string;
+};
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+const useTabsContext = () => {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error(
+      "Tabs.* components must be rendered within a <Tabs> from src/components/tabsV2",
+    );
+  }
+  return context;
+};
+
+export type TabsProps = {
+  path: string;
+  tabs: readonly TabItem[];
+  selectedTabKey: string;
+  children: ReactNode;
+};
+
+/**
+ * Compound root: owns tab-in-URL navigation and provides tab state to
+ * `TabsHeaderList` and `TabsContent`, so those can be placed independently
+ * (e.g. `TabsHeaderList` inside a `PageHeader`'s `tabs` slot, `TabsContent`
+ * below it) instead of being rendered as one fixed block.
+ */
+export const Tabs: FC<TabsProps> = ({
   path,
-  selectedTabKey,
   tabs,
-}: TabsProps<T>) => {
+  selectedTabKey,
+  children,
+}) => {
   const navigate = useNavigate();
-  const { t } = useTranslate("components");
 
   const selectedTabIndex = tabs.findIndex(({ key }) => key === selectedTabKey);
   const activeTabKey = selectedTabIndex > -1 ? selectedTabKey : tabs[0].key;
@@ -41,27 +76,44 @@ const Tabs = <T extends { key: string; label: string; content: ReactNode }>({
     }
   }, [navigate, path, selectedTabIndex, tabs]);
 
+  const contextValue = useMemo(
+    () => ({ tabs, activeTabKey }),
+    [tabs, activeTabKey],
+  );
+
   return (
-    <DSTabs
-      value={activeTabKey}
-      onValueChange={(key) => {
-        void navigate(`${path}/${key}`);
-      }}
-    >
-      <TabsList variant="line" aria-label={t("Tabs")}>
-        {tabs.map(({ key, label }) => (
-          <TabsTrigger key={`tab-${key}`} value={key}>
-            {label}
-          </TabsTrigger>
-        ))}
-      </TabsList>
-      {tabs.map(({ key, content }) => (
-        <TabsContent key={`tab-panel-${key}`} value={key}>
-          {content}
-        </TabsContent>
-      ))}
-    </DSTabs>
+    <TabsContext.Provider value={contextValue}>
+      <DSTabs
+        value={activeTabKey}
+        onValueChange={(key) => void navigate(`${path}/${key}`)}
+      >
+        {children}
+      </DSTabs>
+    </TabsContext.Provider>
   );
 };
 
-export default Tabs;
+export const TabsHeaderList: FC = () => {
+  const { tabs } = useTabsContext();
+  const { t } = useTranslate("components");
+
+  return (
+    <TabsList variant="line" aria-label={t("Tabs")}>
+      {tabs.map(({ key, label }) => (
+        <TabsTrigger key={key} value={key}>
+          {label}
+        </TabsTrigger>
+      ))}
+    </TabsList>
+  );
+};
+
+export const TabsContent: FC = () => {
+  const { tabs } = useTabsContext();
+
+  return tabs.map(({ key, content }) => (
+    <DSTabsContent key={key} value={key}>
+      {content}
+    </DSTabsContent>
+  ));
+};

--- a/identity/client/src/pages/global-task-listeners/ListV2.tsx
+++ b/identity/client/src/pages/global-task-listeners/ListV2.tsx
@@ -46,7 +46,7 @@ const List: FC = () => {
     useEntityModal(DeleteModal, noop);
 
   const shouldShowEmptyState =
-    success && !search && !globalTaskListeners?.items.length;
+    success && !search && globalTaskListeners.items.length === 0;
 
   const pageHeader = (
     <PageHeader
@@ -84,7 +84,7 @@ const List: FC = () => {
     <Page>
       {pageHeader}
       <EntityList
-        data={transformedData ?? []}
+        data={transformedData}
         headers={[
           {
             header: t("globalTaskListenerId"),

--- a/identity/client/src/pages/not-foundV2/index.tsx
+++ b/identity/client/src/pages/not-foundV2/index.tsx
@@ -6,8 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import { Button } from "@camunda/design-system";
 import { FC } from "react";
-import { Link } from "@carbon/react";
 import useTranslate from "src/utility/localization";
 import ErrorPage from "src/components/globalV2/ErrorPage";
 
@@ -19,9 +19,11 @@ const NotFound: FC = () => {
       <Translate>
         What you&apos;re looking for isn&apos;t here, sorry!
       </Translate>
-      <Link href="/">
-        <Translate>Click here to go back home</Translate>
-      </Link>
+      <Button variant="link" size="sm" asChild>
+        <a href="/">
+          <Translate>Click here to go back home</Translate>
+        </a>
+      </Button>
     </ErrorPage>
   );
 };

--- a/identity/client/src/pages/users/ListV2.tsx
+++ b/identity/client/src/pages/users/ListV2.tsx
@@ -47,7 +47,7 @@ const List: FC = () => {
   const showDetails = ({ username }: User) => navigate(`${username}`);
 
   const shouldShowEmptyState =
-    success && !search && !userSearchResults?.items.length;
+    success && !search && userSearchResults.items.length === 0;
 
   const pageHeader = (
     <PageHeader
@@ -76,7 +76,7 @@ const List: FC = () => {
     <Page>
       {pageHeader}
       <EntityList
-        data={userSearchResults == null ? [] : userSearchResults.items}
+        data={userSearchResults?.items}
         headers={[
           {
             header: t("username"),

--- a/identity/client/src/pages/users/detailV2/index.tsx
+++ b/identity/client/src/pages/users/detailV2/index.tsx
@@ -6,20 +6,18 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { Pencil, Trash2 } from "lucide-react";
+import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { userQueries } from "src/utility/api/users/queries";
 import NotFound from "src/pages/not-foundV2";
-import { OverflowMenu, OverflowMenuItem, Section } from "@carbon/react";
 import { StackPage } from "src/components/layoutV2/Page";
-import PageHeadline from "src/components/layoutV2/PageHeadline";
 import UserDetails from "./UserDetailsTab";
-import Tabs from "src/components/tabsV2";
+import { Tabs, TabsHeaderList, TabsContent } from "src/components/tabsV2";
 import { DetailPageHeaderFallback } from "src/components/fallbacksV2";
-// TODO: Replace with Tailwind classes
-import Flex from "src/components/layout/Flex";
 import { useEntityModal } from "src/components/modalV2";
 import EditModal from "src/pages/users/modalsV2/EditModal";
 import DeleteModal from "src/pages/users/modalsV2/DeleteModal";
@@ -35,7 +33,22 @@ const Details: FC = () => {
   const [deleteUser, deleteUserModal] = useEntityModal(DeleteModal, () =>
     navigate("..", { replace: true }),
   );
+
   const user = userSearchResults ? userSearchResults.items[0] : null;
+  const tabs = useMemo(() => {
+    if (!user) {
+      return [];
+    }
+
+    return [
+      {
+        key: "details",
+        label: t("userDetails"),
+        content: <UserDetails user={user} loading={loading} />,
+      },
+    ];
+  }, [user, loading, t]);
+
   if (!loading && !user) return <NotFound />;
 
   return (
@@ -44,41 +57,38 @@ const Details: FC = () => {
         {loading && !user ? (
           <DetailPageHeaderFallback hasOverflowMenu={false} />
         ) : (
-          <Flex>
-            {user && (
-              <>
-                <PageHeadline>{user.username}</PageHeadline>
-                <OverflowMenu ariaLabel={t("openContextMenu")}>
-                  <OverflowMenuItem
-                    itemText={t("update")}
-                    onClick={() => {
-                      editUser(user);
-                    }}
-                  />
-                  <OverflowMenuItem
-                    itemText={t("delete")}
-                    onClick={() => {
-                      deleteUser(user);
-                    }}
-                  />
-                </OverflowMenu>
-              </>
-            )}
-          </Flex>
+          user && (
+            <Tabs path={`../${id}`} tabs={tabs} selectedTabKey={tab}>
+              <PageHeader
+                title={user.username}
+                actions={
+                  <>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => editUser(user)}
+                    >
+                      <Pencil aria-hidden="true" />
+                      {t("update")}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => deleteUser(user)}
+                    >
+                      <Trash2 aria-hidden="true" />
+                      {t("delete")}
+                    </Button>
+                  </>
+                }
+                tabs={<TabsHeaderList />}
+              />
+              <TabsContent />
+            </Tabs>
+          )
         )}
-        <Section>
-          <Tabs
-            tabs={[
-              {
-                key: "details",
-                label: t("userDetails"),
-                content: user && <UserDetails user={user} loading={loading} />,
-              },
-            ]}
-            selectedTabKey={tab}
-            path={`../${id}`}
-          />
-        </Section>
       </>
       {editUserModal}
       {deleteUserModal}

--- a/identity/client/src/pages/users/detailV2/index.tsx
+++ b/identity/client/src/pages/users/detailV2/index.tsx
@@ -14,7 +14,7 @@ import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { userQueries } from "src/utility/api/users/queries";
 import NotFound from "src/pages/not-foundV2";
-import { StackPage } from "src/components/layoutV2/Page";
+import { Breadcrumbs, StackPage } from "src/components/layoutV2/Page";
 import UserDetails from "./UserDetailsTab";
 import { Tabs, TabsHeaderList, TabsContent } from "src/components/tabsV2";
 import { DetailPageHeaderFallback } from "src/components/fallbacksV2";
@@ -35,10 +35,13 @@ const Details: FC = () => {
   );
 
   const user = userSearchResults ? userSearchResults.items[0] : null;
+  const breadcrumbs = useMemo(() => {
+    if (!user) return [];
+
+    return [{ title: t("users"), href: ".." }, { title: user.username }];
+  }, [user, t]);
   const tabs = useMemo(() => {
-    if (!user) {
-      return [];
-    }
+    if (!user) return [];
 
     return [
       {
@@ -61,6 +64,7 @@ const Details: FC = () => {
             <Tabs path={`../${id}`} tabs={tabs} selectedTabKey={tab}>
               <PageHeader
                 title={user.username}
+                breadcrumb={<Breadcrumbs items={breadcrumbs} />}
                 actions={
                   <>
                     <Button

--- a/identity/client/src/pages/users/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/users/modalsV2/EditModal.tsx
@@ -9,10 +9,9 @@
 import { FC, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Heading, Separator, Text } from "@camunda/design-system";
 import TextField from "src/components/formV2/TextField";
 import useTranslate from "src/utility/localization";
-// TODO: Replace `Divider` with `Separator` from Camunda design system.
-import Divider from "src/components/form/Divider";
 import { FormModal, UseEntityModalProps } from "src/components/modalV2";
 import { userMutations } from "src/utility/api/users/mutations";
 import { isValidEmail } from "src/utility/validate";
@@ -113,9 +112,13 @@ const EditModal: FC<UseEntityModalProps<User>> = ({
           />
         )}
       />
-      <Divider />
-      <h3>{t("resetPassword")}</h3>
-      <div>{t("resetPasswordInfo")}</div>
+      <Separator />
+      <div className="grid gap-1">
+        <Heading as="h3" variant="heading-xs">
+          {t("resetPassword")}
+        </Heading>
+        <Text as="p">{t("resetPasswordInfo")}</Text>
+      </div>
       <Controller
         name="password"
         control={control}


### PR DESCRIPTION
## Description

This PR migrates the users page and components it requires to the new design system. Two smaller changes I made:

- Moved actions in the users details page out of a context menu. The `PageHeader` renders them to the right. Looks like all details in Admin only have two actions. This makes them more discoverable.
- Added breadcrumbs to the user details page. All other details have them. Simplifies back navigation on the details page.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60417
