### PR TITLE
test: close leaked search clients created by schema-manager IT tests

### DIFF
--- a/schema-manager/src/test/java/io/camunda/search/schema/DynamicMappingRestrictionIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/DynamicMappingRestrictionIT.java
@@ -8,6 +8,7 @@
 package io.camunda.search.schema;
 
 import static io.camunda.search.schema.utils.SchemaTestUtil.createSchemaManager;
+import static io.camunda.search.schema.utils.SchemaTestUtil.searchEngineClientFromConfig;
 import static io.camunda.search.schema.utils.SchemaTestUtil.startupWithRetry;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,8 +45,13 @@ public class DynamicMappingRestrictionIT {
         new IndexDescriptors(
             config.connect().getIndexPrefix(), config.connect().getTypeEnum().isElasticSearch());
 
-    try (final SchemaManager schemaManager =
-        createSchemaManager(indexDescriptors.indices(), indexDescriptors.templates(), config)) {
+    try (final var searchEngineClient = searchEngineClientFromConfig(config);
+        final SchemaManager schemaManager =
+            createSchemaManager(
+                searchEngineClient,
+                indexDescriptors.indices(),
+                indexDescriptors.templates(),
+                config)) {
 
       startupWithRetry(schemaManager, config);
 

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
@@ -67,6 +67,7 @@ public class SchemaManagerConcurrencyIT {
   private TestTemplateDescriptor indexTemplate;
   private MetadataIndex metadataIndex;
   private final MethodInterceptor methodInterceptor = new MethodInterceptor(SchemaManager.class);
+  private final List<AutoCloseable> closeables = new ArrayList<>();
 
   @BeforeAll
   public static void beforeAll() {
@@ -76,6 +77,15 @@ public class SchemaManagerConcurrencyIT {
   @AfterEach
   public void reset() {
     methodInterceptor.reset();
+    closeables.forEach(
+        closeable -> {
+          try {
+            closeable.close();
+          } catch (Exception e) {
+            LOGGER.warn("Failed to close resource", e);
+          }
+        });
+    closeables.clear();
   }
 
   @BeforeEach
@@ -468,19 +478,24 @@ public class SchemaManagerConcurrencyIT {
     return null;
   }
 
-  private static SchemaManager createSchemaManager(
+  private SchemaManager createSchemaManager(
       final Collection<IndexDescriptor> indexDescriptors,
       final Collection<IndexTemplateDescriptor> templateDescriptors,
       final SearchEngineConfiguration config,
       final String version) {
-    return new SchemaManager(
-        searchEngineClientFromConfig(config),
-        indexDescriptors,
-        templateDescriptors,
-        config,
-        new IndexSchemaValidator(TestObjectMapper.objectMapper()),
-        version,
-        null);
+    final SearchEngineClient searchEngineClient = searchEngineClientFromConfig(config);
+    closeables.add(searchEngineClient);
+    final SchemaManager schemaManager =
+        new SchemaManager(
+            searchEngineClient,
+            indexDescriptors,
+            templateDescriptors,
+            config,
+            new IndexSchemaValidator(TestObjectMapper.objectMapper()),
+            version,
+            null);
+    closeables.add(schemaManager);
+    return schemaManager;
   }
 
   static class PostMethodPauseAdvice {

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -51,14 +51,17 @@ import io.camunda.zeebe.test.util.junit.RegressionTestTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -77,6 +80,7 @@ public class SchemaManagerIT {
   private TestTemplateDescriptor indexTemplate;
   private MetadataIndex metadataIndex;
   private ObjectMapper objectMapper;
+  private final List<AutoCloseable> closeables = new ArrayList<>();
 
   @BeforeEach
   public void refresh() throws IOException {
@@ -86,6 +90,19 @@ public class SchemaManagerIT {
     index = createTestIndexDescriptor("index_name", "/mappings.json");
   }
 
+  @AfterEach
+  public void cleanup() {
+    closeables.forEach(
+        closeable -> {
+          try {
+            closeable.close();
+          } catch (final Exception e) {
+            // ignore
+          }
+        });
+    closeables.clear();
+  }
+
   @TestTemplate
   void shouldAppendToIndexMappingsWithNewProperties(
       final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
@@ -93,7 +110,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(),
             config,
@@ -128,7 +145,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -164,7 +181,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -187,7 +204,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -219,7 +236,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -248,7 +265,7 @@ public class SchemaManagerIT {
     config.schemaManager().setCreateSchema(true);
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -291,7 +308,7 @@ public class SchemaManagerIT {
 
     var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config), indices, indexTemplates, config, objectMapper);
+            getSearchEngineClient(config), indices, indexTemplates, config, objectMapper);
 
     startupWithRetry(schemaManager, config);
 
@@ -304,7 +321,7 @@ public class SchemaManagerIT {
 
     schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config), indices, indexTemplates, config, objectMapper);
+            getSearchEngineClient(config), indices, indexTemplates, config, objectMapper);
     startupWithRetry(schemaManager, config);
 
     // then
@@ -330,7 +347,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -358,11 +375,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
-            Set.of(metadataIndex),
-            Set.of(),
-            config,
-            objectMapper);
+            getSearchEngineClient(config), Set.of(metadataIndex), Set.of(), config, objectMapper);
     // when
     startupWithRetry(schemaManager, config);
 
@@ -393,11 +406,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
-            Set.of(metadataIndex),
-            Set.of(),
-            config,
-            objectMapper);
+            getSearchEngineClient(config), Set.of(metadataIndex), Set.of(), config, objectMapper);
     // when
     startupWithRetry(schemaManager, config);
 
@@ -421,7 +430,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -448,7 +457,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -480,7 +489,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -523,7 +532,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -561,7 +570,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(),
             config,
@@ -605,11 +614,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
-            Set.of(metadataIndex),
-            Set.of(),
-            config,
-            objectMapper);
+            getSearchEngineClient(config), Set.of(metadataIndex), Set.of(), config, objectMapper);
     // when
     startupWithRetry(schemaManager, config);
 
@@ -646,7 +651,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -662,7 +667,7 @@ public class SchemaManagerIT {
   void shouldIsSchemaReadyForUseReturnFalseWhenARuntimeTemplatedIndexIsMissing(
       final SearchEngineConfiguration config, final SearchClientAdapter ignored) {
     // given
-    final SearchEngineClient searchEngineClient = searchEngineClientFromConfig(config);
+    final SearchEngineClient searchEngineClient = getSearchEngineClient(config);
     final var schemaManager =
         new SchemaManager(
             searchEngineClient,
@@ -684,7 +689,7 @@ public class SchemaManagerIT {
   void shouldIsSchemaReadyForUseReturnFalseWhenTemplateHasDifferentMapping(
       final SearchEngineConfiguration config, final SearchClientAdapter ignored) {
     // given
-    final SearchEngineClient searchEngineClient = searchEngineClientFromConfig(config);
+    final SearchEngineClient searchEngineClient = getSearchEngineClient(config);
     final var schemaManager =
         new SchemaManager(
             searchEngineClient, Set.of(metadataIndex), Set.of(indexTemplate), config, objectMapper);
@@ -704,7 +709,7 @@ public class SchemaManagerIT {
       throws IOException {
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -740,7 +745,7 @@ public class SchemaManagerIT {
       final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
       throws IOException {
     // given
-    final var searchEngineClient = searchEngineClientFromConfig(config);
+    final var searchEngineClient = getSearchEngineClient(config);
 
     searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
 
@@ -749,7 +754,7 @@ public class SchemaManagerIT {
     // when
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -779,7 +784,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             indexDescriptors.indices(),
             indexDescriptors.templates(),
             config,
@@ -799,7 +804,7 @@ public class SchemaManagerIT {
 
     final var schemaManager1 =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -807,7 +812,7 @@ public class SchemaManagerIT {
 
     final var schemaManager2 =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -837,9 +842,17 @@ public class SchemaManagerIT {
       throws Exception {
     // given
     final var schemaManager1 =
-        createSchemaManager(Set.of(index, metadataIndex), Set.of(indexTemplate), config);
+        createSchemaManager(
+            getSearchEngineClient(config),
+            Set.of(index, metadataIndex),
+            Set.of(indexTemplate),
+            config);
     final var schemaManager2 =
-        createSchemaManager(Set.of(index, metadataIndex), Set.of(indexTemplate), config);
+        createSchemaManager(
+            getSearchEngineClient(config),
+            Set.of(index, metadataIndex),
+            Set.of(indexTemplate),
+            config);
 
     index.setMappingsClasspathFilename("/mappings-added-property.json");
     indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
@@ -872,9 +885,17 @@ public class SchemaManagerIT {
       throws Exception {
     // given
     final var schemaManager1 =
-        createSchemaManager(Set.of(index, metadataIndex), Set.of(indexTemplate), config);
+        createSchemaManager(
+            getSearchEngineClient(config),
+            Set.of(index, metadataIndex),
+            Set.of(indexTemplate),
+            config);
     final var schemaManager2 =
-        createSchemaManager(Set.of(index, metadataIndex), Set.of(indexTemplate), config);
+        createSchemaManager(
+            getSearchEngineClient(config),
+            Set.of(index, metadataIndex),
+            Set.of(indexTemplate),
+            config);
 
     index.setMappingsClasspathFilename("/mappings-added-property.json");
     indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
@@ -904,7 +925,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -942,7 +963,7 @@ public class SchemaManagerIT {
     // given
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -995,7 +1016,11 @@ public class SchemaManagerIT {
     final var indexDescriptors =
         new IndexDescriptors(newPrefix, config.connect().getTypeEnum().isElasticSearch());
     final SchemaManager schemaManager =
-        createSchemaManager(indexDescriptors.indices(), indexDescriptors.templates(), config);
+        createSchemaManager(
+            getSearchEngineClient(config),
+            indexDescriptors.indices(),
+            indexDescriptors.templates(),
+            config);
 
     final var mappingsBeforeStart = adapter.getAllIndicesAsNode(newPrefix);
     assertThat(mappingsBeforeStart).isEmpty();
@@ -1059,7 +1084,7 @@ public class SchemaManagerIT {
     final var registry = new SimpleMeterRegistry();
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(),
             config,
@@ -1085,7 +1110,7 @@ public class SchemaManagerIT {
     config.schemaManager().getRetry().setMaxRetries(1);
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(index, metadataIndex),
             Set.of(),
             config,
@@ -1116,7 +1141,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1192,7 +1217,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1215,7 +1240,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1241,7 +1266,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1268,7 +1293,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1318,7 +1343,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1352,7 +1377,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1398,7 +1423,7 @@ public class SchemaManagerIT {
 
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1431,7 +1456,7 @@ public class SchemaManagerIT {
   void shouldNotTryToCreateExistingIndexTemplate(
       final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter) {
     // given - create first schema manager with one template and verify it's created
-    final SearchEngineClient searchEngineClient = spy(searchEngineClientFromConfig(config));
+    final SearchEngineClient searchEngineClient = spy(getSearchEngineClient(config));
     final var firstSchemaManager =
         new SchemaManager(
             searchEngineClient, Set.of(metadataIndex), Set.of(indexTemplate), config, objectMapper);
@@ -1483,7 +1508,7 @@ public class SchemaManagerIT {
     // given - create schema first (which creates both template and index)
     final var schemaManager =
         new SchemaManager(
-            searchEngineClientFromConfig(config),
+            getSearchEngineClient(config),
             Set.of(metadataIndex),
             Set.of(indexTemplate),
             config,
@@ -1510,7 +1535,7 @@ public class SchemaManagerIT {
             () -> searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
 
     // recreate schema using startup
-    final SearchEngineClient searchEngineClient = spy(searchEngineClientFromConfig(config));
+    final SearchEngineClient searchEngineClient = spy(getSearchEngineClient(config));
     final var newSchemaManager =
         new SchemaManager(
             searchEngineClient, Set.of(metadataIndex), Set.of(indexTemplate), config, objectMapper);
@@ -1542,7 +1567,7 @@ public class SchemaManagerIT {
       final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
       throws IOException {
     // given - create only the template first (without the index)
-    final SearchEngineClient searchEngineClient = searchEngineClientFromConfig(config);
+    final SearchEngineClient searchEngineClient = getSearchEngineClient(config);
     searchEngineClient.createIndexTemplate(indexTemplate, new IndexConfiguration(), true);
 
     // verify template exists but index doesn't exist yet
@@ -1556,7 +1581,7 @@ public class SchemaManagerIT {
         .hasMessageContaining("no such index");
 
     // when - start schema manager with spy to track index creation
-    final SearchEngineClient spySearchEngineClient = spy(searchEngineClientFromConfig(config));
+    final SearchEngineClient spySearchEngineClient = spy(getSearchEngineClient(config));
     final var schemaManager =
         new SchemaManager(
             spySearchEngineClient,
@@ -1628,5 +1653,11 @@ public class SchemaManagerIT {
   private void initialiseResources(final SchemaManager schemaManager) {
     schemaManager.initialiseIndexTemplates();
     schemaManager.initialiseIndices();
+  }
+
+  private SearchEngineClient getSearchEngineClient(final SearchEngineConfiguration config) {
+    final var searchClient = searchEngineClientFromConfig(config);
+    closeables.add(searchClient);
+    return searchClient;
   }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaUpdateIT.java
@@ -11,6 +11,7 @@ import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.E
 import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.OPENSEARCH_NETWORK_ALIAS;
 import static io.camunda.search.schema.utils.SchemaTestUtil.assertMappingsMatch;
 import static io.camunda.search.schema.utils.SchemaTestUtil.createSchemaManager;
+import static io.camunda.search.schema.utils.SchemaTestUtil.searchEngineClientFromConfig;
 import static io.camunda.search.schema.utils.SchemaTestUtil.startupWithRetry;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -126,32 +127,38 @@ class SchemaUpdateIT {
             indexDescriptors.templates().stream()
                 .filter(template -> !template.getVersion().startsWith(currentMinorVersion))
                 .toList());
-    final SchemaManager schemaManager =
-        createSchemaManager(indexDescriptors.indices(), indexDescriptors.templates(), config);
     final var exceptions = new ConcurrentLinkedQueue<Throwable>();
 
     // when
-    final var threads =
-        IntStream.range(0, numberOfThreads)
-            .mapToObj(
-                i ->
-                    Thread.ofVirtual()
-                        .start(
-                            () -> {
-                              try {
-                                startupWithRetry(schemaManager, config);
-                              } catch (final Throwable e) {
-                                exceptions.add(e);
-                              }
-                            }))
-            .toList();
-    for (final var thread : threads) {
-      thread.join(Duration.ofSeconds(10));
-    }
+    try (final var searchEngineClient = searchEngineClientFromConfig(config);
+        final SchemaManager schemaManager =
+            createSchemaManager(
+                searchEngineClient,
+                indexDescriptors.indices(),
+                indexDescriptors.templates(),
+                config)) {
+      final var threads =
+          IntStream.range(0, numberOfThreads)
+              .mapToObj(
+                  i ->
+                      Thread.ofVirtual()
+                          .start(
+                              () -> {
+                                try {
+                                  startupWithRetry(schemaManager, config);
+                                } catch (final Throwable e) {
+                                  exceptions.add(e);
+                                }
+                              }))
+              .toList();
+      for (final var thread : threads) {
+        thread.join(Duration.ofSeconds(10));
+      }
 
-    // then
-    assertThat(exceptions).isEmpty();
-    assertThat(schemaManager.isSchemaReadyForUse()).isTrue();
+      // then
+      assertThat(exceptions).isEmpty();
+      assertThat(schemaManager.isSchemaReadyForUse()).isTrue();
+    }
 
     // validate "camunda-history-retention-policy" retention policy is created
     assertThat(

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaManagerITInvocationProvider.java
@@ -100,6 +100,8 @@ public class SchemaManagerITInvocationProvider
     elsClient = esConnector.createClient();
     elsClientAdapter = new SearchClientAdapter(elsClient, esConnector.objectMapper());
 
+    closeables.add(elsClient);
+    closeables.add(osClient._transport());
     closeables.add(elsContainer);
     closeables.add(osContainer);
   }

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
@@ -141,11 +141,12 @@ public final class SchemaTestUtil {
   }
 
   public static SchemaManager createSchemaManager(
+      final SearchEngineClient searchEngineClient,
       final Collection<IndexDescriptor> indexDescriptors,
       final Collection<IndexTemplateDescriptor> templateDescriptors,
       final SearchEngineConfiguration config) {
     return new SchemaManager(
-        searchEngineClientFromConfig(config),
+        searchEngineClient,
         indexDescriptors,
         templateDescriptors,
         config,


### PR DESCRIPTION
Closes the ES/OS REST client leak in schema-manager IT test that was causing SchemaUpdateIT to hang in CI