### PR TITLE
ci: load-test: rename/prefix load tests workflows for stable/8.9

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -254,7 +254,7 @@
 
 # CI/CD Workflows
 /.github/workflows/*load-test*.yml @camunda/reliability-testing
-/.github/workflows/profile-load-test.yml @camunda/reliability-testing
+/.github/workflows/load-test-profile.yml @camunda/reliability-testing
 
 ################################
 ## @camunda/data-layer

--- a/.github/scripts/ci-relevance/check.bats
+++ b/.github/scripts/ci-relevance/check.bats
@@ -16,7 +16,7 @@ check() {
 @test "should not be CI-relevant when only a load-test workflow changed" {
   # given a PR that only changes a load-test workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml"
+  run check ".github/workflows/load-test-weekly.yml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -24,7 +24,7 @@ check() {
 @test "should not be CI-relevant when only a daily load-test workflow changed" {
   # given a PR that only changes a daily load-test workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-daily-load-tests.yml"
+  run check ".github/workflows/load-test-daily.yml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -32,7 +32,7 @@ check() {
 @test "should not be CI-relevant when only a benchmark workflow changed" {
   # given a PR that only changes a benchmark workflow
   # when checking CI relevance
-  run check ".github/workflows/zeebe-update-long-running-migrating-benchmark.yaml"
+  run check ".github/workflows/load-test-zeebe-migrating-benchmark.yaml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -101,7 +101,7 @@ check() {
 @test "should be CI-relevant when a load-test workflow and a CI workflow both changed" {
   # given a PR that changes both a load-test workflow and the CI workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml" \
+  run check ".github/workflows/load-test-weekly.yml" \
             ".github/workflows/ci.yml"
   # then CI should be triggered (non-excluded file wins)
   [ "$status" -eq 0 ]
@@ -110,7 +110,7 @@ check() {
 @test "should be CI-relevant when a load-test workflow and a .github/actions/ file both changed" {
   # given a PR that changes both a load-test workflow and a CI-relevant action
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml" \
+  run check ".github/workflows/load-test-weekly.yml" \
             ".github/actions/paths-filter/action.yml"
   # then CI should be triggered (non-excluded file wins)
   [ "$status" -eq 0 ]

--- a/.github/scripts/render-comparison.py
+++ b/.github/scripts/render-comparison.py
@@ -2,7 +2,7 @@
 """Render the PR-vs-daily load-test comparison Markdown table.
 
 Invoked by the `Build comparison markdown` step of the `render-comparison`
-job in `.github/workflows/camunda-pr-load-test.yaml`.
+job in `.github/workflows/load-test-pr.yaml`.
 """
 
 from __future__ import annotations

--- a/.github/workflows/load-test-daily.yml
+++ b/.github/workflows/load-test-daily.yml
@@ -1,7 +1,7 @@
 # description: Deploys new load test daily.
 # type: CI
 # owner: @camunda/reliability-testing
-name: Daily Camunda Platform Load Tests
+name: "Load Test: Daily"
 on:
   workflow_dispatch:
      inputs:
@@ -67,7 +67,7 @@ jobs:
     name: Setup max load test
     needs:
       - benchmark-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -79,7 +79,7 @@ jobs:
     name: Setup max REST load test
     needs:
       - benchmark-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}-rest

--- a/.github/workflows/load-test-delete.yml
+++ b/.github/workflows/load-test-delete.yml
@@ -3,11 +3,11 @@
 #              (prefix `c8-` and label `camunda.io/purpose=load-test`), then runs
 #              `kubectl delete ns --wait=false --ignore-not-found`. Idempotent on missing
 #              namespaces, fails loudly on guardrail mismatches.
-# called-by: camunda-verify-and-cleanup-load-test.yml, camunda-pr-load-test.yaml
+# called-by: load-test-verify-and-cleanup.yml, load-test-pr.yaml
 # also: triggerable manually via workflow_dispatch for ad-hoc cleanup
 # type: CI
 # owner: @camunda/reliability-testing
-name: Delete load test
+name: "Load Test: Delete"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/load-test-metrics.yaml
+++ b/.github/workflows/load-test-metrics.yaml
@@ -4,7 +4,7 @@
 # calls: load-tests/docs/scripts/loadTestMetrics.sh
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Load Test Metrics
+name: "Load Test: Metrics"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/load-test-pr-dispatch.yml
+++ b/.github/workflows/load-test-pr-dispatch.yml
@@ -20,7 +20,7 @@
 #
 # No workflow-level concurrency: all event-triggered runs coexist independently. The reusable
 # pipeline's job conditions ensure correct create vs. delete behavior per DB per event.
-name: Camunda PR Benchmark
+name: "Load Test: Dispatch on PR"
 on:
   pull_request:
     types:
@@ -119,7 +119,7 @@ jobs:
     concurrency:
       group: pr-benchmark-${{ matrix.db }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    uses: ./.github/workflows/camunda-pr-load-test.yaml
+    uses: ./.github/workflows/load-test-pr.yaml
     secrets: inherit
     with:
       label: ${{ matrix.label }}

--- a/.github/workflows/load-test-pr.yaml
+++ b/.github/workflows/load-test-pr.yaml
@@ -5,12 +5,12 @@
 #                                post the comparison comment, then tear the namespace down
 #              On unlabel or PR close, fires an explicit cleanup. New commits on the PR
 #              cancel the in-flight run (via dispatch-level concurrency) and redeploy fresh.
-# called by: pr-load-test-dispatch.yml
-# calls: camunda-load-test.yml (scenario: max), profile-load-test.yml,
-#        camunda-load-test-metrics.yaml, camunda-delete-load-test.yml
+# called by: load-test-pr-dispatch.yml
+# calls: load-test.yml (scenario: max), load-test-profile.yml,
+#        load-test-metrics.yaml, load-test-delete.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Pull Request Benchmark
+name: "Load Test: Pull Request"
 on:
   workflow_call:
     inputs:
@@ -97,7 +97,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == inputs.label) ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, inputs.label))
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -129,7 +129,7 @@ jobs:
   run-profiling:
     name: Run Profiling
     needs: [sanitize-branch-name, await-benchmark]
-    uses: ./.github/workflows/profile-load-test.yml
+    uses: ./.github/workflows/load-test-profile.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -194,7 +194,7 @@ jobs:
   get-pr-metrics:
     name: Collect PR namespace metrics
     needs: [sanitize-branch-name, await-benchmark]
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -204,7 +204,7 @@ jobs:
     name: Collect daily-on-main metrics
     needs: resolve-daily-namespace
     if: needs.resolve-daily-namespace.outputs.daily-namespace != ''
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: ${{ needs.resolve-daily-namespace.outputs.daily-namespace }}
@@ -308,7 +308,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -396,7 +396,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/load-test-profile.yml
+++ b/.github/workflows/load-test-profile.yml
@@ -2,10 +2,10 @@
 #              When no pod is specified, profiles all 3 pods in parallel (cpu, wall, alloc events).
 #              When a specific pod is given, profiles that pod with cpu event only.
 #              Uploads flamegraph artifacts named flamegraph-{database}-{event}-{pod}.
-# called-by: camunda-pr-load-test.yaml
+# called-by: load-test-pr.yaml
 # type: CI
 # owner: @camunda/zeebe-distributed-platform
-name: Profile running load test
+name: "Load Test: Profile"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/load-test-release.yaml
+++ b/.github/workflows/load-test-release.yaml
@@ -3,15 +3,15 @@
 #              accepting required name and tag inputs plus optional per-component
 #              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
-# called-by: camunda-scheduled-release-load-tests.yml from the main branch,
+# called-by: load-test-scheduled-release.yml from the main branch,
 #            release BPMN process (workflow_dispatch via GitHub API)
-# calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
+# calls: load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow
-#       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
+#       via load-test-verify-and-cleanup.yml, not by this workflow.
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Release load test workflow
-run-name: "Camunda Release load test workflow: ${{ inputs.name }}"
+name: "Load Test: Release"
+run-name: "Load Test: Release: ${{ inputs.name }}"
 
 on:
   workflow_dispatch:
@@ -106,7 +106,7 @@ jobs:
   create-load-test:
     name: Create release load test
     needs: sanitize-inputs
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}

--- a/.github/workflows/load-test-smoke.yml
+++ b/.github/workflows/load-test-smoke.yml
@@ -1,12 +1,12 @@
 # description: Smoke-tests the load-test setup on every push that touches load-test infra.
 #              Deploys a minimal load test from the PR head ref, for supported secondary storages,
 #              waits for pod readiness and gateway connectivity, then deletes the namespace.
-# calls: camunda-load-test.yml (scenario: realistic),
-#        camunda-verify-and-cleanup-load-test.yml (verify + delete namespace)
+# calls: load-test.yml (scenario: realistic),
+#        load-test-verify-and-cleanup.yml (verify + delete namespace)
 # notifications: Slack (#reliability-testing-alerts) on failure only
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Smoke Load Test
+name: "Load Test: Smoke Test"
 on:
   pull_request:
     # Sequence of patterns matched against refs/heads
@@ -15,9 +15,9 @@ on:
       - 'stable/**'
     paths:
       - 'load-tests/setup/**'
-      - '.github/workflows/camunda-load-test.yml'
-      - '.github/workflows/camunda-verify-and-cleanup-load-test.yml'
-      - '.github/workflows/camunda-load-test-smoke.yml'
+      - '.github/workflows/load-test.yml'
+      - '.github/workflows/load-test-verify-and-cleanup.yml'
+      - '.github/workflows/load-test-smoke.yml'
   workflow_dispatch:
     inputs:
       ref:
@@ -81,7 +81,7 @@ jobs:
   smoke-install:
     name: Smoke Install
     needs: [ sanitize-branch-name, utils-get-snapshot-docker-tag ]
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -111,7 +111,7 @@ jobs:
   smoke-update:
     name: Smoke update
     needs: [sanitize-branch-name, utils-get-snapshot-docker-tag, verify-install]
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -131,7 +131,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/load-test-ttl-cleanup.yml
+++ b/.github/workflows/load-test-ttl-cleanup.yml
@@ -1,7 +1,7 @@
 # description: This workflow deletes eligible load tests that reached or passed their deadline
 # type: CI
 # owner: camunda/orchestration-cluster-team
-name: camunda-load-test-ttl-cleanup.yml
+name: "Load Test: TTL Cleanup"
 on:
   schedule:
     - cron: "0 4 * * *"

--- a/.github/workflows/load-test-verify-and-cleanup.yml
+++ b/.github/workflows/load-test-verify-and-cleanup.yml
@@ -1,9 +1,9 @@
 # description: Verifies a load test deployment is healthy. Cleanup is delegated to
-#              camunda-delete-load-test.yml and runs regardless of verify outcome.
-# called-by: camunda-scheduled-release-load-tests.yml
+#              load-test-delete.yml and runs regardless of verify outcome.
+# called-by: load-test-scheduled-release.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Verify and cleanup load test
+name: "Load Test: Verify and Cleanup"
 on:
   workflow_call:
     inputs:
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ inputs.namespace }}
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ inputs.namespace }}

--- a/.github/workflows/load-test-verify.yml
+++ b/.github/workflows/load-test-verify.yml
@@ -1,8 +1,8 @@
 # description: Verifies a load test deployment is healthy.
-# called-by: camunda-scheduled-release-load-tests.yml, camunda-verify-and-cleanup-load-test.yml
+# called-by: load-test-scheduled-release.yml, load-test-verify-and-cleanup.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Verify load test
+name: "Load Test: Verify"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/load-test-weekly.yml
+++ b/.github/workflows/load-test-weekly.yml
@@ -1,7 +1,7 @@
 # description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - typical, realistic, latency
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda weekly medic load test
+name: "Load Test: Weekly Medic"
 on:
   workflow_dispatch:
      inputs:
@@ -57,7 +57,7 @@ jobs:
     name: Typical load test
     needs:
       - test-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-typical
@@ -69,7 +69,7 @@ jobs:
     name: Postgres realistic load test
     needs:
       - test-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-rdbms-realistic
@@ -80,7 +80,7 @@ jobs:
       scenario: realistic
   setup-realistic-test:
     name: Realistic load test
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     needs:
       - test-data
@@ -92,7 +92,7 @@ jobs:
       build-frontend: true
   setup-latency-test:
     name: Latency test
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     needs:
       - test-data

--- a/.github/workflows/load-test-zeebe-migrating-benchmark.yaml
+++ b/.github/workflows/load-test-zeebe-migrating-benchmark.yaml
@@ -1,7 +1,7 @@
 # description: Run weekly benchmark test on a long running migration
 # type: CI
 # owner @camunda/core-features
-name: Zeebe Long Running Migrating Benchmark
+name: "Load Test: Long Running Zeebe Migration"
 on:
   workflow_dispatch:
   schedule:
@@ -23,7 +23,7 @@ jobs:
     name: Update Long Running Migrating Benchmark with mixed load
     needs:
       - fetch-release
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: release-rolling

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,9 +1,9 @@
 # description: Central reusable workflow for deploying load tests. All load test creation
 #              routes through this workflow. Builds Docker images (or reuses existing ones),
 #              then deploys via newLoadTest.sh + `make install` to a GKE cluster.
-# called-by: camunda-daily-load-tests.yml, camunda-weekly-load-tests.yml,
-#            camunda-pr-load-test.yaml, camunda-release-load-test.yaml,
-#            zeebe-update-long-running-migrating-benchmark.yaml
+# called-by: load-test-daily.yml, load-test-weekly.yml,
+#            load-test-pr.yaml, load-test-release.yaml,
+#            load-test-zeebe-migrating-benchmark.yaml
 # also: triggerable manually via workflow_dispatch for ad-hoc load tests
 # monitoring: https://dashboard.benchmark.camunda.cloud/
 # type: CI
@@ -15,7 +15,7 @@
 #   To use them in a namespace, the namespace must be labeled with "registry=harbor"
 #   You must also set the image pull secret to "harbor-registry" in the helm values.
 
-name: Camunda load test
+name: "Load Test"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -5,7 +5,7 @@
 # against a new camunda cluster with the specified version. This is started daily by the github
 # action zeebe-daily-qa.yml. Github workflows just start the process instance and do not monitor it.
 #  The results of these tests are posted to #zeebe-ci via Testbench workers once the test is completed.
-# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, zeebe-update-long-running-migrating-benchmark.yaml
+# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, load-test-zeebe-migrating-benchmark.yaml
 # type: CI
 # owner @camunda/core-features
 name: Start a Zeebe test in Testbench

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -176,7 +176,7 @@ We have different scenarios targeting different use cases and versions.
 
 #### Release load tests
 
-For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.action?pageId=245400921&spaceKey=HAN&title=Standard%2Band%2BExtended%2BSupport%2BPeriods) version, we run a continuous load test with artificial load. They are created or updated [as part of the release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn). Triggering our ad-hoc [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml).
+For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.action?pageId=245400921&spaceKey=HAN&title=Standard%2Band%2BExtended%2BSupport%2BPeriods) version, we run a continuous load test with artificial load. They are created or updated [as part of the release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn). Triggering our ad-hoc [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml).
 
 **Goal:** Validating the reliability of our releases and detecting earlier issues, especially with alpha versions and updates.
 
@@ -205,14 +205,14 @@ graph TD
         SCHEDULE["Scheduled Smoke Tests<br/>(daily 04:00 UTC)"]
     end
 
-    subgraph "Abstraction Layer — camunda-release-load-test.yaml"
+    subgraph "Abstraction Layer — load-test-release.yaml"
         direction TB
         API["Public API<br/>inputs: name, tag<br/>optional: optimize-tag, identity-tag, connectors-tag"]
         SANITIZE["Sanitize inputs"]
         API --> SANITIZE
     end
 
-    subgraph "Implementation — camunda-load-test.yml"
+    subgraph "Implementation — load-test.yml"
         LOAD["Create load test cluster<br/>• orchestration-tag: &lt;tag&gt;<br/>• scenario: realistic<br/>• ttl: 60 days"]
     end
 
@@ -220,7 +220,7 @@ graph TD
     SCHEDULE -->|"workflow_call @stable/8.x<br/>name + tag"| API
     SANITIZE --> LOAD
 
-    subgraph "Verification — camunda-verify-and-cleanup-load-test.yml"
+    subgraph "Verification — load-test-verify-and-cleanup.yml"
         VERIFY["await-load-test action<br/>• pod readiness<br/>• gateway connectivity"]
         CLEANUP["Delete namespace"]
         VERIFY --> CLEANUP
@@ -234,7 +234,7 @@ This decoupling provides several benefits:
 * **Clear API**: The release process only needs to provide a test name and tag (with optional per-component image tags) — implementation details (official images, realistic scenario, TTL) are encapsulated in the release load test workflow
 * **Independent evolution**: Changes to load test infrastructure (helm values, Makefiles, scripts) don't require changes to the release process BPMN
 * **Per-branch workflows**: Each stable branch has its own copy of the release load test workflow (via backports), ensuring the correct infrastructure files are used for each version
-* **Daily smoke tests**: The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-scheduled-release-load-tests.yml) validates daily that release load tests can be created for all active stable branches
+* **Daily smoke tests**: The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-scheduled-release.yml) validates daily that release load tests can be created for all active stable branches
 
 ##### Setup and integration
 
@@ -244,7 +244,7 @@ There exists a separate process (called a sub-process) to set up the load test, 
 
 ![setup-benchmark](assets/setup_benchmark.png)
 
-The used REST-Connector initiates a call against the GitHub API (`https://api.github.com/repos/camunda/camunda/actions/workflows/camunda-load-test.yml/dispatches`) to trigger the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test.yml) on a specific git reference (_The reference can be a branch or tag name._).
+The used REST-Connector initiates a call against the GitHub API (`https://api.github.com/repos/camunda/camunda/actions/workflows/load-test.yml/dispatches`) to trigger the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test.yml) on a specific git reference (_The reference can be a branch or tag name._).
 
 > [!Important]
 >
@@ -277,9 +277,9 @@ When we look at an example release process instance from the past, we can find t
 
 ##### Scheduled smoke tests
 
-The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-scheduled-release-load-tests.yml) runs daily at 04:00 UTC to validate that release load tests can be created for all active stable branches (8.6, 8.7, 8.8, 8.9) and main. Each branch's load test is created by calling the release load test workflow on that branch (`@stable/8.x`), ensuring the correct infrastructure files are used.
+The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-scheduled-release.yml) runs daily at 04:00 UTC to validate that release load tests can be created for all active stable branches (8.6, 8.7, 8.8, 8.9) and main. Each branch's load test is created by calling the release load test workflow on that branch (`@stable/8.x`), ensuring the correct infrastructure files are used.
 
-After deployment, each load test is verified by the [verify-and-cleanup workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-verify-and-cleanup-load-test.yml), which:
+After deployment, each load test is verified by the [verify-and-cleanup workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-verify-and-cleanup.yml), which:
 
 1. Waits for all pods to be ready
 2. Checks gateway connectivity via the `app.connected` gauge metric (set to 1 when topology is first received)
@@ -293,7 +293,7 @@ Results are posted to the `#reliability-testing-alerts` Slack channel.
 
 #### Weekly load tests
 
-In addition to our release tests, we ran weekly load tests for all [endurance test variants](#endurance-test-variants) based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). The load tests are automatically created every Monday and run for 4 weeks. They are automatically cleaned up by our [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-clean-up.yml). This means we have three variants per week times four weeks running at the same time (makes 12 weekly load tests running concurrently).
+In addition to our release tests, we ran weekly load tests for all [endurance test variants](#endurance-test-variants) based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml). The load tests are automatically created every Monday and run for 4 weeks. They are automatically cleaned up by our [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-clean-up.yml). This means we have three variants per week times four weeks running at the same time (makes 12 weekly load tests running concurrently).
 
 **Goal:** Validating the reliability of our current main, and detecting earlier issues, allowing us to detect newly introduced instabilities and potential memory leaks or performance degradation.
 
@@ -316,7 +316,7 @@ As an example, we have the following tests running:
 
 #### Daily load tests
 
-In addition to our weekly load tests, we ran daily stress tests based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml).
+In addition to our weekly load tests, we ran daily stress tests based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml).
 
 **Goal:** Validating the reliability of our current main (putting it under stress), and detecting earlier issues, allowing us to detect newly introduced instabilities.
 
@@ -330,7 +330,7 @@ In addition to our weekly load tests, we ran daily stress tests based on the sta
 
 #### Ad-Hoc load tests
 
-On top of the previous scenarios, we support running ad-hoc load tests. They can be either set up by labeling an existing a pull-request (PR) at the mono repository with **benchmark** label, using the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml), or deploying the [Camunda Platform](https://github.com/camunda/camunda-platform-helm) and [load test](https://github.com/camunda/camunda-load-tests-helm) Helm Chart [manually](https://github.com/camunda/camunda/tree/main/zeebe/load-tests/setup).
+On top of the previous scenarios, we support running ad-hoc load tests. They can be either set up by labeling an existing a pull-request (PR) at the mono repository with **benchmark** label, using the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml), or deploying the [Camunda Platform](https://github.com/camunda/camunda-platform-helm) and [load test](https://github.com/camunda/camunda-load-tests-helm) Helm Chart [manually](https://github.com/camunda/camunda/tree/main/zeebe/load-tests/setup).
 
 **Goal:** The goal of these ad-hoc load tests is to have a quick way to validate certain changes (reducing the feedback loop). The intentions can be manifold, may it be stability/reliability, performance, or something else.
 
@@ -340,13 +340,13 @@ On top of the previous scenarios, we support running ad-hoc load tests. They can
 
 ##### Labeling a PR
 
-It is as easy as it sounds; we can label an existing PR with the [**benchmark**](https://github.com/camunda/camunda/labels/benchmark) label, which triggers a [GitHub Workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-pr-load-test.yaml). The workflow will build a new Docker image, based on the PR branch, and deploy a new load test against this version.
+It is as easy as it sounds; we can label an existing PR with the [**benchmark**](https://github.com/camunda/camunda/labels/benchmark) label, which triggers a [GitHub Workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-pr.yaml). The workflow will build a new Docker image, based on the PR branch, and deploy a new load test against this version.
 
-This method allows no specific configuration or adjustment. If this is needed, triggering the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) is recommended.
+This method allows no specific configuration or adjustment. If this is needed, triggering the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) is recommended.
 
 ##### Trigger Camunda load test GitHub Workflow
 
-The [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) is the **easiest** way to run a load test for a specific branch or main (default) with more customization. We support to set up load tests for different Camunda/Zeebe versions, by selecting the specific workflow revision as part of the workflow dispatch form (UI).
+The [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) is the **easiest** way to run a load test for a specific branch or main (default) with more customization. We support to set up load tests for different Camunda/Zeebe versions, by selecting the specific workflow revision as part of the workflow dispatch form (UI).
 
 It allows high customization:
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -15,7 +15,7 @@ More details can also be found in our [reliability testing documentation](../doc
 
 ### Via GitHub Actions (recommended)
 
-Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
+Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
 
 ### Via Makefile (manual)
 
@@ -30,30 +30,30 @@ See the [setup README](setup/README.md) for full details.
 
 ## Workflow Overview
 
-All automated load tests flow through `camunda-load-test.yml`, which builds images and deploys via the same Makefiles used for manual deployments.
+All automated load tests flow through `load-test.yml`, which builds images and deploys via the same Makefiles used for manual deployments.
 
 ```mermaid
 graph TD
     subgraph "Scheduled Triggers"
-        SCHEDULED["camunda-scheduled-release-<br/>load-tests.yml<br/><i>Daily 04:00 UTC</i>"]
-        DAILY["camunda-daily-load-tests.yml<br/><i>Daily 04:00 UTC</i>"]
-        WEEKLY["camunda-weekly-load-tests.yml<br/><i>Monday 01:00 UTC</i>"]
-        ROLLING["zeebe-update-long-running-<br/>migrating-benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]
-        CLEANUP["camunda-load-test-ttl-cleanup.yml<br/><i>Daily 04:00 UTC</i>"]
+        SCHEDULED["load-test-scheduled-release.yml<br/><i>Daily 04:00 UTC</i>"]
+        DAILY["load-test-daily.yml<br/><i>Daily 04:00 UTC</i>"]
+        WEEKLY["load-test-weekly.yml<br/><i>Monday 01:00 UTC</i>"]
+        ROLLING["load-test-zeebe-migrating-<br/>benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]
+        CLEANUP["load-test-ttl-cleanup.yml<br/><i>Daily 04:00 UTC</i>"]
     end
 
     subgraph "Event Triggers"
-        PR["camunda-pr-load-test.yaml<br/><i>PR label: benchmark</i>"]
+        PR["load-test-pr.yaml<br/><i>PR label: benchmark</i>"]
         ADHOC["Manual workflow_dispatch"]
     end
 
     subgraph "Reusable Workflows"
-        RELEASE["camunda-release-load-test.yaml<br/><i>workflow_call</i>"]
-        CORE["camunda-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
-        VERIFY["camunda-verify-and-cleanup-<br/>load-test.yml<br/><i>workflow_call</i>"]
-        PROFILE["profile-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
-        METRICS["camunda-load-test-metrics.yaml<br/><i>workflow_call + workflow_dispatch</i>"]
-        DELETE["camunda-delete-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        RELEASE["load-test-release.yaml<br/><i>workflow_call</i>"]
+        CORE["load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        VERIFY["load-test-verify-and-cleanup.yml<br/><i>workflow_call</i>"]
+        PROFILE["load-test-profile.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        METRICS["load-test-metrics.yaml<br/><i>workflow_call + workflow_dispatch</i>"]
+        DELETE["load-test-delete.yml<br/><i>workflow_call + workflow_dispatch</i>"]
     end
 
     subgraph "Deployment Layer"
@@ -89,12 +89,12 @@ graph TD
 
 ### Schedule
 
-|       Time       |                       Workflow                       | Frequency |
-|------------------|------------------------------------------------------|-----------|
-| 00:00 UTC Monday | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
-| 01:00 UTC Monday | `camunda-weekly-load-tests.yml`                      | Weekly    |
-| 04:00 UTC        | `camunda-scheduled-release-load-tests.yml`           | Daily     |
-| 04:00 UTC        | `camunda-daily-load-tests.yml`                       | Daily     |
-| 04:00 UTC        | `camunda-load-test-clean-up.yml`                     | Daily     |
+|       Time       |                  Workflow                  | Frequency |
+|------------------|--------------------------------------------|-----------|
+| 00:00 UTC Monday | `load-test-zeebe-migrating-benchmark.yaml` | Weekly    |
+| 01:00 UTC Monday | `load-test-weekly.yml`                     | Weekly    |
+| 04:00 UTC        | `load-test-scheduled-release.yml`          | Daily     |
+| 04:00 UTC        | `load-test-daily.yml`                      | Daily     |
+| 04:00 UTC        | `camunda-load-test-clean-up.yml`           | Daily     |
 
 For detailed inputs, triggers, and job definitions, see each workflow's header comments in [`.github/workflows/`](../.github/workflows/). For branch-specific path differences, see [directory structure history](docs/directory-structure.md).

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -58,12 +58,12 @@ Done
 ```
 
 **GitHub Actions Workflow:**
-You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/profile-load-test.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
+You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/load-test-profile.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
 
 ## loadTestMetrics.sh
 
 **Usage:**
-Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
+Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
 
 **Syntax:**
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -93,7 +93,7 @@ workflow.
 
 - Format: `c8-<initials>-<slug>-<YYYYMMDD>` — always prefixed with `c8-`
 - Example: `c8-ck-my-feature-20260427` (ck = ChrisKujawa)
-- `camunda-load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
+- `load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
 - Metrics/profile/delete workflows take the full namespace and require it to start with `c8-`
 **Use a unique name for each new run.** Reusing a namespace mixes the new run's metrics with the
 prior run's data and makes comparisons ambiguous; for intentional in-place iteration (config
@@ -121,7 +121,7 @@ Namespaces carry these labels (set by `newLoadTest.sh`):
 ### Via GHA (builds image from branch)
 
 ```bash
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=ck-<slug>-<YYYYMMDD>
 ```
@@ -141,7 +141,7 @@ Most useful inputs:
 | `enable-optimize`        | Toggle Optimize (defaults to `true`)                          |
 | `ttl`                    | Days before auto-cleanup (defaults to `1`)                    |
 
-The full input list lives in the `inputs:` block of `.github/workflows/camunda-load-test.yml`.
+The full input list lives in the `inputs:` block of `.github/workflows/load-test.yml`.
 
 > **Pick the right tag input — `reuse-tag` and `orchestration-tag` hit different registries:**
 > - `reuse-tag` pulls from the **internal Camunda registry**. Only works for tags built by a
@@ -217,7 +217,7 @@ kubectl get events -n <namespace> --sort-by='.lastTimestamp' | tail -20
 
 ```bash
 # Via GHA (default — works without kubectl)
-gh run list --workflow=camunda-load-test.yml --repo camunda/camunda \
+gh run list --workflow=load-test.yml --repo camunda/camunda \
   --user $(gh api /user --jq .login) --limit 20
 
 # Via kubectl labels (if you have cluster access)
@@ -251,7 +251,7 @@ Default to GHA. Use kubectl only for config-only iteration on an existing image 
 ### Via GHA (default — handles builds and config changes)
 
 ```bash
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=ck-<slug>-<YYYYMMDD>
 ```
@@ -262,7 +262,7 @@ Reuse an existing image to skip the Docker build:
 # Read the previous run's image tag from its GHA step summary
 gh run view <run-id> --repo camunda/camunda
 
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=<name-without-c8-prefix> \
   --field reuse-tag=<image-tag> \
@@ -298,14 +298,14 @@ make max additional_platform_configuration="\
 Profiles all 3 broker pods in parallel (cpu / wall / alloc):
 
 ```bash
-gh workflow run profile-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-profile.yml --repo camunda/camunda \
   --field name=<full-namespace-with-c8-prefix>
 ```
 
 Profile a single pod (cpu only):
 
 ```bash
-gh workflow run profile-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-profile.yml --repo camunda/camunda \
   --field name=<full-namespace-with-c8-prefix> \
   --field pod=camunda-1
 ```
@@ -340,14 +340,14 @@ expose all of them — start there when the headline numbers don't explain what 
 ### Via GHA (default — no kubectl needed)
 
 ```bash
-gh workflow run camunda-load-test-metrics.yaml --repo camunda/camunda \
+gh workflow run load-test-metrics.yaml --repo camunda/camunda \
   --field namespace=<full-namespace-with-c8-prefix> \
   --field duration-seconds=1200
 
 # Chain dispatch → watch → render: capture the run, wait for it,
 # and pull the rendered job summary inline (no "should I wait?" prompt).
 sleep 3   # let GitHub register the dispatched run
-RUN_ID=$(gh run list --workflow=camunda-load-test-metrics.yaml --repo camunda/camunda \
+RUN_ID=$(gh run list --workflow=load-test-metrics.yaml --repo camunda/camunda \
   --limit 1 --json databaseId --jq '.[0].databaseId')
 gh run watch "$RUN_ID" --repo camunda/camunda --exit-status
 gh run view "$RUN_ID" --repo camunda/camunda
@@ -454,7 +454,7 @@ outputs. The metrics workflow's `results-json` makes this scriptable.
 ### Via GHA (default — no kubectl needed)
 
 ```bash
-gh workflow run camunda-delete-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-delete.yml --repo camunda/camunda \
   --field namespace=<full-namespace-with-c8-prefix>
 ```
 


### PR DESCRIPTION


## Description

All the load test-related GitHub Actions workflows have been renamed and prefixed with `load-test-` to make them uniform. The repository instructions have also been updated the same way.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
