### PR TITLE
pg/raft-log-followups

### DIFF
--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -212,6 +212,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
@@ -16,7 +16,6 @@
  */
 package io.atomix.raft.roles;
 
-import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
@@ -24,9 +23,9 @@ import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
+import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import org.slf4j.event.Level;
 
 /** Abstract active state. */
 public abstract class ActiveRole extends PassiveRole {
@@ -36,18 +35,18 @@ public abstract class ActiveRole extends PassiveRole {
   }
 
   /**
-   * Logs a failed poll or vote request to a member, demoting the expected failure mode - the member
-   * is not in the membership view, e.g. while it boots or after it was removed - to TRACE to avoid
-   * flooding the log on every election round.
+   * Logs a failed poll or vote request to a member and returns how the failure was classified, so
+   * the caller reports the same status to the vote quorum it just logged. The status decides the
+   * level, see {@link VoteErrorStatus#logLevel()}.
    */
-  protected void logRequestFailure(
+  protected VoteErrorStatus logRequestFailure(
       final String requestType, final RaftMember member, final Throwable error) {
     // request futures complete exceptionally with the cause wrapped in a CompletionException
-    final var cause =
-        error instanceof CompletionException && error.getCause() != null ? error.getCause() : error;
-    final var logLevel = cause instanceof NoSuchMemberException ? Level.TRACE : Level.WARN;
-    log.atLevel(logLevel)
-        .log("{} request to {} failed: {}", requestType, member.memberId(), cause.getMessage());
+    final var cause = FuturesUtil.unwrapCompletionException(error);
+    final var status = VoteErrorStatus.of(cause);
+    log.atLevel(status.logLevel())
+        .log("{} request to {} failed with {}: {}", requestType, member.memberId(), status, cause);
+    return status;
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/ActiveRole.java
@@ -16,19 +16,38 @@
  */
 package io.atomix.raft.roles;
 
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.raft.RaftServer;
+import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.slf4j.event.Level;
 
 /** Abstract active state. */
 public abstract class ActiveRole extends PassiveRole {
 
   protected ActiveRole(final RaftContext context) {
     super(context);
+  }
+
+  /**
+   * Logs a failed poll or vote request to a member, demoting the expected failure mode - the member
+   * is not in the membership view, e.g. while it boots or after it was removed - to TRACE to avoid
+   * flooding the log on every election round.
+   */
+  protected void logRequestFailure(
+      final String requestType, final RaftMember member, final Throwable error) {
+    // request futures complete exceptionally with the cause wrapped in a CompletionException
+    final var cause =
+        error instanceof CompletionException && error.getCause() != null ? error.getCause() : error;
+    final var logLevel = cause instanceof NoSuchMemberException ? Level.TRACE : Level.WARN;
+    log.atLevel(logLevel)
+        .log("{} request to {} failed: {}", requestType, member.memberId(), cause.getMessage());
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -255,10 +255,8 @@ public final class CandidateRole extends ActiveRole {
                 () -> sendVoteRequestToMember(complete, quorum, member, request));
       }
     } else {
-      final var status = VoteErrorStatus.of(cause);
-      log.atLevel(status.logLevel())
-          .log("Vote request to {} failed with {}: {}", member.memberId(), status, cause);
-      quorum.fail(member.memberId(), status);
+      logRequestFailure("Vote", member, error);
+      quorum.fail(member.memberId(), VoteErrorStatus.of(error));
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -255,8 +255,7 @@ public final class CandidateRole extends ActiveRole {
                 () -> sendVoteRequestToMember(complete, quorum, member, request));
       }
     } else {
-      logRequestFailure("Vote", member, error);
-      quorum.fail(member.memberId(), VoteErrorStatus.of(error));
+      quorum.fail(member.memberId(), logRequestFailure("Vote", member, error));
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -42,7 +42,6 @@ import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.VoteQuorum;
 import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
-import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -319,8 +318,7 @@ public final class FollowerRole extends ActiveRole {
 
     if (isRunning() && !complete.get()) {
       if (error != null) {
-        logRequestFailure("Poll", member, error);
-        quorum.fail(member.memberId(), VoteErrorStatus.of(error));
+        quorum.fail(member.memberId(), logRequestFailure("Poll", member, error));
       } else {
         final boolean respondedWithGreaterTerm = response.term() > raft.getTerm();
         if (respondedWithGreaterTerm) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -325,13 +325,16 @@ public final class FollowerRole extends ActiveRole {
             .log("Poll request to {} failed with {}: {}", member.memberId(), status, cause);
         quorum.fail(member.memberId(), status);
       } else {
-        if (response.term() > raft.getTerm()) {
+        final boolean respondedWithGreaterTerm = response.term() > raft.getTerm();
+        if (respondedWithGreaterTerm) {
           raft.setTerm(response.term());
         }
 
         if (!response.accepted()) {
           log.debug("Received rejected poll from {}", member);
-          quorum.fail(member.memberId(), VoteErrorStatus.REJECTED);
+          quorum.fail(
+              member.memberId(),
+              respondedWithGreaterTerm ? VoteErrorStatus.INVALID_TERM : VoteErrorStatus.REJECTED);
         } else if (response.term() != raft.getTerm()) {
           log.debug("Received accepted poll for a different term from {}", member);
           quorum.fail(member.memberId(), VoteErrorStatus.INVALID_TERM);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -319,11 +319,8 @@ public final class FollowerRole extends ActiveRole {
 
     if (isRunning() && !complete.get()) {
       if (error != null) {
-        final var cause = FuturesUtil.unwrapCompletionException(error);
-        final var status = VoteErrorStatus.of(cause);
-        log.atLevel(status.logLevel())
-            .log("Poll request to {} failed with {}: {}", member.memberId(), status, cause);
-        quorum.fail(member.memberId(), status);
+        logRequestFailure("Poll", member, error);
+        quorum.fail(member.memberId(), VoteErrorStatus.of(error));
       } else {
         final boolean respondedWithGreaterTerm = response.term() > raft.getTerm();
         if (respondedWithGreaterTerm) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
@@ -68,9 +68,9 @@ public class JointConsensusVoteQuorum implements VoteQuorum {
   }
 
   @Override
-  public void fail(final MemberId member, final VoteErrorStatus statusCode) {
-    oldQuorum.fail(member, statusCode);
-    newQuorum.fail(member, statusCode);
+  public void fail(final MemberId member, final VoteErrorStatus status) {
+    oldQuorum.fail(member, status);
+    newQuorum.fail(member, status);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
@@ -59,8 +59,8 @@ public class JointConsensusVoteQuorum implements VoteQuorum {
       completed = true;
       // the joint election is decided; stop the still-pending sub-quorum from processing and
       // reporting responses for an election that is already over
-      oldQuorum.cancel();
-      newQuorum.cancel();
+      oldQuorum.abandon();
+      newQuorum.abandon();
       callback.accept(false);
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/JointConsensusVoteQuorum.java
@@ -24,8 +24,8 @@ public class JointConsensusVoteQuorum implements VoteQuorum {
       final Consumer<Boolean> callback,
       final Collection<MemberId> oldMembers,
       final Collection<MemberId> newMembers) {
-    oldQuorum = new SimpleVoteQuorum(this::finishOldQuorum, oldMembers);
-    newQuorum = new SimpleVoteQuorum(this::finishNewQuorum, newMembers);
+    oldQuorum = new SimpleVoteQuorum(this::finishOldQuorum, oldMembers, "Old configuration quorum");
+    newQuorum = new SimpleVoteQuorum(this::finishNewQuorum, newMembers, "New configuration quorum");
     this.callback = callback;
   }
 
@@ -57,6 +57,10 @@ public class JointConsensusVoteQuorum implements VoteQuorum {
       callback.accept(true);
     } else if (oldState == State.Failed || newState == State.Failed) {
       completed = true;
+      // the joint election is decided; stop the still-pending sub-quorum from processing and
+      // reporting responses for an election that is already over
+      oldQuorum.cancel();
+      newQuorum.cancel();
       callback.accept(false);
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -28,17 +28,28 @@ public class SimpleVoteQuorum implements VoteQuorum {
   private final int totalMembers;
   private final int quorum;
   private final Map<MemberId, VoteErrorStatus> failedStatuses;
+  private final String name;
 
   /**
    * @param callback will be called with the result of the vote, either true or false.
    * @param members All members participating, including the local member.
    */
   public SimpleVoteQuorum(final Consumer<Boolean> callback, final Collection<MemberId> members) {
+    this(callback, members, "Quorum");
+  }
+
+  /**
+   * @param name identifies this quorum in failure reports, e.g. to tell the old and new
+   *     configuration apart during joint consensus.
+   */
+  public SimpleVoteQuorum(
+      final Consumer<Boolean> callback, final Collection<MemberId> members, final String name) {
     this.callback = callback;
     this.members = new HashSet<>(members);
     failedStatuses = new HashMap<>();
     totalMembers = members.size();
     quorum = members.size() / 2 + 1;
+    this.name = name;
   }
 
   @Override
@@ -76,7 +87,8 @@ public class SimpleVoteQuorum implements VoteQuorum {
         complete = true;
         LOG.atLevel(reportLevel())
             .log(
-                "Quorum failed with {}/{} failed members: {}",
+                "{} failed with {}/{} failed members: {}",
+                name,
                 failedStatuses.size(),
                 totalMembers,
                 failedStatuses);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -107,10 +107,6 @@ public class SimpleVoteQuorum implements VoteQuorum {
     }
   }
 
-  /**
-   * Failures to reach members are actionable for operators and warrant a warning; regular protocol
-   * outcomes such as denied votes happen during normal operation and stay at debug.
-   */
   private Level reportLevel() {
     return failedStatuses.values().stream().allMatch(VoteErrorStatus::isProtocolOutcome)
         ? Level.DEBUG

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -24,7 +24,7 @@ public class SimpleVoteQuorum implements VoteQuorum {
   private boolean complete;
   private final Set<MemberId> members;
   private int succeeded;
-  private int failed;
+  private final int totalMembers;
   private final int quorum;
   private final Map<MemberId, VoteErrorStatus> failedStatuses;
 
@@ -36,6 +36,7 @@ public class SimpleVoteQuorum implements VoteQuorum {
     this.callback = callback;
     this.members = new HashSet<>(members);
     failedStatuses = new HashMap<>();
+    totalMembers = members.size();
     quorum = members.size() / 2 + 1;
   }
 
@@ -50,7 +51,6 @@ public class SimpleVoteQuorum implements VoteQuorum {
   @Override
   public void fail(final MemberId member, final VoteErrorStatus status) {
     if (members.remove(member)) {
-      failed++;
       failedStatuses.put(member, status);
       checkComplete();
     }
@@ -71,11 +71,13 @@ public class SimpleVoteQuorum implements VoteQuorum {
       if (succeeded >= quorum) {
         complete = true;
         callback.accept(true);
-      } else if (failed >= quorum) {
+      } else if (failedStatuses.size() >= quorum) {
         complete = true;
-        final int memberCount = succeeded + failed + members.size();
         LOG.warn(
-            "Quorum failed with {}/{} failed members: {}", failed, memberCount, failedStatuses);
+            "Quorum failed with {}/{} failed members: {}",
+            failedStatuses.size(),
+            totalMembers,
+            failedStatuses);
         callback.accept(false);
       }
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -74,8 +74,22 @@ public class SimpleVoteQuorum implements VoteQuorum {
    */
   @Override
   public void cancel() {
+    close(reportLevel());
+  }
+
+  /**
+   * Cancels the quorum whose result is no longer needed because the election is already decided,
+   * e.g. the sibling configuration failed a joint election. Unlike {@link #cancel()}, the collected
+   * member states are only logged at debug so a single election produces a single default-level
+   * report.
+   */
+  void abandon() {
+    close(Level.DEBUG);
+  }
+
+  private void close(final Level level) {
     if (!complete && !failedStatuses.isEmpty()) {
-      LOG.atLevel(reportLevel())
+      LOG.atLevel(level)
           .log(
               "{} cancelled before completion with {}/{} failed members: {}, pending members: {}",
               name,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -74,6 +74,16 @@ public class SimpleVoteQuorum implements VoteQuorum {
    */
   @Override
   public void cancel() {
+    if (!complete && !failedStatuses.isEmpty()) {
+      LOG.atLevel(reportLevel())
+          .log(
+              "{} cancelled before completion with {}/{} failed members: {}, pending members: {}",
+              name,
+              failedStatuses.size(),
+              totalMembers,
+              failedStatuses,
+              members);
+    }
     callback = null;
     complete = true;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/SimpleVoteQuorum.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 public class SimpleVoteQuorum implements VoteQuorum {
 
@@ -73,13 +74,24 @@ public class SimpleVoteQuorum implements VoteQuorum {
         callback.accept(true);
       } else if (failedStatuses.size() >= quorum) {
         complete = true;
-        LOG.warn(
-            "Quorum failed with {}/{} failed members: {}",
-            failedStatuses.size(),
-            totalMembers,
-            failedStatuses);
+        LOG.atLevel(reportLevel())
+            .log(
+                "Quorum failed with {}/{} failed members: {}",
+                failedStatuses.size(),
+                totalMembers,
+                failedStatuses);
         callback.accept(false);
       }
     }
+  }
+
+  /**
+   * Failures to reach members are actionable for operators and warrant a warning; regular protocol
+   * outcomes such as denied votes happen during normal operation and stay at debug.
+   */
+  private Level reportLevel() {
+    return failedStatuses.values().stream().allMatch(VoteErrorStatus::isProtocolOutcome)
+        ? Level.DEBUG
+        : Level.WARN;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -32,6 +32,14 @@ public interface VoteQuorum {
     INVALID_TERM,
     UNKNOWN;
 
+    /**
+     * True when the member delivered a response and the failure is a regular protocol outcome (a
+     * denied vote or a term conflict) rather than a failure to reach the member.
+     */
+    public boolean isProtocolOutcome() {
+      return this == REJECTED || this == INVALID_TERM;
+    }
+
     public static VoteErrorStatus of(final Throwable error) {
       return switch (FuturesUtil.unwrapCompletionException(error)) {
         case final NoSuchMemberException noSuchMemberException -> NO_SUCH_MEMBER;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -25,6 +25,8 @@ public interface VoteQuorum {
 
   enum VoteErrorStatus {
     NO_SUCH_MEMBER,
+    MEMBER_UNREACHABLE,
+    MEMBER_NOT_READY,
     MEMBER_TIMED_OUT,
     REJECTED,
     INVALID_TERM,
@@ -33,8 +35,8 @@ public interface VoteQuorum {
     public static VoteErrorStatus of(final Throwable error) {
       return switch (FuturesUtil.unwrapCompletionException(error)) {
         case final NoSuchMemberException noSuchMemberException -> NO_SUCH_MEMBER;
-        case final ConnectException connectException -> NO_SUCH_MEMBER;
-        case final NoRemoteHandler noRemoteHandler -> NO_SUCH_MEMBER;
+        case final ConnectException connectException -> MEMBER_UNREACHABLE;
+        case final NoRemoteHandler noRemoteHandler -> MEMBER_NOT_READY;
         case final TimeoutException timeoutException -> MEMBER_TIMED_OUT;
         default -> UNKNOWN;
       };

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/utils/VoteQuorum.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.net.ConnectException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.event.Level;
 
@@ -46,12 +47,22 @@ public interface VoteQuorum {
         case final ConnectException connectException -> MEMBER_UNREACHABLE;
         case final NoRemoteHandler noRemoteHandler -> MEMBER_NOT_READY;
         case final TimeoutException timeoutException -> MEMBER_TIMED_OUT;
+        case final CompletionException wrapper when wrapper.getCause() != null ->
+            of(wrapper.getCause());
         default -> UNKNOWN;
       };
     }
 
+    /**
+     * The level to report a single failed request at. Every failure that means the member could not
+     * be reached is demoted, so a booting or removed member does not flood the log once per
+     * election round; the quorum still reports the collected states once when the election fails.
+     */
     public Level logLevel() {
-      return this == NO_SUCH_MEMBER ? Level.TRACE : Level.WARN;
+      return switch (this) {
+        case NO_SUCH_MEMBER, MEMBER_UNREACHABLE, MEMBER_NOT_READY -> Level.TRACE;
+        default -> Level.WARN;
+      };
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteErrorStatusTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteErrorStatusTest.java
@@ -40,10 +40,10 @@ final class VoteErrorStatusTest {
               VoteErrorStatus.NO_SUCH_MEMBER),
           Arguments.of(
               Named.of("connection refused", new ConnectException("connection refused")),
-              VoteErrorStatus.NO_SUCH_MEMBER),
+              VoteErrorStatus.MEMBER_UNREACHABLE),
           Arguments.of(
               Named.of("partition handler not registered", new NoRemoteHandler("vote-subject")),
-              VoteErrorStatus.NO_SUCH_MEMBER),
+              VoteErrorStatus.MEMBER_NOT_READY),
           Arguments.of(
               Named.of(
                   "no response within the request timeout",
@@ -73,6 +73,19 @@ final class VoteErrorStatusTest {
 
       // then
       assertThat(status).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldClassifyTransportFailureWrappedMoreThanOnce() {
+      // given
+      final var error =
+          new CompletionException(new CompletionException(new ConnectException("refused")));
+
+      // when
+      final var status = VoteErrorStatus.of(error);
+
+      // then
+      assertThat(status).isEqualTo(VoteErrorStatus.MEMBER_UNREACHABLE);
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
@@ -7,6 +7,7 @@
  */
 package io.atomix.raft.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -14,8 +15,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
+import io.camunda.zeebe.test.util.logging.RecordingAppender;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -264,6 +271,145 @@ final class VoteQuorumTest {
 
       // then
       verify(callback, only()).accept(false);
+    }
+  }
+
+  @Nested
+  final class FailureReports {
+    private final RecordingAppender recorder = new RecordingAppender();
+    private Logger quorumLogger;
+    private Level previousLevel;
+
+    @BeforeEach
+    void setUp() {
+      quorumLogger = (Logger) LogManager.getLogger(SimpleVoteQuorum.class);
+      previousLevel = quorumLogger.getLevel();
+      quorumLogger.setLevel(Level.DEBUG);
+      recorder.start();
+      quorumLogger.addAppender(recorder);
+    }
+
+    @AfterEach
+    void tearDown() {
+      quorumLogger.removeAppender(recorder);
+      recorder.stop();
+      quorumLogger.setLevel(previousLevel);
+    }
+
+    @Test
+    void shouldWarnWithMemberStatesWhenQuorumFails() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new SimpleVoteQuorum(
+              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
+
+      // when
+      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+      quorum.fail(new MemberId("2"), VoteErrorStatus.MEMBER_TIMED_OUT);
+
+      // then
+      assertThat(recorder.getAppendedEvents())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage().getFormattedMessage())
+                    .contains("2/3")
+                    .contains("1=NO_SUCH_MEMBER")
+                    .contains("2=MEMBER_TIMED_OUT");
+              });
+    }
+
+    @Test
+    void shouldReportDeniedVotesAtDebug() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new SimpleVoteQuorum(
+              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
+
+      // when
+      quorum.fail(new MemberId("1"), VoteErrorStatus.REJECTED);
+      quorum.fail(new MemberId("2"), VoteErrorStatus.INVALID_TERM);
+
+      // then
+      assertThat(recorder.getAppendedEvents())
+          .hasSize(1)
+          .first()
+          .satisfies(event -> assertThat(event.getLevel()).isEqualTo(Level.DEBUG));
+    }
+
+    @Test
+    void shouldReportCollectedFailuresAndPendingMembersWhenCancelled() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new SimpleVoteQuorum(
+              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
+
+      // when
+      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+      quorum.cancel();
+
+      // then
+      assertThat(recorder.getAppendedEvents())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage().getFormattedMessage())
+                    .contains("cancelled before completion")
+                    .contains("1=NO_SUCH_MEMBER")
+                    .contains("2")
+                    .contains("3");
+              });
+    }
+
+    @Test
+    void shouldStayQuietWhenCancelledWithoutFailures() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new SimpleVoteQuorum(
+              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
+
+      // when
+      quorum.succeed(new MemberId("1"));
+      quorum.cancel();
+
+      // then
+      assertThat(recorder.getAppendedEvents()).isEmpty();
+    }
+
+    @Test
+    void shouldReportJointConsensusFailureOnce() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new JointConsensusVoteQuorum(
+              callback,
+              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
+              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
+
+      // when
+      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+      quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
+
+      // then
+      final var failureReports =
+          recorder.getAppendedEvents().stream()
+              .filter(event -> event.getMessage().getFormattedMessage().contains("failed with"))
+              .toList();
+      assertThat(failureReports)
+          .hasSize(1)
+          .first()
+          .satisfies(
+              event ->
+                  assertThat(event.getMessage().getFormattedMessage())
+                      .contains("Old configuration quorum"));
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
@@ -15,14 +15,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.utils.VoteQuorum.VoteErrorStatus;
-import io.camunda.zeebe.test.util.logging.RecordingAppender;
+import io.camunda.zeebe.test.util.logging.LogCapturer;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Logger;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -276,196 +272,182 @@ final class VoteQuorumTest {
 
   @Nested
   final class FailureReports {
-    private final RecordingAppender recorder = new RecordingAppender();
-    private Logger quorumLogger;
-    private Level previousLevel;
-
-    @BeforeEach
-    void setUp() {
-      quorumLogger = (Logger) LogManager.getLogger(SimpleVoteQuorum.class);
-      previousLevel = quorumLogger.getLevel();
-      quorumLogger.setLevel(Level.DEBUG);
-      recorder.start();
-      quorumLogger.addAppender(recorder);
-    }
-
-    @AfterEach
-    void tearDown() {
-      quorumLogger.removeAppender(recorder);
-      recorder.stop();
-      quorumLogger.setLevel(previousLevel);
-    }
 
     @Test
     void shouldWarnWithMemberStatesWhenQuorumFails() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new SimpleVoteQuorum(
-              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // when
-      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
-      quorum.fail(new MemberId("2"), VoteErrorStatus.MEMBER_TIMED_OUT);
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new SimpleVoteQuorum(
+                callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // then
-      assertThat(recorder.getAppendedEvents())
-          .hasSize(1)
-          .first()
-          .satisfies(
-              event -> {
-                assertThat(event.getLevel()).isEqualTo(Level.WARN);
-                assertThat(event.getMessage().getFormattedMessage())
-                    .contains("2/3")
-                    .contains("1=NO_SUCH_MEMBER")
-                    .contains("2=MEMBER_TIMED_OUT");
-              });
+        // when
+        quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+        quorum.fail(new MemberId("2"), VoteErrorStatus.MEMBER_TIMED_OUT);
+
+        // then
+        assertThat(logs.messages()).hasSize(1);
+        assertThat(logs.messagesAt(Level.WARN))
+            .singleElement()
+            .satisfies(
+                message ->
+                    assertThat(message)
+                        .contains("2/3")
+                        .contains("1=NO_SUCH_MEMBER")
+                        .contains("2=MEMBER_TIMED_OUT"));
+      }
     }
 
     @Test
     void shouldReportDeniedVotesAtDebug() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new SimpleVoteQuorum(
-              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // when
-      quorum.fail(new MemberId("1"), VoteErrorStatus.REJECTED);
-      quorum.fail(new MemberId("2"), VoteErrorStatus.INVALID_TERM);
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new SimpleVoteQuorum(
+                callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // then
-      assertThat(recorder.getAppendedEvents())
-          .hasSize(1)
-          .first()
-          .satisfies(event -> assertThat(event.getLevel()).isEqualTo(Level.DEBUG));
+        // when
+        quorum.fail(new MemberId("1"), VoteErrorStatus.REJECTED);
+        quorum.fail(new MemberId("2"), VoteErrorStatus.INVALID_TERM);
+
+        // then
+        assertThat(logs.messages()).hasSize(1);
+        assertThat(logs.messagesAt(Level.DEBUG)).hasSize(1);
+      }
     }
 
     @Test
     void shouldReportCollectedFailuresAndPendingMembersWhenCancelled() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new SimpleVoteQuorum(
-              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // when
-      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
-      quorum.cancel();
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new SimpleVoteQuorum(
+                callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // then
-      assertThat(recorder.getAppendedEvents())
-          .hasSize(1)
-          .first()
-          .satisfies(
-              event -> {
-                assertThat(event.getLevel()).isEqualTo(Level.WARN);
-                assertThat(event.getMessage().getFormattedMessage())
-                    .contains("cancelled before completion")
-                    .contains("1=NO_SUCH_MEMBER")
-                    .contains("2")
-                    .contains("3");
-              });
+        // when
+        quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+        quorum.cancel();
+
+        // then
+        assertThat(logs.messages()).hasSize(1);
+        assertThat(logs.messagesAt(Level.WARN))
+            .singleElement()
+            .satisfies(
+                message ->
+                    assertThat(message)
+                        .contains("cancelled before completion")
+                        .contains("1=NO_SUCH_MEMBER")
+                        .contains("2")
+                        .contains("3"));
+      }
     }
 
     @Test
     void shouldStayQuietWhenCancelledWithoutFailures() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new SimpleVoteQuorum(
-              callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // when
-      quorum.succeed(new MemberId("1"));
-      quorum.cancel();
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new SimpleVoteQuorum(
+                callback, Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")));
 
-      // then
-      assertThat(recorder.getAppendedEvents()).isEmpty();
+        // when
+        quorum.succeed(new MemberId("1"));
+        quorum.cancel();
+
+        // then
+        assertThat(logs.messages()).isEmpty();
+      }
     }
 
     @Test
     void shouldWarnOnceWhenJointConsensusFails() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new JointConsensusVoteQuorum(
-              callback,
-              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
-              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
 
-      // when
-      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
-      quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new JointConsensusVoteQuorum(
+                callback,
+                Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
+                Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
 
-      // then
-      assertThat(recorder.getAppendedEvents())
-          .filteredOn(event -> event.getLevel().isMoreSpecificThan(Level.WARN))
-          .hasSize(1)
-          .first()
-          .satisfies(
-              event ->
-                  assertThat(event.getMessage().getFormattedMessage())
-                      .contains("Old configuration quorum failed with"));
+        // when
+        quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+        quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
+
+        // then
+        assertThat(logs.messagesAt(Level.WARN))
+            .singleElement()
+            .satisfies(
+                message -> assertThat(message).contains("Old configuration quorum failed with"));
+      }
     }
 
     @Test
     void shouldLogAbandonedSiblingStatesAtDebugWhenJointConsensusFails() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new JointConsensusVoteQuorum(
-              callback,
-              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
-              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
 
-      // when
-      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
-      quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new JointConsensusVoteQuorum(
+                callback,
+                Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
+                Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
 
-      // then
-      assertThat(recorder.getAppendedEvents())
-          .filteredOn(event -> event.getLevel() == Level.DEBUG)
-          .anySatisfy(
-              event ->
-                  assertThat(event.getMessage().getFormattedMessage())
-                      .contains("New configuration quorum cancelled before completion")
-                      .contains("1=NO_SUCH_MEMBER"));
+        // when
+        quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+        quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
+
+        // then
+        assertThat(logs.messagesAt(Level.DEBUG))
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("New configuration quorum cancelled before completion")
+                        .contains("1=NO_SUCH_MEMBER"));
+      }
     }
 
     @Test
     void shouldWarnPerConfigurationWhenAJointElectionIsCancelled() {
       // given
       final Consumer<Boolean> callback = mock();
-      final var quorum =
-          new JointConsensusVoteQuorum(
-              callback,
-              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
-              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
 
-      // when
-      quorum.fail(new MemberId("3"), VoteErrorStatus.NO_SUCH_MEMBER);
-      quorum.fail(new MemberId("4"), VoteErrorStatus.MEMBER_TIMED_OUT);
-      quorum.cancel();
+      try (final var logs = LogCapturer.capturing(SimpleVoteQuorum.class, Level.DEBUG)) {
+        final var quorum =
+            new JointConsensusVoteQuorum(
+                callback,
+                Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
+                Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
 
-      // then
-      final var warnings =
-          recorder.getAppendedEvents().stream()
-              .filter(event -> event.getLevel().isMoreSpecificThan(Level.WARN))
-              .map(event -> event.getMessage().getFormattedMessage())
-              .toList();
-      assertThat(warnings)
-          .hasSize(2)
-          .anySatisfy(
-              message ->
-                  assertThat(message)
-                      .contains("Old configuration quorum cancelled before completion")
-                      .contains("3=NO_SUCH_MEMBER"))
-          .anySatisfy(
-              message ->
-                  assertThat(message)
-                      .contains("New configuration quorum cancelled before completion")
-                      .contains("4=MEMBER_TIMED_OUT"));
+        // when
+        quorum.fail(new MemberId("3"), VoteErrorStatus.NO_SUCH_MEMBER);
+        quorum.fail(new MemberId("4"), VoteErrorStatus.MEMBER_TIMED_OUT);
+        quorum.cancel();
+
+        // then
+        assertThat(logs.messagesAt(Level.WARN))
+            .hasSize(2)
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("Old configuration quorum cancelled before completion")
+                        .contains("3=NO_SUCH_MEMBER"))
+            .anySatisfy(
+                message ->
+                    assertThat(message)
+                        .contains("New configuration quorum cancelled before completion")
+                        .contains("4=MEMBER_TIMED_OUT"));
+      }
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/utils/VoteQuorumTest.java
@@ -385,7 +385,7 @@ final class VoteQuorumTest {
     }
 
     @Test
-    void shouldReportJointConsensusFailureOnce() {
+    void shouldWarnOnceWhenJointConsensusFails() {
       // given
       final Consumer<Boolean> callback = mock();
       final var quorum =
@@ -399,17 +399,73 @@ final class VoteQuorumTest {
       quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
 
       // then
-      final var failureReports =
-          recorder.getAppendedEvents().stream()
-              .filter(event -> event.getMessage().getFormattedMessage().contains("failed with"))
-              .toList();
-      assertThat(failureReports)
+      assertThat(recorder.getAppendedEvents())
+          .filteredOn(event -> event.getLevel().isMoreSpecificThan(Level.WARN))
           .hasSize(1)
           .first()
           .satisfies(
               event ->
                   assertThat(event.getMessage().getFormattedMessage())
-                      .contains("Old configuration quorum"));
+                      .contains("Old configuration quorum failed with"));
+    }
+
+    @Test
+    void shouldLogAbandonedSiblingStatesAtDebugWhenJointConsensusFails() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new JointConsensusVoteQuorum(
+              callback,
+              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
+              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
+
+      // when
+      quorum.fail(new MemberId("1"), VoteErrorStatus.NO_SUCH_MEMBER);
+      quorum.fail(new MemberId("2"), VoteErrorStatus.NO_SUCH_MEMBER);
+
+      // then
+      assertThat(recorder.getAppendedEvents())
+          .filteredOn(event -> event.getLevel() == Level.DEBUG)
+          .anySatisfy(
+              event ->
+                  assertThat(event.getMessage().getFormattedMessage())
+                      .contains("New configuration quorum cancelled before completion")
+                      .contains("1=NO_SUCH_MEMBER"));
+    }
+
+    @Test
+    void shouldWarnPerConfigurationWhenAJointElectionIsCancelled() {
+      // given
+      final Consumer<Boolean> callback = mock();
+      final var quorum =
+          new JointConsensusVoteQuorum(
+              callback,
+              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("3")),
+              Set.of(MemberId.from("1"), MemberId.from("2"), MemberId.from("4")));
+
+      // when
+      quorum.fail(new MemberId("3"), VoteErrorStatus.NO_SUCH_MEMBER);
+      quorum.fail(new MemberId("4"), VoteErrorStatus.MEMBER_TIMED_OUT);
+      quorum.cancel();
+
+      // then
+      final var warnings =
+          recorder.getAppendedEvents().stream()
+              .filter(event -> event.getLevel().isMoreSpecificThan(Level.WARN))
+              .map(event -> event.getMessage().getFormattedMessage())
+              .toList();
+      assertThat(warnings)
+          .hasSize(2)
+          .anySatisfy(
+              message ->
+                  assertThat(message)
+                      .contains("Old configuration quorum cancelled before completion")
+                      .contains("3=NO_SUCH_MEMBER"))
+          .anySatisfy(
+              message ->
+                  assertThat(message)
+                      .contains("New configuration quorum cancelled before completion")
+                      .contains("4=MEMBER_TIMED_OUT"));
     }
   }
 }


### PR DESCRIPTION
## Description

Follow-ups to #59033, which introduced `VoteErrorStatus` so a failed vote quorum could
report an aggregate of member states instead of one line per failing member.

That first pass left the diagnostics coarse and still noisy in the cases that matter most:
every non-`NoSuchMemberException` failure was a `WARN`, a joint-consensus election reported
twice (once per configuration), and an election round that timed out reported nothing at all
because the quorum never reached its threshold. This branch finishes that work.

**Sharper classification** — `ConnectException` and `NoRemoteHandler` are no longer flattened
into `NO_SUCH_MEMBER`; they become `MEMBER_UNREACHABLE` and `MEMBER_NOT_READY`, so a report
distinguishes a member that is gone from one that is unreachable or still booting. Poll
rejections carrying a higher term are recorded as `INVALID_TERM` rather than a plain denial.

**One report per election, at the right level** — a failed joint-consensus election emits a
single default-level report naming which configuration failed, instead of one per sub-quorum;
the sibling quorum whose result is no longer needed logs its collected states at `DEBUG`. A
quorum that fails purely on denied votes and term conflicts reports at `DEBUG`, since that is
a normal protocol outcome, not an operational problem. A quorum cancelled mid-round now reports
the failures it had already collected plus the members still pending, so a timed-out election
round is no longer silent.

**Less noise per request** — poll and vote request failures are logged in one place
(`ActiveRole#logRequestFailure`) and every failure that means the member could not be reached
is demoted to `TRACE`. A booting or removed member no longer warns once per member per election
round; the quorum still reports the collected states once when the election actually fails.

### Alternatives considered

Keeping `VoteErrorStatus` coarse and deciding the level at each call site was simpler, but the
level policy then lives in two role classes and drifts — which is exactly what happened during
the rebase below. Classification now decides the level (`VoteErrorStatus#logLevel`), and the
roles only pass it through.

### Note on the rebase

While this branch was open, 6b50ffb5329 landed on `main` with an independent take on the same
problem: `logLevel()` demoting `NO_SUCH_MEMBER` to `TRACE`, with `ConnectException` and
`NoRemoteHandler` folded into that status so one check covered all three unreachable cases.
Rebasing put the two designs together and silently undid the demotion, because this branch
splits those statuses apart. `a32ecfda1ee` reconciles them — `logLevel()` now demotes all three
unreachable-member statuses, keeping `main`'s quiet logging and this branch's finer
classification. It also restores recursive unwrapping of nested `CompletionException`s, which
`FuturesUtil.unwrapCompletionException` only does one level deep.

### Testing

`VoteQuorumTest` covers the report level policy, the single-report-per-joint-election
behaviour, the abandoned sibling and the cancellation paths; `VoteErrorStatusTest` covers the
classification and level mapping. Both capture logs through `zeebe-test-util`'s shared
`LogCapturer`.

Full module run: 581 tests, 0 failures. Two errors in `DynamicDiscoveryProviderTest` are
pre-existing — they reproduce identically on a clean `origin/main` in the same environment and
are unrelated to this change.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #9648
follows up on #59033
