### PR TITLE
Avoid AgentInstance:COMPLETE commands when no agent instances exist

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
@@ -26,11 +27,15 @@ public final class AgentInstanceBehavior {
   }
 
   /**
-   * Completes every agent instance still associated with the given process instance. Does nothing
-   * if the process instance has no associated agent instances, to avoid appending a command that
-   * the {@code AgentInstanceCompleteProcessor} would just reject as NOT_FOUND.
+   * Completes every agent instance still associated with the given process instance, if any.
+   *
+   * <p>Does nothing if the process instance has no associated agent instances.
    */
-  public void completeAgentInstancesOfProcessInstance(final BpmnElementContext context) {
+  public void completeAgentInstancesOfProcessInstance(
+      final ExecutableProcess process, final BpmnElementContext context) {
+    if (!process.isAgentic()) {
+      return;
+    }
     final long processInstanceKey = context.getProcessInstanceKey();
     if (agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey)
         == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/AgentInstanceBehavior.java
@@ -10,20 +10,32 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 
 public final class AgentInstanceBehavior {
 
   private final TypedCommandWriter commandWriter;
+  private final AgentInstanceState agentInstanceState;
 
-  public AgentInstanceBehavior(final Writers writers) {
+  public AgentInstanceBehavior(final Writers writers, final ProcessingState processingState) {
     commandWriter = writers.command();
+    agentInstanceState = processingState.getAgentInstanceState();
   }
 
-  /** Completes every agent instance still associated with the given process instance. */
+  /**
+   * Completes every agent instance still associated with the given process instance. Does nothing
+   * if the process instance has no associated agent instances, to avoid appending a command that
+   * the {@code AgentInstanceCompleteProcessor} would just reject as NOT_FOUND.
+   */
   public void completeAgentInstancesOfProcessInstance(final BpmnElementContext context) {
     final long processInstanceKey = context.getProcessInstanceKey();
+    if (agentInstanceState.getFirstAgentInstanceKeyByProcessInstanceKey(processInstanceKey)
+        == null) {
+      return;
+    }
     commandWriter.appendNewCommand(
         AgentInstanceIntent.COMPLETE,
         new AgentInstanceRecord().setProcessInstanceKey(processInstanceKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -300,7 +300,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             variableBehavior,
             processingState);
 
-    agentInstanceBehavior = new AgentInstanceBehavior(writers);
+    agentInstanceBehavior = new AgentInstanceBehavior(writers, processingState);
 
     processDeletionBehavior =
         new BpmnProcessDeletionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -82,7 +82,7 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
     compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstance(context);
-    agentInstanceBehavior.completeAgentInstancesOfProcessInstance(context);
+    agentInstanceBehavior.completeAgentInstancesOfProcessInstance(element, context);
     return SUCCESS;
   }
 
@@ -118,7 +118,7 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
   @Override
   public void finalizeTermination(
       final ExecutableProcess element, final BpmnElementContext terminationContext) {
-    agentInstanceBehavior.completeAgentInstancesOfProcessInstance(terminationContext);
+    agentInstanceBehavior.completeAgentInstancesOfProcessInstance(element, terminationContext);
     transitionTo(
         element,
         terminationContext,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessResultSenderB
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
 import io.camunda.zeebe.engine.state.immutable.AsyncRequestState.AsyncRequest;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -31,8 +31,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public final class ProcessProcessor
-    implements BpmnElementContainerProcessor<ExecutableFlowElementContainer> {
+public final class ProcessProcessor implements BpmnElementContainerProcessor<ExecutableProcess> {
 
   private final BpmnStateBehavior stateBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
@@ -64,13 +63,13 @@ public final class ProcessProcessor
   }
 
   @Override
-  public Class<ExecutableFlowElementContainer> getType() {
-    return ExecutableFlowElementContainer.class;
+  public Class<ExecutableProcess> getType() {
+    return ExecutableProcess.class;
   }
 
   @Override
   public Either<Failure, ?> finalizeActivation(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+      final ExecutableProcess element, final BpmnElementContext context) {
     final var activatedContext =
         stateTransitionBehavior.transitionToActivated(context, element.getEventType());
     activateStartEvent(element, activatedContext);
@@ -79,7 +78,7 @@ public final class ProcessProcessor
 
   @Override
   public Either<Failure, ?> onComplete(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+      final ExecutableProcess element, final BpmnElementContext context) {
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
     compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstance(context);
@@ -89,7 +88,7 @@ public final class ProcessProcessor
 
   @Override
   public Either<Failure, ?> finalizeCompletion(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+      final ExecutableProcess element, final BpmnElementContext context) {
 
     // we need to send the result before we transition to completed, since the
     // event applier will delete the element instance
@@ -103,7 +102,7 @@ public final class ProcessProcessor
 
   @Override
   public TransitionOutcome onTerminate(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+      final ExecutableProcess element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
     }
@@ -118,7 +117,7 @@ public final class ProcessProcessor
 
   @Override
   public void finalizeTermination(
-      final ExecutableFlowElementContainer element, final BpmnElementContext terminationContext) {
+      final ExecutableProcess element, final BpmnElementContext terminationContext) {
     agentInstanceBehavior.completeAgentInstancesOfProcessInstance(terminationContext);
     transitionTo(
         element,
@@ -139,7 +138,7 @@ public final class ProcessProcessor
   }
 
   private void activateStartEvent(
-      final ExecutableFlowElementContainer element, final BpmnElementContext activated) {
+      final ExecutableProcess element, final BpmnElementContext activated) {
     if (element.hasMessageStartEvent()
         || element.hasTimerStartEvent()
         || element.hasSignalStartEvent()
@@ -157,7 +156,7 @@ public final class ProcessProcessor
   }
 
   private void activateNoneStartEvent(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+      final ExecutableProcess element, final BpmnElementContext context) {
     final var noneStartEvent = element.getNoneStartEvent();
     if (noneStartEvent == null) {
       throw new BpmnProcessingException(
@@ -169,7 +168,7 @@ public final class ProcessProcessor
 
   @Override
   public void afterExecutionPathCompleted(
-      final ExecutableFlowElementContainer element,
+      final ExecutableProcess element,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext,
       final Boolean satisfiesCompletionCondition) {
@@ -181,7 +180,7 @@ public final class ProcessProcessor
 
   @Override
   public void onChildTerminated(
-      final ExecutableFlowElementContainer element,
+      final ExecutableProcess element,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
     final var flowScopeInstance = stateBehavior.getElementInstance(flowScopeContext);
@@ -221,7 +220,7 @@ public final class ProcessProcessor
   }
 
   private Either<Failure, ?> transitionTo(
-      final ExecutableFlowElementContainer element,
+      final ExecutableProcess element,
       final BpmnElementContext context,
       final Function<BpmnElementContext, Either<Failure, BpmnElementContext>> transitionOperation) {
 
@@ -234,7 +233,7 @@ public final class ProcessProcessor
   }
 
   private Consumer<BpmnElementContext> getPostTransitionAction(
-      final ExecutableFlowElementContainer processElement, final BpmnElementContext context) {
+      final ExecutableProcess processElement, final BpmnElementContext context) {
 
     // fetch the data before the element instance is removed while performing the transition
     final var parentProcessInstanceKey = context.getParentProcessInstanceKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
@@ -22,6 +22,7 @@ public class ExecutableProcess extends ExecutableFlowElementContainer {
 
   private final Map<DirectBuffer, AbstractFlowElement> flowElements = new HashMap<>();
   private Expression defaultJobPriority;
+  private boolean agentic;
 
   public ExecutableProcess(final String id) {
     super(id);
@@ -112,5 +113,21 @@ public class ExecutableProcess extends ExecutableFlowElementContainer {
 
   public Collection<AbstractFlowElement> getFlowElements() {
     return flowElements.values();
+  }
+
+  /**
+   * A process is agentic when it contains at least one agent-marked element: a {@code serviceTask}
+   * or {@code adHocSubProcess} carrying an explicit {@code zeebe:agentDefinition} marker, anywhere
+   * in its element tree.
+   *
+   * @return {@code true} if this process was detected at deploy time to be agentic.
+   */
+  public boolean isAgentic() {
+    return agentic;
+  }
+
+  /** Marks this process as agentic, detected at deploy time from an agent-marked element. */
+  public void markAgentic() {
+    agentic = true;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformerV2.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformerV2.java
@@ -82,7 +82,7 @@ public final class AdHocSubProcessTransformerV2
     setImplementationType(executableAdHocSubProcess, element);
     setInnerInstance(executableAdHocSubProcess, childElements, process);
     setJobWorkerProperties(executableAdHocSubProcess, context, element);
-    setAgentDefinitionType(executableAdHocSubProcess, element);
+    setAgentDefinitionType(executableAdHocSubProcess, element, process);
     setAdHocActivitiesMetadata(executableAdHocSubProcess);
     setOutputCollectionAndElement(executableAdHocSubProcess, element, context);
   }
@@ -160,9 +160,14 @@ public final class AdHocSubProcessTransformerV2
   }
 
   private void setAgentDefinitionType(
-      final ExecutableAdHocSubProcess executableAdHocSubProcess, final AdHocSubProcess element) {
+      final ExecutableAdHocSubProcess executableAdHocSubProcess,
+      final AdHocSubProcess element,
+      final ExecutableProcess process) {
     final var agentDefinition = element.getSingleExtensionElement(ZeebeAgentDefinition.class);
     agentElementTypeTransformer.transform(executableAdHocSubProcess, agentDefinition);
+    if (executableAdHocSubProcess.isAgentDefinition()) {
+      process.markAgentic();
+    }
   }
 
   private void setAdHocActivitiesMetadata(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformerV2.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformerV2.java
@@ -75,6 +75,9 @@ public final class JobWorkerElementTransformerV2<T extends FlowElement>
 
       final var agentDefinition = element.getSingleExtensionElement(ZeebeAgentDefinition.class);
       agentElementTypeTransformer.transform(jobWorkerElement, agentDefinition);
+      if (jobWorkerElement.isAgentDefinition()) {
+        process.markAgentic();
+      }
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
@@ -549,6 +549,129 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
         .isTrue();
   }
 
+  @Test
+  public void shouldNotAppendCompletionCommandWhenNoAgentInstancesOnNormalCompletion() {
+    // given
+    final String processId = "plain-process-normal-completion";
+    ENGINE
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.agentInstanceRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .describedAs(
+            "No AgentInstance record of any kind should exist for a process instance that "
+                + "never had any associated agent instances")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotAppendCompletionCommandWhenNoAgentInstancesOnCancellationWithActiveChild() {
+    // given
+    final String processId = "plain-process-cancel-active-child";
+    final String jobType = "plain-task-cancel-active-child";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(jobType)
+        .await();
+
+    // when — cancellation reaches the process instance only after this active child has fully
+    // terminated
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .await();
+
+    // then
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.agentInstanceRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .describedAs(
+            "No AgentInstance record of any kind should exist for a process instance that "
+                + "never had any associated agent instances")
+        .isFalse();
+  }
+
+  @Test
+  public void
+      shouldNotAppendCompletionCommandWhenNoAgentInstancesOnCancellationWithZeroActiveChildren() {
+    // given — the start listener job is deliberately left incomplete, so the process instance
+    // is stuck activating with no child element instance created yet
+    final String processId = "plain-process-cancel-zero-active-children";
+    final String startListenerType = "plain-start-listener-zero-active-children";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .zeebeStartExecutionListener(startListenerType)
+                .startEvent()
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(startListenerType)
+        .await();
+
+    // when — termination reaches the process element directly, without going through a
+    // terminating child element instance
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.processInstanceRecords(
+                            ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .filter(r -> r.getValue().getBpmnElementType() != BpmnElementType.PROCESS)
+                        .exists()))
+        .describedAs(
+            "This test only exercises the intended zero-active-children path if no child "
+                + "element instance was ever created, neither before cancellation nor as part "
+                + "of it")
+        .isFalse();
+
+    // then
+    assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.agentInstanceRecords()
+                        .withProcessInstanceKey(processInstanceKey)
+                        .exists()))
+        .describedAs(
+            "No AgentInstance record of any kind should exist for a process instance that "
+                + "never had any associated agent instances")
+        .isFalse();
+  }
+
   private static Record<ProcessInstanceRecordValue> awaitElementActivated(
       final long processInstanceKey, final String elementId) {
     return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExecutableProcessAgenticTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExecutableProcessAgenticTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link ExecutableProcess#isAgentic()}, the deploy-time-detected flag that lets {@code
+ * AgentInstanceBehavior} skip its per-instance {@code AgentInstanceState} lookup for processes that
+ * can never have an agent instance in the first place.
+ */
+class ExecutableProcessAgenticTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  @Test
+  void shouldNotBeAgenticWithoutAnyAgentMarkedElement() {
+    // given
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("plain-task", t -> t.zeebeJobType("plain-task-job"))
+            .endEvent()
+            .done();
+
+    // when
+    final ExecutableProcess process = transform(model);
+
+    // then
+    assertThat(process.isAgentic())
+        .describedAs("A process with no agent-marked element must not be flagged agentic")
+        .isFalse();
+  }
+
+  @Test
+  void shouldBeAgenticWithAgentMarkedServiceTask() {
+    // given
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "agent-task", t -> t.zeebeJobType("agent-task-job").zeebeAiAgentTaskDefinition())
+            .endEvent()
+            .done();
+
+    // when
+    final ExecutableProcess process = transform(model);
+
+    // then
+    assertThat(process.isAgentic())
+        .describedAs("A process with an agent-marked service task must be flagged agentic")
+        .isTrue();
+  }
+
+  @Test
+  void shouldBeAgenticWithAgentMarkedAdHocSubProcess() {
+    // given
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .adHocSubProcess(
+                "agent-sub-process",
+                ahsp -> {
+                  ahsp.zeebeAiAgentSubProcessDefinition();
+                  ahsp.task("inner");
+                  ahsp.zeebeJobType("agent-sub-process-job");
+                })
+            .endEvent()
+            .done();
+
+    // when
+    final ExecutableProcess process = transform(model);
+
+    // then
+    assertThat(process.isAgentic())
+        .describedAs("A process with an agent-marked ad-hoc sub-process must be flagged agentic")
+        .isTrue();
+  }
+
+  @Test
+  void shouldBeAgenticWithAgentMarkedElementNestedInsideSubProcess() {
+    // given - the agent-marked service task is nested inside a plain embedded sub-process, not a
+    // direct child of the root process
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .subProcess(
+                "sub-process",
+                sub ->
+                    sub.embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask(
+                            "agent-task",
+                            t -> t.zeebeJobType("agent-task-job").zeebeAiAgentTaskDefinition())
+                        .endEvent())
+            .endEvent()
+            .done();
+
+    // when
+    final ExecutableProcess process = transform(model);
+
+    // then
+    assertThat(process.isAgentic())
+        .describedAs(
+            "A root process must be flagged agentic even when its only agent-marked element is"
+                + " nested inside a sub-process, since ExecutableProcess.flowElements is flat"
+                + " regardless of nesting depth")
+        .isTrue();
+  }
+
+  @Test
+  void shouldOnlyFlagTheMarkedProcessAmongSiblingsSharingOneResource() {
+    // given - a single BPMN resource with two independent, executable <process> elements: only
+    // the first carries an agent marker
+    final BpmnModelInstance model =
+        Bpmn.readModelFromStream(
+            getClass()
+                .getClassLoader()
+                .getResourceAsStream("processes/agent-definition-multi-process-mixed.bpmn"));
+
+    // when
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(model);
+    final ExecutableProcess markedProcess =
+        processes.stream()
+            .filter(p -> "process-multi-mixed-marked".equals(BufferUtil.bufferAsString(p.getId())))
+            .findFirst()
+            .orElseThrow();
+    final ExecutableProcess plainProcess =
+        processes.stream()
+            .filter(p -> "process-multi-mixed-plain".equals(BufferUtil.bufferAsString(p.getId())))
+            .findFirst()
+            .orElseThrow();
+
+    // then
+    assertThat(markedProcess.isAgentic())
+        .describedAs(
+            "The process containing the agent-marked element must be flagged agentic, correctly"
+                + " resolved among several processes sharing one resource")
+        .isTrue();
+    assertThat(plainProcess.isAgentic())
+        .describedAs(
+            "The sibling process without any agent-marked element must not be flagged agentic,"
+                + " proving the flag isn't leaked across sibling processes")
+        .isFalse();
+  }
+
+  private ExecutableProcess transform(final BpmnModelInstance model) {
+    return transformer.transformDefinitions(model).getFirst();
+  }
+}

--- a/zeebe/engine/src/test/resources/processes/agent-definition-multi-process-mixed.bpmn
+++ b/zeebe/engine/src/test/resources/processes/agent-definition-multi-process-mixed.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_agent_multi_process_mixed" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:collaboration id="Collaboration_agent_multi_process_mixed">
+    <bpmn:documentation>The Zeebe BPMN model Java Builder API has no fluent equivalent for authoring multiple &lt;process&gt; elements, collaborations, or pools/participants, so this fixture is hand-authored XML rather than generated via Bpmn.createProcess(...). Only the first process carries an agent marker; the second is plain, to prove the isAgentic() flag isn't leaked across sibling processes sharing one resource.</bpmn:documentation>
+    <bpmn:participant id="Participant_Marked" name="process-multi-mixed-marked" processRef="process-multi-mixed-marked" />
+    <bpmn:participant id="Participant_Plain" name="process-multi-mixed-plain" processRef="process-multi-mixed-plain" />
+  </bpmn:collaboration>
+  <bpmn:process id="process-multi-mixed-marked" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Marked">
+      <bpmn:outgoing>Flow_Marked_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="agent-task-marked" name="agent-task-marked">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="agent-task-job-marked" />
+        <zeebe:agentDefinition agentType="aiAgentTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Marked_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_Marked_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_Marked">
+      <bpmn:incoming>Flow_Marked_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Marked_1" sourceRef="StartEvent_Marked" targetRef="agent-task-marked" />
+    <bpmn:sequenceFlow id="Flow_Marked_2" sourceRef="agent-task-marked" targetRef="EndEvent_Marked" />
+  </bpmn:process>
+  <bpmn:process id="process-multi-mixed-plain" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Plain">
+      <bpmn:outgoing>Flow_Plain_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="plain-task" name="plain-task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="plain-task-job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Plain_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_Plain_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_Plain">
+      <bpmn:incoming>Flow_Plain_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Plain_1" sourceRef="StartEvent_Plain" targetRef="plain-task" />
+    <bpmn:sequenceFlow id="Flow_Plain_2" sourceRef="plain-task" targetRef="EndEvent_Plain" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_agent_multi_process_mixed">
+      <bpmndi:BPMNShape id="Participant_Marked_di" bpmnElement="Participant_Marked" isHorizontal="true">
+        <dc:Bounds x="129" y="57" width="600" height="180" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_Marked_di" bpmnElement="StartEvent_Marked">
+        <dc:Bounds x="192" y="129" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_Marked_di" bpmnElement="agent-task-marked">
+        <dc:Bounds x="280" y="107" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Marked_di" bpmnElement="EndEvent_Marked">
+        <dc:Bounds x="432" y="129" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_Marked_1_di" bpmnElement="Flow_Marked_1">
+        <di:waypoint x="228" y="147" />
+        <di:waypoint x="280" y="147" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Marked_2_di" bpmnElement="Flow_Marked_2">
+        <di:waypoint x="380" y="147" />
+        <di:waypoint x="432" y="147" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_Plain_di" bpmnElement="Participant_Plain" isHorizontal="true">
+        <dc:Bounds x="129" y="257" width="600" height="180" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_Plain_di" bpmnElement="StartEvent_Plain">
+        <dc:Bounds x="192" y="329" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_Plain_di" bpmnElement="plain-task">
+        <dc:Bounds x="280" y="307" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Plain_di" bpmnElement="EndEvent_Plain">
+        <dc:Bounds x="432" y="329" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_Plain_1_di" bpmnElement="Flow_Plain_1">
+        <di:waypoint x="228" y="347" />
+        <di:waypoint x="280" y="347" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Plain_2_di" bpmnElement="Flow_Plain_2">
+        <di:waypoint x="380" y="347" />
+        <di:waypoint x="432" y="347" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Users completing or terminating processes without agentic elements no longer generate redundant `AgentInstance:COMPLETE` commands and corresponding `NOT_FOUND` rejection records.

Previously, `AgentInstanceBehavior.completeAgentInstancesOfProcessInstance` appended an `AgentInstance:COMPLETE` command for every process-instance completion or termination—even when no agent instance had ever existed. `AgentInstanceCompleteProcessor` then rejected that command as `NOT_FOUND`. This produced unnecessary load on systems that don't even use agents.

This PR prevents those records by:

- Checking whether the process definition is agentic before doing any agent-instance work.
- Looking up `AgentInstanceState` only for agentic process definitions.
- Appending `AgentInstance:COMPLETE` only when the process instance actually has at least one agent instance.

`isAgentic()` is computed once during deployment and stored on the process definition when an agent-marked service task or ad-hoc sub-process is transformed. Because a non-agentic process can never create an agent instance, this avoids unnecessary RocksDB lookups on the common path without changing observable behavior.

Agent instances are unreleased and have not shipped in any release, so no rolling-upgrade compatibility gating or backport is required.

## Related issues

Closes #61043