### PR TITLE
Dedup embedded agent history items across jobs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistoryDedupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistoryDedupIT.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryItem;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers idempotency of the embedded {@code history[]} batch on {@code UpdateAgentInstance} across
+ * job activations: an item committed by an earlier job, then resent by a later, different job for
+ * the same agent instance, must still be recognized as a duplicate — over the real REST API, not
+ * just at the engine level.
+ */
+@MultiDbTest
+@CompatibilityTest
+public class AgentInstanceHistoryDedupIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentDedupElement";
+  private static final String PROCESS_ID = "agentHistoryDedupProcess";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldFlagResentHistoryItemAsDuplicateAcrossJobActivations() {
+    // given — a sequential multi-instance AI-agent service task: job1 pushes "item-x" and
+    // completes, then job2 — a brand-new job on a brand-new element instance — resends "item-x"
+    final var processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                AGENT_ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeAiAgentTaskDefinition()
+                        .multiInstance(
+                            m ->
+                                m.sequential()
+                                    .zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "agent-history-dedup.bpmn");
+
+    final var processInstanceKey =
+        camundaClient
+            .newCreateInstanceCommand()
+            .processDefinitionKey(process.getProcessDefinitionKey())
+            .variables(Map.of("items", List.of("a", "b")))
+            .execute()
+            .getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.elementId(AGENT_ELEMENT_ID)
+                .type(ElementInstanceType.SERVICE_TASK)
+                .processInstanceKey(processInstanceKey),
+        1);
+    final var ei1 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(AGENT_ELEMENT_ID)
+                        .type(ElementInstanceType.SERVICE_TASK)
+                        .processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    // CREATE requires a jobKey/jobLease backed by an actual activation of the agentic job; fail
+    // it straight back so the activation below can pick the same job up again
+    final var creationJob =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .withLease(true)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+    final var agentInstanceKey =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(ei1)
+            .jobKey(creationJob.getKey())
+            .jobLease(creationJob.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.CONFIGURATION)
+                        .content(List.of(AgentInstanceHistoryContent.text("configuration")))
+                        .producedAt(OffsetDateTime.now())
+                        .model("gpt-4o")
+                        .provider("openai")
+                        .systemPrompt(
+                            List.of(
+                                AgentInstanceHistoryContent.text("You are a helpful assistant.")))))
+            .send()
+            .join()
+            .getAgentInstanceKey();
+    camundaClient.newFailCommand(creationJob).retries(1).execute();
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+
+    final var job1 =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .withLease(true)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+
+    // when — job1 pushes "item-x", then completes, committing it
+    final var firstResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(ei1)
+            .jobKey(job1.getKey())
+            .jobLease(job1.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId("item-x")
+                        .role(AgentInstanceHistoryRole.USER)
+                        .loopIteration(1)
+                        .content(List.of(AgentInstanceHistoryContent.text("hi")))
+                        .producedAt(OffsetDateTime.now())))
+            .send()
+            .join();
+    final var originalKey = firstResponse.getCreatedHistory().getFirst().getHistoryItemKey();
+
+    camundaClient.newCompleteCommand(job1).send().join();
+
+    // given — the multi-instance body advances: a second element instance activates
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.elementId(AGENT_ELEMENT_ID)
+                .type(ElementInstanceType.SERVICE_TASK)
+                .processInstanceKey(processInstanceKey),
+        2);
+    final var ei2 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(AGENT_ELEMENT_ID)
+                        .type(ElementInstanceType.SERVICE_TASK)
+                        .processInstanceKey(processInstanceKey))
+            .sort(s -> s.elementInstanceKey().asc())
+            .execute()
+            .items()
+            .get(1)
+            .getElementInstanceKey();
+
+    final var job2 =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .withLease(true)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+
+    // when — job2 (a brand-new job, on a brand-new element instance) resends "item-x", with
+    // different content
+    final var secondResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(ei2)
+            .jobKey(job2.getKey())
+            .jobLease(job2.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId("item-x")
+                        .role(AgentInstanceHistoryRole.USER)
+                        .loopIteration(1)
+                        .content(List.of(AgentInstanceHistoryContent.text("hi again")))
+                        .producedAt(OffsetDateTime.now())))
+            .send()
+            .join();
+
+    // then
+    final var echoed = secondResponse.getCreatedHistory();
+    assertThat(echoed).hasSize(1);
+    assertThat(echoed.getFirst().isDuplicate())
+        .as("resent item is flagged a duplicate of the original, over the real REST API")
+        .isTrue();
+    assertThat(echoed.getFirst().getHistoryItemKey()).isEqualTo(originalKey);
+    assertThat(job2.getElementInstanceKey())
+        .as("job2 must be the job activated for the second element instance")
+        .isEqualTo(ei2);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -243,11 +243,15 @@ public final class AgentHistoryBatchBehavior {
       final boolean applyConfigurationChanges) {
     final var changedAttributes = new HashSet<String>();
     final var items = new ArrayList<AgentHistoryRecord>(history.size());
+    final var agentHistoryState = processingState.getAgentHistoryState();
     final var pendingByHistoryItemId = collectPendingByHistoryItemId(jobKey, jobLease);
 
     for (final var item : history) {
       final var historyItemId = item.getHistoryItemId();
-      final var matchedKey = pendingByHistoryItemId.get(historyItemId);
+      final var committedKey =
+          agentHistoryState.getCommittedHistoryItemKey(target.getAgentInstanceKey(), historyItemId);
+      final var matchedKey =
+          committedKey != null ? committedKey : pendingByHistoryItemId.get(historyItemId);
       final var isDuplicate = matchedKey != null;
       final var historyKey = isDuplicate ? matchedKey : keyGenerator.nextKey();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import java.util.ArrayList;
+import java.util.function.Consumer;
 
 public final class DbAgentHistoryState implements MutableAgentHistoryState {
 
@@ -36,6 +38,17 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
   private final ColumnFamily<DbCompositeKey<DbCompositeKey<DbLong, DbString>, DbLong>, DbNil>
       byJobKeyColumnFamily;
 
+  // Committed ids: (agentInstanceKey, historyItemId) -> agentHistoryKey
+  // Supports prefix search by agentInstanceKey alone, for the one-shot delete on instance
+  // completion.
+  private final DbLong committedAgentInstanceKey = new DbLong();
+  private final DbString committedHistoryItemId = new DbString();
+  private final DbCompositeKey<DbLong, DbString> committedKey =
+      new DbCompositeKey<>(committedAgentInstanceKey, committedHistoryItemId);
+  private final DbLong committedAgentHistoryKey = new DbLong();
+  private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbLong>
+      committedHistoryItemIdsColumnFamily;
+
   public DbAgentHistoryState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     agentHistoryColumnFamily =
@@ -47,6 +60,12 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
             transactionContext,
             jobKeyLeaseAndHistoryItemKey,
             DbNil.INSTANCE);
+    committedHistoryItemIdsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AGENT_HISTORY_COMMITTED_IDS,
+            transactionContext,
+            committedKey,
+            committedAgentHistoryKey);
   }
 
   @Override
@@ -110,5 +129,39 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
     jobLease.wrapString(record.getJobLease());
     agentHistoryColumnFamily.deleteIfExists(historyItemKey);
     byJobKeyColumnFamily.deleteIfExists(jobKeyLeaseAndHistoryItemKey);
+  }
+
+  @Override
+  public Long getCommittedHistoryItemKey(final long agentInstanceKey, final String historyItemId) {
+    committedAgentInstanceKey.wrapLong(agentInstanceKey);
+    committedHistoryItemId.wrapString(historyItemId);
+    final var stored = committedHistoryItemIdsColumnFamily.get(committedKey);
+    return stored == null ? null : stored.getValue();
+  }
+
+  @Override
+  public void putCommittedHistoryItemKey(
+      final long agentInstanceKey, final String historyItemId, final long agentHistoryKeyValue) {
+    committedAgentInstanceKey.wrapLong(agentInstanceKey);
+    committedHistoryItemId.wrapString(historyItemId);
+    committedAgentHistoryKey.wrapLong(agentHistoryKeyValue);
+    committedHistoryItemIdsColumnFamily.upsert(committedKey, committedAgentHistoryKey);
+  }
+
+  @Override
+  public void deleteCommittedHistoryItemKeys(final long agentInstanceKey) {
+    committedAgentInstanceKey.wrapLong(agentInstanceKey);
+    // Collect the ids in one pass, then delete in a second: mutating the column family while its
+    // own iterator is still open is unsafe (RocksDB explicitly warns against it), so this must not
+    // call deleteExisting from inside the whileEqualPrefix visitor below.
+    final var historyItemIds = new ArrayList<String>();
+    final Consumer<DbCompositeKey<DbLong, DbString>> collectHistoryItemId =
+        key -> historyItemIds.add(key.second().toString());
+    committedHistoryItemIdsColumnFamily.whileEqualPrefix(
+        committedAgentInstanceKey, collectHistoryItemId);
+    for (final var historyItemId : historyItemIds) {
+      committedHistoryItemId.wrapString(historyItemId);
+      committedHistoryItemIdsColumnFamily.deleteExisting(committedKey);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -24,6 +24,8 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    agentHistoryState.putCommittedHistoryItemKey(
+        value.getAgentInstanceKey(), value.getHistoryItemId(), key);
     agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -16,13 +17,19 @@ public final class AgentInstanceCompletedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
 
   private final MutableAgentInstanceState agentInstanceState;
+  private final MutableAgentHistoryState agentHistoryState;
 
-  public AgentInstanceCompletedApplier(final MutableAgentInstanceState agentInstanceState) {
+  public AgentInstanceCompletedApplier(
+      final MutableAgentInstanceState agentInstanceState,
+      final MutableAgentHistoryState agentHistoryState) {
     this.agentInstanceState = agentInstanceState;
+    this.agentHistoryState = agentHistoryState;
   }
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    // Only removal path for an agent instance; any new one needs this same cleanup call.
+    agentHistoryState.deleteCommittedHistoryItemKeys(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -223,7 +223,8 @@ public final class EventAppliers implements EventApplier {
             state.getAgentInstanceState(), state.getElementInstanceState()));
     register(
         AgentInstanceIntent.COMPLETED,
-        new AgentInstanceCompletedApplier(state.getAgentInstanceState()));
+        new AgentInstanceCompletedApplier(
+            state.getAgentInstanceState(), state.getAgentHistoryState()));
     register(
         AgentInstanceIntent.MIGRATED,
         new AgentInstanceMigratedApplier(state.getAgentInstanceState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
@@ -34,6 +34,12 @@ public interface AgentHistoryState {
    */
   void visitByJobLease(long jobKey, String jobLease, AgentHistoryVisitor visitor);
 
+  /**
+   * @return the {@code agentHistoryKey} of the history item that was committed under this {@code
+   *     historyItemId} for this agent instance, or {@code null} if none was
+   */
+  Long getCommittedHistoryItemKey(long agentInstanceKey, String historyItemId);
+
   @FunctionalInterface
   interface AgentHistoryVisitor {
     void visit(AgentHistoryRecord record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
@@ -36,7 +36,7 @@ public interface AgentHistoryState {
 
   /**
    * @return the {@code agentHistoryKey} of the history item that was committed under this {@code
-   *     historyItemId} for this agent instance, or {@code null} if none was
+   *     historyItemId} for this agent instance, or {@code null} if none was committed
    */
   Long getCommittedHistoryItemKey(long agentInstanceKey, String historyItemId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
@@ -25,4 +25,18 @@ public interface MutableAgentHistoryState extends AgentHistoryState {
    * to locate the secondary index entry, avoiding an extra state lookup.
    */
   void delete(long historyItemKey, AgentHistoryRecord record);
+
+  /**
+   * Records that {@code historyItemId} was committed under {@code agentHistoryKey} for {@code
+   * agentInstanceKey}, so a later job resending this id can still be recognized as a duplicate once
+   * the pending item itself is gone.
+   */
+  void putCommittedHistoryItemKey(
+      long agentInstanceKey, String historyItemId, long agentHistoryKey);
+
+  /**
+   * Deletes every committed-id entry recorded for {@code agentInstanceKey}. Called once, when the
+   * agent instance completes.
+   */
+  void deleteCommittedHistoryItemKeys(long agentInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -2756,4 +2756,425 @@ public class AgentInstanceHistoryBatchProcessingTest {
     // then — accepted, not rejected: EI1 already completed, so it no longer holds the write lock.
     assertThat(updated.getValue().getHistory()).hasSize(1);
   }
+
+  @Test
+  public void shouldMarkResentItemAsDuplicateAcrossJobActivations() {
+    // given — a sequential multi-instance AI-agent service task: job1 pushes "item-x" and
+    // completes (committing it), then job2 — a brand-new job on a brand-new element instance,
+    // for the same agent instance — resends "item-x"
+    final var multiInstanceProcessId = "cross-job-dedup-sequential-multi-instance";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(helper.getJobType())
+                            .zeebeAiAgentTaskDefinition()
+                            .multiInstance(
+                                m ->
+                                    m.sequential()
+                                        .zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var ei1 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — job1 pushes "item-x", then completes, committing it
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei1)
+            .withJobKey(job1Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-x")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+        .withJobKey(job1Key)
+        .getFirst();
+
+    final var ei2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList()
+            .get(1)
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var job2Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei2)
+            .getFirst()
+            .getKey();
+
+    // when — job2 (a brand-new job, on a brand-new element instance) resends "item-x", with
+    // different content
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2)
+            .withJobKey(job2Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-x")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again"))))
+            .update();
+
+    // then
+    final var echoed = secondUpdate.getValue().getHistory();
+    assertThat(echoed).hasSize(1);
+    assertThat(echoed.get(0).isDuplicate())
+        .as("resent item is flagged a duplicate, not minted as a new entry")
+        .isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(originalKey);
+
+    // bounded via a clock-reset sentinel so the check cannot hang on a record that never arrives
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var createdForItem =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(
+                r -> ((AgentHistoryRecordValue) r.getValue()).getHistoryItemId().equals("item-x"))
+            .toList();
+    assertThat(createdForItem).as("no second CREATED event was appended for item-x").hasSize(1);
+  }
+
+  @Test
+  public void shouldScopeDuplicateDetectionPerAgentInstance() {
+    // given — agent instance A: an item is committed via an explicit COMMIT command (the job
+    // itself stays ACTIVATED throughout)
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKeyA = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKeyA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyA)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKeyA =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobAKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKeyA)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyA)
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-shared")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var originalKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+    ENGINE.agentHistories().withJobKey(jobAKey).commit();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+        .withJobKey(jobAKey)
+        .getFirst();
+
+    // when — the same historyItemId is resent to agent instance A itself
+    final var resendToA =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyA)
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-shared")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again"))))
+            .update();
+
+    // then
+    assertThat(resendToA.getValue().getHistory().get(0).isDuplicate())
+        .as("flagged a duplicate of the original, within A")
+        .isTrue();
+    assertThat(resendToA.getValue().getHistory().get(0).getAgentHistoryKey())
+        .isEqualTo(originalKey);
+
+    // given — a second, unrelated agent instance B
+    final var processInstanceKeyB = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKeyB =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyB)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKeyB =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKeyB)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — the SAME historyItemId ("item-shared") is sent under agent instance B for the first
+    // time
+    final var sentToB =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyB)
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withJobKey(jobBKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-shared")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+
+    // then
+    assertThat(sentToB.getValue().getHistory().get(0).isDuplicate())
+        .as("not a duplicate: the committed-ids scope is per agent instance, not global")
+        .isFalse();
+    assertThat(sentToB.getValue().getHistory().get(0).getAgentHistoryKey())
+        .isNotEqualTo(originalKey);
+  }
+
+  @Test
+  public void shouldNotTreatDiscardedItemAsDuplicateWhenResent() {
+    // given — one job pushes two items under two different leases: "item-committed" under
+    // lease-1, "item-discarded" under lease-2
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-1")
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-committed")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .update();
+    final var committedOriginalKey =
+        firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    ENGINE
+        .agentInstances()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobKey(jobKey)
+        .withJobLease("lease-2")
+        .withHistory(
+            List.of(
+                new AgentHistoryRecord()
+                    .setHistoryItemId("item-discarded")
+                    .setRole(AgentHistoryRole.USER)
+                    .setLoopIteration(1)
+                    .addContent(
+                        new AgentHistoryMessageContent()
+                            .setContentType(AgentHistoryContentType.TEXT)
+                            .setText("hey"))))
+        .update();
+
+    // when — COMMIT with lease-1: "item-committed" is committed, "item-discarded" (lease-2, a
+    // superseded activation) is discarded
+    ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-1").commit();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+        .withJobKey(jobKey)
+        .getFirst();
+    RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+        .withJobKey(jobKey)
+        .getFirst();
+
+    // when — a later request resends both historyItemIds
+    final var resend =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-committed")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi again")),
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-discarded")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hey again"))))
+            .update();
+
+    // then
+    final var echoed = resend.getValue().getHistory();
+    assertThat(echoed).hasSize(2);
+    assertThat(echoed.get(0).isDuplicate())
+        .as("the committed item is flagged a duplicate of the original")
+        .isTrue();
+    assertThat(echoed.get(0).getAgentHistoryKey()).isEqualTo(committedOriginalKey);
+    assertThat(echoed.get(1).isDuplicate())
+        .as("the discarded item left no trace, so it is treated as brand new")
+        .isFalse();
+
+    // bounded via a clock-reset sentinel so the check cannot hang on a record that never arrives
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    final var createdForDiscardedItem =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.CREATED)
+            .filter(
+                r ->
+                    ((AgentHistoryRecordValue) r.getValue())
+                        .getHistoryItemId()
+                        .equals("item-discarded"))
+            .toList();
+    assertThat(createdForDiscardedItem)
+        .as(
+            "two CREATED events exist for item-discarded in total: one from the first push, one"
+                + " from this resend")
+        .hasSize(2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -26,16 +27,18 @@ public class AgentInstanceCompletedApplierTest {
   private MutableProcessingState processingState;
 
   private MutableAgentInstanceState agentInstanceState;
+  private MutableAgentHistoryState agentHistoryState;
   private AgentInstanceCreatedApplier createdApplier;
   private AgentInstanceCompletedApplier completedApplier;
 
   @BeforeEach
   public void setup() {
     agentInstanceState = processingState.getAgentInstanceState();
+    agentHistoryState = processingState.getAgentHistoryState();
     final MutableElementInstanceState elementInstanceState =
         processingState.getElementInstanceState();
     createdApplier = new AgentInstanceCreatedApplier(agentInstanceState, elementInstanceState);
-    completedApplier = new AgentInstanceCompletedApplier(agentInstanceState);
+    completedApplier = new AgentInstanceCompletedApplier(agentInstanceState, agentHistoryState);
   }
 
   @Test
@@ -96,5 +99,63 @@ public class AgentInstanceCompletedApplierTest {
     assertThat(agentInstanceState.getRecord(secondAgentInstanceKey)).isNotNull();
     assertThat(agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(processInstanceKey))
         .containsExactly(secondAgentInstanceKey);
+  }
+
+  @Test
+  void shouldDeleteCommittedHistoryItemIdsOnCompletion() {
+    // given — a completed agent instance with committed history item ids recorded against it.
+    final long agentInstanceKey = 21L;
+    final long processInstanceKey = 5L;
+    createdApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentHistoryState.putCommittedHistoryItemKey(agentInstanceKey, "history-item-1", 101L);
+    agentHistoryState.putCommittedHistoryItemKey(agentInstanceKey, "history-item-2", 102L);
+
+    // when — the agent instance completes.
+    completedApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — every committed id recorded for this agent instance is gone.
+    assertThat(agentHistoryState.getCommittedHistoryItemKey(agentInstanceKey, "history-item-1"))
+        .isNull();
+    assertThat(agentHistoryState.getCommittedHistoryItemKey(agentInstanceKey, "history-item-2"))
+        .isNull();
+  }
+
+  @Test
+  void shouldNotAffectCommittedHistoryItemIdsOfOtherAgentInstances() {
+    // given — committed ids for two different agent instances.
+    final long processInstanceKey = 5L;
+    final long firstAgentInstanceKey = 22L;
+    final long secondAgentInstanceKey = 23L;
+    createdApplier.applyState(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentHistoryState.putCommittedHistoryItemKey(firstAgentInstanceKey, "history-item-1", 101L);
+    agentHistoryState.putCommittedHistoryItemKey(secondAgentInstanceKey, "history-item-1", 201L);
+
+    // when — only the first agent instance completes.
+    completedApplier.applyState(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — the second agent instance's committed id is untouched.
+    assertThat(
+            agentHistoryState.getCommittedHistoryItemKey(secondAgentInstanceKey, "history-item-1"))
+        .isEqualTo(201L);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -128,6 +129,45 @@ public class AgentInstanceCompletedApplierTest {
         .isNull();
     assertThat(agentHistoryState.getCommittedHistoryItemKey(agentInstanceKey, "history-item-2"))
         .isNull();
+  }
+
+  @Test
+  void shouldDeleteCommittedHistoryItemIdsAtScaleOnCompletion() {
+    // given — an agent instance that accumulated more than 1,000 committed history-item ids,
+    // seeded directly against state rather than by applying 1,500 real COMMITTED events, since
+    // only the collect-then-delete cleanup in the applier is under test here
+    final long agentInstanceKey = 24L;
+    final long processInstanceKey = 5L;
+    final int committedIdCount = 1500;
+    createdApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    IntStream.range(0, committedIdCount)
+        .forEach(
+            i ->
+                agentHistoryState.putCommittedHistoryItemKey(
+                    agentInstanceKey, "history-item-" + i, i));
+
+    // when — the agent instance completes.
+    completedApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — every committed id seeded for this agent instance is gone.
+    IntStream.range(0, committedIdCount)
+        .forEach(
+            i ->
+                assertThat(
+                        agentHistoryState.getCommittedHistoryItemKey(
+                            agentInstanceKey, "history-item-" + i))
+                    .describedAs("committed id history-item-%d should be removed on completion", i)
+                    .isNull());
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -24,9 +24,6 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    // Recorded before the delete below removes the pending entry this id would otherwise still
-    // be found through: a later job resending this id has only this map left to check against
-    // once the committing job's own pending item is gone.
     agentHistoryState.putCommittedHistoryItemKey(
         value.getAgentInstanceKey(), value.getHistoryItemId(), key);
     agentHistoryState.delete(key, value);

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -24,6 +24,11 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
+    // Recorded before the delete below removes the pending entry this id would otherwise still
+    // be found through: a later job resending this id has only this map left to check against
+    // once the committing job's own pending item is gone.
+    agentHistoryState.putCommittedHistoryItemKey(
+        value.getAgentInstanceKey(), value.getHistoryItemId(), key);
     agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentHistoryState;
 import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -16,13 +17,21 @@ public final class AgentInstanceCompletedApplier
     implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
 
   private final MutableAgentInstanceState agentInstanceState;
+  private final MutableAgentHistoryState agentHistoryState;
 
-  public AgentInstanceCompletedApplier(final MutableAgentInstanceState agentInstanceState) {
+  public AgentInstanceCompletedApplier(
+      final MutableAgentInstanceState agentInstanceState,
+      final MutableAgentHistoryState agentHistoryState) {
     this.agentInstanceState = agentInstanceState;
+    this.agentHistoryState = agentHistoryState;
   }
 
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
+    // The committed-ids map is retained for exactly the agent instance's lifetime; this is the
+    // one point where that lifetime ends, and the only path that removes an agent instance at
+    // all, so this is the single place cleanup needs to happen.
+    agentHistoryState.deleteCommittedHistoryItemKeys(key);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
@@ -29,9 +29,7 @@ public final class AgentInstanceCompletedApplier
   @Override
   public void applyState(final long key, final AgentInstanceRecord value) {
     agentInstanceState.delete(key, value);
-    // The committed-ids map is retained for exactly the agent instance's lifetime; this is the
-    // one point where that lifetime ends, and the only path that removes an agent instance at
-    // all, so this is the single place cleanup needs to happen.
+    // Only removal path for an agent instance; any new one needs this same cleanup call.
     agentHistoryState.deleteCommittedHistoryItemKeys(key);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -383,7 +383,15 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
    * for every currently {@code SUSPENDED} job but not an authoritative "all jobs of this instance"
    * list.
    */
-  JOBS_BY_PROCESS_INSTANCE(163, PARTITION_LOCAL);
+  JOBS_BY_PROCESS_INSTANCE(163, PARTITION_LOCAL),
+
+  // (agentInstanceKey, historyItemId) -> agentHistoryKey. Records every history item ever
+  // committed for an agent instance, so a later job resending an id that an earlier, already-
+  // completed job committed can still be recognized as a duplicate — pending state alone can't do
+  // this, since a committed item is deleted from it. Retained for the agent instance's whole
+  // lifetime and deleted in one pass when the instance completes (see
+  // AgentInstanceCompletedApplier).
+  AGENT_HISTORY_COMMITTED_IDS(164, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

Third of three stacked PRs adding duplicate detection for embedded agent history items (`historyItemId`). Stacked on #61044. Dedups across jobs: if a later job resends an id that an earlier, already-committed job already pushed, we skip it and mark it `isDuplicate: true`, returning the original key.

Scope is per agent instance — the same id under a different agent instance is not a duplicate. A discarded item leaves no trace, so resending its id creates a new item.

We keep committed ids for the whole life of the agent instance, in one uncapped map keyed by `(agentInstanceKey, historyItemId)`, and delete them all at once when the instance completes.

## Cleanup cost at scale

We keep every committed id for an agent instance's whole lifetime. When the instance completes, we delete each id one by one — there's no limit on how many, and we don't split the deletes into batches. The risk: if one instance holds a lot of ids, deleting them all at once could block the stream processor for a processing cycle.

We measured this with a one-off test (not committed). Many agent instances complete at the same time, each holding some number of committed ids:

| agent instances | ids per instance | total deletes | completion time |
|---|---|---|---|
| 1,000 | 100 | 100,000 | 381ms |
| 100 | 10,000 | 1,000,000 | 2,616ms |
| 1,000 | 10,000 | 10,000,000 | 28,514ms |

Cost per id stays flat, around 3µs, no matter the shape. Normal cases will complete well within acceptable bounds. Even the most extreme case we tested — 10,000 ids on one instance — completes in under 30ms, which is still acceptable but will be felt in cases with low latency constraints.

This isn't a theoretical worst case: a parallel multi-instance where each child element has its own agent instance can produce hundreds or thousands of agent instances completing together in one process-instance completion. However, agent instances are completed asynchronous in separate commands, each command blocking the stream processor but only for as long as needed to clear the ids of that agent instance. Generally, we only batch 100 commands together. So, other commands will have a chance to get in between.

Based on these numbers, we're keeping the simple, uncapped delete. No follow-up needed.

(Numbers carried over unchanged from #60741, the original combined PR this was split from — the measured code path, cleanup on agent-instance completion, wasn't touched by the split.)

## Out of scope

Not in scope: undoing an agent instance's status when a lease's history gets discarded. That's a separate PR, planned after this one.

I also scoped out:
- #61379
- #61380

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58792
