### PR TITLE
ci: load-test: disable Renovate for Data Layer team dependencies

### DIFF
--- a/.github/renovate/team-reliability-testing.json5
+++ b/.github/renovate/team-reliability-testing.json5
@@ -98,6 +98,22 @@
       matchManagers: ["gomod"],
       postUpdateOptions: ["gomodTidy"],
     },
+
+    {
+      // Disable Renovate for Data Layer team dependencies.
+      // They will be addressed differently: https://github.com/camunda/camunda/issues/60658
+      matchFileNames: ["load-tests/**"],
+      // Only disable the update of Docker images. The related Helm Charts can
+      // still be updated, as long as we specifically configure the underlying
+      // Docker images they deploy.
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "**/elasticsearch",
+        "**/opensearch",
+        "**/postgres",
+      ],
+      enabled: false,
+    },
   ],
 
   ignorePaths: [


### PR DESCRIPTION


## Description

The dependencies will be synced differently from the SSOT provided by the team.

See: https://github.com/camunda/camunda/issues/60658

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/60658
