### PR TITLE
ci: load-test: rename/prefix load tests workflows for stable/8.10

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -337,7 +337,7 @@ optimize.Dockerfile         @camunda/core-features
 # CI/CD Workflows
 /.github/workflows/*load-test*.yml @camunda/reliability-testing
 /.github/workflows/*load-test*.yaml @camunda/reliability-testing
-/.github/workflows/profile-load-test.yml @camunda/reliability-testing
+/.github/workflows/load-test-profile.yml @camunda/reliability-testing
 
 # Helm version pin consumed by the load test setup golden file workflow
 /.tool-versions             @camunda/reliability-testing

--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -1,8 +1,22 @@
 ---
-applyTo: "load-tests/**,.github/workflows/*load-test*,.github/workflows/*load_test*,.github/workflows/*benchmark*,.github/workflows/profile-load-test*,.github/workflows/camunda-*-load-tests*,.github/workflows/camunda-release-load-test*,.github/workflows/camunda-scheduled-release*,.github/workflows/camunda-verify-and-cleanup*,.github/scripts/*load*"
+applyTo: "load-tests/**,.github/workflows/load-test-*,.github/workflows/load-test.yml,.github/workflows/*benchmark*,.github/scripts/*load*"
 ---
 
 # Load Test Review Guidelines
+
+## Workflow naming convention
+
+Every GitHub Actions workflow file that belongs to the load test / reliability-testing
+suite must have a filename prefixed with `load-test-` (e.g. `load-test-daily.yml`,
+`load-test-metrics.yaml`), with the single exception of the central reusable workflow
+`load-test.yml` itself. This applies to workflows owned by
+`@camunda/reliability-testing` and to load-test-pipeline workflows owned by other teams
+(e.g. `load-test-profile.yml`, `load-test-ecs-weekly.yml`, owned by
+`@camunda/zeebe-distributed-platform`) — ownership doesn't change the naming rule.
+
+A workflow that is merely a *caller* of the load-test suite (e.g. a team's own benchmark
+workflow that invokes `load-test.yml` as a reusable workflow) is not itself part of the
+suite and does not need the `load-test-` prefix.
 
 ## Required Review Checks
 
@@ -47,7 +61,7 @@ When reviewing changes to load tests, workflows, or load test infrastructure:
 4. **Command-line flag precedence**: A flag added via `+=` to
    `additional_load_test_setup_configuration` or `additional_load_test_configuration` in a
    `load-tests/setup/*/Makefile` is silently dropped when CI passes that same variable on the
-   `make` command line (as `camunda-load-test.yml` always does) — GNU Make blocks any later `+=`
+   `make` command line (as `load-test.yml` always does) — GNU Make blocks any later `+=`
    to a variable once it has command-line origin, even if the CLI value is empty
    ([Overriding](https://www.gnu.org/software/make/manual/html_node/Overriding.html),
    [Override Directive](https://www.gnu.org/software/make/manual/html_node/Override-Directive.html)).
@@ -85,7 +99,7 @@ if related documentation needs updating:
 
 ## Scheduled Release Load Tests
 
-The file `camunda-scheduled-release-load-tests.yml` uses hardcoded release tags
+The file `load-test-scheduled-release.yml` uses hardcoded release tags
 per stable branch. Patch releases do not require updates. When reviewing PRs that
 create a new minor version (e.g., 8.10) or deprecate a stable branch, verify that
 this workflow is updated accordingly.

--- a/.github/scripts/ci-relevance/check.bats
+++ b/.github/scripts/ci-relevance/check.bats
@@ -16,7 +16,7 @@ check() {
 @test "should not be CI-relevant when only a load-test workflow changed" {
   # given a PR that only changes a load-test workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml"
+  run check ".github/workflows/load-test-weekly.yml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -24,7 +24,7 @@ check() {
 @test "should not be CI-relevant when only a daily load-test workflow changed" {
   # given a PR that only changes a daily load-test workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-daily-load-tests.yml"
+  run check ".github/workflows/load-test-daily.yml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -32,7 +32,7 @@ check() {
 @test "should not be CI-relevant when only a benchmark workflow changed" {
   # given a PR that only changes a benchmark workflow
   # when checking CI relevance
-  run check ".github/workflows/zeebe-update-long-running-migrating-benchmark.yaml"
+  run check ".github/workflows/load-test-zeebe-migrating-benchmark.yaml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -101,7 +101,7 @@ check() {
 @test "should be CI-relevant when a load-test workflow and a CI workflow both changed" {
   # given a PR that changes both a load-test workflow and the CI workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml" \
+  run check ".github/workflows/load-test-weekly.yml" \
             ".github/workflows/ci.yml"
   # then CI should be triggered (non-excluded file wins)
   [ "$status" -eq 0 ]
@@ -110,7 +110,7 @@ check() {
 @test "should be CI-relevant when a load-test workflow and a .github/actions/ file both changed" {
   # given a PR that changes both a load-test workflow and a CI-relevant action
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml" \
+  run check ".github/workflows/load-test-weekly.yml" \
             ".github/actions/paths-filter/action.yml"
   # then CI should be triggered (non-excluded file wins)
   [ "$status" -eq 0 ]

--- a/.github/scripts/load-test-detect-versions-changed.sh
+++ b/.github/scripts/load-test-detect-versions-changed.sh
@@ -27,7 +27,7 @@ echo "Finding versions changed compared to ${PARENT}..."
 changed="$(git diff --name-only "${PARENT}...HEAD")"
 
 run_all=false
-if grep -qE '\.github/workflows/camunda-load-test' <<<"$changed"; then
+if grep -qE '\.github/workflows/load-test(-smoke(-dispatch)?)?\.yml' <<<"$changed"; then
     echo "⇒ Load-test workflow changed, running all versions..."
     run_all=true
 fi

--- a/.github/scripts/post-load-test-results-to-slack.py
+++ b/.github/scripts/post-load-test-results-to-slack.py
@@ -4,7 +4,7 @@
 Renders a side-by-side gRPC vs REST metrics table from the end-of-soak metric
 snapshots and posts it to the reliability-testing Slack channel via an incoming
 webhook. Invoked by the `notify-results` job of
-`.github/workflows/camunda-daily-load-tests.yml`.
+`.github/workflows/load-test-daily.yml`.
 
 Metric names, descriptions, and display formats are sourced from `queries.yaml`
 (the single source of truth shared with `loadTestMetrics.sh`), so adding a metric

--- a/.github/scripts/render-comparison.py
+++ b/.github/scripts/render-comparison.py
@@ -2,7 +2,7 @@
 """Render the PR-vs-daily load-test comparison Markdown table.
 
 Invoked by the `Build comparison markdown` step of the `render-comparison`
-job in `.github/workflows/camunda-pr-load-test.yaml`.
+job in `.github/workflows/load-test-pr.yaml`.
 """
 
 import json

--- a/.github/scripts/resolve-daily.py
+++ b/.github/scripts/resolve-daily.py
@@ -14,7 +14,7 @@ import sys
 from datetime import date, datetime, timedelta, timezone
 
 REPO = os.environ.get("GITHUB_REPOSITORY", "")
-WORKFLOW = "camunda-daily-load-tests.yml"
+WORKFLOW = "load-test-daily.yml"
 ARTIFACT_PREFIX = "daily-load-test-metrics-"
 ARTIFACT_NAME_PREFIX = ARTIFACT_PREFIX + "medic-daily-"
 SOAK_JOB_NAME = "Soak"

--- a/.github/workflows/load-test-daily.yml
+++ b/.github/workflows/load-test-daily.yml
@@ -5,13 +5,13 @@
 #              posts a side-by-side summary table (with flamegraph links) to
 #              Slack, then immediately deletes both namespaces to reduce cost.
 #              Naming pattern: medic-daily-YYYY-MM-DD-<sha>
-# calls: camunda-load-test.yml (scenario: max),
-#        profile-load-test.yml,
-#        camunda-load-test-metrics.yaml,
-#        camunda-delete-load-test.yml
+# calls: load-test.yml (scenario: max),
+#        load-test-profile.yml,
+#        load-test-metrics.yaml,
+#        load-test-delete.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Daily Camunda Platform Load Tests
+name: "Load Test: Daily"
 on:
   workflow_dispatch:
      inputs:
@@ -77,7 +77,7 @@ jobs:
     name: Setup max load test
     needs:
       - benchmark-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -92,7 +92,7 @@ jobs:
     name: Setup max REST load test
     needs:
       - benchmark-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}-rest
@@ -105,7 +105,7 @@ jobs:
   # Wait 15 minutes after setup succeeds before profiling starts, mirroring the
   # warmup convention the rest of the load-test flow already uses (see
   # WARMUP_SECONDS in resolve-daily.py and await-benchmark's `sleep 900` in
-  # camunda-pr-load-test.yaml): profiling from t=0 would capture pod startup
+  # load-test-pr.yaml): profiling from t=0 would capture pod startup
   # and ramp-up noise instead of steady-state behavior.
   warmup-grpc:
     name: Warmup before profiling (gRPC)
@@ -138,7 +138,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/profile-load-test.yml
+    uses: ./.github/workflows/load-test-profile.yml
     secrets: inherit
     with:
       name: c8-${{ needs.benchmark-data.outputs.benchmark }}
@@ -153,7 +153,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/profile-load-test.yml
+    uses: ./.github/workflows/load-test-profile.yml
     secrets: inherit
     with:
       name: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
@@ -212,7 +212,7 @@ jobs:
     name: Collect metrics (gRPC)
     needs: [ benchmark-data, setup-max-load-test, soak-grpc ]
     if: needs.soak-grpc.result == 'success' && needs.setup-max-load-test.result == 'success'
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
@@ -223,7 +223,7 @@ jobs:
     name: Collect metrics (REST)
     needs: [ benchmark-data, setup-max-rest-load-test, soak-rest ]
     if: needs.soak-rest.result == 'success' && needs.setup-max-rest-load-test.result == 'success'
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest
@@ -352,7 +352,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}
@@ -364,7 +364,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: c8-${{ needs.benchmark-data.outputs.benchmark }}-rest

--- a/.github/workflows/load-test-delete.yml
+++ b/.github/workflows/load-test-delete.yml
@@ -3,12 +3,12 @@
 #              (prefix `c8-` and label `camunda.io/purpose=load-test`), then runs
 #              `kubectl delete ns --wait=false --ignore-not-found`. Idempotent on missing
 #              namespaces, fails loudly on guardrail mismatches.
-# called-by: camunda-verify-and-cleanup-load-test.yml, camunda-pr-load-test.yaml
+# called-by: load-test-verify-and-cleanup.yml, load-test-pr.yaml
 # also: triggerable manually via workflow_dispatch for ad-hoc cleanup
 # type: CI
 # owner: @camunda/reliability-testing
-name: Delete load test
-run-name: "Delete load test: ${{ inputs.namespace }}"
+name: "Load Test: Delete"
+run-name: "Load Test: Delete: ${{ inputs.namespace }}"
 
 on:
   workflow_call:

--- a/.github/workflows/load-test-ecs-weekly.yml
+++ b/.github/workflows/load-test-ecs-weekly.yml
@@ -4,7 +4,7 @@
 # type: CI
 # owner: @camunda/zeebe-distributed-platform
 
-name: Camunda Weekly Benchmark on ECS
+name: "Load Test: ECS Weekly"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/load-test-golden-update.yml
+++ b/.github/workflows/load-test-golden-update.yml
@@ -5,7 +5,7 @@
 # type: ci
 # owner: @camunda/reliability-testing
 ---
-name: Load Test Setup - Golden File Update
+name: "Load Test: Update Golden Files"
 
 on:
   push:

--- a/.github/workflows/load-test-metrics-exporter-ci.yaml
+++ b/.github/workflows/load-test-metrics-exporter-ci.yaml
@@ -2,7 +2,7 @@
 # type: CI
 # owner: @camunda/reliability-testing
 ---
-name: "Load test: metrics exporter: build/test"
+name: "Load Test: Metrics Exporter"
 
 on:
   push:
@@ -10,11 +10,11 @@ on:
       - main
     paths:
       - "load-tests/metrics-exporter/**"
-      - ".github/workflows/camunda-load-test-metrics-exporter-ci.yaml"
+      - ".github/workflows/load-test-metrics-exporter-ci.yaml"
   pull_request:
     paths:
       - "load-tests/metrics-exporter/**"
-      - ".github/workflows/camunda-load-test-metrics-exporter-ci.yaml"
+      - ".github/workflows/load-test-metrics-exporter-ci.yaml"
 
 permissions: {}
 

--- a/.github/workflows/load-test-metrics.yaml
+++ b/.github/workflows/load-test-metrics.yaml
@@ -4,8 +4,8 @@
 # calls: load-tests/docs/scripts/loadTestMetrics.sh
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Load Test Metrics
-run-name: "Camunda Load Test Metrics: ${{ inputs.namespace }}"
+name: "Load Test: Metrics"
+run-name: "Load Test: Metrics: ${{ inputs.namespace }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/load-test-pr-dispatch.yml
+++ b/.github/workflows/load-test-pr-dispatch.yml
@@ -20,7 +20,7 @@
 #
 # No workflow-level concurrency: all event-triggered runs coexist independently. The reusable
 # pipeline's job conditions ensure correct create vs. delete behavior per DB per event.
-name: Camunda PR Benchmark
+name: "Load Test: Dispatch on PR"
 on:
   pull_request:
     types:
@@ -117,7 +117,7 @@ jobs:
     concurrency:
       group: pr-benchmark-${{ matrix.db }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    uses: ./.github/workflows/camunda-pr-load-test.yaml
+    uses: ./.github/workflows/load-test-pr.yaml
     secrets: inherit
     with:
       label: ${{ matrix.label }}

--- a/.github/workflows/load-test-pr.yaml
+++ b/.github/workflows/load-test-pr.yaml
@@ -5,12 +5,12 @@
 #                                post the comparison comment, then tear the namespace down
 #              On unlabel or PR close, fires an explicit cleanup. New commits on the PR
 #              cancel the in-flight run (via dispatch-level concurrency) and redeploy fresh.
-# called by: pr-load-test-dispatch.yml
-# calls: camunda-load-test.yml (scenario: max), profile-load-test.yml,
-#        camunda-load-test-metrics.yaml, camunda-delete-load-test.yml
+# called by: load-test-pr-dispatch.yml
+# calls: load-test.yml (scenario: max), load-test-profile.yml,
+#        load-test-metrics.yaml, load-test-delete.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Pull Request Benchmark
+name: "Load Test: Pull Request"
 on:
   workflow_call:
     inputs:
@@ -100,7 +100,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == inputs.label) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, inputs.label))
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -115,7 +115,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -148,7 +148,7 @@ jobs:
   run-profiling:
     name: Run Profiling
     needs: [sanitize-branch-name, await-benchmark]
-    uses: ./.github/workflows/profile-load-test.yml
+    uses: ./.github/workflows/load-test-profile.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -189,7 +189,7 @@ jobs:
   get-pr-metrics:
     name: Collect PR namespace metrics
     needs: [sanitize-branch-name, await-benchmark]
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -199,7 +199,7 @@ jobs:
     name: Collect daily-on-main metrics
     needs: resolve-daily-namespace
     if: needs.resolve-daily-namespace.outputs.daily-namespace != ''
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: ${{ needs.resolve-daily-namespace.outputs.daily-namespace }}
@@ -310,7 +310,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -410,7 +410,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/load-test-profile.yml
+++ b/.github/workflows/load-test-profile.yml
@@ -8,11 +8,11 @@
 #              When a specific pod is given, profiles that pod with cpu event only.
 #              Uploads flamegraph artifacts named
 #              flamegraph-{test-type}-{event}-{pod}-{date}.
-# called-by: camunda-pr-load-test.yml, camunda-daily-load-tests.yml
+# called-by: load-test-pr.yaml, load-test-daily.yml
 # type: CI
 # owner: @camunda/zeebe-distributed-platform
-name: Profile running load test
-run-name: "Profile running load test: ${{ inputs.name }}"
+name: "Load Test: Profile"
+run-name: "Load Test: Profile: ${{ inputs.name }}"
 
 on:
   workflow_dispatch:
@@ -89,7 +89,7 @@ jobs:
     # GitHub Actions does not support arithmetic in `timeout-minutes` expressions (no
     # +/-/*// operators), so this can't be computed from `inputs.duration-seconds`
     # automatically -- bump it manually if a caller raises duration-seconds. Largest known
-    # caller today: camunda-daily-load-tests.yml's profile-grpc/profile-rest jobs pass
+    # caller today: load-test-daily.yml's profile-grpc/profile-rest jobs pass
     # duration-seconds: '1800' (30 min), i.e. up to 90 minutes of profiling alone per pod.
     # If the job timeout is increased, make sure to also increase the Teleport
     # "certificate-ttl" below to keep it roughly greater or equal to the job
@@ -186,7 +186,7 @@ jobs:
     # job may time out mid-profile. GitHub Actions does not support arithmetic in
     # `timeout-minutes` expressions (no +/-/*// operators), so this can't be computed from
     # `inputs.duration-seconds` automatically -- bump it manually if a caller raises
-    # duration-seconds. Largest known caller today: camunda-daily-load-tests.yml's
+    # duration-seconds. Largest known caller today: load-test-daily.yml's
     # profile-grpc/profile-rest jobs pass duration-seconds: '1800' (30 min).
     timeout-minutes: 60
     if: ${{ inputs.pod != '' }}

--- a/.github/workflows/load-test-release.yaml
+++ b/.github/workflows/load-test-release.yaml
@@ -3,15 +3,15 @@
 #              accepting required name and tag inputs plus optional per-component
 #              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
-# called-by: camunda-scheduled-release-load-tests.yml from the main branch,
+# called-by: load-test-scheduled-release.yml from the main branch,
 #            release BPMN process (workflow_dispatch via GitHub API)
-# calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
+# calls: load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow
-#       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
+#       via load-test-verify-and-cleanup.yml, not by this workflow.
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Release load test workflow
-run-name: "Camunda Release load test workflow: ${{ inputs.name }}"
+name: "Load Test: Release"
+run-name: "Load Test: Release: ${{ inputs.name }}"
 
 on:
   workflow_dispatch:
@@ -106,7 +106,7 @@ jobs:
   create-load-test:
     name: Create release load test
     needs: sanitize-inputs
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}

--- a/.github/workflows/load-test-smoke.yml
+++ b/.github/workflows/load-test-smoke.yml
@@ -1,12 +1,12 @@
 # description: Smoke-tests the load-test setup on every push that touches load-test infra.
 #              Deploys a minimal load test from the PR head ref, for supported secondary storages,
 #              waits for pod readiness and gateway connectivity, then deletes the namespace.
-# calls: camunda-load-test.yml (scenario: realistic),
-#        camunda-verify-and-cleanup-load-test.yml (verify + delete namespace)
+# calls: load-test.yml (scenario: realistic),
+#        load-test-verify-and-cleanup.yml (verify + delete namespace)
 # notifications: Slack (#reliability-testing-alerts) on failure only
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Smoke Load Test
+name: "Load Test: Smoke Test"
 on:
   pull_request:
     # Sequence of patterns matched against refs/heads
@@ -81,7 +81,7 @@ jobs:
   smoke-install:
     name: Smoke Install
     needs: [ sanitize-branch-name, utils-get-snapshot-docker-tag ]
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -111,7 +111,7 @@ jobs:
   smoke-update:
     name: Smoke update
     needs: [sanitize-branch-name, utils-get-snapshot-docker-tag, verify-install]
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -131,7 +131,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/load-test-ttl-cleanup.yml
+++ b/.github/workflows/load-test-ttl-cleanup.yml
@@ -3,7 +3,7 @@
 #              one for new infra (Teleport auth). Posts deleted namespaces to Slack.
 # type: CI
 # owner: camunda/orchestration-cluster-team
-name: camunda-load-test-ttl-cleanup.yml
+name: "Load Test: TTL Cleanup"
 on:
   schedule:
     - cron: "0 4 * * *"

--- a/.github/workflows/load-test-verify-and-cleanup.yml
+++ b/.github/workflows/load-test-verify-and-cleanup.yml
@@ -1,10 +1,10 @@
 # description: Verifies a load test deployment is healthy. Cleanup is delegated to
-#              camunda-delete-load-test.yml and runs regardless of verify outcome.
-# called-by: camunda-scheduled-release-load-tests.yml
+#              load-test-delete.yml and runs regardless of verify outcome.
+# called-by: load-test-scheduled-release.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Verify and cleanup load test
-run-name: "Verify and cleanup load test: ${{ inputs.namespace }}"
+name: "Load Test: Verify and Cleanup"
+run-name: "Load Test: Verify and Cleanup: ${{ inputs.namespace }}"
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ inputs.namespace }}
@@ -37,7 +37,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ inputs.namespace }}

--- a/.github/workflows/load-test-verify.yml
+++ b/.github/workflows/load-test-verify.yml
@@ -1,9 +1,9 @@
 # description: Verifies a load test deployment is healthy.
-# called-by: camunda-scheduled-release-load-tests.yml, camunda-verify-and-cleanup-load-test.yml
+# called-by: load-test-scheduled-release.yml, load-test-verify-and-cleanup.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Verify load test
-run-name: "Verify load test: ${{ inputs.namespace }}"
+name: "Load Test: Verify"
+run-name: "Load Test: Verify: ${{ inputs.namespace }}"
 
 on:
   workflow_call:

--- a/.github/workflows/load-test-weekly.yml
+++ b/.github/workflows/load-test-weekly.yml
@@ -1,11 +1,11 @@
 # description: Runs parallel endurance tests weekly against main (TTL: 28 days).
 #              Variants: realistic, rdbms-realistic (PostgreSQL), opensearch-realistic, ECS.
 #              Naming pattern: medic-y-YYYY-cw-WW-<sha>
-# calls: camunda-load-test.yml (3 parallel calls, one per scenario) +
-#        camunda-ecs-weekly-load-test.yml (1 parallel call) — 4 load tests total
+# calls: load-test.yml (3 parallel calls, one per scenario) +
+#        load-test-ecs-weekly.yml (1 parallel call) — 4 load tests total
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda weekly medic load test
+name: "Load Test: Weekly Medic"
 on:
   workflow_dispatch:
      inputs:
@@ -188,7 +188,7 @@ jobs:
       needs.test-data.result == 'success' &&
       (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.image-tag }}-rdbms-realistic
@@ -208,7 +208,7 @@ jobs:
       needs.test-data.result == 'success' &&
       (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.image-tag }}-opensearch-realistic
@@ -219,7 +219,7 @@ jobs:
 
   setup-realistic-test:
     name: Realistic load test
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     needs:
       - test-data
@@ -252,7 +252,7 @@ jobs:
       needs.test-data.result == 'success' &&
       (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
       (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-    uses: ./.github/workflows/camunda-ecs-weekly-load-test.yml
+    uses: ./.github/workflows/load-test-ecs-weekly.yml
     secrets: inherit
     with:
       image_tag: ${{ needs.test-data.outputs.image-tag }}

--- a/.github/workflows/load-test-zeebe-migrating-benchmark.yaml
+++ b/.github/workflows/load-test-zeebe-migrating-benchmark.yaml
@@ -1,10 +1,10 @@
 # description: Updates the rolling release benchmark weekly with the latest release tag.
 #              Fetches the latest GitHub release, then deploys as 'release-rolling' with
 #              a realistic workload via custom Helm values.
-# calls: camunda-load-test.yml
+# calls: load-test.yml
 # type: CI
 # owner: @camunda/core-features
-name: Zeebe Long Running Migrating Benchmark
+name: "Load Test: Long Running Zeebe Migration"
 on:
   workflow_dispatch:
   schedule:
@@ -41,7 +41,7 @@ jobs:
     permissions: {}
     needs:
       - fetch-release
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: release-rolling

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,9 +1,9 @@
 # description: Central reusable workflow for deploying load tests. All load test creation
 #              routes through this workflow. Builds Docker images (or reuses existing ones),
 #              then deploys via newLoadTest.sh + `make install` to a GKE cluster.
-# called-by: camunda-daily-load-tests.yml, camunda-weekly-load-tests.yml,
-#            camunda-pr-load-test.yaml, camunda-release-load-test.yaml,
-#            zeebe-update-long-running-migrating-benchmark.yaml
+# called-by: load-test-daily.yml, load-test-weekly.yml,
+#            load-test-pr.yaml, load-test-release.yaml,
+#            load-test-zeebe-migrating-benchmark.yaml
 # also: triggerable manually via workflow_dispatch for ad-hoc load tests
 # monitoring: https://dashboard.benchmark.camunda.cloud/
 # type: CI
@@ -15,8 +15,8 @@
 #   To use them in a namespace, the namespace must be labeled with "registry=harbor"
 #   You must also set the image pull secret to "harbor-registry" in the helm values.
 
-name: Camunda load test
-run-name: "Camunda load test: ${{ inputs.name }}"
+name: "Load Test"
+run-name: "Load Test: ${{ inputs.name }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -5,7 +5,7 @@
 # against a new camunda cluster with the specified version. This is started daily by the github
 # action zeebe-daily-qa.yml. Github workflows just start the process instance and do not monitor it.
 #  The results of these tests are posted to #zeebe-ci via Testbench workers once the test is completed.
-# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, zeebe-update-long-running-migrating-benchmark.yaml
+# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, load-test-zeebe-migrating-benchmark.yaml
 # type: CI
 # owner @camunda/core-features
 name: Start a Zeebe test in Testbench

--- a/docs/monorepo-docs/release/release-monorepo.md
+++ b/docs/monorepo-docs/release/release-monorepo.md
@@ -131,14 +131,14 @@ For [the ZPT (zeebe-process-test) project](https://github.com/camunda/zeebe-proc
   * There's a [dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-medic-benchmark/zeebe-medic-benchmarks?orgId=1&refresh=1m&from=now-24h&to=now&timezone=browser&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-namespace=$__all&var-pod=$__all&var-partition=$__all) to observe the status of the benchmarks
 * Every created benchmark has a dedicated namespace in the Kubernetes cluster (e.g. `c8-release-8-7-x`)
 * There's a benchmark for every currently supported ([maintained](https://docs.camunda.io/docs/next/reference/announcements-release-notes/overview/#announcements--release-notes)) version + previously released alpha version.
-* A benchmark is installed/upgraded by this [GHA workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test.yml)
+* A benchmark is installed/upgraded by this [GHA workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test.yml)
   * Under the hood, it's running a `helm install --upgrade` command for a benchmark creation/update
   * installs a special [Helm chart](https://github.com/camunda/camunda-load-tests-helm) containing the load test applications
   * installs the standard Camunda 8 [Helm chart](https://github.com/camunda/camunda-platform-helm)
 
 **:leaves: Benchmark flow**
 
-* A benchmark is automatically created via GitHub Action call after a release candidate (RC) is triggered ([GHA workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test.yml))
+* A benchmark is automatically created via GitHub Action call after a release candidate (RC) is triggered ([GHA workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test.yml))
   * Benchmark creation applies only to alpha, minor, and major releases.
   * Patches don't require a new benchmark creation. What is required is to re-use the same namespace + the recently released patch version, and update the the applicable benchmark with the newest patch version.
 * If during the release, new commits are merged into the release branch (major, minor, alpha), the corresponding benchmark needs to be updated to run the code from latest commit of the release branch.

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -16,7 +16,7 @@ For background on goals and test variants, see the [reliability testing document
 
 ### Via GitHub Actions (recommended)
 
-Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
+Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
 
 ### Via Makefile (manual)
 
@@ -33,31 +33,31 @@ See the [setup README](setup/README.md) for full details.
 
 ## Workflow Overview
 
-All automated load tests flow through `camunda-load-test.yml`, which builds images and deploys via the same Makefiles used for manual deployments.
+All automated load tests flow through `load-test.yml`, which builds images and deploys via the same Makefiles used for manual deployments.
 
 ```mermaid
 graph TD
     subgraph "Scheduled Triggers"
-        SCHEDULED["camunda-scheduled-release-<br/>load-tests.yml<br/><i>Weekdays 02:00 UTC</i>"]
-        DAILY["camunda-daily-load-tests.yml<br/><i>Weekdays 02:00 UTC</i>"]
-        WEEKLY["camunda-weekly-load-tests.yml<br/><i>Monday 01:00 UTC</i>"]
-        ROLLING["zeebe-update-long-running-<br/>migrating-benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]
-        CLEANUP["camunda-load-test-ttl-cleanup.yml<br/><i>Daily 04:00 UTC</i>"]
+        SCHEDULED["load-test-scheduled-release.yml<br/><i>Weekdays 02:00 UTC</i>"]
+        DAILY["load-test-daily.yml<br/><i>Weekdays 02:00 UTC</i>"]
+        WEEKLY["load-test-weekly.yml<br/><i>Monday 01:00 UTC</i>"]
+        ROLLING["load-test-zeebe-migrating-<br/>benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]
+        CLEANUP["load-test-ttl-cleanup.yml<br/><i>Daily 04:00 UTC</i>"]
     end
 
     subgraph "Event Triggers"
-        PR["camunda-pr-load-test.yaml<br/><i>PR label: benchmark</i>"]
+        PR["load-test-pr.yaml<br/><i>PR label: benchmark</i>"]
         ADHOC["Manual workflow_dispatch"]
     end
 
     subgraph "Reusable Workflows"
-        RELEASE["camunda-release-load-test.yaml<br/><i>workflow_call</i>"]
-        CORE["camunda-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
-        ECS["camunda-ecs-weekly-load-test.yaml<br/><i>workflow_call + workflow_dispatch</i>"]
-        VERIFY["camunda-verify-and-cleanup-<br/>load-test.yml<br/><i>workflow_call</i>"]
-        PROFILE["profile-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
-        METRICS["camunda-load-test-metrics.yaml<br/><i>workflow_call + workflow_dispatch</i>"]
-        DELETE["camunda-delete-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        RELEASE["load-test-release.yaml<br/><i>workflow_call</i>"]
+        CORE["load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        ECS["load-test-ecs-weekly.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        VERIFY["load-test-verify-and-cleanup.yml<br/><i>workflow_call</i>"]
+        PROFILE["load-test-profile.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        METRICS["load-test-metrics.yaml<br/><i>workflow_call + workflow_dispatch</i>"]
+        DELETE["load-test-delete.yml<br/><i>workflow_call + workflow_dispatch</i>"]
     end
 
     subgraph "Deployment Layer"
@@ -95,13 +95,13 @@ graph TD
 
 ### Schedule
 
-|       Time        |                       Workflow                       | Frequency |
-|-------------------|------------------------------------------------------|-----------|
-| 00:00 UTC Monday  | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
-| 01:00 UTC Monday  | `camunda-weekly-load-tests.yml`                      | Weekly    |
-| 02:00 UTC Mon-Fri | `camunda-scheduled-release-load-tests.yml`           | Weekdays  |
-| 02:00 UTC Mon-Fri | `camunda-daily-load-tests.yml`                       | Weekdays  |
-| 04:00 UTC         | `camunda-load-test-ttl-cleanup.yml`                  | Daily     |
+|       Time        |                  Workflow                  | Frequency |
+|-------------------|--------------------------------------------|-----------|
+| 00:00 UTC Monday  | `load-test-zeebe-migrating-benchmark.yaml` | Weekly    |
+| 01:00 UTC Monday  | `load-test-weekly.yml`                     | Weekly    |
+| 02:00 UTC Mon-Fri | `load-test-scheduled-release.yml`          | Weekdays  |
+| 02:00 UTC Mon-Fri | `load-test-daily.yml`                      | Weekdays  |
+| 04:00 UTC         | `load-test-ttl-cleanup.yml`                | Daily     |
 
 For detailed inputs, triggers, and job definitions, see each workflow's header comments in [`.github/workflows/`](../.github/workflows/).
 
@@ -143,7 +143,7 @@ The [`load-test-setup`](setup/charts/load-test-setup) chart exposes its own [val
    ```sh
    make install additional_load_test_setup_configuration="--set elasticsearch.storage.requests=64Gi"
    ```
-3. **Via the GitHub Actions workflow:** set the `load-test-setup-helm-values` input on the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml), e.g. `--set elasticsearch.storage.requests=64Gi`. See [Workflow inputs, Helm values, and common pitfalls](#workflow-inputs-helm-values-and-common-pitfalls) below.
+3. **Via the GitHub Actions workflow:** set the `load-test-setup-helm-values` input on the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml), e.g. `--set elasticsearch.storage.requests=64Gi`. See [Workflow inputs, Helm values, and common pitfalls](#workflow-inputs-helm-values-and-common-pitfalls) below.
 
 ### Secondary Storage Options
 
@@ -241,7 +241,7 @@ We have different scenarios targeting different use cases and versions. All use 
 
 ### Release load tests
 
-For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.action?pageId=245400921&spaceKey=HAN&title=Standard%2Band%2BExtended%2BSupport%2BPeriods) version, we run a continuous load test with a realistic workload. They are created or updated [as part of the release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn), which triggers the [Camunda release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-release-load-test.yaml).
+For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.action?pageId=245400921&spaceKey=HAN&title=Standard%2Band%2BExtended%2BSupport%2BPeriods) version, we run a continuous load test with a realistic workload. They are created or updated [as part of the release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn), which triggers the [Camunda release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-release.yaml).
 
 **Goal:** Validating the reliability of our releases and detecting earlier issues, especially with alpha versions and updates.
 
@@ -258,14 +258,14 @@ graph TD
         SCHEDULE["Scheduled Smoke Tests<br/>(weekdays 02:00 UTC)"]
     end
 
-    subgraph "Abstraction Layer — camunda-release-load-test.yaml"
+    subgraph "Abstraction Layer — load-test-release.yaml"
         direction TB
         API["Public API<br/>inputs: name, tag<br/>optional: optimize-tag, identity-tag, connectors-tag"]
         SANITIZE["Sanitize inputs"]
         API --> SANITIZE
     end
 
-    subgraph "Implementation — camunda-load-test.yml"
+    subgraph "Implementation — load-test.yml"
         LOAD["Create load test cluster<br/>• orchestration-tag: &lt;tag&gt;<br/>• scenario: realistic<br/>• ttl: 60 days"]
     end
 
@@ -273,7 +273,7 @@ graph TD
     SCHEDULE -->|"workflow_call @stable/8.x<br/>name + tag"| API
     SANITIZE --> LOAD
 
-    subgraph "Verification — camunda-verify-and-cleanup-load-test.yml"
+    subgraph "Verification — load-test-verify-and-cleanup.yml"
         VERIFY["await-load-test action<br/>• pod readiness<br/>• gateway connectivity"]
         CLEANUP["Delete namespace"]
         VERIFY --> CLEANUP
@@ -287,7 +287,7 @@ This decoupling provides several benefits:
 - **Clear API**: The release process only needs to provide a test name and tag — implementation details (official images, realistic scenario, TTL) are encapsulated in the release load test workflow.
 - **Independent evolution**: Changes to load test infrastructure (helm values, Makefiles, scripts) don't require changes to the release process BPMN.
 - **Per-branch workflows**: Each stable branch has its own copy of the release load test workflow (via backports), ensuring the correct infrastructure files are used for each version.
-- **Daily smoke tests**: The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-scheduled-release-load-tests.yml) validates daily that release load tests can be created for all active stable branches.
+- **Daily smoke tests**: The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-scheduled-release.yml) validates daily that release load tests can be created for all active stable branches.
 
 #### Setup and integration
 
@@ -295,7 +295,7 @@ The release load tests are created as part of the [release process](https://gith
 
 ![setup-benchmark](docs/assets/setup_benchmark.png)
 
-The REST-Connector calls the GitHub API (`https://api.github.com/repos/camunda/camunda/actions/workflows/camunda-release-load-test.yaml/dispatches`) to trigger the [Camunda release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-release-load-test.yaml) on a specific git reference.
+The REST-Connector calls the GitHub API (`https://api.github.com/repos/camunda/camunda/actions/workflows/load-test-release.yaml/dispatches`) to trigger the [Camunda release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-release.yaml) on a specific git reference.
 
 > [!Important]
 >
@@ -327,9 +327,9 @@ Example values from a past release:
 
 #### Scheduled smoke tests
 
-The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-scheduled-release-load-tests.yml) runs on weekdays at 02:00 UTC to validate that release load tests can be created for the currently active stable branches (`stable/8.7`, `stable/8.8`, `stable/8.9`) and `main`. Each branch's load test is created by calling the release load test workflow on that branch (`@stable/8.x`), ensuring the correct infrastructure files are used.
+The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-scheduled-release.yml) runs on weekdays at 02:00 UTC to validate that release load tests can be created for the currently active stable branches (`stable/8.7`, `stable/8.8`, `stable/8.9`) and `main`. Each branch's load test is created by calling the release load test workflow on that branch (`@stable/8.x`), ensuring the correct infrastructure files are used.
 
-After deployment, each load test is verified by the [verify-and-cleanup workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-verify-and-cleanup-load-test.yml), which:
+After deployment, each load test is verified by the [verify-and-cleanup workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-verify-and-cleanup.yml), which:
 
 1. Waits for all pods to be ready
 2. Checks gateway connectivity via the `app.connected` gauge metric
@@ -343,7 +343,7 @@ Results are posted to the `#reliability-testing-alerts` Slack channel.
 
 ### Weekly load tests
 
-Weekly load tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). They are automatically created every Monday and run for 4 weeks, then cleaned up by the [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-ttl-cleanup.yml). This results in several concurrent weekly tests (multiple variants × four weeks).
+Weekly load tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml). They are automatically created every Monday and run for 4 weeks, then cleaned up by the [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-ttl-cleanup.yml). This results in several concurrent weekly tests (multiple variants × four weeks).
 
 The weekly tests cover, for example, the [realistic load](../docs/testing/reliability-testing.md#realistic-load) variants (one with Elasticsearch, one with OpenSearch, and one with PostgreSQL).
 
@@ -360,7 +360,7 @@ Example running tests (naming pattern: `medic-y-<year>-cw-<week>-<sha>-<variant>
 
 ### Daily load tests
 
-Daily stress tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml).
+Daily stress tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml).
 
 **Goal:** Validating the reliability of the current main under stress, and detecting newly introduced instabilities with a short feedback loop.
 
@@ -372,11 +372,11 @@ Daily stress tests run against the state of the **main** branch via the [Camunda
 
 **Validation:** TBD — explicit dashboard with KPIs is tracked in [#42274](https://github.com/camunda/camunda/issues/42274).
 
-**Profiling:** unlike the PR-label flow, profiling here is unconditional — after each run's setup job succeeds, the reusable [`profile-load-test.yml`](../.github/workflows/profile-load-test.yml) workflow waits out the same 15-minute warmup as the metrics path, then captures a 30-minute async-profiler flamegraph for both the gRPC and REST runs, in parallel with the 3-hour soak. Flamegraph artifacts upload the same way as the PR path.
+**Profiling:** unlike the PR-label flow, profiling here is unconditional — after each run's setup job succeeds, the reusable [`load-test-profile.yml`](../.github/workflows/load-test-profile.yml) workflow waits out the same 15-minute warmup as the metrics path, then captures a 30-minute async-profiler flamegraph for both the gRPC and REST runs, in parallel with the 3-hour soak. Flamegraph artifacts upload the same way as the PR path.
 
 ### Ad-hoc load tests
 
-On top of the previous scenarios, we support running ad-hoc load tests. They can be either set up by labeling an existing pull-request (PR) at the mono repository with the **benchmark** label, using the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml), or deploying the [Camunda Platform](https://github.com/camunda/camunda-platform-helm) and [load test](https://github.com/camunda/camunda-load-tests-helm) Helm Charts [manually](setup/README.md).
+On top of the previous scenarios, we support running ad-hoc load tests. They can be either set up by labeling an existing pull-request (PR) at the mono repository with the **benchmark** label, using the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml), or deploying the [Camunda Platform](https://github.com/camunda/camunda-platform-helm) and [load test](https://github.com/camunda/camunda-load-tests-helm) Helm Charts [manually](setup/README.md).
 
 **Goal:** The goal of these ad-hoc load tests is to have a quick way to validate certain changes (reducing the feedback loop). The intentions can be manifold, may it be stability/reliability, performance, or something else.
 
@@ -386,9 +386,9 @@ On top of the previous scenarios, we support running ad-hoc load tests. They can
 
 #### Labeling a PR
 
-It is as easy as it sounds; we can label an existing PR with the [**benchmark**](https://github.com/camunda/camunda/labels/benchmark) label, which triggers a [GitHub Workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-pr-load-test.yaml). The workflow will build a new Docker image, based on the PR branch, and deploy a new load test against this version.
+It is as easy as it sounds; we can label an existing PR with the [**benchmark**](https://github.com/camunda/camunda/labels/benchmark) label, which triggers a [GitHub Workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-pr.yaml). The workflow will build a new Docker image, based on the PR branch, and deploy a new load test against this version.
 
-This method allows no specific configuration or adjustment. If this is needed, triggering the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) is recommended.
+This method allows no specific configuration or adjustment. If this is needed, triggering the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) is recommended.
 
 Alongside the flamegraph comment, the `benchmark` label also posts a **metrics-comparison comment** on the PR. Both paths share a 15-minute warmup, after which the metrics path opens a 30-minute collection window:
 
@@ -396,15 +396,15 @@ Alongside the flamegraph comment, the `benchmark` label also posts a **metrics-c
 - **Metrics path:**
   1. Waits 15 minutes (warmup), then 30 minutes (metrics accumulation), so PromQL `rate`/`increase` numbers cover steady-state traffic with no ramp-up bias.
   2. Resolves the last completed daily-on-main run via the GitHub Actions API ([`.github/scripts/resolve-daily.py`](../.github/scripts/resolve-daily.py)), walking back up to 7 business days. Derives the daily comparison anchor from `soak.started_at + 45 min` to match the same post-warmup slice as the PR side.
-  3. Calls the reusable [`camunda-load-test-metrics.yaml`](../.github/workflows/camunda-load-test-metrics.yaml) workflow against the PR's namespace and the resolved daily namespace, both over an 1800s window.
+  3. Calls the reusable [`load-test-metrics.yaml`](../.github/workflows/load-test-metrics.yaml) workflow against the PR's namespace and the resolved daily namespace, both over an 1800s window.
   4. Renders a Current / Daily / Optimal / Δ table from [`docs/scripts/queries.yaml`](docs/scripts/queries.yaml) and [`docs/scripts/optimal.json`](docs/scripts/optimal.json), with per-metric tolerances driving the verdict (✅/⚠️/❔). Missing daily values render as `-` so the comment still posts when no completed daily run is found.
   5. Tears the PR namespace down once the comparison comment is posted, so namespaces no longer linger after the metrics window closes. Event-driven cleanup on label removal / PR close is unchanged.
 
-A new commit on the PR cancels the in-flight run — including mid-sleep waits — and redeploys fresh. This is handled by job-level concurrency in [`pr-load-test-dispatch.yml`](../.github/workflows/pr-load-test-dispatch.yml), keyed per-DB and per-PR.
+A new commit on the PR cancels the in-flight run — including mid-sleep waits — and redeploys fresh. This is handled by job-level concurrency in [`load-test-pr-dispatch.yml`](../.github/workflows/load-test-pr-dispatch.yml), keyed per-DB and per-PR.
 
 #### Trigger Camunda load test GitHub workflow (recommended)
 
-The [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) is the **easiest** way to run a load test for a specific branch or main (default) with more customization. We support setting up load tests for different Camunda/Zeebe versions by selecting the specific workflow revision as part of the workflow dispatch form (UI).
+The [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) is the **easiest** way to run a load test for a specific branch or main (default) with more customization. We support setting up load tests for different Camunda/Zeebe versions by selecting the specific workflow revision as part of the workflow dispatch form (UI).
 
 In practice, most ad-hoc runs only need a test `name`, a Git `ref`, a built-in `scenario`, and optional Helm overrides. The workflow supports:
 

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -58,12 +58,12 @@ Done
 ```
 
 **GitHub Actions Workflow:**
-You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/profile-load-test.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
+You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/load-test-profile.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
 
 ## loadTestMetrics.sh
 
 **Usage:**
-Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
+Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
 
 **Syntax:**
 

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -213,7 +213,7 @@ func TestGoldenFiles(t *testing.T) {
 }
 
 // TestInstallLoadTestSetupKeepsMakefileFlagsWhenAdditionalConfigurationIsProvided
-// simulates the real CI invocation (camunda-load-test.yml), which always sets
+// simulates the real CI invocation (load-test.yml), which always sets
 // additional_load_test_setup_configuration on the make command line. In GNU
 // Make, a command-line-origin variable silently suppresses any later `+=` to
 // it inside the Makefile, so a makefile-computed default routed through that

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -93,7 +93,7 @@ workflow.
 
 - Format: `c8-<initials>-<slug>-<YYYYMMDD>` — always prefixed with `c8-`
 - Example: `c8-ck-my-feature-20260427` (ck = ChrisKujawa)
-- `camunda-load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
+- `load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
 - Metrics/profile/delete workflows take the full namespace and require it to start with `c8-`
 **Use a unique name for each new run.** Reusing a namespace mixes the new run's metrics with the
 prior run's data and makes comparisons ambiguous; for intentional in-place iteration (config
@@ -121,7 +121,7 @@ Namespaces carry these labels (set by `newLoadTest.sh`):
 ### Via GHA (builds image from branch)
 
 ```bash
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=ck-<slug>-<YYYYMMDD>
 ```
@@ -141,7 +141,7 @@ Most useful inputs:
 | `enable-optimize`        | Toggle Optimize (defaults to `true`)                          |
 | `ttl`                    | Days before auto-cleanup (defaults to `1`)                    |
 
-The full input list lives in the `inputs:` block of `.github/workflows/camunda-load-test.yml`.
+The full input list lives in the `inputs:` block of `.github/workflows/load-test.yml`.
 
 > **Pick the right tag input — `reuse-tag` and `orchestration-tag` hit different registries:**
 > - `reuse-tag` pulls from the **internal Camunda registry**. Only works for tags built by a
@@ -217,7 +217,7 @@ kubectl get events -n <namespace> --sort-by='.lastTimestamp' | tail -20
 
 ```bash
 # Via GHA (default — works without kubectl)
-gh run list --workflow=camunda-load-test.yml --repo camunda/camunda \
+gh run list --workflow=load-test.yml --repo camunda/camunda \
   --user $(gh api /user --jq .login) --limit 20
 
 # Via kubectl labels (if you have cluster access)
@@ -251,7 +251,7 @@ Default to GHA. Use kubectl only for config-only iteration on an existing image 
 ### Via GHA (default — handles builds and config changes)
 
 ```bash
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=ck-<slug>-<YYYYMMDD>
 ```
@@ -262,7 +262,7 @@ Reuse an existing image to skip the Docker build:
 # Read the previous run's image tag from its GHA step summary
 gh run view <run-id> --repo camunda/camunda
 
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=<name-without-c8-prefix> \
   --field reuse-tag=<image-tag> \
@@ -298,14 +298,14 @@ make max additional_platform_configuration="\
 Profiles all 3 broker pods in parallel (cpu / wall / alloc):
 
 ```bash
-gh workflow run profile-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-profile.yml --repo camunda/camunda \
   --field name=<full-namespace-with-c8-prefix>
 ```
 
 Profile a single pod (cpu only):
 
 ```bash
-gh workflow run profile-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-profile.yml --repo camunda/camunda \
   --field name=<full-namespace-with-c8-prefix> \
   --field pod=camunda-1
 ```
@@ -340,14 +340,14 @@ expose all of them — start there when the headline numbers don't explain what 
 ### Via GHA (default — no kubectl needed)
 
 ```bash
-gh workflow run camunda-load-test-metrics.yaml --repo camunda/camunda \
+gh workflow run load-test-metrics.yaml --repo camunda/camunda \
   --field namespace=<full-namespace-with-c8-prefix> \
   --field duration-seconds=1200
 
 # Chain dispatch → watch → render: capture the run, wait for it,
 # and pull the rendered job summary inline (no "should I wait?" prompt).
 sleep 3   # let GitHub register the dispatched run
-RUN_ID=$(gh run list --workflow=camunda-load-test-metrics.yaml --repo camunda/camunda \
+RUN_ID=$(gh run list --workflow=load-test-metrics.yaml --repo camunda/camunda \
   --limit 1 --json databaseId --jq '.[0].databaseId')
 gh run watch "$RUN_ID" --repo camunda/camunda --exit-status
 gh run view "$RUN_ID" --repo camunda/camunda
@@ -453,7 +453,7 @@ outputs. The metrics workflow's `results-json` makes this scriptable.
 ### Via GHA (default — no kubectl needed)
 
 ```bash
-gh workflow run camunda-delete-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-delete.yml --repo camunda/camunda \
   --field namespace=<full-namespace-with-c8-prefix>
 ```
 


### PR DESCRIPTION
## Description

All the load test-related GitHub Actions workflows have been renamed and prefixed with `load-test-` to make them uniform. The repository instructions have also been updated the same way.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
