### PR TITLE
fix: prevent concurrent tenant migrations from leaking changelog locks and stalling the next start

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import javax.sql.DataSource;
 import liquibase.database.Database;
@@ -51,6 +52,32 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
   private static final int DEFAULT_MIGRATION_RETRY_ATTEMPTS = 3;
   private static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofMillis(200);
   private static final String CHANGE_LOG = "db/changelog/rdbms-exporter/changelog-master.xml";
+
+  /**
+   * Forces Liquibase runs in this JVM to execute one at a time, because two of them overlapping
+   * corrupts each other's lock bookkeeping — even against entirely separate databases.
+   *
+   * <p>Liquibase ends each update with {@code LockServiceFactory.getInstance().resetAll()} ({@code
+   * AbstractUpdateCommandStep#cleanUp}), which discards that factory's JVM-wide singleton along
+   * with every database's {@code LockService}. A run that finishes while another is still between
+   * acquiring and releasing its lock therefore leaves the second run looking up a factory that no
+   * longer knows it holds one: {@code hasChangeLogLock()} reads false, the release is skipped
+   * without so much as a log line, and that tenant's {@code DATABASECHANGELOGLOCK} row stays set.
+   * The next start then blocks for Liquibase's full changelog-lock wait, fails, and keeps retrying
+   * until {@link #releaseStaleLockIfPresent()} force-releases the row a {@code
+   * ddl-lock-wait-timeout} later. Liquibase applies the per-database fix this needs to the sibling
+   * {@code ChangeLogHistoryServiceFactory} on the very next line of that same method, and documents
+   * the hazard in its javadoc; {@code LockServiceFactory} has not been given it (5.0.4).
+   *
+   * <p>Serializing costs the physical tenants their overlap, not their independence: each still
+   * migrates on its own thread, with its own retry loop, and one tenant's failure still degrades
+   * only itself. Held interruptibly so that a shutdown does not have to wait out a peer's
+   * migration.
+   *
+   * <p>Meant to be temporary: it can go as soon as Liquibase discards that factory per database
+   * rather than JVM-wide. See #61009 for the analysis and the upstream state.
+   */
+  private static final ReentrantLock MIGRATION_LOCK = new ReentrantLock(true);
 
   private static final Set<String> RETRYABLE_MESSAGES =
       Set.of(
@@ -220,7 +247,12 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
 
   @VisibleForTesting
   protected void performMigration(final SpringLiquibase runner) throws Exception {
-    runner.afterPropertiesSet();
+    MIGRATION_LOCK.lockInterruptibly();
+    try {
+      runner.afterPropertiesSet();
+    } finally {
+      MIGRATION_LOCK.unlock();
+    }
   }
 
   protected void waitBeforeRetry(final Duration retryBackoff) throws InterruptedException {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerConcurrentMigrationH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerConcurrentMigrationH2Test.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.sql.DataSource;
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.integration.spring.SpringLiquibase;
+import liquibase.resource.ResourceAccessor;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies that physical tenants migrating at the same time each end up with their changelog lock
+ * released, running real Liquibase and the production changelog against real H2 databases.
+ *
+ * <p>Liquibase ends every update by discarding its {@code LockServiceFactory} singleton JVM-wide,
+ * so a run that finishes while another is still holding its lock used to leave that second lock set
+ * — silently, since the release is skipped rather than attempted and failed. The tenant then lost
+ * its next start to Liquibase's full changelog-lock wait, over and over, until the lock aged past
+ * {@code ddl-lock-wait-timeout} and the stale-lock probe force-released it (#61009).
+ *
+ * <p>The interleaving that does this is decided here rather than raced for. The tenant under test
+ * runs a changelog that ends by handing control back to the test from inside the update, while
+ * Liquibase still holds its changelog lock, and it stays there while its peer runs a whole
+ * migration of its own — the interleaving that leaks. Waiting for that peer is bounded, and the
+ * bound decides nothing: if the peer finished, the assertions below catch the lock it left behind;
+ * if it never started, there was no reset to skip a release, which is what the serialization in
+ * {@link LiquibaseSchemaManager} buys. The bound is sized from a measured uncontended run of the
+ * very migration being waited for, so that "the peer did not finish" cannot quietly come to mean
+ * "the peer was slow".
+ */
+class LiquibaseSchemaManagerConcurrentMigrationH2Test {
+
+  private static final Duration DDL_LOCK_WAIT_TIMEOUT = Duration.ofMinutes(15);
+  private static final String PARKING_CHANGELOG =
+      "db/changelog/rdbms-concurrent-migration/parking-changelog.xml";
+
+  /**
+   * How much longer than an uncontended run of the same migration the peer is given before this
+   * test concludes that it never started at all, plus a grace so that a run measured in
+   * single-digit milliseconds still leaves a workable margin. Capped, so that a slow measurement
+   * cannot stretch the passing case out.
+   */
+  private static final int UNCONTENDED_RUN_MARGIN = 10;
+
+  private static final Duration MEASUREMENT_GRACE = Duration.ofSeconds(1);
+  private static final Duration MAX_PEER_CHANCE = Duration.ofSeconds(15);
+
+  private final List<Throwable> migrationFailures = new CopyOnWriteArrayList<>();
+
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
+  void shouldReleaseEveryTenantsLockWhenTheirMigrationsOverlap() throws Exception {
+    // given — two tenants on their own databases; the peer is migrated up front, so the run it
+    // makes below is the same no-op re-run every restart makes, and one uncontended such run is
+    // timed to size the wait for it
+    final var parkedTenant = dataSourceFor("overlap-parked");
+    final var peerTenant = dataSourceFor("overlap-peer");
+    schemaManagerFor(peerTenant).initialize();
+    final var peersChance = peersChanceToFinish(timeUncontendedRunOf(peerTenant));
+
+    final var parkedIsInsideItsUpdate = new CountDownLatch(1);
+    final var peerHasFinished = new CountDownLatch(1);
+    ParkInsideUpdate.onExecute(
+        () -> {
+          parkedIsInsideItsUpdate.countDown();
+          awaitPeerToFinishIfItCan(peerHasFinished, peersChance);
+        });
+    final var parked =
+        migrationThread("parked", () -> parkingSchemaManagerFor(parkedTenant).initialize());
+    final var peer =
+        migrationThread(
+            "peer",
+            () -> {
+              parkedIsInsideItsUpdate.await();
+              try {
+                schemaManagerFor(peerTenant).initialize();
+              } finally {
+                peerHasFinished.countDown();
+              }
+            });
+
+    // when — both tenants migrate at the same time, as PerTenantSchemaInitialization runs them,
+    // with the peer's whole run falling inside the window in which the other holds its lock
+    parked.start();
+    peer.start();
+    parked.join();
+    peer.join();
+
+    // then — both migrations went through, and neither tenant left its changelog lock behind for
+    // its own next start to wait out
+    assertThat(migrationFailures).as("both tenants migrated successfully").isEmpty();
+    assertThat(isLockHeld(parkedTenant)).as("parked tenant's changelog lock").isFalse();
+    assertThat(isLockHeld(peerTenant)).as("peer tenant's changelog lock").isFalse();
+  }
+
+  /**
+   * Returns either once the peer has finished a migration of its own — the interleaving that used
+   * to leave this tenant's lock behind — or once it has had long enough that it cannot have started
+   * one.
+   */
+  private void awaitPeerToFinishIfItCan(
+      final CountDownLatch peerHasFinished, final Duration peersChance) {
+    try {
+      peerHasFinished.await(peersChance.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while giving the peer tenant its turn", e);
+    }
+  }
+
+  /** Times the no-op re-run that the peer will make again, with nothing else running. */
+  private Duration timeUncontendedRunOf(final DataSource tenant) throws Exception {
+    final var startedAt = System.nanoTime();
+    schemaManagerFor(tenant).initialize();
+    return Duration.ofNanos(System.nanoTime() - startedAt);
+  }
+
+  private Duration peersChanceToFinish(final Duration uncontendedRun) {
+    final var scaled = uncontendedRun.multipliedBy(UNCONTENDED_RUN_MARGIN).plus(MEASUREMENT_GRACE);
+    return scaled.compareTo(MAX_PEER_CHANCE) > 0 ? MAX_PEER_CHANCE : scaled;
+  }
+
+  private Thread migrationThread(final String tenantId, final TenantMigration migration) {
+    return Thread.ofVirtual()
+        .name("schema-init-" + tenantId)
+        .unstarted(
+            () -> {
+              try {
+                migration.run();
+              } catch (final Throwable t) {
+                migrationFailures.add(
+                    new IllegalStateException(
+                        "Schema initialization failed for tenant '" + tenantId + "'", t));
+              }
+            });
+  }
+
+  private LiquibaseSchemaManager schemaManagerFor(final DataSource dataSource) throws Exception {
+    return new LiquibaseSchemaManager(schemaConfigFor(dataSource), "8.10.0");
+  }
+
+  /** A schema manager whose changelog ends by handing control back to this test. */
+  private LiquibaseSchemaManager parkingSchemaManagerFor(final DataSource dataSource)
+      throws Exception {
+    return new LiquibaseSchemaManager(schemaConfigFor(dataSource), "8.10.0") {
+      @Override
+      protected SpringLiquibase buildRunner() {
+        final var runner = super.buildRunner();
+        runner.setChangeLog(PARKING_CHANGELOG);
+        return runner;
+      }
+    };
+  }
+
+  private PerTenantSchemaConfig schemaConfigFor(final DataSource dataSource) throws Exception {
+    return new PerTenantSchemaConfig(
+        dataSource, VendorDatabasePropertiesLoader.load("h2"), "", true, DDL_LOCK_WAIT_TIMEOUT);
+  }
+
+  private DataSource dataSourceFor(final String name) {
+    final var dataSource = new JdbcDataSource();
+    dataSource.setURL(
+        "jdbc:h2:mem:" + name + "-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+    dataSource.setUser("sa");
+    dataSource.setPassword("");
+    return dataSource;
+  }
+
+  private boolean isLockHeld(final DataSource dataSource) throws Exception {
+    try (final var connection = dataSource.getConnection();
+        final var statement = connection.createStatement();
+        final var result =
+            statement.executeQuery("SELECT LOCKED FROM DATABASECHANGELOGLOCK WHERE ID = 1")) {
+      return result.next() && result.getBoolean("LOCKED");
+    }
+  }
+
+  @FunctionalInterface
+  private interface TenantMigration {
+    void run() throws Exception;
+  }
+
+  public static final class ParkInsideUpdate implements CustomTaskChange {
+
+    private static final AtomicReference<Runnable> BEHAVIOUR = new AtomicReference<>(() -> {});
+
+    static void onExecute(final Runnable behaviour) {
+      BEHAVIOUR.set(behaviour);
+    }
+
+    @Override
+    public void execute(final Database database) {
+      BEHAVIOUR.get().run();
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+      return "Handed control back to the test while holding this tenant's changelog lock";
+    }
+
+    @Override
+    public void setUp() {}
+
+    @Override
+    public void setFileOpener(final ResourceAccessor resourceAccessor) {}
+
+    @Override
+    public ValidationErrors validate(final Database database) {
+      return new ValidationErrors();
+    }
+  }
+}

--- a/db/rdbms/src/test/resources/db/changelog/rdbms-concurrent-migration/parking-changelog.xml
+++ b/db/rdbms/src/test/resources/db/changelog/rdbms-concurrent-migration/parking-changelog.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!--
+  ~ The production changelog, followed by a changeset that hands control back to the test while
+  ~ Liquibase still holds this tenant's changelog lock. That window is what
+  ~ LiquibaseSchemaManagerConcurrentMigrationH2Test needs in order to decide the interleaving of two
+  ~ tenants' migrations instead of racing for it.
+  -->
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <include file="/db/changelog/rdbms-exporter/changelog-master.xml" />
+
+  <changeSet id="park-while-holding-the-changelog-lock" author="camunda" runAlways="true">
+    <customChange
+      class="io.camunda.db.rdbms.LiquibaseSchemaManagerConcurrentMigrationH2Test$ParkInsideUpdate" />
+  </changeSet>
+
+</databaseChangeLog>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PhysicalTenantWebSessionIsolationIT.java
@@ -26,11 +26,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -118,9 +119,7 @@ class PhysicalTenantWebSessionIsolationIT {
   }
 
   @Test
-  @Disabled(
-      "Blocks for ~600s inside the full rdbms suite and times out CI. Re-enable with the fix: "
-          + "https://github.com/camunda/camunda/issues/61009")
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   void shouldSurviveRestartInCorrectPhysicalTenantStore() {
     // given — write via app1's tenant A store
     final String id = UUID.randomUUID().toString();


### PR DESCRIPTION
## Summary

`PhysicalTenantWebSessionIsolationIT#shouldSurviveRestartInCorrectPhysicalTenantStore` stalled 300–665s inside the full `rdbms` suite and was disabled by #61010 to unblock the merge queue. The cause turned out not to be: a node with two or more physical tenants on RDBMS can **finish** a tenant's schema migration and leave that tenant's `DATABASECHANGELOGLOCK` row set. This PR fixes that and re-enables the test.

## Root cause

Liquibase ends every update with a JVM-wide teardown of its lock registry — [`AbstractUpdateCommandStep#cleanUp`, liquibase-core 5.0.4](https://github.com/liquibase/liquibase/blob/v5.0.4/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java#L209-L213):

```java
public void cleanUp(CommandResultsBuilder resultsBuilder) {
    isDBLocked.remove();
    LockServiceFactory.getInstance().resetAll();          // JVM-wide: discards the singleton and every database's LockService
    Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
    Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);   // per-database
}
```

The `ChangeLogHistoryServiceFactory` line one below is per-database *on purpose*. Its [javadoc](https://github.com/liquibase/liquibase/blob/v5.0.4/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java#L102-L112) says it outright: *"Since this factory is a single JVM-wide singleton, `resetAll()` called from one execution's cleanup would otherwise discard other concurrently running executions' (different database's) services too."* `LockServiceFactory` never got the same treatment.

So when `PerTenantSchemaInitialization` runs each tenant's migration on its own thread, concurrently:

1. Tenants A and B each acquire their own changelog lock, on their own database.
2. A finishes, releases its lock, then `cleanUp()` nulls the shared singleton.
3. B reaches its own `finally`, which is `if (lockService.hasChangeLogLock()) lockService.releaseLock();`. `getLockService(database)` now hits a brand-new empty factory and hands back a fresh `LockService` with `hasChangeLogLock == false` — so **the release is skipped rather than attempted and failed, and nothing is logged either way**.
4. B's `LOCKED=TRUE` row survives.
5. B's next start blocks for Liquibase's full `changeLogLockWaitTime` (5 minutes by default — the 300s in the logs), fails with a `LockException`, and the retry loop repeats it until the row ages past `ddl-lock-wait-timeout` and `releaseStaleLockIfPresent()` force-releases it. That tenant is degraded and rejecting requests for the whole of that.

The CI logs show exactly this shape — two acquires, one release, one silent nothing:

```
00:01:06.082 [schema-init-tenanta] Successfully acquired change log lock
00:01:06.082 [schema-init-default] Successfully acquired change log lock
00:01:06.129 [schema-init-default] Successfully released change log lock
00:01:06.130 [schema-init-tenanta] Command execution complete          ← no release, no error
```

and a direct JDBC probe confirms `ws-isol-tenanta DATABASECHANGELOGLOCK LOCKED=true GRANTED=00:01:06.082`.

## Fix

Synchronize the Liquibase run per JVM in `LiquibaseSchemaManager#performMigration`, held interruptibly so shutdown need not wait out a peer.

The cost is the tenants' overlap, not their independence: each still migrates on its own thread, with its own retry loop and its own gate contribution, and one tenant's failure still degrades only itself. 

This fix should be temporary until a fix is provided in Liquibase (I will propose a fix to the community)

Closes #61009
