### PR TITLE
ci: route stable/8.10 correctly in the release E2E workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -410,7 +410,13 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   build-rdbms-dist:
-    if: ${{ needs.validate-release.outputs.base == 'stable/8.9' || needs.validate-release.outputs.base == 'main' }}
+    # RDBMS exists from 8.9 onwards. Listed as an exclusion of the branches
+    # that predate it rather than an allow-list of the ones that have it, so a
+    # newly cut stable branch gets these tests by default: stable/8.10 silently
+    # skipped this whole matrix on 8.10.0-alpha5-rc1 (run 32859395813) because
+    # the allow-list still named only 8.9 and main, while every earlier 8.10 RC
+    # had run it by falling through to base=main.
+    if: ${{ !contains(fromJSON('["stable/8.6","stable/8.7","stable/8.8"]'), needs.validate-release.outputs.base) }}
     name: "Build Camunda distribution"
     needs: [validate-release]
     runs-on: gcp-perf-core-16-default
@@ -482,7 +488,13 @@ jobs:
   c8-orchestration-cluster-api-tests-rdbms:
     name: API Tests (RDBMS) (${{ needs.validate-release.outputs.base }} / ${{ matrix.database.database-name }})
     needs: [validate-release, build-rdbms-dist]
-    if: ${{ needs.validate-release.outputs.base == 'stable/8.9' || needs.validate-release.outputs.base == 'main' }}
+    # RDBMS exists from 8.9 onwards. Listed as an exclusion of the branches
+    # that predate it rather than an allow-list of the ones that have it, so a
+    # newly cut stable branch gets these tests by default: stable/8.10 silently
+    # skipped this whole matrix on 8.10.0-alpha5-rc1 (run 32859395813) because
+    # the allow-list still named only 8.9 and main, while every earlier 8.10 RC
+    # had run it by falling through to base=main.
+    if: ${{ !contains(fromJSON('["stable/8.6","stable/8.7","stable/8.8"]'), needs.validate-release.outputs.base) }}
     runs-on: gcp-perf-core-16-default
     timeout-minutes: 60
     permissions: {}
@@ -825,7 +837,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tasklist_mode: ${{ fromJSON( (needs.validate-release.outputs.base == 'stable/8.6' || needs.validate-release.outputs.base == 'stable/8.7') && '["v1"]' || needs.validate-release.outputs.base == 'main' && '["v2"]' || '["v1","v2"]' ) }}
+        # Tasklist v1 exists only on 8.6-8.9; 8.10 removed it, as main did.
+        # Named as an allow-list of the branches that HAVE v1, defaulting to
+        # v2-only, so a new stable branch does not inherit a v1 leg: the old
+        # `|| '["v1","v2"]'` catch-all gave stable/8.10 one, and it failed with
+        # "No tests found" pointing at tests/tasklist/v1/ (run 32859395813).
+        tasklist_mode: ${{ fromJSON( (needs.validate-release.outputs.base == 'stable/8.6' || needs.validate-release.outputs.base == 'stable/8.7') && '["v1"]' || (needs.validate-release.outputs.base == 'stable/8.8' || needs.validate-release.outputs.base == 'stable/8.9') && '["v1","v2"]' || '["v2"]' ) }}
     needs: validate-release
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1039,15 +1056,18 @@ jobs:
 
             if [[ "${{ matrix.tasklist_mode }}" == "v2" ]]; then
               echo "Running V2 mode tests"
-              if [[ "${{ needs.validate-release.outputs.base }}" == "main" ]]; then
-                # main: V1 directories removed, run all tests
-                TEST_ARGS+=(tests/)
-              elif [[ "${{ needs.validate-release.outputs.base }}" == "stable/8.8" ]]; then
+              if [[ "${{ needs.validate-release.outputs.base }}" == "stable/8.8" ]]; then
                 # stable/8.8: run all tests excluding @v1-only tagged tests
                 TEST_ARGS+=(tests/ --grep-invert '@v1-only')
-              else
+              elif [[ "${{ needs.validate-release.outputs.base }}" == "stable/8.9" ]]; then
                 # stable/8.9: run all tests excluding v1/ directories
                 TEST_ARGS+=(tests/ --grep-invert 'v1/')
+              else
+                # main and stable/8.10+: V1 directories removed, run all tests.
+                # Was the 8.9 arm's else, so stable/8.10 inherited a pointless
+                # --grep-invert 'v1/'; harmless here (verified: 281 tests
+                # collected either way) but wrong by accident.
+                TEST_ARGS+=(tests/)
               fi
             else
               echo "Running V1 mode tests"


### PR DESCRIPTION
## Problem

Giving 8.10 its own routing value in #61000 (`base="stable/8.10"`, merged 13:04Z on 25 Aug) exposed three enumerations in this workflow that still treat *"not 8.6/8.7 and not `main`"* as meaning 8.8/8.9. The first 8.10 release run after that merge — [8.10.0-alpha5-rc1, run 32859395813](https://github.com/camunda/camunda/actions/runs/32859395813) at 14:25Z — hit all three.

Before the change, `8.10.x` matched no arm and fell through to `base="main"`, so 8.10 was getting correct behaviour by accident.

### 1. RDBMS coverage silently disappeared (the reason for this PR)

`build-rdbms-dist` and `c8-orchestration-cluster-api-tests-rdbms` were gated on an allow-list, `base == 'stable/8.9' || base == 'main'`, so `stable/8.10` skipped both:

| Release run | RDBMS jobs |
|---|---|
| 8.10.0-alpha3-rc2 | 9 × success |
| 8.10.0-alpha4-rc1 | 10 × ran |
| 8.10.0-alpha4-rc2 | 10 × success |
| **8.10.0-alpha5-rc1** | **skipped** |

Nothing went red — the jobs just didn't exist in the run — so alpha5-rc1 is the first 8.10 RC shipped without RDBMS API coverage.

### 2. A Tasklist v1 leg that cannot pass

The matrix catch-all `|| '["v1","v2"]'` gave `stable/8.10` a v1 leg. 8.10 removed Tasklist v1, so the v1 arm resolved to `tests/tasklist/v1/ tests/common-flows/v1/` — directories that don't exist on the branch — and Playwright exited `Error: No tests found`. That's the visible failure on the run.

### 3. v2 args inherited the wrong arm

`stable/8.10` fell into the `stable/8.9` else and ran `tests/ --grep-invert 'v1/'` instead of plain `tests/`. Harmless in practice, but wrong by accident.

## Fix

Four edits, all flipping allow-lists into default-forward logic so the next stable cut doesn't repeat this:

- **RDBMS** — gate on `!contains(fromJSON('["stable/8.6","stable/8.7","stable/8.8"]'), base)`. RDBMS exists from 8.9 onward, so exclude the branches that predate it rather than list the ones that have it. `stable/8.11` will get these tests without an edit.
- **`tasklist_mode`** — v1 becomes an allow-list of the branches that actually have it (8.6/8.7 → `["v1"]`, 8.8/8.9 → `["v1","v2"]`), defaulting to `["v2"]`. A new branch no longer inherits a v1 leg.
- **v2 args** — `tests/` is now the default; 8.8 and 8.9 keep their explicit arms.

## Verification

GHA `&&`/`||` operand-returning semantics simulated per base, and the arg-selection block run as bash for each base:

| base | tasklist_mode | RDBMS | v2 args |
|---|---|---|---|
| stable/8.6 | `["v1"]` | skipped | — |
| stable/8.7 | `["v1"]` | skipped | — |
| stable/8.8 | `["v1","v2"]` | skipped | `tests/ --grep-invert @v1-only` |
| stable/8.9 | `["v1","v2"]` | runs | `tests/ --grep-invert v1/` |
| **stable/8.10** | **`["v2"]`** | **runs** | **`tests/`** |
| stable/8.11 | `["v2"]` | runs | `tests/` |
| main | `["v2"]` | runs | `tests/` |

Only `stable/8.10` and hypothetical later branches change; 8.6–8.9 and `main` all resolve exactly as before. YAML parses and `bash -n` is clean on every `run` block.

The v2 E2E results on alpha5-rc1 are unaffected and remain trustworthy — I checked the wrong `--grep-invert` excluded nothing, comparing that run (281 tests collected: 258 passed, 5 flaky, 18 skipped) against the `stable/8.10` nightly running plain `tests/` (280 collected).

## Not in scope

The `stable/8.10` nightly is currently red on `tests/api/v2/optimize/optimize-startup.spec.ts:15` (OIDC login redirect, failed both attempts). The release E2E runs `--project=chromium` only, so it never executes the `optimize-startup` project — unrelated to this routing change, but worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
