### PR TITLE
deps: update spring-ai-bom from 2.0.0-M7 to 2.0.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,7 +120,7 @@
     <version.spring>7.0.9</version.spring>
     <version.spring-security>7.1.1</version.spring-security>
     <version.spring-boot>4.1.1</version.spring-boot>
-    <version.spring-ai>2.0.0-M7</version.spring-ai>
+    <version.spring-ai>2.0.1</version.spring-ai>
     <version.mcp-sdk>2.0.1</version.mcp-sdk>
     <version.jsonschema-generator>5.0.0</version.jsonschema-generator>
     <version.tomcat>11.0.25</version.tomcat>


### PR DESCRIPTION
## Summary

- Upgrades `spring-ai-bom` from `2.0.0-M7` to `2.0.1`
- `2.0.1` is the patched release for CVE-2026-59318

## Context

CVE-2026-59318 is a privilege escalation vulnerability in Spring AI's tool calling support. The `DefaultToolCallingManager` global resolver fallback allowed unadvertised tool dispatch via prompt injection — a tool not in the per-request boundary could be invoked.

Camunda's MCP gateway (`gateways/gateway-mcp`) uses Spring AI as an MCP server framework only and replaces the default `tools/call` handler via `RequestHandlerCustomizer`, so exploitation was already prevented in practice. This upgrade aligns the pinned version with the patched release.

Affected versions per advisory: Spring AI 1.0.0–1.0.9, 1.1.0–1.1.8, 2.0.0. Fix: 2.0.1.

Reference: https://nvd.nist.gov/vuln/detail/CVE-2026-59318