### PR TITLE
refactor: migrate carbon icons in migrated design systems code

### DIFF
--- a/identity/client/src/components/entityListV2/EntityList.tsx
+++ b/identity/client/src/components/entityListV2/EntityList.tsx
@@ -19,7 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@camunda/design-system";
-import { Add, CarbonIconType } from "@carbon/react/icons";
+import { LucideIcon, Plus } from "lucide-react";
 import { DocumentationLink } from "src/components/documentationV2";
 import useTranslate from "src/utility/localization";
 import { PageResult, SortConfig } from "src/utility/api";
@@ -55,7 +55,7 @@ type TextMenuItem<D> = {
 };
 
 type MenuItem<D> = TextMenuItem<D> & {
-  icon?: CarbonIconType;
+  icon?: LucideIcon;
 };
 
 type EntityListProps<D extends EntityData> = {
@@ -288,7 +288,7 @@ const EntityList = <D extends EntityData>({
           )}
           {addEntityLabel && (
             <Button onClick={onAddEntity} disabled={addEntityDisabled}>
-              <Add data-icon="inline-start" aria-hidden="true" />
+              <Plus data-icon="inline-start" aria-hidden="true" />
               {addEntityLabel}
             </Button>
           )}

--- a/identity/client/src/components/layout/AppHeaderV2/InfoMenu.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/InfoMenu.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Help } from "@carbon/react/icons";
+import { HelpCircle } from "lucide-react";
 import {
   Button,
   DropdownMenu,
@@ -48,7 +48,7 @@ const InfoMenu = () => {
           size="icon"
           aria-label={t("info")}
         >
-          <Help aria-hidden className="size-4" />
+          <HelpCircle aria-hidden className="size-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end">

--- a/identity/client/src/components/layout/AppHeaderV2/useSidebarChildren.tsx
+++ b/identity/client/src/components/layout/AppHeaderV2/useSidebarChildren.tsx
@@ -7,34 +7,34 @@
  */
 
 import {
-  Connect,
-  Document,
-  Enterprise,
-  Folder,
-  Group,
-  License,
-  ListChecked,
+  Bot,
+  File,
+  ListChecks,
+  Package,
   Settings,
+  ShieldCheck,
   User,
-  UserAccess,
-} from "@carbon/react/icons";
-import type { CarbonIconType } from "@carbon/icons-react";
-import type { SidebarNode } from "@camunda/design-system";
+  UserCog,
+  Users,
+  Waypoints,
+  Zap,
+} from "lucide-react";
+import type { NavIcon, SidebarNode } from "@camunda/design-system";
 
 import { useGlobalRoutes } from "src/components/global/useGlobalRoutes";
 import { Paths } from "src/components/global/routePaths";
 
-const ROUTE_ICONS: Record<string, CarbonIconType> = {
+const ROUTE_ICONS: Record<string, NavIcon> = {
   [Paths.users()]: User,
-  [Paths.groups()]: Group,
-  [Paths.roles()]: UserAccess,
-  [Paths.tenants()]: Enterprise,
-  [Paths.mappingRules()]: Connect,
-  [Paths.authorizations()]: License,
+  [Paths.groups()]: Users,
+  [Paths.roles()]: UserCog,
+  [Paths.tenants()]: Package,
+  [Paths.mappingRules()]: Waypoints,
+  [Paths.authorizations()]: ShieldCheck,
   [Paths.clusterVariables()]: Settings,
-  [Paths.operationsLog()]: ListChecked,
-  [Paths.globalTaskListeners()]: Folder,
-  [Paths.mcpProcesses()]: Folder,
+  [Paths.operationsLog()]: ListChecks,
+  [Paths.globalTaskListeners()]: Zap,
+  [Paths.mcpProcesses()]: Bot,
 };
 
 export function useSidebarChildren(hideNavLinks: boolean): SidebarNode[] {
@@ -48,7 +48,7 @@ export function useSidebarChildren(hideNavLinks: boolean): SidebarNode[] {
     type: "item" as const,
     key: route.key,
     label: route.label,
-    icon: ROUTE_ICONS[route.key] ?? Document,
+    icon: ROUTE_ICONS[route.key] ?? File,
     isActive: route.isCurrentPage,
     linkProps: { to: route.key },
   }));

--- a/identity/client/src/pages/global-task-listeners/ListV2.tsx
+++ b/identity/client/src/pages/global-task-listeners/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Edit, TrashCan } from "@carbon/react/icons";
+import { Pencil, Trash2 } from "lucide-react";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
 import { useQuery } from "@tanstack/react-query";
@@ -111,13 +111,13 @@ const List: FC = () => {
         menuItems={[
           {
             label: t("editGlobalTaskListener"),
-            icon: Edit,
+            icon: Pencil,
             onClick: (entity) =>
               editGlobalTaskListener(entity.originalListener),
           },
           {
             label: t("delete"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: (entity) =>
               deleteGlobalTaskListener(entity.originalListener),

--- a/identity/client/src/pages/mapping-rules/ListV2.tsx
+++ b/identity/client/src/pages/mapping-rules/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Edit, TrashCan } from "@carbon/react/icons";
+import { Pencil, Trash2 } from "lucide-react";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
 import { useQuery } from "@tanstack/react-query";
@@ -96,12 +96,12 @@ const List: FC = () => {
         menuItems={[
           {
             label: t("edit"),
-            icon: Edit,
+            icon: Pencil,
             onClick: editMappingRule,
           },
           {
             label: t("delete"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: deleteMappingRule,
           },

--- a/identity/client/src/pages/users/ListV2.tsx
+++ b/identity/client/src/pages/users/ListV2.tsx
@@ -8,7 +8,7 @@
 
 import { FC } from "react";
 import { useNavigate } from "react-router-dom";
-import { Edit, TrashCan } from "@carbon/react/icons";
+import { Pencil, Trash2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
@@ -90,11 +90,11 @@ const List: FC = () => {
           {
             label: t("editUser"),
             onClick: editUser,
-            icon: Edit,
+            icon: Pencil,
           },
           {
             label: t("delete"),
-            icon: TrashCan,
+            icon: Trash2,
             onClick: deleteUser,
             isDangerous: true,
           },


### PR DESCRIPTION
## Description

This PR goes through already migrated Admin code and replaces dangling Carbon icons with Lucide icons. The new app header icons:

<img width="379" height="466" alt="Screenshot 2026-08-26 at 09 07 03" src="https://github.com/user-attachments/assets/41c73577-985c-49af-9e33-5ae646cc204b" />




## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60637
