### PR TITLE
ci: load-test: CODEOWNERS for Reliability Testing team's Renovate

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -129,9 +129,10 @@
 ##########################
 
 # Performance + Load testing
-/load-tests/ @camunda/reliability-testing
+/.github/renovate/team-reliability-testing.json5 @camunda/reliability-testing
 /.github/workflows/*load-test*.yml @camunda/reliability-testing
 /.tool-versions @camunda/reliability-testing
+/load-tests/ @camunda/reliability-testing
 
 #################
 ## Agentic AI  ##


### PR DESCRIPTION
## Description

Automatically grants ownership for [these changes](https://github.com/camunda/camunda/pull/61110) (+ sort the entries alphabetically).

The `CODEOWNERS` file reports unrelated error, signaled here: https://camunda.slack.com/archives/C071KP5BTHB/p1787732287598209

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
