### PR TITLE
ci: add robot account for camunda monorepo CI

### DIFF
--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,22 +35,23 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-|          Input           |                            Description                             | Required |  Default  |
-|--------------------------|--------------------------------------------------------------------|----------|-----------|
-| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)        | false    | `"true"`  |
-| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)       | false    | `"false"` |
-| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits   | false    | `"false"` |
-| harbor                   | Log into Harbor with a CI account (disabled for fork PRs)          | false    | `"false"` |
-| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)         | false    | `"false"` |
-| java-distribution        | Java distribution to install                                       | false    | `temurin` |
-| java-version             | JDK version to install                                             | false    | `"21"`    |
-| maven-cache-key-modifier | Modifier for the Maven cache key                                   | false    | `shared`  |
-| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)   | false    | `'[]'`    |
-| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)   | false    | `'[]'`    |
-| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only) | false    |           |
-| vault-address            | Vault URL to retrieve secrets from                                 | false    |           |
-| vault-role-id            | Vault AppRole role id                                              | false    |           |
-| vault-secret-id          | Vault AppRole secret id                                            | false    |           |
+
+|          Input           |                             Description                             | Required |  Default  |
+|--------------------------|---------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)        | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits    | false    | `"false"` |
+| harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs) | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)          | false    | `"false"` |
+| java-distribution        | Java distribution to install                                        | false    | `temurin` |
+| java-version             | JDK version to install                                              | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                    | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)    | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)    | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)  | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                  | false    |           |
+| vault-role-id            | Vault AppRole role id                                               | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                             | false    |           |
 
 ### Outputs
 

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -35,7 +35,6 @@ Vault/WIF hang (see that action's README).
 
 ### Inputs
 
-
 |          Input           |                             Description                             | Required |  Default  |
 |--------------------------|---------------------------------------------------------------------|----------|-----------|
 | camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)         | false    | `"true"`  |

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: "false"
   harbor:
     description: |
-      If enabled, logs into Harbor with a CI account.
+      If enabled, logs into Harbor with a Harbor robot account.
       Harbor login is automatically disabled for fork PRs.
     required: false
     default: "false"

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -151,7 +151,9 @@ runs:
         secret/data/github.com/organizations/camunda NEXUS_USR | ci-account-username;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
-        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+        secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+        secret/data/products/camunda/ci/harbor username | harbor-username;
+        secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
     uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
     with:
@@ -280,8 +282,8 @@ runs:
       inputs.harbor == 'true'
     uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
     env:
-      DOCKER_USERNAME: ${{ steps.secrets.outputs.ci-account-username }}
-      DOCKER_PASSWORD: ${{ steps.secrets.outputs.ci-account-password }}
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.harbor-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.harbor-password }}
     with:
       max_attempts: 3
       retry_wait_seconds: 10


### PR DESCRIPTION


## Description

This re-applies the Harbor robot-account switch from #60169 to stable/8.8, after it was reverted because the robot account's Harbor scope didn't cover team-operate and team-hto, causing 401 Unauthorized on every Operate and Tasklist image push on this branch. That gap has now been closed on the infra side, so docker login and the subsequent push against registry.camunda.cloud succeed for both projects. The change itself is unchanged from the original backport: setup-build now reads Harbor credentials from secret/data/products/camunda/ci/harbor via a dedicated robot account instead of the shared ci-account, so docker login no longer depends on a live LDAP bind. This removes the monorepo's exposure to the recurring LDAP outages tracked in INC-7155, where Harbor's ldap_auth mode caused thousands of login failures during LDAP downtime. No workflow-level behavior changes — only the credential source used during Harbor login.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

INC-7155 ([Slack thread](https://camunda.slack.com/archives/C0BPTLSGEBV/p1786693626053019))
