### PR TITLE
ci: load-test: rename/prefix load tests workflows for stable/8.8

### DIFF
--- a/.github/scripts/ci-relevance/check.bats
+++ b/.github/scripts/ci-relevance/check.bats
@@ -16,7 +16,7 @@ check() {
 @test "should not be CI-relevant when only a load-test workflow changed" {
   # given a PR that only changes a load-test workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml"
+  run check ".github/workflows/load-test-weekly.yml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -24,7 +24,7 @@ check() {
 @test "should not be CI-relevant when only a daily load-test workflow changed" {
   # given a PR that only changes a daily load-test workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-daily-load-tests.yml"
+  run check ".github/workflows/load-test-daily.yml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -32,7 +32,7 @@ check() {
 @test "should not be CI-relevant when only a benchmark workflow changed" {
   # given a PR that only changes a benchmark workflow
   # when checking CI relevance
-  run check ".github/workflows/zeebe-update-long-running-migrating-benchmark.yaml"
+  run check ".github/workflows/load-test-zeebe-migrating-benchmark.yaml"
   # then CI should not be triggered
   [ "$status" -eq 1 ]
 }
@@ -101,7 +101,7 @@ check() {
 @test "should be CI-relevant when a load-test workflow and a CI workflow both changed" {
   # given a PR that changes both a load-test workflow and the CI workflow
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml" \
+  run check ".github/workflows/load-test-weekly.yml" \
             ".github/workflows/ci.yml"
   # then CI should be triggered (non-excluded file wins)
   [ "$status" -eq 0 ]
@@ -110,7 +110,7 @@ check() {
 @test "should be CI-relevant when a load-test workflow and a .github/actions/ file both changed" {
   # given a PR that changes both a load-test workflow and a CI-relevant action
   # when checking CI relevance
-  run check ".github/workflows/camunda-weekly-load-tests.yml" \
+  run check ".github/workflows/load-test-weekly.yml" \
             ".github/actions/paths-filter/action.yml"
   # then CI should be triggered (non-excluded file wins)
   [ "$status" -eq 0 ]

--- a/.github/scripts/render-comparison.py
+++ b/.github/scripts/render-comparison.py
@@ -2,7 +2,7 @@
 """Render the PR-vs-daily load-test comparison Markdown table.
 
 Invoked by the `Build comparison markdown` step of the `render-comparison`
-job in `.github/workflows/camunda-pr-load-test.yaml`.
+job in `.github/workflows/load-test-pr.yaml`.
 """
 
 from __future__ import annotations

--- a/.github/workflows/load-test-daily.yml
+++ b/.github/workflows/load-test-daily.yml
@@ -1,7 +1,7 @@
 # description: Deploys new load test daily.
 # type: CI
 # owner: @camunda/reliability-testing
-name: Daily Camunda Platform Load Tests
+name: "Load Test: Daily"
 on:
   workflow_dispatch:
      inputs:
@@ -67,7 +67,7 @@ jobs:
     name: Setup max load test
     needs:
       - benchmark-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -79,7 +79,7 @@ jobs:
     name: Setup max REST load test
     needs:
       - benchmark-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}-rest

--- a/.github/workflows/load-test-delete.yml
+++ b/.github/workflows/load-test-delete.yml
@@ -3,11 +3,11 @@
 #              (prefix `c8-` and label `camunda.io/purpose=load-test`), then runs
 #              `kubectl delete ns --wait=false --ignore-not-found`. Idempotent on missing
 #              namespaces, fails loudly on guardrail mismatches.
-# called-by: camunda-verify-and-cleanup-load-test.yml, camunda-pr-load-test.yaml
+# called-by: load-test-verify-and-cleanup.yml, load-test-pr.yaml
 # also: triggerable manually via workflow_dispatch for ad-hoc cleanup
 # type: CI
 # owner: @camunda/reliability-testing
-name: Delete load test
+name: "Load Test: Delete"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/load-test-metrics.yaml
+++ b/.github/workflows/load-test-metrics.yaml
@@ -4,7 +4,7 @@
 # calls: load-tests/docs/scripts/loadTestMetrics.sh
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Load Test Metrics
+name: "Load Test: Metrics"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/load-test-pr.yaml
+++ b/.github/workflows/load-test-pr.yaml
@@ -5,12 +5,12 @@
 #                                post the comparison comment, then tear the namespace down
 #              On unlabel or PR close, fires an explicit cleanup. New commits on the PR
 #              cancel the in-flight run (via dispatch-level concurrency) and redeploy fresh.
-# called by: pr-load-test-dispatch.yml
-# calls: camunda-load-test.yml (scenario: max), profile-load-test.yml,
-#        camunda-load-test-metrics.yaml, camunda-delete-load-test.yml
+# called by: load-test-pr-dispatch.yml
+# calls: load-test.yml (scenario: max), load-test-profile.yml,
+#        load-test-metrics.yaml, load-test-delete.yml
 # type: CI
 # owner @camunda/reliability-testing
-name: Camunda Pull Request Benchmark
+name: "Load Test: Pull Request"
 on:
   pull_request:
     types:
@@ -65,7 +65,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -103,7 +103,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
-    uses: ./.github/workflows/profile-load-test.yml
+    uses: ./.github/workflows/load-test-profile.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -167,7 +167,7 @@ jobs:
   get-pr-metrics:
     name: Collect PR namespace metrics
     needs: [sanitize-branch-name, await-benchmark]
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -177,7 +177,7 @@ jobs:
     name: Collect daily-on-main metrics
     needs: resolve-daily-namespace
     if: needs.resolve-daily-namespace.outputs.daily-namespace != ''
-    uses: ./.github/workflows/camunda-load-test-metrics.yaml
+    uses: ./.github/workflows/load-test-metrics.yaml
     secrets: inherit
     with:
       namespace: ${{ needs.resolve-daily-namespace.outputs.daily-namespace }}
@@ -280,7 +280,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -371,7 +371,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/load-test-profile.yml
+++ b/.github/workflows/load-test-profile.yml
@@ -1,7 +1,7 @@
 # description: This workflow allows to profile more easily running load tests
 # type: CI
 # owner: @camunda/zeebe-distributed-platform
-name: Profile running load test
+name: "Load Test: Profile"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/load-test-release.yaml
+++ b/.github/workflows/load-test-release.yaml
@@ -3,15 +3,15 @@
 #              accepting required name and tag inputs plus optional per-component
 #              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
-# called-by: camunda-scheduled-release-load-tests.yml from the main branch,
+# called-by: load-test-scheduled-release.yml from the main branch,
 #            release BPMN process (workflow_dispatch via GitHub API)
-# calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
+# calls: load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow
-#       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
+#       via load-test-verify-and-cleanup.yml, not by this workflow.
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Release load test workflow
-run-name: "Camunda Release load test workflow: ${{ inputs.name }}"
+name: "Load Test: Release"
+run-name: "Load Test: Release: ${{ inputs.name }}"
 
 on:
   workflow_dispatch:
@@ -106,7 +106,7 @@ jobs:
   create-load-test:
     name: Create release load test
     needs: sanitize-inputs
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}

--- a/.github/workflows/load-test-smoke.yml
+++ b/.github/workflows/load-test-smoke.yml
@@ -1,12 +1,12 @@
 # description: Smoke-tests the load-test setup on every push that touches load-test infra.
 #              Deploys a minimal load test from the PR head ref, for supported secondary storages,
 #              waits for pod readiness and gateway connectivity, then deletes the namespace.
-# calls: camunda-load-test.yml (scenario: realistic),
-#        camunda-verify-and-cleanup-load-test.yml (verify + delete namespace)
+# calls: load-test.yml (scenario: realistic),
+#        load-test-verify-and-cleanup.yml (verify + delete namespace)
 # notifications: Slack (#reliability-testing-alerts) on failure only
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda Smoke Load Test
+name: "Load Test: Smoke Test"
 on:
   pull_request:
     # Sequence of patterns matched against refs/heads
@@ -15,9 +15,9 @@ on:
       - 'stable/**'
     paths:
       - 'load-tests/setup/**'
-      - '.github/workflows/camunda-load-test.yml'
-      - '.github/workflows/camunda-verify-and-cleanup-load-test.yml'
-      - '.github/workflows/camunda-load-test-smoke.yml'
+      - '.github/workflows/load-test.yml'
+      - '.github/workflows/load-test-verify-and-cleanup.yml'
+      - '.github/workflows/load-test-smoke.yml'
   workflow_dispatch:
     inputs:
       ref:
@@ -81,7 +81,7 @@ jobs:
   smoke-install:
     name: Smoke Install
     needs: [ sanitize-branch-name, utils-get-snapshot-docker-tag ]
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -111,7 +111,7 @@ jobs:
   smoke-update:
     name: Smoke update
     needs: [sanitize-branch-name, utils-get-snapshot-docker-tag, verify-install]
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -131,7 +131,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/load-test-ttl-cleanup.yml
+++ b/.github/workflows/load-test-ttl-cleanup.yml
@@ -1,7 +1,7 @@
 # description: This workflow deletes eligible load tests that reached or passed their deadline
 # type: CI
 # owner: camunda/orchestration-cluster-team
-name: camunda-load-test-ttl-cleanup.yml
+name: "Load Test: TTL Cleanup"
 on:
   schedule:
     - cron: "0 4 * * *"

--- a/.github/workflows/load-test-verify-and-cleanup.yml
+++ b/.github/workflows/load-test-verify-and-cleanup.yml
@@ -1,9 +1,9 @@
 # description: Verifies a load test deployment is healthy. Cleanup is delegated to
-#              camunda-delete-load-test.yml and runs regardless of verify outcome.
-# called-by: camunda-scheduled-release-load-tests.yml
+#              load-test-delete.yml and runs regardless of verify outcome.
+# called-by: load-test-scheduled-release.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Verify and cleanup load test
+name: "Load Test: Verify and Cleanup"
 on:
   workflow_call:
     inputs:
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    uses: ./.github/workflows/camunda-verify-load-test.yml
+    uses: ./.github/workflows/load-test-verify.yml
     secrets: inherit
     with:
       namespace: ${{ inputs.namespace }}
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/camunda-delete-load-test.yml
+    uses: ./.github/workflows/load-test-delete.yml
     secrets: inherit
     with:
       namespace: ${{ inputs.namespace }}

--- a/.github/workflows/load-test-verify.yml
+++ b/.github/workflows/load-test-verify.yml
@@ -1,8 +1,8 @@
 # description: Verifies a load test deployment is healthy.
-# called-by: camunda-scheduled-release-load-tests.yml, camunda-verify-and-cleanup-load-test.yml
+# called-by: load-test-scheduled-release.yml, load-test-verify-and-cleanup.yml
 # type: CI
 # owner: @camunda/reliability-testing
-name: Verify load test
+name: "Load Test: Verify"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/load-test-weekly.yml
+++ b/.github/workflows/load-test-weekly.yml
@@ -1,7 +1,7 @@
 # description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - typical, realistic, latency
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda weekly medic load test
+name: "Load Test: Weekly Medic"
 on:
   workflow_dispatch:
      inputs:
@@ -56,7 +56,7 @@ jobs:
     name: Typical load test
     needs:
       - test-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-typical
@@ -68,7 +68,7 @@ jobs:
     name: Postgres realistic load test
     needs:
       - test-data
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: ${{ needs.test-data.outputs.test }}-rdbms-realistic
@@ -79,7 +79,7 @@ jobs:
       scenario: realistic
   setup-realistic-test:
     name: Realistic load test
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     needs:
       - test-data
@@ -91,7 +91,7 @@ jobs:
       build-frontend: true
   setup-latency-test:
     name: Latency test
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     needs:
       - test-data

--- a/.github/workflows/load-test-zeebe-migrating-benchmark.yaml
+++ b/.github/workflows/load-test-zeebe-migrating-benchmark.yaml
@@ -1,7 +1,7 @@
 # description: Run weekly benchmark test on a long running migration
 # type: CI
 # owner @camunda/core-features
-name: Zeebe Long Running Migrating Benchmark
+name: "Load Test: Long Running Zeebe Migration"
 on:
   workflow_dispatch:
   schedule:
@@ -23,7 +23,7 @@ jobs:
     name: Update Long Running Migrating Benchmark with mixed load
     needs:
       - fetch-release
-    uses: ./.github/workflows/camunda-load-test.yml
+    uses: ./.github/workflows/load-test.yml
     secrets: inherit
     with:
       name: release-rolling

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -2,7 +2,7 @@
 # We use this workflow to start ad-hoc load tests or weekly medic load tests.
 # The health of the cluster and results of the load tests are monitored by Core team's regularly.
 # https://dashboard.benchmark.camunda.cloud/
-# called by: camunda-weekly-load-tests.yml, camunda-pr-load-test.yaml
+# called by: load-test-weekly.yml, load-test-pr.yaml
 # type: CI
 # owner: camunda/orchestration-cluster-team
 #
@@ -12,7 +12,7 @@
 #   To use them in a namespace, the namespace must be labeled with "registry=harbor"
 #   You must also set the image pull secret to "harbor-registry" in the helm values.
 
-name: Camunda load test
+name: "Load Test"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -5,7 +5,7 @@
 # against a new camunda cluster with the specified version. This is started daily by the github
 # action zeebe-daily-qa.yml. Github workflows just start the process instance and do not monitor it.
 #  The results of these tests are posted to #zeebe-ci via Testbench workers once the test is completed.
-# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, zeebe-update-long-running-migrating-benchmark.yaml
+# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, load-test-zeebe-migrating-benchmark.yaml
 # type: CI
 # owner @camunda/core-features
 name: Start a Zeebe test in Testbench

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -125,7 +125,7 @@ We have different scenarios targeting different use cases and versions.
 
 #### Release load tests
 
-For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.action?pageId=245400921&spaceKey=HAN&title=Standard%2Band%2BExtended%2BSupport%2BPeriods) version, we run a continuous load test with a realistic workload. They are created or updated [as part of the release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn), which triggers the [Camunda release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-release-load-test.yaml).
+For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.action?pageId=245400921&spaceKey=HAN&title=Standard%2Band%2BExtended%2BSupport%2BPeriods) version, we run a continuous load test with a realistic workload. They are created or updated [as part of the release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn), which triggers the [Camunda release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/load-test-release.yaml).
 
 **Goal:** Validating the reliability of our releases and detecting earlier issues, especially with alpha versions and updates.
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -18,7 +18,7 @@ Prerequisites: access to the GKE benchmark cluster via [Teleport](https://camund
 
 ### Via GitHub Actions (recommended)
 
-Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
+Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
 
 ### Via Makefile (manual)
 

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -58,12 +58,12 @@ Done
 ```
 
 **GitHub Actions Workflow:**
-You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/profile-load-test.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
+You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/load-test-profile.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
 
 ## loadTestMetrics.sh
 
 **Usage:**
-Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
+Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
 
 **Syntax:**
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -93,7 +93,7 @@ workflow.
 
 - Format: `c8-<initials>-<slug>-<YYYYMMDD>` — always prefixed with `c8-`
 - Example: `c8-ck-my-feature-20260427` (ck = ChrisKujawa)
-- `camunda-load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
+- `load-test.yml` input `name` may be passed with or without `c8-` (it will add the prefix if missing)
 - Metrics/profile/delete workflows take the full namespace and require it to start with `c8-`
 **Use a unique name for each new run.** Reusing a namespace mixes the new run's metrics with the
 prior run's data and makes comparisons ambiguous; for intentional in-place iteration (config
@@ -121,7 +121,7 @@ Namespaces carry these labels (set by `newLoadTest.sh`):
 ### Via GHA (builds image from branch)
 
 ```bash
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=ck-<slug>-<YYYYMMDD>
 ```
@@ -141,7 +141,7 @@ Most useful inputs:
 | `enable-optimize`        | Toggle Optimize (defaults to `true`)                          |
 | `ttl`                    | Days before auto-cleanup (defaults to `1`)                    |
 
-The full input list lives in the `inputs:` block of `.github/workflows/camunda-load-test.yml`.
+The full input list lives in the `inputs:` block of `.github/workflows/load-test.yml`.
 
 > **Pick the right tag input — `reuse-tag` and `orchestration-tag` hit different registries:**
 > - `reuse-tag` pulls from the **internal Camunda registry**. Only works for tags built by a
@@ -217,7 +217,7 @@ kubectl get events -n <namespace> --sort-by='.lastTimestamp' | tail -20
 
 ```bash
 # Via GHA (default — works without kubectl)
-gh run list --workflow=camunda-load-test.yml --repo camunda/camunda \
+gh run list --workflow=load-test.yml --repo camunda/camunda \
   --user $(gh api /user --jq .login) --limit 20
 
 # Via kubectl labels (if you have cluster access)
@@ -251,7 +251,7 @@ Default to GHA. Use kubectl only for config-only iteration on an existing image 
 ### Via GHA (default — handles builds and config changes)
 
 ```bash
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=ck-<slug>-<YYYYMMDD>
 ```
@@ -262,7 +262,7 @@ Reuse an existing image to skip the Docker build:
 # Read the previous run's image tag from its GHA step summary
 gh run view <run-id> --repo camunda/camunda
 
-gh workflow run camunda-load-test.yml --repo camunda/camunda \
+gh workflow run load-test.yml --repo camunda/camunda \
   --field ref=<branch> \
   --field name=<name-without-c8-prefix> \
   --field reuse-tag=<image-tag> \
@@ -298,14 +298,14 @@ make max additional_platform_configuration="\
 Profiles all 3 broker pods in parallel (cpu / wall / alloc):
 
 ```bash
-gh workflow run profile-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-profile.yml --repo camunda/camunda \
   --field name=<full-namespace-with-c8-prefix>
 ```
 
 Profile a single pod (cpu only):
 
 ```bash
-gh workflow run profile-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-profile.yml --repo camunda/camunda \
   --field name=<full-namespace-with-c8-prefix> \
   --field pod=camunda-1
 ```
@@ -340,14 +340,14 @@ expose all of them — start there when the headline numbers don't explain what 
 ### Via GHA (default — no kubectl needed)
 
 ```bash
-gh workflow run camunda-load-test-metrics.yaml --repo camunda/camunda \
+gh workflow run load-test-metrics.yaml --repo camunda/camunda \
   --field namespace=<full-namespace-with-c8-prefix> \
   --field duration-seconds=1200
 
 # Chain dispatch → watch → render: capture the run, wait for it,
 # and pull the rendered job summary inline (no "should I wait?" prompt).
 sleep 3   # let GitHub register the dispatched run
-RUN_ID=$(gh run list --workflow=camunda-load-test-metrics.yaml --repo camunda/camunda \
+RUN_ID=$(gh run list --workflow=load-test-metrics.yaml --repo camunda/camunda \
   --limit 1 --json databaseId --jq '.[0].databaseId')
 gh run watch "$RUN_ID" --repo camunda/camunda --exit-status
 gh run view "$RUN_ID" --repo camunda/camunda
@@ -454,7 +454,7 @@ outputs. The metrics workflow's `results-json` makes this scriptable.
 ### Via GHA (default — no kubectl needed)
 
 ```bash
-gh workflow run camunda-delete-load-test.yml --repo camunda/camunda \
+gh workflow run load-test-delete.yml --repo camunda/camunda \
   --field namespace=<full-namespace-with-c8-prefix>
 ```
 


### PR DESCRIPTION


## Description

All the load test-related GitHub Actions workflows have been renamed and prefixed with `load-test-` to make them uniform. The repository instructions have also been updated the same way.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
