### PR TITLE
feat: chart analytics exporter on the core features dashboard

### DIFF
--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -6594,6 +6594,717 @@
         "x": 0,
         "y": 15
       },
+      "id": 119,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Discrepancy between last committed log appender position and the position the analytics exporter has acknowledged. A growing backlog means analytics is falling behind the log, so contractual counters and events are shipped late.\n\nA flat zero is not evidence that analytics delivery is healthy. AnalyticsExporter.export() acknowledges the record position unconditionally, outside the try that swallows handler failures, so the acknowledged position keeps advancing even when every handler throws and every OTLP batch is dropped. This panel only moves when the exporter director itself is behind — use the OTLP delivery outcome and records dropped panels to judge delivery health.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 120,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    max (\n        zeebe_log_appender_last_committed_position{\n            cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n            }\n    ) by (partition, namespace, physicalTenant)\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    -\n    max (\n        zeebe_exporter_last_exported_position{\n            exporter=\"analytics\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n            }\n    ) by (partition, namespace, physicalTenant)\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n)",
+              "legendFormat": "{{namespace}} p{{partition}} {{physicalTenant}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Analytics Exporter (records to export backlog)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of analytics log records the exporter emits (process instance, user task, incident, tenant and heartbeat events).\n\nIncludes the periodic heartbeat, which uses the same logger as the analytics events and is scheduled unconditionally by AnalyticsExporter.open() — there is no category or sampling gate on it. A cluster processing nothing therefore still shows a low steady rate here, so read this alongside the record handling panel rather than as proof that analytics data is being produced. By the same token, zero does not mean the handler categories are misconfigured: it means the exporter never opened or the log pipeline is dead.\n\nThe series is otel_sdk_log_total, not otel_sdk_log_created_total: the SDK counter is otel.sdk.log.created, and the Prometheus client strips the reserved _created suffix before appending _total.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 121,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    sum by (namespace, pod, partition, physicalTenant) (\n        rate(\n            otel_sdk_log_total{\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n                }[$__rate_interval]\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n)",
+              "legendFormat": "{{namespace}} p{{partition}} {{physicalTenant}} {{pod}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Analytics Exporter (events emitted)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of log records and metric data points the OTLP exporters hand off to the analytics backend, split into delivered and failed. Failures carry the exception class in error_type; sustained failure means analytics data is being lost once the batch queue fills.\n\nCovers both signals: otel_component_type distinguishes the log exporter from the metric exporter.\n\nShows the top 10 series per target.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 122,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    sum by (namespace, otel_component_type, physicalTenant) (\n        rate(\n            {\n                __name__=~\"otel_sdk_exporter_(log|metric_data_point)_exported_total\",\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\", error_type=\"\"\n                }[$__rate_interval]\n        )\n        * on(namespace)\n        group_left(\n            label_cloud_camunda_io_generation,\n            label_cloud_camunda_io_sales_plan_type\n        )\n        max(\n            kube_namespace_labels{\n            namespace=~\"$namespace\",\n            label_cloud_camunda_io_generation=~\"$generation\",\n            label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n            }\n        ) by (\n            namespace\n        )\n    )\n)",
+              "legendFormat": "delivered {{otel_component_type}} {{physicalTenant}} [{{namespace}}]",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    sum by (namespace, otel_component_type, error_type, physicalTenant) (\n        rate(\n            {\n                __name__=~\"otel_sdk_exporter_(log|metric_data_point)_exported_total\",\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\", error_type!=\"\"\n                }[$__rate_interval]\n        )\n        * on(namespace)\n        group_left(\n            label_cloud_camunda_io_generation,\n            label_cloud_camunda_io_sales_plan_type\n        )\n        max(\n            kube_namespace_labels{\n            namespace=~\"$namespace\",\n            label_cloud_camunda_io_generation=~\"$generation\",\n            label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n            }\n        ) by (\n            namespace\n        )\n    )\n)",
+              "legendFormat": "failed {{otel_component_type}} {{error_type}} {{physicalTenant}} [{{namespace}}]",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Analytics Exporter (OTLP delivery outcome)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Average duration of an OTLP export request to the analytics backend, by signal and HTTP response status. The instrument is a summary, so only the average is available — there are no buckets to take a quantile from.\n\nShows the top 10 series.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 123,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    sum by (namespace, otel_component_type, http_response_status_code, physicalTenant) (\n        rate(\n            otel_sdk_exporter_operation_duration_seconds_sum{\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n                }[$__rate_interval]\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n    /\n    sum by (namespace, otel_component_type, http_response_status_code, physicalTenant) (\n        rate(\n            otel_sdk_exporter_operation_duration_seconds_count{\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n                }[$__rate_interval]\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n)",
+              "legendFormat": "{{otel_component_type}} {{http_response_status_code}} {{physicalTenant}} [{{namespace}}]",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Analytics Exporter (OTLP request duration avg)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Fraction of the batch log record processor's queue that is occupied. The queue only fills when the analytics backend cannot absorb batches as fast as the engine produces events; once it reaches 1 the next record is dropped.\n\nThe otel_component_name filter excludes the bridge's placeholder gauge, which is always reported as zero.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 124,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    max by (namespace, pod, partition, physicalTenant) (\n        (\n            otel_sdk_processor_log_queue_size{\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\", otel_component_name!=\"\"\n                }\n            /\n            otel_sdk_processor_log_queue_capacity{\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\", otel_component_name!=\"\"\n                }\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n)",
+              "legendFormat": "{{namespace}} p{{partition}} {{physicalTenant}} {{pod}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Analytics Exporter (batch queue utilisation)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of analytics records the batch processor could not hand to the OTLP exporter, labelled with the reason. Anything above zero is analytics data loss that the engine will not retry — the exporter never blocks the processing stream.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 125,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    sum by (namespace, partition, error_type, physicalTenant) (\n        rate(\n            otel_sdk_processor_log_processed_total{\n                otel_component_origin=\"analytics_exporter\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\", error_type!=\"\"\n                }[$__rate_interval]\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n)",
+              "legendFormat": "{{error_type}} p{{partition}} {{physicalTenant}} [{{namespace}}]",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Analytics Exporter (records dropped)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Average time the analytics handlers spend on one record inside the exporter director. This is engine-thread time, so a regression here slows exporting for every exporter on the partition, unlike the OTLP request duration which happens off the hot path.\n\nCovers export() only. The periodic metric flush and the heartbeat run as scheduled tasks on the same partition thread and are not timed here, so this understates the exporter total partition-thread cost.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 5,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 127,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "topk(10,\n    sum by (namespace, pod, partition, physicalTenant) (\n        rate(\n            zeebe_exporter_exporting_duration_seconds_sum{\n                exporter=\"analytics\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n                }[$__rate_interval]\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n    /\n    sum by (namespace, pod, partition, physicalTenant) (\n        rate(\n            zeebe_exporter_exporting_duration_seconds_count{\n                exporter=\"analytics\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"\n                }[$__rate_interval]\n        )\n    * on(namespace)\n    group_left(\n        label_cloud_camunda_io_generation,\n        label_cloud_camunda_io_sales_plan_type\n    )\n    max(\n        kube_namespace_labels{\n        namespace=~\"$namespace\",\n        label_cloud_camunda_io_generation=~\"$generation\",\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\n        }\n    ) by (\n        namespace\n    )\n    )\n)",
+              "legendFormat": "{{namespace}} p{{partition}} {{physicalTenant}} {{pod}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Analytics Exporter (record handling duration avg)",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Analytics Exporter",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
       "id": 101,
       "panels": [
         {
@@ -6704,7 +7415,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 100,
       "panels": [
@@ -7344,7 +8055,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 47,
       "panels": [

--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -6698,7 +6698,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Rate of analytics log records the exporter emits (process instance, user task, incident, tenant and heartbeat events).\n\nIncludes the periodic heartbeat, which uses the same logger as the analytics events and is scheduled unconditionally by AnalyticsExporter.open() — there is no category or sampling gate on it. A cluster processing nothing therefore still shows a low steady rate here, so read this alongside the record handling panel rather than as proof that analytics data is being produced. By the same token, zero does not mean the handler categories are misconfigured: it means the exporter never opened or the log pipeline is dead.\n\nThe series is otel_sdk_log_total, not otel_sdk_log_created_total: the SDK counter is otel.sdk.log.created, and the Prometheus client strips the reserved _created suffix before appending _total.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "description": "Rate of analytics log records the exporter emits (process instance, user task, incident, tenant and heartbeat events).\n\nIncludes the periodic heartbeat, which uses the same logger as the analytics events and is scheduled unconditionally by AnalyticsExporter.open() — there is no category or sampling gate on it. A cluster processing nothing therefore still shows a low steady rate here, so read this alongside the record handling panel rather than as proof that analytics data is being produced. By the same token, zero does not mean the handler categories are misconfigured: it means the exporter never opened or the log pipeline is dead.\n\nShows the top 10 partitions.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6905,7 +6905,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Average duration of an OTLP export request to the analytics backend, by signal and HTTP response status. The instrument is a summary, so only the average is available — there are no buckets to take a quantile from.\n\nShows the top 10 series.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
+          "description": "Average duration of an OTLP export request to the analytics backend, by signal and HTTP response status.\n\nShows the top 10 series.\n\nFilters by cluster, namespace, geo area, cloud provider, generation, sales plan type.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -9041,5 +9041,5 @@
   "timezone": "browser",
   "title": "Core Features Overview",
   "uid": "core-features-overview",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
## Description

Adds a collapsed **Analytics Exporter** row to the Core Features Overview dashboard, so the                                                                                                    
  analytics exporter is observable in SaaS alongside the other exporters. Seven panels, split along
  the exporter's two independent failure modes — handlers on the partition thread (costs engine
  latency) and OTLP delivery off the hot path (costs analytics data).

  | Panel | Shows |
  |---|---|
  | records to export backlog | last committed log position minus the position analytics acknowledged |
  | events emitted | rate of analytics log records produced |
  | OTLP delivery outcome | delivered vs failed, split by signal, failures labelled with the exception class |
  | OTLP request duration avg | average OTLP request time by signal and HTTP status |
  | batch queue utilisation | queue occupancy as a fraction of capacity |
  | records dropped | rate of records the batch processor could not hand off, with reason |
  | record handling duration avg | average handler time per record inside the exporter director |

  Same conventions as the rest of the dashboard: `topk(10, …)`, joined against `kube_namespace_labels`
  so the `generation` and `sales_plan_type` variables filter.

  ## Why these panels

  - **Queue utilisation and records dropped both stay**, despite looking redundant: utilisation is the
    warning, dropped is the damage. You alert on the first and prove the second.
  - **Two duration panels**, because the halves have different consequences — slow OTLP is a backend
    problem, slow handlers are an engine problem.
  - **Every panel groups by `physicalTenant`.** One exporter instance runs per physical tenant per
    partition; without it, two tenants sharing a partition collapse into one line and a stalled tenant
    hides behind a healthy one. No other row on this dashboard does this, deliberately: most of their
    metrics carry no `physicalTenant` label, and where it exists, adding it multiplies series per
    namespace by tenant count so `topk(10)` starts returning ten tenants of one cluster instead of ten
    clusters.

  ### Considered and dropped

  - **OTLP requests in flight.** Both in-flight gauges read zero in every observation, healthy or
    failing — the OTLP HTTP exporter sends one batch at a time. Request duration and queue utilisation
    cover the same ground sooner.
  - **Per-event-name / per-category breakdown.** No such metric exists in the module; it needs new
    instrumentation, not a new query.

  ## Validation

  Ran locally against a broker with **3 physical tenants × 3 partitions** (9 exporter instances) and
  an OTLP collector, driving uneven load per tenant:

  - healthy: all five delivery/throughput panels populated, 9 series each, ~4 ms OTLP requests
  - OTLP sink stopped: failure panels populated as expected — `error_type` on failed deliveries,
    request duration ~11 s, queue to 1.0, drops at roughly the emit rate
  - backlog stayed flat at ~0 throughout the outage, confirming an unreachable endpoint costs
    analytics data but never stalls log compaction
  - recovery: back to the healthy shape

  Every panel query was executed against Prometheus with the dashboard's own variable substitution, so
  the label sets and legends are verified rather than assumed.

  ## Known limits

  Two are properties of the metrics, documented in the panel descriptions:

  - **events emitted** includes the periodic heartbeat, which uses the same logger as analytics events,
    so an idle cluster still shows a low steady rate. Read it alongside record handling duration.
  - **OTLP request duration** is a Micrometer summary, not a histogram — no buckets, so no quantiles.

  Two are gaps in the exporter that no query can surface, and are not addressed here:
  - recovery: back to the healthy shape

  Every panel query was executed against Prometheus with the dashboard's own variable substitution, so
  the label sets and legends are verified rather than assumed.

  ## Known limits

  Two are properties of the metrics, documented in the panel descriptions:

  - **events emitted** includes the periodic heartbeat, which uses the same logger as analytics events,
    so an idle cluster still shows a low steady rate. Read it alongside record handling duration.
  - **OTLP request duration** is a Micrometer summary, not a histogram — no buckets, so no quantiles.

  Two are gaps in the exporter that no query can surface, and are not addressed here:

  - `export()` swallows handler exceptions while the position update sits outside the `try`
    ([AnalyticsExporter.java#L104-L116](https://github.com/camunda/camunda/blob/0b4ea5cd1aaef5238d6277e69730a98793c38300/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java#L104-L116)),
    so a failing handler permanently drops that record's analytics with no counter and only a
    once-per-minute throttled log line. Distinct from the queue-full drops the dashboard does show.
  - The metric flush runs as a scheduled task on the partition thread
    ([AnalyticsExporter.java#L124-L132](https://github.com/camunda/camunda/blob/0b4ea5cd1aaef5238d6277e69730a98793c38300/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java#L124-L132)),
    so its cost never reaches `zeebe_exporter_exporting_duration_seconds` and does not appear in the
    record handling panel.

  Both are fixable with a counter and a `Timer` on the `MeterRegistry` the exporter already holds.
  Worth noting for #60843: a latency delta measured there has a known unmeasured component.

---

With dummy local data

<img width="2229" height="1114" alt="Image" src="https://github.com/user-attachments/assets/20f28c32-12bc-4ab2-8042-df3cc129cb53" />

<img width="2242" height="1056" alt="image" src="https://github.com/user-attachments/assets/d77f6d8e-581b-4b48-8a8c-32dde9c6ddea" />

## Related issues

closes #56592
