### PR TITLE
fix: handle concurrent deletion of manifests while walking directory

### DIFF
--- a/zeebe/backup-stores/filesystem/pom.xml
+++ b/zeebe/backup-stores/filesystem/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <classifier>tests</classifier>

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -22,17 +22,22 @@ import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
+import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,16 +180,13 @@ public final class ManifestManager {
   }
 
   Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
-    try (final Stream<Path> files = Files.walk(manifestsPath)) {
-      return files
-          .filter(filePath -> filterBlobsByWildcard(wildcard, filePath.toString()))
-          .map(this::getManifestWithPath)
-          .filter(Objects::nonNull)
-          .filter(m -> wildcard.matches(m.id()))
-          .toList();
+    final var collector = new ManifestCollector(wildcard);
+    try {
+      Files.walkFileTree(manifestsPath, collector);
     } catch (final IOException e) {
       throw new UncheckedIOException("Unable to list manifests from " + manifestsPath, e);
     }
+    return collector.manifests();
   }
 
   private Manifest getManifestWithPath(final Path path) {
@@ -194,6 +196,8 @@ public final class ManifestManager {
 
     try {
       return MAPPER.readValue(path.toFile(), Manifest.class);
+    } catch (final FileNotFoundException | NoSuchFileException e) {
+      return null;
     } catch (final IOException e) {
       throw new UncheckedIOException("Unable to read manifest from path " + path, e);
     }
@@ -229,5 +233,62 @@ public final class ManifestManager {
         .resolve(checkpointId)
         .resolve(nodeId)
         .resolve(MANIFEST_FILENAME);
+  }
+
+  /**
+   * Collects every manifest matching the wildcard, continuing past entries that a concurrent
+   * deletion removes while the traversal is running: an entry gone mid-walk is the same listing the
+   * caller would have seen after the delete, so it is skipped rather than failing the caller. The
+   * traversal keeps its position and everything collected so far — nothing is re-walked.
+   */
+  @VisibleForTesting
+  final class ManifestCollector extends SimpleFileVisitor<Path> {
+
+    private final BackupIdentifierWildcard wildcard;
+    private final List<Manifest> manifests = new ArrayList<>();
+
+    @VisibleForTesting
+    ManifestCollector(final BackupIdentifierWildcard wildcard) {
+      this.wildcard = wildcard;
+    }
+
+    @Override
+    public @NonNull FileVisitResult visitFile(
+        final Path file, final @NonNull BasicFileAttributes attributes) {
+      if (filterBlobsByWildcard(wildcard, file.toString())) {
+        final var manifest = getManifestWithPath(file);
+        if (manifest != null && wildcard.matches(manifest.id())) {
+          manifests.add(manifest);
+        }
+      }
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public @NonNull FileVisitResult visitFileFailed(
+        final @NonNull Path file, final @NonNull IOException failure) throws IOException {
+      return continueIfDeletedConcurrently(file, failure);
+    }
+
+    @Override
+    public @NonNull FileVisitResult postVisitDirectory(
+        final @NonNull Path directory, final IOException failure) throws IOException {
+      return failure == null
+          ? FileVisitResult.CONTINUE
+          : continueIfDeletedConcurrently(directory, failure);
+    }
+
+    private FileVisitResult continueIfDeletedConcurrently(
+        final Path path, final IOException failure) throws IOException {
+      if (failure instanceof NoSuchFileException && !path.equals(manifestsPath)) {
+        return FileVisitResult.CONTINUE;
+      }
+      throw failure;
+    }
+
+    @VisibleForTesting
+    List<Manifest> manifests() {
+      return manifests;
+    }
   }
 }

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -181,13 +181,13 @@ class ManifestManagerTest {
     var listings = 0;
     try {
       final var deleting = deleter.submit(() -> deletable.forEach(manifestManager::deleteManifest));
-      while (!deleting.isDone()) {
+      do {
         // then every listing succeeds and still reports the manifest nothing deleted
         assertThat(manifestManager.listManifests(wildcard))
             .extracting(manifest -> manifest.id().checkpointId())
             .contains(1L);
         listings++;
-      }
+      } while (!deleting.isDone());
       // surfaces a failure of the deleting side, which the loop above would otherwise hide
       deleting.get(30, TimeUnit.SECONDS);
     } finally {

--- a/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
+++ b/zeebe/backup-stores/filesystem/src/test/java/io/camunda/zeebe/backup/filesystem/ManifestManagerTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
@@ -27,14 +28,21 @@ import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystemLoopException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -148,6 +156,48 @@ class ManifestManagerTest {
     assertThat(manifests).hasSize(expectedSize);
   }
 
+  /**
+   * Deleting a backup removes its manifest and then the parent directories that removal left empty,
+   * so a listing already walking the tree can find entries gone by the time it reaches them. The
+   * store serves both calls concurrently, and nothing orders them against each other — a broker
+   * deleting a superseded checkpoint while taking the next one does exactly this, and the listing
+   * used to fail the backup being taken.
+   */
+  @Test
+  void shouldListManifestsWhileOthersAreConcurrentlyDeleted() throws Exception {
+    // given one manifest that stays, and many on the same partition that are deleted concurrently
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(0), CheckpointPattern.any());
+    manifestManager.createInitialManifest(createBackup(new BackupIdentifierImpl(1337, 0, 1L)));
+    final var deletable = new ArrayList<Manifest>();
+    for (long checkpointId = 2; checkpointId <= 400; checkpointId++) {
+      deletable.add(
+          manifestManager.createInitialManifest(
+              createBackup(new BackupIdentifierImpl(1337, 0, checkpointId))));
+    }
+
+    // when listing for as long as the deletions run
+    final var deleter = Executors.newSingleThreadExecutor();
+    var listings = 0;
+    try {
+      final var deleting = deleter.submit(() -> deletable.forEach(manifestManager::deleteManifest));
+      while (!deleting.isDone()) {
+        // then every listing succeeds and still reports the manifest nothing deleted
+        assertThat(manifestManager.listManifests(wildcard))
+            .extracting(manifest -> manifest.id().checkpointId())
+            .contains(1L);
+        listings++;
+      }
+      // surfaces a failure of the deleting side, which the loop above would otherwise hide
+      deleting.get(30, TimeUnit.SECONDS);
+    } finally {
+      deleter.shutdownNow();
+    }
+
+    // and the listings really did overlap the deletions
+    assertThat(listings).isPositive();
+  }
+
   private static Stream<Arguments> provideWildcardsForListManifests() {
     return Stream.of(
         Arguments.of(
@@ -179,6 +229,91 @@ class ManifestManagerTest {
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
         new NamedFileSetImpl(Map.of()));
+  }
+
+  @Nested
+  class ManifestCollectorTest {
+
+    private final BackupIdentifierWildcard anyBackup =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), CheckpointPattern.any());
+
+    @Test
+    void shouldContinuePastAFileDeletedDuringTheWalk() throws IOException {
+      // given
+      final var collector = manifestManager.new ManifestCollector(anyBackup);
+      final var vanishedManifest = tempDir.resolve("0/42/1337/manifest.json");
+
+      // when
+      final var result =
+          collector.visitFileFailed(
+              vanishedManifest, new NoSuchFileException(vanishedManifest.toString()));
+
+      // then the walk carries on, having collected nothing for the entry that is no longer there
+      assertThat(result).isEqualTo(FileVisitResult.CONTINUE);
+      assertThat(collector.manifests()).isEmpty();
+    }
+
+    @Test
+    void shouldContinuePastADirectoryDeletedDuringTheWalk() throws IOException {
+      // given
+      final var collector = manifestManager.new ManifestCollector(anyBackup);
+      final var vanishedCheckpointDir = tempDir.resolve("0/42");
+
+      // when
+      final var result =
+          collector.postVisitDirectory(
+              vanishedCheckpointDir, new NoSuchFileException(vanishedCheckpointDir.toString()));
+
+      // then
+      assertThat(result).isEqualTo(FileVisitResult.CONTINUE);
+    }
+
+    @Test
+    void shouldContinueWhenADirectoryIsVisitedWithoutFailure() throws IOException {
+      // given
+      final var collector = manifestManager.new ManifestCollector(anyBackup);
+
+      // when
+      final var result = collector.postVisitDirectory(tempDir.resolve("0"), null);
+
+      // then
+      assertThat(result).isEqualTo(FileVisitResult.CONTINUE);
+    }
+
+    @Test
+    void shouldFailWhenTheManifestsRootItselfIsMissing() {
+      // given the failing path is the store's own root, not an entry below it
+      final var collector = manifestManager.new ManifestCollector(anyBackup);
+
+      // when listing the root itself as gone, then that is a broken store, not a concurrent
+      // delete — every backup this tenant ever took would silently read back as zero
+      assertThatThrownBy(
+              () -> collector.visitFileFailed(tempDir, new NoSuchFileException(tempDir.toString())))
+          .isInstanceOf(NoSuchFileException.class);
+      assertThatThrownBy(
+              () ->
+                  collector.postVisitDirectory(
+                      tempDir, new NoSuchFileException(tempDir.toString())))
+          .isInstanceOf(NoSuchFileException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNonRaceFailures")
+    void shouldNotSwallowAFailureThatIsNotAConcurrentDelete(final IOException failure) {
+      // given a failure that concurrent deletion never produces (permissions, a symlink loop, ...)
+      final var collector = manifestManager.new ManifestCollector(anyBackup);
+      final var path = tempDir.resolve("0/42/1337/manifest.json");
+
+      // when — then it propagates rather than being read as "the entry is not there"
+      assertThatThrownBy(() -> collector.visitFileFailed(path, failure)).isEqualTo(failure);
+      assertThatThrownBy(() -> collector.postVisitDirectory(path, failure)).isEqualTo(failure);
+    }
+
+    private static Stream<IOException> provideNonRaceFailures() {
+      return Stream.of(
+          new AccessDeniedException("manifest.json"), new FileSystemLoopException("manifest.json"));
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

While walking a directory during manifest listing in the FileSystem backup store, there's a potential of stumbling upon an in-flight deletion that can cause `UncheckedIOException` in the traversal. This became apparent with the async deletion of backups handled as part of the engine processors  on 8.9.

Introduce a custom `FileVisitor` implementation in order to accommodate for this case, skipping files that are amidst deletion.

Relates to [flakes](https://camunda.slack.com/archives/C071KP5BTHB/p1787664109974069?thread_ts=1787638500.131539&cid=C071KP5BTHB) in `ClusterRuntimeBackupIT.shouldTakeReadAndDeleteABackupOnEveryPhysicalTenant`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
