### PR TITLE
feat: add OR-connected search criteria to identity search endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ scripts/codeowners-utils/output/
 
 # Superpowers scratch specs/plans (local workflow docs, not tracked)
 docs/superpowers/
+.superpowers/
 
 # Load test
 load-tests/setup/c8-*

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
@@ -42,6 +42,9 @@ public interface GroupFilter extends GroupFilterBase {
   @Override
   GroupFilter name(final String name);
 
+  @Override
+  GroupFilter name(Consumer<StringProperty> fn);
+
   /**
    * Combine this filter with a list of alternative filter groups using OR logic.
    *

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilterBase.java
@@ -38,4 +38,6 @@ public interface GroupFilterBase extends SearchRequestFilter {
    * @return the updated filter
    */
   GroupFilterBase name(final String name);
+
+  GroupFilterBase name(Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilterBase.java
@@ -16,10 +16,10 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import java.util.List;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
-public interface GroupFilter extends GroupFilterBase {
+public interface GroupFilterBase extends SearchRequestFilter {
 
   /**
    * Filters groups by the specified groupId.
@@ -27,11 +27,9 @@ public interface GroupFilter extends GroupFilterBase {
    * @param groupId the ID of the group
    * @return the updated filter
    */
-  @Override
-  GroupFilter groupId(final String groupId);
+  GroupFilterBase groupId(final String groupId);
 
-  @Override
-  GroupFilter groupId(Consumer<StringProperty> fn);
+  GroupFilterBase groupId(Consumer<StringProperty> fn);
 
   /**
    * Filters groups by the specified name.
@@ -39,14 +37,5 @@ public interface GroupFilter extends GroupFilterBase {
    * @param name the name of the group
    * @return the updated filter
    */
-  @Override
-  GroupFilter name(final String name);
-
-  /**
-   * Combine this filter with a list of alternative filter groups using OR logic.
-   *
-   * @param filters the alternative filter groups
-   * @return the updated filter
-   */
-  GroupFilterBase orFilters(List<Consumer<GroupFilterBase>> filters);
+  GroupFilterBase name(final String name);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingRuleFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingRuleFilter.java
@@ -30,6 +30,9 @@ public interface MappingRuleFilter extends MappingRuleFilterBase {
   @Override
   MappingRuleFilter mappingRuleId(final String mappingRuleId);
 
+  @Override
+  MappingRuleFilter mappingRuleId(Consumer<StringProperty> fn);
+
   /**
    * Filter mapping rules by the specified claim name.
    *

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingRuleFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingRuleFilterBase.java
@@ -29,6 +29,8 @@ public interface MappingRuleFilterBase extends SearchRequestFilter {
    */
   MappingRuleFilterBase mappingRuleId(final String mappingRuleId);
 
+  MappingRuleFilterBase mappingRuleId(Consumer<StringProperty> fn);
+
   /**
    * Filter mapping rules by the specified claim name.
    *

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingRuleFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingRuleFilterBase.java
@@ -16,10 +16,10 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import java.util.List;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
-public interface MappingRuleFilter extends MappingRuleFilterBase {
+public interface MappingRuleFilterBase extends SearchRequestFilter {
 
   /**
    * Filter mapping rules by the specified mapping rule id.
@@ -27,8 +27,7 @@ public interface MappingRuleFilter extends MappingRuleFilterBase {
    * @param mappingRuleId the id of the mapping rule
    * @return the updated filter
    */
-  @Override
-  MappingRuleFilter mappingRuleId(final String mappingRuleId);
+  MappingRuleFilterBase mappingRuleId(final String mappingRuleId);
 
   /**
    * Filter mapping rules by the specified claim name.
@@ -36,8 +35,7 @@ public interface MappingRuleFilter extends MappingRuleFilterBase {
    * @param claimName the name of the claim
    * @return the updated filter
    */
-  @Override
-  MappingRuleFilter claimName(final String claimName);
+  MappingRuleFilterBase claimName(final String claimName);
 
   /**
    * Filter mapping rules by the specified claim value.
@@ -45,8 +43,7 @@ public interface MappingRuleFilter extends MappingRuleFilterBase {
    * @param claimValue the value of the claim
    * @return the updated filter
    */
-  @Override
-  MappingRuleFilter claimValue(final String claimValue);
+  MappingRuleFilterBase claimValue(final String claimValue);
 
   /**
    * Filter mapping rules by the specified name.
@@ -54,17 +51,7 @@ public interface MappingRuleFilter extends MappingRuleFilterBase {
    * @param name the name of the mapping rule
    * @return the updated filter
    */
-  @Override
-  MappingRuleFilter name(final String name);
+  MappingRuleFilterBase name(final String name);
 
-  @Override
-  MappingRuleFilter name(Consumer<StringProperty> fn);
-
-  /**
-   * Combine this filter with a list of alternative filter groups using OR logic.
-   *
-   * @param filters the alternative filter groups
-   * @return the updated filter
-   */
-  MappingRuleFilterBase orFilters(List<Consumer<MappingRuleFilterBase>> filters);
+  MappingRuleFilterBase name(Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilter.java
@@ -30,6 +30,9 @@ public interface RoleFilter extends RoleFilterBase {
   @Override
   RoleFilter roleId(final String roleId);
 
+  @Override
+  RoleFilter roleId(Consumer<StringProperty> fn);
+
   /**
    * Filter roles by the specified name.
    *

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilterBase.java
@@ -16,10 +16,10 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import java.util.List;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
-public interface RoleFilter extends RoleFilterBase {
+public interface RoleFilterBase extends SearchRequestFilter {
 
   /**
    * Filter roles by the specified role ID.
@@ -27,8 +27,7 @@ public interface RoleFilter extends RoleFilterBase {
    * @param roleId the ID of the role
    * @return the updated filter
    */
-  @Override
-  RoleFilter roleId(final String roleId);
+  RoleFilterBase roleId(final String roleId);
 
   /**
    * Filter roles by the specified name.
@@ -36,17 +35,7 @@ public interface RoleFilter extends RoleFilterBase {
    * @param name the name of the role
    * @return the updated filter
    */
-  @Override
-  RoleFilter name(final String name);
+  RoleFilterBase name(final String name);
 
-  @Override
-  RoleFilter name(Consumer<StringProperty> fn);
-
-  /**
-   * Combine this filter with a list of alternative filter groups using OR logic.
-   *
-   * @param filters the alternative filter groups
-   * @return the updated filter
-   */
-  RoleFilterBase orFilters(List<Consumer<RoleFilterBase>> filters);
+  RoleFilterBase name(Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilterBase.java
@@ -29,6 +29,8 @@ public interface RoleFilterBase extends SearchRequestFilter {
    */
   RoleFilterBase roleId(final String roleId);
 
+  RoleFilterBase roleId(Consumer<StringProperty> fn);
+
   /**
    * Filter roles by the specified name.
    *

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilterBase.java
@@ -16,10 +16,10 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import java.util.List;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
-public interface UserFilter extends UserFilterBase {
+public interface UserFilterBase extends SearchRequestFilter {
 
   /**
    * Filter users by the specified username.
@@ -27,8 +27,7 @@ public interface UserFilter extends UserFilterBase {
    * @param username the username of the user
    * @return the updated filter
    */
-  @Override
-  UserFilter username(final String username);
+  UserFilterBase username(final String username);
 
   /**
    * Filters users by the specified username using {@link StringProperty} consumer.
@@ -36,8 +35,7 @@ public interface UserFilter extends UserFilterBase {
    * @param fn the username {@link StringProperty} consumer of the user
    * @return the updated filter
    */
-  @Override
-  UserFilter username(final Consumer<StringProperty> fn);
+  UserFilterBase username(final Consumer<StringProperty> fn);
 
   /**
    * Filter users by the specified name.
@@ -45,8 +43,7 @@ public interface UserFilter extends UserFilterBase {
    * @param name the name of the user
    * @return the updated filter
    */
-  @Override
-  UserFilter name(final String name);
+  UserFilterBase name(final String name);
 
   /**
    * Filters users by the specified name using {@link StringProperty} consumer.
@@ -54,8 +51,7 @@ public interface UserFilter extends UserFilterBase {
    * @param fn the name {@link StringProperty} consumer of the user
    * @return the updated filter
    */
-  @Override
-  UserFilter name(final Consumer<StringProperty> fn);
+  UserFilterBase name(final Consumer<StringProperty> fn);
 
   /**
    * Filter users by the specified email.
@@ -63,8 +59,7 @@ public interface UserFilter extends UserFilterBase {
    * @param email the email of the user
    * @return the updated filter
    */
-  @Override
-  UserFilter email(final String email);
+  UserFilterBase email(final String email);
 
   /**
    * Filters users by the specified email using {@link StringProperty} consumer.
@@ -72,14 +67,5 @@ public interface UserFilter extends UserFilterBase {
    * @param fn the email {@link StringProperty} consumer of the user
    * @return the updated filter
    */
-  @Override
-  UserFilter email(final Consumer<StringProperty> fn);
-
-  /**
-   * Combine this filter with a list of alternative filter groups using OR logic.
-   *
-   * @param filters the alternative filter groups
-   * @return the updated filter
-   */
-  UserFilterBase orFilters(List<Consumer<UserFilterBase>> filters);
+  UserFilterBase email(final Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
@@ -16,9 +16,13 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.filter.GroupFilterBase;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.GroupFilterMapper;
+import io.camunda.client.protocol.rest.GroupFilterFields;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class GroupFilterImpl
@@ -47,6 +51,18 @@ public class GroupFilterImpl
   @Override
   public GroupFilter name(final String name) {
     filter.setName(name);
+    return this;
+  }
+
+  @Override
+  public GroupFilterBase orFilters(final List<Consumer<GroupFilterBase>> fns) {
+    for (final Consumer<GroupFilterBase> fn : fns) {
+      final GroupFilterImpl orFilter = new GroupFilterImpl();
+      fn.accept(orFilter);
+      final GroupFilterFields protocolFilterFields =
+          GroupFilterMapper.from(orFilter.getSearchRequestProperty());
+      filter.add$OrItem(protocolFilterFields);
+    }
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
@@ -50,7 +50,14 @@ public class GroupFilterImpl
 
   @Override
   public GroupFilter name(final String name) {
-    filter.setName(name);
+    return name(b -> b.eq(name));
+  }
+
+  @Override
+  public GroupFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingRuleFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingRuleFilterImpl.java
@@ -16,9 +16,13 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.MappingRuleFilter;
+import io.camunda.client.api.search.filter.MappingRuleFilterBase;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.MappingRuleFilterMapper;
+import io.camunda.client.protocol.rest.MappingRuleFilterFields;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class MappingRuleFilterImpl
@@ -59,6 +63,18 @@ public class MappingRuleFilterImpl
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public MappingRuleFilterBase orFilters(final List<Consumer<MappingRuleFilterBase>> fns) {
+    for (final Consumer<MappingRuleFilterBase> fn : fns) {
+      final MappingRuleFilterImpl orFilter = new MappingRuleFilterImpl();
+      fn.accept(orFilter);
+      final MappingRuleFilterFields protocolFilterFields =
+          MappingRuleFilterMapper.from(orFilter.getSearchRequestProperty());
+      filter.add$OrItem(protocolFilterFields);
+    }
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingRuleFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingRuleFilterImpl.java
@@ -37,7 +37,14 @@ public class MappingRuleFilterImpl
 
   @Override
   public MappingRuleFilter mappingRuleId(final String mappingRuleId) {
-    filter.setMappingRuleId(mappingRuleId);
+    return mappingRuleId(b -> b.eq(mappingRuleId));
+  }
+
+  @Override
+  public MappingRuleFilter mappingRuleId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setMappingRuleId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/RoleFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/RoleFilterImpl.java
@@ -16,9 +16,13 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.RoleFilter;
+import io.camunda.client.api.search.filter.RoleFilterBase;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.RoleFilterMapper;
+import io.camunda.client.protocol.rest.RoleFilterFields;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class RoleFilterImpl
@@ -47,6 +51,18 @@ public class RoleFilterImpl
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public RoleFilterBase orFilters(final List<Consumer<RoleFilterBase>> fns) {
+    for (final Consumer<RoleFilterBase> fn : fns) {
+      final RoleFilterImpl orFilter = new RoleFilterImpl();
+      fn.accept(orFilter);
+      final RoleFilterFields protocolFilterFields =
+          RoleFilterMapper.from(orFilter.getSearchRequestProperty());
+      filter.add$OrItem(protocolFilterFields);
+    }
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/RoleFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/RoleFilterImpl.java
@@ -37,7 +37,14 @@ public class RoleFilterImpl
 
   @Override
   public RoleFilter roleId(final String roleId) {
-    filter.setRoleId(roleId);
+    return roleId(b -> b.eq(roleId));
+  }
+
+  @Override
+  public RoleFilter roleId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setRoleId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
@@ -16,9 +16,13 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.UserFilter;
+import io.camunda.client.api.search.filter.UserFilterBase;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.UserFilterMapper;
+import io.camunda.client.protocol.rest.UserFilterFields;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class UserFilterImpl
@@ -67,6 +71,18 @@ public class UserFilterImpl
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setEmail(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public UserFilterBase orFilters(final List<Consumer<UserFilterBase>> fns) {
+    for (final Consumer<UserFilterBase> fn : fns) {
+      final UserFilterImpl orFilter = new UserFilterImpl();
+      fn.accept(orFilter);
+      final UserFilterFields protocolFilterFields =
+          UserFilterMapper.from(orFilter.getSearchRequestProperty());
+      filter.add$OrItem(protocolFilterFields);
+    }
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/util/GroupFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/GroupFilterMapper.java
@@ -29,6 +29,9 @@ public final class GroupFilterMapper {
     if (filter == null) {
       return null;
     }
+    if (filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      throw new IllegalArgumentException("Nesting $or filters is not supported");
+    }
 
     final GroupFilterFields target = new GroupFilterFields();
     target.setGroupId(filter.getGroupId());

--- a/clients/java/src/main/java/io/camunda/client/impl/util/GroupFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/GroupFilterMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import io.camunda.client.protocol.rest.GroupFilter;
+import io.camunda.client.protocol.rest.GroupFilterFields;
+
+/** Utility class for mapping {@link GroupFilter} to {@link GroupFilterFields}. */
+public final class GroupFilterMapper {
+
+  private GroupFilterMapper() {
+    // Prevent instantiation
+  }
+
+  public static GroupFilterFields from(final GroupFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+
+    final GroupFilterFields target = new GroupFilterFields();
+    target.setGroupId(filter.getGroupId());
+    target.setName(filter.getName());
+    return target;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/util/MappingRuleFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/MappingRuleFilterMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import io.camunda.client.protocol.rest.MappingRuleFilter;
+import io.camunda.client.protocol.rest.MappingRuleFilterFields;
+
+/** Utility class for mapping {@link MappingRuleFilter} to {@link MappingRuleFilterFields}. */
+public final class MappingRuleFilterMapper {
+
+  private MappingRuleFilterMapper() {
+    // Prevent instantiation
+  }
+
+  public static MappingRuleFilterFields from(final MappingRuleFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+
+    final MappingRuleFilterFields target = new MappingRuleFilterFields();
+    target.setMappingRuleId(filter.getMappingRuleId());
+    target.setClaimName(filter.getClaimName());
+    target.setClaimValue(filter.getClaimValue());
+    target.setName(filter.getName());
+    return target;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/util/MappingRuleFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/MappingRuleFilterMapper.java
@@ -29,6 +29,9 @@ public final class MappingRuleFilterMapper {
     if (filter == null) {
       return null;
     }
+    if (filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      throw new IllegalArgumentException("Nesting $or filters is not supported");
+    }
 
     final MappingRuleFilterFields target = new MappingRuleFilterFields();
     target.setMappingRuleId(filter.getMappingRuleId());

--- a/clients/java/src/main/java/io/camunda/client/impl/util/RoleFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/RoleFilterMapper.java
@@ -29,6 +29,9 @@ public final class RoleFilterMapper {
     if (filter == null) {
       return null;
     }
+    if (filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      throw new IllegalArgumentException("Nesting $or filters is not supported");
+    }
 
     final RoleFilterFields target = new RoleFilterFields();
     target.setRoleId(filter.getRoleId());

--- a/clients/java/src/main/java/io/camunda/client/impl/util/RoleFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/RoleFilterMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import io.camunda.client.protocol.rest.RoleFilter;
+import io.camunda.client.protocol.rest.RoleFilterFields;
+
+/** Utility class for mapping {@link RoleFilter} to {@link RoleFilterFields}. */
+public final class RoleFilterMapper {
+
+  private RoleFilterMapper() {
+    // Prevent instantiation
+  }
+
+  public static RoleFilterFields from(final RoleFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+
+    final RoleFilterFields target = new RoleFilterFields();
+    target.setRoleId(filter.getRoleId());
+    target.setName(filter.getName());
+    return target;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/util/UserFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/UserFilterMapper.java
@@ -29,6 +29,9 @@ public final class UserFilterMapper {
     if (filter == null) {
       return null;
     }
+    if (filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      throw new IllegalArgumentException("Nesting $or filters is not supported");
+    }
 
     final UserFilterFields target = new UserFilterFields();
     target.setUsername(filter.getUsername());

--- a/clients/java/src/main/java/io/camunda/client/impl/util/UserFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/UserFilterMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import io.camunda.client.protocol.rest.UserFilter;
+import io.camunda.client.protocol.rest.UserFilterFields;
+
+/** Utility class for mapping {@link UserFilter} to {@link UserFilterFields}. */
+public final class UserFilterMapper {
+
+  private UserFilterMapper() {
+    // Prevent instantiation
+  }
+
+  public static UserFilterFields from(final UserFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+
+    final UserFilterFields target = new UserFilterFields();
+    target.setUsername(filter.getUsername());
+    target.setName(filter.getName());
+    target.setEmail(filter.getEmail());
+    return target;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -21,14 +21,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.filter.ClientFilter;
+import io.camunda.client.api.search.filter.GroupFilterBase;
 import io.camunda.client.api.search.filter.GroupUserFilter;
 import io.camunda.client.api.search.sort.ClientSort;
 import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.api.search.sort.GroupUserSort;
 import io.camunda.client.api.search.sort.MappingRuleSort;
 import io.camunda.client.api.search.sort.RoleSort;
+import io.camunda.client.protocol.rest.GroupFilter;
 import io.camunda.client.protocol.rest.GroupResult;
+import io.camunda.client.protocol.rest.GroupSearchQueryRequest;
 import io.camunda.client.util.ClientRestTest;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -223,5 +231,54 @@ public class GroupSearchTest extends ClientRestTest {
                     .join())
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageContaining("This command does not support filtering");
+  }
+
+  @Test
+  void shouldSearchGroupsWithOrFilters() {
+    // when
+    client
+        .newGroupsSearchRequest()
+        .filter(
+            fn ->
+                fn.orFilters(
+                    Arrays.asList(f1 -> f1.groupId("group-1"), f2 -> f2.groupId("group-2"))))
+        .send()
+        .join();
+
+    // then
+    final GroupSearchQueryRequest request =
+        gatewayService.getLastRequest(GroupSearchQueryRequest.class);
+    final GroupFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.get$Or()).hasSize(2);
+    assertThat(filter.get$Or().get(0).getGroupId().get$Eq()).isEqualTo("group-1");
+    assertThat(filter.get$Or().get(1).getGroupId().get$Eq()).isEqualTo("group-2");
+  }
+
+  @Test
+  void shouldHaveMatchingFilterMethodsInBaseAndFullInterfaces() {
+    final Set<String> baseMethods = publicMethodSignatures(GroupFilterBase.class);
+    final Set<String> fullMethods =
+        publicMethodSignatures(io.camunda.client.api.search.filter.GroupFilter.class);
+
+    assertThat(fullMethods)
+        .withFailMessage("Full interface is missing methods from base interface")
+        .containsAll(baseMethods);
+
+    final Set<String> expectedExtras = new HashSet<>();
+    expectedExtras.add("orFilters[interface java.util.List]");
+    final Set<String> actualExtras = new HashSet<>(fullMethods);
+    actualExtras.removeAll(baseMethods);
+
+    assertThat(actualExtras)
+        .withFailMessage("Unexpected methods in full interface: %s", actualExtras)
+        .isEqualTo(expectedExtras);
+  }
+
+  private static Set<String> publicMethodSignatures(final Class<?> clazz) {
+    return Arrays.stream(clazz.getMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()) && !m.isSynthetic())
+        .map(m -> m.getName() + Arrays.toString(m.getParameterTypes()))
+        .collect(Collectors.toSet());
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -256,6 +256,19 @@ public class GroupSearchTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchGroupsByNameLike() {
+    // when
+    client.newGroupsSearchRequest().filter(f -> f.name(b -> b.like("Group*"))).send().join();
+
+    // then
+    final GroupSearchQueryRequest request =
+        gatewayService.getLastRequest(GroupSearchQueryRequest.class);
+    final GroupFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getName().get$Like()).isEqualTo("Group*");
+  }
+
+  @Test
   void shouldHaveMatchingFilterMethodsInBaseAndFullInterfaces() {
     final Set<String> baseMethods = publicMethodSignatures(GroupFilterBase.class);
     final Set<String> fullMethods =

--- a/clients/java/src/test/java/io/camunda/client/impl/util/GroupFilterMapperTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/GroupFilterMapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.protocol.rest.GroupFilter;
+import io.camunda.client.protocol.rest.GroupFilterFields;
+import io.camunda.client.protocol.rest.StringFilterProperty;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+final class GroupFilterMapperTest {
+
+  @Test
+  void shouldMapFilterFields() {
+    // given
+    final GroupFilter filter =
+        new GroupFilter()
+            .groupId(new StringFilterProperty().$eq("groupId"))
+            .name(new StringFilterProperty().$eq("name"));
+
+    // when
+    final GroupFilterFields result = GroupFilterMapper.from(filter);
+
+    // then
+    assertThat(result.getGroupId().get$Eq()).isEqualTo("groupId");
+    assertThat(result.getName().get$Eq()).isEqualTo("name");
+  }
+
+  @Test
+  void shouldRejectNestedOrFilters() {
+    // given
+    final GroupFilterFields branch =
+        new GroupFilterFields().groupId(new StringFilterProperty().$eq("groupId"));
+    final GroupFilter filter = new GroupFilter();
+    filter.set$Or(Collections.singletonList(branch));
+
+    // when/then
+    assertThatThrownBy(() -> GroupFilterMapper.from(filter))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/MappingRuleFilterMapperTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/MappingRuleFilterMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.protocol.rest.MappingRuleFilter;
+import io.camunda.client.protocol.rest.MappingRuleFilterFields;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+final class MappingRuleFilterMapperTest {
+
+  @Test
+  void shouldMapFilterFields() {
+    // given
+    final MappingRuleFilter filter =
+        new MappingRuleFilter().claimName("claimName").claimValue("claimValue");
+
+    // when
+    final MappingRuleFilterFields result = MappingRuleFilterMapper.from(filter);
+
+    // then
+    assertThat(result.getClaimName()).isEqualTo("claimName");
+    assertThat(result.getClaimValue()).isEqualTo("claimValue");
+  }
+
+  @Test
+  void shouldRejectNestedOrFilters() {
+    // given
+    final MappingRuleFilterFields branch = new MappingRuleFilterFields().claimName("claimName");
+    final MappingRuleFilter filter = new MappingRuleFilter();
+    filter.set$Or(Collections.singletonList(branch));
+
+    // when/then
+    assertThatThrownBy(() -> MappingRuleFilterMapper.from(filter))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/RoleFilterMapperTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/RoleFilterMapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.protocol.rest.RoleFilter;
+import io.camunda.client.protocol.rest.RoleFilterFields;
+import io.camunda.client.protocol.rest.StringFilterProperty;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+final class RoleFilterMapperTest {
+
+  @Test
+  void shouldMapFilterFields() {
+    // given
+    final RoleFilter filter =
+        new RoleFilter()
+            .roleId(new StringFilterProperty().$eq("roleId"))
+            .name(new StringFilterProperty().$eq("name"));
+
+    // when
+    final RoleFilterFields result = RoleFilterMapper.from(filter);
+
+    // then
+    assertThat(result.getRoleId().get$Eq()).isEqualTo("roleId");
+    assertThat(result.getName().get$Eq()).isEqualTo("name");
+  }
+
+  @Test
+  void shouldRejectNestedOrFilters() {
+    // given
+    final RoleFilterFields branch =
+        new RoleFilterFields().roleId(new StringFilterProperty().$eq("roleId"));
+    final RoleFilter filter = new RoleFilter();
+    filter.set$Or(Collections.singletonList(branch));
+
+    // when/then
+    assertThatThrownBy(() -> RoleFilterMapper.from(filter))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/UserFilterMapperTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/UserFilterMapperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.protocol.rest.StringFilterProperty;
+import io.camunda.client.protocol.rest.UserFilter;
+import io.camunda.client.protocol.rest.UserFilterFields;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+final class UserFilterMapperTest {
+
+  @Test
+  void shouldMapFilterFields() {
+    // given
+    final UserFilter filter =
+        new UserFilter()
+            .username(new StringFilterProperty().$eq("username"))
+            .name(new StringFilterProperty().$eq("name"))
+            .email(new StringFilterProperty().$eq("email"));
+
+    // when
+    final UserFilterFields result = UserFilterMapper.from(filter);
+
+    // then
+    assertThat(result.getUsername().get$Eq()).isEqualTo("username");
+    assertThat(result.getName().get$Eq()).isEqualTo("name");
+    assertThat(result.getEmail().get$Eq()).isEqualTo("email");
+  }
+
+  @Test
+  void shouldRejectNestedOrFilters() {
+    // given
+    final UserFilterFields branch =
+        new UserFilterFields().username(new StringFilterProperty().$eq("username"));
+    final UserFilter filter = new UserFilter();
+    filter.set$Or(Collections.singletonList(branch));
+
+    // when/then
+    assertThatThrownBy(() -> UserFilterMapper.from(filter))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/SearchMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/SearchMappingRuleTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.MappingRuleFilterBase;
 import io.camunda.client.protocol.rest.MappingRuleFilter;
 import io.camunda.client.protocol.rest.MappingRuleSearchQueryRequest;
 import io.camunda.client.protocol.rest.MappingRuleSearchQuerySortRequest;
@@ -26,7 +27,12 @@ import io.camunda.client.protocol.rest.MappingRuleSearchQuerySortRequest.FieldEn
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import io.camunda.client.protocol.rest.SortOrderEnum;
 import io.camunda.client.util.ClientRestTest;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class SearchMappingRuleTest extends ClientRestTest {
@@ -185,5 +191,55 @@ public class SearchMappingRuleTest extends ClientRestTest {
 
     assertThat(requestBody.getFilter()).isNull();
     assertThat(requestBody.getSort()).isEmpty();
+  }
+
+  @Test
+  void shouldSearchMappingRulesWithOrFilters() {
+    // when
+    client
+        .newMappingRulesSearchRequest()
+        .filter(
+            fn ->
+                fn.orFilters(
+                    Arrays.asList(
+                        f1 -> f1.mappingRuleId("rule-1"), f2 -> f2.mappingRuleId("rule-2"))))
+        .send()
+        .join();
+
+    // then
+    final MappingRuleSearchQueryRequest request =
+        gatewayService.getLastRequest(MappingRuleSearchQueryRequest.class);
+    final MappingRuleFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.get$Or()).hasSize(2);
+    assertThat(filter.get$Or().get(0).getMappingRuleId()).isEqualTo("rule-1");
+    assertThat(filter.get$Or().get(1).getMappingRuleId()).isEqualTo("rule-2");
+  }
+
+  @Test
+  void shouldHaveMatchingFilterMethodsInBaseAndFullInterfaces() {
+    final Set<String> baseMethods = publicMethodSignatures(MappingRuleFilterBase.class);
+    final Set<String> fullMethods =
+        publicMethodSignatures(io.camunda.client.api.search.filter.MappingRuleFilter.class);
+
+    assertThat(fullMethods)
+        .withFailMessage("Full interface is missing methods from base interface")
+        .containsAll(baseMethods);
+
+    final Set<String> expectedExtras = new HashSet<>();
+    expectedExtras.add("orFilters[interface java.util.List]");
+    final Set<String> actualExtras = new HashSet<>(fullMethods);
+    actualExtras.removeAll(baseMethods);
+
+    assertThat(actualExtras)
+        .withFailMessage("Unexpected methods in full interface: %s", actualExtras)
+        .isEqualTo(expectedExtras);
+  }
+
+  private static Set<String> publicMethodSignatures(final Class<?> clazz) {
+    return Arrays.stream(clazz.getMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()) && !m.isSynthetic())
+        .map(m -> m.getName() + Arrays.toString(m.getParameterTypes()))
+        .collect(Collectors.toSet());
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/mappingrule/SearchMappingRuleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mappingrule/SearchMappingRuleTest.java
@@ -91,7 +91,25 @@ public class SearchMappingRuleTest extends ClientRestTest {
 
     final MappingRuleFilter filter = requestBody.getFilter();
     assertThat(filter).isNotNull();
-    assertThat(filter.getMappingRuleId()).isEqualTo("rule123");
+    assertThat(filter.getMappingRuleId().get$Eq()).isEqualTo("rule123");
+  }
+
+  @Test
+  void shouldSearchMappingRulesByMappingRuleIdLike() {
+    // when
+    client
+        .newMappingRulesSearchRequest()
+        .filter(f -> f.mappingRuleId(b -> b.like("rule*")))
+        .send()
+        .join();
+
+    // then
+    final MappingRuleSearchQueryRequest requestBody =
+        gatewayService.getLastRequest(MappingRuleSearchQueryRequest.class);
+
+    final MappingRuleFilter filter = requestBody.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getMappingRuleId().get$Like()).isEqualTo("rule*");
   }
 
   @Test
@@ -150,7 +168,7 @@ public class SearchMappingRuleTest extends ClientRestTest {
         gatewayService.getLastRequest(MappingRuleSearchQueryRequest.class);
     final MappingRuleFilter filter = requestBody.getFilter();
     assertThat(filter).isNotNull();
-    assertThat(filter.getMappingRuleId()).isEqualTo("rule123");
+    assertThat(filter.getMappingRuleId().get$Eq()).isEqualTo("rule123");
 
     assertThat(requestBody.getSort()).isEmpty();
     assertThat(requestBody.getPage()).isNull();
@@ -212,8 +230,8 @@ public class SearchMappingRuleTest extends ClientRestTest {
     final MappingRuleFilter filter = request.getFilter();
     assertThat(filter).isNotNull();
     assertThat(filter.get$Or()).hasSize(2);
-    assertThat(filter.get$Or().get(0).getMappingRuleId()).isEqualTo("rule-1");
-    assertThat(filter.get$Or().get(1).getMappingRuleId()).isEqualTo("rule-2");
+    assertThat(filter.get$Or().get(0).getMappingRuleId().get$Eq()).isEqualTo("rule-1");
+    assertThat(filter.get$Or().get(1).getMappingRuleId().get$Eq()).isEqualTo("rule-2");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
@@ -167,8 +167,21 @@ public class SearchRoleTest extends ClientRestTest {
     assertThat(filter).isNotNull();
     assertThat(filter.getName().get$Eq()).isEqualTo("Admin");
     assertThat(filter.get$Or()).hasSize(2);
-    assertThat(filter.get$Or().get(0).getRoleId()).isEqualTo("role-1");
-    assertThat(filter.get$Or().get(1).getRoleId()).isEqualTo("role-2");
+    assertThat(filter.get$Or().get(0).getRoleId().get$Eq()).isEqualTo("role-1");
+    assertThat(filter.get$Or().get(1).getRoleId().get$Eq()).isEqualTo("role-2");
+  }
+
+  @Test
+  void shouldSearchRolesByRoleIdLike() {
+    // when
+    client.newRolesSearchRequest().filter(f -> f.roleId(b -> b.like("role*"))).send().join();
+
+    // then
+    final RoleSearchQueryRequest request =
+        gatewayService.getLastRequest(RoleSearchQueryRequest.class);
+    final RoleFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getRoleId().get$Like()).isEqualTo("role*");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
@@ -23,11 +23,19 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.filter.ClientFilter;
+import io.camunda.client.api.search.filter.RoleFilterBase;
 import io.camunda.client.api.search.sort.ClientSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.RoleFilter;
 import io.camunda.client.protocol.rest.RoleResult;
+import io.camunda.client.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.client.util.ClientRestTest;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -138,5 +146,55 @@ public class SearchRoleTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newRoleGetRequest(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
+  }
+
+  @Test
+  void shouldSearchRolesWithOrFilters() {
+    // when
+    client
+        .newRolesSearchRequest()
+        .filter(
+            fn ->
+                fn.name("Admin")
+                    .orFilters(Arrays.asList(f1 -> f1.roleId("role-1"), f2 -> f2.roleId("role-2"))))
+        .send()
+        .join();
+
+    // then
+    final RoleSearchQueryRequest request =
+        gatewayService.getLastRequest(RoleSearchQueryRequest.class);
+    final RoleFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.getName().get$Eq()).isEqualTo("Admin");
+    assertThat(filter.get$Or()).hasSize(2);
+    assertThat(filter.get$Or().get(0).getRoleId()).isEqualTo("role-1");
+    assertThat(filter.get$Or().get(1).getRoleId()).isEqualTo("role-2");
+  }
+
+  @Test
+  void shouldHaveMatchingFilterMethodsInBaseAndFullInterfaces() {
+    final Set<String> baseMethods = publicMethodSignatures(RoleFilterBase.class);
+    final Set<String> fullMethods =
+        publicMethodSignatures(io.camunda.client.api.search.filter.RoleFilter.class);
+
+    assertThat(fullMethods)
+        .withFailMessage("Full interface is missing methods from base interface")
+        .containsAll(baseMethods);
+
+    final Set<String> expectedExtras = new HashSet<>();
+    expectedExtras.add("orFilters[interface java.util.List]");
+    final Set<String> actualExtras = new HashSet<>(fullMethods);
+    actualExtras.removeAll(baseMethods);
+
+    assertThat(actualExtras)
+        .withFailMessage("Unexpected methods in full interface: %s", actualExtras)
+        .isEqualTo(expectedExtras);
+  }
+
+  private static Set<String> publicMethodSignatures(final Class<?> clazz) {
+    return Arrays.stream(clazz.getMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()) && !m.isSynthetic())
+        .map(m -> m.getName() + Arrays.toString(m.getParameterTypes()))
+        .collect(Collectors.toSet());
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchRolesByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchRolesByTenantTest.java
@@ -51,7 +51,7 @@ public class SearchRolesByTenantTest extends ClientRestTest {
     final LoggedRequest lastRequest = RestGatewayService.getLastRequest();
     final String requestBody = lastRequest.getBodyAsString();
 
-    assertThat(requestBody).contains("\"roleId\":\"roleId\"");
+    assertThat(requestBody).contains("\"roleId\":{\"$eq\":\"roleId\",\"$in\":[],\"$notIn\":[]}");
     assertThat(requestBody).contains("\"name\":{\"$eq\":\"roleName\",\"$in\":[],\"$notIn\":[]}");
   }
 

--- a/clients/java/src/test/java/io/camunda/client/user/SearchUsersTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/SearchUsersTest.java
@@ -20,10 +20,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.filter.UserFilterBase;
 import io.camunda.client.api.search.sort.UserSort;
+import io.camunda.client.protocol.rest.UserFilter;
 import io.camunda.client.protocol.rest.UserResult;
+import io.camunda.client.protocol.rest.UserSearchQueryRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -75,5 +83,54 @@ public class SearchUsersTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newUserGetRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("username must not be empty");
+  }
+
+  @Test
+  void shouldSearchUsersWithOrFilters() {
+    // when
+    client
+        .newUsersSearchRequest()
+        .filter(
+            fn ->
+                fn.orFilters(
+                    Arrays.asList(f1 -> f1.username("user-1"), f2 -> f2.username("user-2"))))
+        .send()
+        .join();
+
+    // then
+    final UserSearchQueryRequest request =
+        gatewayService.getLastRequest(UserSearchQueryRequest.class);
+    final UserFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    assertThat(filter.get$Or()).hasSize(2);
+    assertThat(filter.get$Or().get(0).getUsername().get$Eq()).isEqualTo("user-1");
+    assertThat(filter.get$Or().get(1).getUsername().get$Eq()).isEqualTo("user-2");
+  }
+
+  @Test
+  void shouldHaveMatchingFilterMethodsInBaseAndFullInterfaces() {
+    final Set<String> baseMethods = publicMethodSignatures(UserFilterBase.class);
+    final Set<String> fullMethods =
+        publicMethodSignatures(io.camunda.client.api.search.filter.UserFilter.class);
+
+    assertThat(fullMethods)
+        .withFailMessage("Full interface is missing methods from base interface")
+        .containsAll(baseMethods);
+
+    final Set<String> expectedExtras = new HashSet<>();
+    expectedExtras.add("orFilters[interface java.util.List]");
+    final Set<String> actualExtras = new HashSet<>(fullMethods);
+    actualExtras.removeAll(baseMethods);
+
+    assertThat(actualExtras)
+        .withFailMessage("Unexpected methods in full interface: %s", actualExtras)
+        .isEqualTo(expectedExtras);
+  }
+
+  private static Set<String> publicMethodSignatures(final Class<?> clazz) {
+    return Arrays.stream(clazz.getMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()) && !m.isSynthetic())
+        .map(m -> m.getName() + Arrays.toString(m.getParameterTypes()))
+        .collect(Collectors.toSet());
   }
 }

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -107,7 +107,12 @@ SELECT
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.name != null">AND g.NAME = #{filter.name}</if>
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
+        AND g.NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
     <if test="filter.description != null">AND g.DESCRIPTION = #{filter.description}</if>
     <if
       test="filter.memberIds != null and !filter.memberIds.isEmpty() and filter.childMemberType != null">

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -14,7 +14,7 @@
     SELECT COUNT(*) FROM (
       SELECT 1 as col
       FROM ${prefix}GROUP_ g
-      <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchAndAuthFilter"/>
       ${count.limit}
     ) t
   </select>
@@ -37,7 +37,7 @@ SELECT
     g.NAME,
     g.DESCRIPTION
     FROM ${prefix}GROUP_ g
-    <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchAndAuthFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
@@ -76,17 +76,31 @@ SELECT
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
-  <sql id="searchFilter">
-    WHERE 1 = 1
-    <!-- authorization filters -->
-    <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
-      AND g.GROUP_ID IN
-      <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
-        close=")">
-        #{resourceId}
-      </foreach>
-    </if>
+  <sql id="searchAndAuthFilter">
+    <where>
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND g.GROUP_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
+          close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+      <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
+      <if test="filter.orFilters != null and !filter.orFilters.isEmpty()">
+        AND (
+        <foreach collection="filter.orFilters" item="filter" separator=" OR ">
+          <trim prefix="(" suffix=")">
+            <trim prefixOverrides="AND">
+              <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
+            </trim>
+          </trim>
+        </foreach>
+        )
+      </if>
+    </where>
+  </sql>
 
+  <sql id="searchFilter">
     <if test="filter.groupIdOperations != null and !filter.groupIdOperations.isEmpty()">
       <foreach collection="filter.groupIdOperations" item="operation">
         AND g.GROUP_ID
@@ -95,7 +109,6 @@ SELECT
     </if>
     <if test="filter.name != null">AND g.NAME = #{filter.name}</if>
     <if test="filter.description != null">AND g.DESCRIPTION = #{filter.description}</if>
-
     <if
       test="filter.memberIds != null and !filter.memberIds.isEmpty() and filter.childMemberType != null">
       AND g.GROUP_ID IN ( SELECT gmf.GROUP_ID FROM ${prefix}GROUP_MEMBER gmf

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -54,7 +54,7 @@
     SELECT COUNT(*) FROM (
       SELECT 1 as col
       FROM ${prefix}MAPPING_RULES m
-      <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchAndAuthFilter"/>
       ${count.limit}
     ) t
   </select>
@@ -69,14 +69,14 @@
     CLAIM_VALUE,
     NAME
     FROM ${prefix}MAPPING_RULES m
-      <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchAndAuthFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
-  <sql id="searchFilter">
+  <sql id="searchAndAuthFilter">
     <where>
       <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
         AND MAPPING_RULE_ID IN
@@ -85,47 +85,62 @@
           #{resourceId}
         </foreach>
       </if>
-      <if test="filter.mappingRuleId != null">
-        AND MAPPING_RULE_ID = #{filter.mappingRuleId}
-      </if>
-      <if test="filter.claimName != null">
-        AND CLAIM_NAME = #{filter.claimName}
-      </if>
-      <if test="filter.claimValue">
-        AND CLAIM_VALUE = #{filter.claimValue}
-      </if>
-      <if test="filter.claimNames != null and !filter.claimNames.isEmpty()">
-        AND CLAIM_NAME IN
-        <foreach collection="filter.claimNames" item="claimName" open="(" separator=","
-          close=")">
-          #{claimName}
+      <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchFilter"/>
+      <if test="filter.orFilters != null and !filter.orFilters.isEmpty()">
+        AND (
+        <foreach collection="filter.orFilters" item="filter" separator=" OR ">
+          <trim prefix="(" suffix=")">
+            <trim prefixOverrides="AND">
+              <include refid="io.camunda.db.rdbms.sql.MappingRuleMapper.searchFilter"/>
+            </trim>
+          </trim>
         </foreach>
-      </if>
-      <if test="filter.claims != null and !filter.claims.isEmpty()">
-        AND
-        <foreach collection="filter.claims" item="claim" separator="OR">
-          (CLAIM_NAME = #{claim.name} AND CLAIM_VALUE = #{claim.value})
-        </foreach>
-      </if>
-      <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
-        <foreach collection="filter.nameOperations" item="operation">
-          AND NAME
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.groupId != null">AND MAPPING_RULE_ID IN (SELECT ENTITY_ID FROM
-        ${prefix}GROUP_MEMBER
-        WHERE ENTITY_TYPE = 'MAPPING_RULE' AND GROUP_ID = #{filter.groupId})
-      </if>
-      <if test="filter.roleId != null">AND MAPPING_RULE_ID IN (SELECT ENTITY_ID FROM
-        ${prefix}ROLE_MEMBER
-        WHERE ENTITY_TYPE = 'MAPPING_RULE' AND ROLE_ID = #{filter.roleId})
-      </if>
-      <if test="filter.tenantId != null">AND MAPPING_RULE_ID IN (SELECT ENTITY_ID FROM
-        ${prefix}TENANT_MEMBER
-        WHERE ENTITY_TYPE = 'MAPPING_RULE' AND TENANT_ID = #{filter.tenantId})
+        )
       </if>
     </where>
+  </sql>
+
+  <sql id="searchFilter">
+    <if test="filter.mappingRuleId != null">
+      AND MAPPING_RULE_ID = #{filter.mappingRuleId}
+    </if>
+    <if test="filter.claimName != null">
+      AND CLAIM_NAME = #{filter.claimName}
+    </if>
+    <if test="filter.claimValue">
+      AND CLAIM_VALUE = #{filter.claimValue}
+    </if>
+    <if test="filter.claimNames != null and !filter.claimNames.isEmpty()">
+      AND CLAIM_NAME IN
+      <foreach collection="filter.claimNames" item="claimName" open="(" separator=","
+        close=")">
+        #{claimName}
+      </foreach>
+    </if>
+    <if test="filter.claims != null and !filter.claims.isEmpty()">
+      AND
+      <foreach collection="filter.claims" item="claim" separator="OR">
+        (CLAIM_NAME = #{claim.name} AND CLAIM_VALUE = #{claim.value})
+      </foreach>
+    </if>
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
+        AND NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.groupId != null">AND MAPPING_RULE_ID IN (SELECT ENTITY_ID FROM
+      ${prefix}GROUP_MEMBER
+      WHERE ENTITY_TYPE = 'MAPPING_RULE' AND GROUP_ID = #{filter.groupId})
+    </if>
+    <if test="filter.roleId != null">AND MAPPING_RULE_ID IN (SELECT ENTITY_ID FROM
+      ${prefix}ROLE_MEMBER
+      WHERE ENTITY_TYPE = 'MAPPING_RULE' AND ROLE_ID = #{filter.roleId})
+    </if>
+    <if test="filter.tenantId != null">AND MAPPING_RULE_ID IN (SELECT ENTITY_ID FROM
+      ${prefix}TENANT_MEMBER
+      WHERE ENTITY_TYPE = 'MAPPING_RULE' AND TENANT_ID = #{filter.tenantId})
+    </if>
   </sql>
 
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -101,8 +101,11 @@
   </sql>
 
   <sql id="searchFilter">
-    <if test="filter.mappingRuleId != null">
-      AND MAPPING_RULE_ID = #{filter.mappingRuleId}
+    <if test="filter.mappingRuleIdOperations != null and !filter.mappingRuleIdOperations.isEmpty()">
+      <foreach collection="filter.mappingRuleIdOperations" item="operation">
+        AND MAPPING_RULE_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
     <if test="filter.claimName != null">
       AND CLAIM_NAME = #{filter.claimName}

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -105,7 +105,12 @@ FROM (
   </sql>
 
   <sql id="searchFilter">
-    <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
+    <if test="filter.roleIdOperations != null and !filter.roleIdOperations.isEmpty()">
+      <foreach collection="filter.roleIdOperations" item="operation">
+        AND r.ROLE_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
     <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
       <foreach collection="filter.nameOperations" item="operation">
         AND r.NAME

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -14,7 +14,7 @@
     SELECT COUNT(*) FROM (
       SELECT 1 as col
       FROM ${prefix}ROLES r
-      <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchAndAuthFilter"/>
       ${count.limit}
     ) t
   </select>
@@ -47,7 +47,7 @@ FROM (
     r.NAME,
     r.DESCRIPTION
     FROM ${prefix}ROLES r
-    <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchAndAuthFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
@@ -80,46 +80,8 @@ FROM (
   </select>
 
 
-  <sql id="searchFilter">
+  <sql id="searchAndAuthFilter">
     <where>
-      <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
-      <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
-        <foreach collection="filter.nameOperations" item="operation">
-          AND r.NAME
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.description != null">AND r.DESCRIPTION = #{filter.description}</if>
-      <if
-        test="filter.memberIds != null and !filter.memberIds.isEmpty() and filter.childMemberType != null">
-        AND r.ROLE_ID IN ( SELECT rmf.ROLE_ID FROM ${prefix}ROLE_MEMBER rmf
-        WHERE
-        rmf.ENTITY_TYPE = #{filter.childMemberType}
-        AND rmf.ENTITY_ID IN
-        <foreach collection="filter.memberIds" item="memberId" open="(" separator="," close=")">
-          #{memberId}
-        </foreach>
-        )
-      </if>
-      <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
-        AND r.ROLE_ID IN ( SELECT rmt.ROLE_ID FROM ${prefix}ROLE_MEMBER rmt
-        WHERE 1=1
-        <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND ("
-          separator=" OR " close=")">
-          <if test="values != null and !values.isEmpty()">
-            rmt.ENTITY_TYPE = #{memberType} AND rmt.ENTITY_ID IN
-            <foreach collection="values" item="value" open="(" separator=" , " close=")">
-              #{value}
-            </foreach>
-          </if>
-        </foreach>
-        )
-      </if>
-      <if test="filter.tenantId != null">
-        AND r.ROLE_ID IN ( SELECT tm.ENTITY_ID FROM ${prefix}TENANT_MEMBER tm
-        WHERE tm.ENTITY_TYPE = 'ROLE'
-        AND tm.TENANT_ID = #{filter.tenantId})
-      </if>
       <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
         AND r.ROLE_ID IN
         <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
@@ -127,7 +89,60 @@ FROM (
           #{resourceId}
         </foreach>
       </if>
+      <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
+      <if test="filter.orFilters != null and !filter.orFilters.isEmpty()">
+        AND (
+        <foreach collection="filter.orFilters" item="filter" separator=" OR ">
+          <trim prefix="(" suffix=")">
+            <trim prefixOverrides="AND">
+              <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
+            </trim>
+          </trim>
+        </foreach>
+        )
+      </if>
     </where>
+  </sql>
+
+  <sql id="searchFilter">
+    <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
+        AND r.NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.description != null">AND r.DESCRIPTION = #{filter.description}</if>
+    <if
+      test="filter.memberIds != null and !filter.memberIds.isEmpty() and filter.childMemberType != null">
+      AND r.ROLE_ID IN ( SELECT rmf.ROLE_ID FROM ${prefix}ROLE_MEMBER rmf
+      WHERE
+      rmf.ENTITY_TYPE = #{filter.childMemberType}
+      AND rmf.ENTITY_ID IN
+      <foreach collection="filter.memberIds" item="memberId" open="(" separator="," close=")">
+        #{memberId}
+      </foreach>
+      )
+    </if>
+    <if test="filter.memberIdsByType != null and !filter.memberIdsByType.isEmpty()">
+      AND r.ROLE_ID IN ( SELECT rmt.ROLE_ID FROM ${prefix}ROLE_MEMBER rmt
+      WHERE 1=1
+      <foreach collection="filter.memberIdsByType" index="memberType" item="values" open="AND ("
+        separator=" OR " close=")">
+        <if test="values != null and !values.isEmpty()">
+          rmt.ENTITY_TYPE = #{memberType} AND rmt.ENTITY_ID IN
+          <foreach collection="values" item="value" open="(" separator=" , " close=")">
+            #{value}
+          </foreach>
+        </if>
+      </foreach>
+      )
+    </if>
+    <if test="filter.tenantId != null">
+      AND r.ROLE_ID IN ( SELECT tm.ENTITY_ID FROM ${prefix}TENANT_MEMBER tm
+      WHERE tm.ENTITY_TYPE = 'ROLE'
+      AND tm.TENANT_ID = #{filter.tenantId})
+    </if>
   </sql>
 
   <sql id="searchMemberFilter">

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -22,7 +22,7 @@
         JOIN ${prefix}ROLE_MEMBER rm ON t.USERNAME = rm.ENTITY_ID
         AND rm.ENTITY_TYPE = 'USER'
       </if>
-        <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
+        <include refid="io.camunda.db.rdbms.sql.UserMapper.searchAndAuthFilter"/>
       ${count.limit}
     ) t
   </select>
@@ -37,16 +37,15 @@
     EMAIL,
     PASSWORD
     FROM ${prefix}USER_ t
-    <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.UserMapper.searchAndAuthFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
-  <sql id="searchFilter">
+  <sql id="searchAndAuthFilter">
     <where>
-      <!-- authorization filters -->
       <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
         AND USERNAME IN
         <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator=","
@@ -54,35 +53,49 @@
           #{resourceId}
         </foreach>
       </if>
-      <!-- basic filters -->
-      <if test="filter.usernameOperations != null and !filter.usernameOperations.isEmpty()">
-        <foreach collection="filter.usernameOperations" item="operation">
-          AND t.USERNAME
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
+      <if test="filter.orFilters != null and !filter.orFilters.isEmpty()">
+        AND (
+        <foreach collection="filter.orFilters" item="filter" separator=" OR ">
+          <trim prefix="(" suffix=")">
+            <trim prefixOverrides="AND">
+              <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
+            </trim>
+          </trim>
         </foreach>
-      </if>
-      <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
-        <foreach collection="filter.nameOperations" item="operation">
-          AND t.NAME
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.emailOperations != null and !filter.emailOperations.isEmpty()">
-        <foreach collection="filter.emailOperations" item="operation">
-          AND t.EMAIL
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.tenantId != null">AND username IN (SELECT ENTITY_ID FROM
-        ${prefix}TENANT_MEMBER WHERE ENTITY_TYPE = 'USER' AND TENANT_ID = #{filter.tenantId})
-      </if>
-      <if test="filter.groupId != null">AND username IN (SELECT ENTITY_ID FROM ${prefix}GROUP_MEMBER
-        WHERE ENTITY_TYPE = 'USER' AND GROUP_ID = #{filter.groupId})
-      </if>
-      <if test="filter.roleId != null">AND username IN (SELECT ENTITY_ID FROM ${prefix}ROLE_MEMBER
-        WHERE ENTITY_TYPE = 'USER' AND ROLE_ID = #{filter.roleId})
+        )
       </if>
     </where>
+  </sql>
+
+  <sql id="searchFilter">
+    <if test="filter.usernameOperations != null and !filter.usernameOperations.isEmpty()">
+      <foreach collection="filter.usernameOperations" item="operation">
+        AND t.USERNAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
+        AND t.NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.emailOperations != null and !filter.emailOperations.isEmpty()">
+      <foreach collection="filter.emailOperations" item="operation">
+        AND t.EMAIL
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.tenantId != null">AND username IN (SELECT ENTITY_ID FROM
+      ${prefix}TENANT_MEMBER WHERE ENTITY_TYPE = 'USER' AND TENANT_ID = #{filter.tenantId})
+    </if>
+    <if test="filter.groupId != null">AND username IN (SELECT ENTITY_ID FROM ${prefix}GROUP_MEMBER
+      WHERE ENTITY_TYPE = 'USER' AND GROUP_ID = #{filter.groupId})
+    </if>
+    <if test="filter.roleId != null">AND username IN (SELECT ENTITY_ID FROM ${prefix}ROLE_MEMBER
+      WHERE ENTITY_TYPE = 'USER' AND ROLE_ID = #{filter.roleId})
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.UserEntity">

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -826,7 +826,7 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getGroupId())
           .map(mapToStringOperations())
           .ifPresent(builder::groupIdOperations);
-      ofNullable(filter.getName()).ifPresent(builder::name);
+      ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
     }
     return builder;
   }
@@ -846,7 +846,9 @@ public class SearchQueryFilterMapper {
       final io.camunda.gateway.protocol.model.@Nullable RoleFilterFields filter) {
     final var builder = FilterBuilders.role();
     if (filter != null) {
-      ofNullable(filter.getRoleId()).ifPresent(builder::roleId);
+      ofNullable(filter.getRoleId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::roleIdOperations);
       ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
     }
     return builder;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -37,6 +37,7 @@ import io.camunda.gateway.protocol.model.ElementInstanceFilterFields;
 import io.camunda.gateway.protocol.model.GlobalTaskListenerSearchQueryFilterRequest;
 import io.camunda.gateway.protocol.model.GroupFilterFields;
 import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByDefinitionFilter;
+import io.camunda.gateway.protocol.model.MappingRuleFilterFields;
 import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ResourceFilter;
@@ -853,6 +854,17 @@ public class SearchQueryFilterMapper {
 
   static MappingRuleFilter toMappingRuleFilter(
       final io.camunda.gateway.protocol.model.@Nullable MappingRuleFilter filter) {
+    final var builder = toMappingRuleFilterFields(filter);
+    if (filter != null && filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      for (final MappingRuleFilterFields or : filter.get$Or()) {
+        builder.addOrOperation(toMappingRuleFilterFields(or).build());
+      }
+    }
+    return builder.build();
+  }
+
+  static MappingRuleFilter.Builder toMappingRuleFilterFields(
+      final io.camunda.gateway.protocol.model.@Nullable MappingRuleFilterFields filter) {
     final var builder = FilterBuilders.mappingRule();
     if (filter != null) {
       ofNullable(filter.getClaimName()).ifPresent(builder::claimName);
@@ -860,7 +872,7 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
       ofNullable(filter.getMappingRuleId()).ifPresent(builder::mappingRuleId);
     }
-    return builder.build();
+    return builder;
   }
 
   static Either<List<String>, DecisionDefinitionFilter> toDecisionDefinitionFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -870,7 +870,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getClaimName()).ifPresent(builder::claimName);
       ofNullable(filter.getClaimValue()).ifPresent(builder::claimValue);
       ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
-      ofNullable(filter.getMappingRuleId()).ifPresent(builder::mappingRuleId);
+      ofNullable(filter.getMappingRuleId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::mappingRuleIdOperations);
     }
     return builder;
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -42,6 +42,7 @@ import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ResourceFilter;
 import io.camunda.gateway.protocol.model.RoleFilterFields;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
+import io.camunda.gateway.protocol.model.UserFilterFields;
 import io.camunda.gateway.protocol.model.UserTaskAuditLogFilter;
 import io.camunda.gateway.protocol.model.UserTaskVariableFilter;
 import io.camunda.gateway.protocol.model.VariableValueFilterProperty;
@@ -1127,7 +1128,17 @@ public class SearchQueryFilterMapper {
 
   static UserFilter toUserFilter(
       final io.camunda.gateway.protocol.model.@Nullable UserFilter filter) {
+    final var builder = toUserFilterFields(filter);
+    if (filter != null && filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      for (final UserFilterFields or : filter.get$Or()) {
+        builder.addOrOperation(toUserFilterFields(or).build());
+      }
+    }
+    return builder.build();
+  }
 
+  static UserFilter.Builder toUserFilterFields(
+      final io.camunda.gateway.protocol.model.@Nullable UserFilterFields filter) {
     final var builder = FilterBuilders.user();
     if (filter != null) {
       Optional.ofNullable(filter.getUsername())
@@ -1140,7 +1151,7 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::emailOperations);
     }
-    return builder.build();
+    return builder;
   }
 
   static Either<List<String>, IncidentFilter> toIncidentFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -35,6 +35,7 @@ import io.camunda.gateway.protocol.model.BaseProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryFilterRequest;
 import io.camunda.gateway.protocol.model.ElementInstanceFilterFields;
 import io.camunda.gateway.protocol.model.GlobalTaskListenerSearchQueryFilterRequest;
+import io.camunda.gateway.protocol.model.GroupFilterFields;
 import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByDefinitionFilter;
 import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
@@ -807,6 +808,17 @@ public class SearchQueryFilterMapper {
 
   static GroupFilter toGroupFilter(
       final io.camunda.gateway.protocol.model.@Nullable GroupFilter filter) {
+    final var builder = toGroupFilterFields(filter);
+    if (filter != null && filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      for (final GroupFilterFields or : filter.get$Or()) {
+        builder.addOrOperation(toGroupFilterFields(or).build());
+      }
+    }
+    return builder.build();
+  }
+
+  static GroupFilter.Builder toGroupFilterFields(
+      final io.camunda.gateway.protocol.model.@Nullable GroupFilterFields filter) {
     final var builder = FilterBuilders.group();
     if (filter != null) {
       ofNullable(filter.getGroupId())
@@ -814,7 +826,7 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::groupIdOperations);
       ofNullable(filter.getName()).ifPresent(builder::name);
     }
-    return builder.build();
+    return builder;
   }
 
   static RoleFilter toRoleFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -39,6 +39,7 @@ import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByDefi
 import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ResourceFilter;
+import io.camunda.gateway.protocol.model.RoleFilterFields;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
 import io.camunda.gateway.protocol.model.UserTaskAuditLogFilter;
 import io.camunda.gateway.protocol.model.UserTaskVariableFilter;
@@ -818,12 +819,23 @@ public class SearchQueryFilterMapper {
 
   static RoleFilter toRoleFilter(
       final io.camunda.gateway.protocol.model.@Nullable RoleFilter filter) {
+    final var builder = toRoleFilterFields(filter);
+    if (filter != null && filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+      for (final RoleFilterFields or : filter.get$Or()) {
+        builder.addOrOperation(toRoleFilterFields(or).build());
+      }
+    }
+    return builder.build();
+  }
+
+  static RoleFilter.Builder toRoleFilterFields(
+      final io.camunda.gateway.protocol.model.@Nullable RoleFilterFields filter) {
     final var builder = FilterBuilders.role();
     if (filter != null) {
       ofNullable(filter.getRoleId()).ifPresent(builder::roleId);
       ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
     }
-    return builder.build();
+    return builder;
   }
 
   static MappingRuleFilter toMappingRuleFilter(

--- a/identity/client/src/components/form/DropdownSearch.tsx
+++ b/identity/client/src/components/form/DropdownSearch.tsx
@@ -77,12 +77,14 @@ const DropdownSearch = <Item extends Record<string, unknown>>({
   // text, so it's rendered directly rather than accumulated/re-filtered here.
   const filteredItems: ItemWithTitleAndSubTitle<Item>[] = useMemo(
     () =>
-      items.map((item) => ({
-        ...item,
-        title: itemTitle(item),
-        subTitle: itemSubTitle ? itemSubTitle(item) : undefined,
-      })),
-    [items, itemTitle, itemSubTitle],
+      items
+        .map((item) => ({
+          ...item,
+          title: itemTitle(item),
+          subTitle: itemSubTitle ? itemSubTitle(item) : undefined,
+        }))
+        .filter(filter),
+    [items, itemTitle, itemSubTitle, filter],
   );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/identity/client/src/components/form/EntitySearchMultiSelect.tsx
+++ b/identity/client/src/components/form/EntitySearchMultiSelect.tsx
@@ -34,9 +34,10 @@ type AbstractEntitySearchMultiSelectProps<
 
 /**
  * Public props for a concrete per-entity multi-select (e.g. UserMultiSelect):
- * everything technical (search, getId, errorTitle) is bound by the concrete
- * implementation. itemSubTitle/placeholder get concrete defaults but remain
- * overridable per call site, since some consumers need different copy.
+ * everything technical (search, getId, itemSubTitle, errorTitle) is fixed by
+ * the concrete implementation and not overridable per call site. placeholder
+ * gets a concrete default but remains overridable per call site, since some
+ * consumers need different copy.
  */
 export type EntitySearchMultiSelectProps<
   Entity extends Record<string, unknown>,
@@ -44,12 +45,7 @@ export type EntitySearchMultiSelectProps<
   AbstractEntitySearchMultiSelectProps<Entity>,
   "search" | "getId" | "itemSubTitle" | "placeholder" | "errorTitle"
 > &
-  Partial<
-    Pick<
-      AbstractEntitySearchMultiSelectProps<Entity>,
-      "itemSubTitle" | "placeholder"
-    >
-  >;
+  Partial<Pick<AbstractEntitySearchMultiSelectProps<Entity>, "placeholder">>;
 
 const EntitySearchMultiSelect = <Entity extends Record<string, unknown>>({
   search,

--- a/identity/client/src/components/form/EntitySearchSingleSelect.tsx
+++ b/identity/client/src/components/form/EntitySearchSingleSelect.tsx
@@ -31,17 +31,15 @@ type AbstractEntitySearchSingleSelectProps<
 
 /**
  * Public props for a concrete per-entity single-select (e.g. UserSingleSelect):
- * everything technical (search, getId, itemToString, errorTitle) is bound by
- * the concrete implementation. itemSubTitle gets a concrete default but
- * remains overridable per call site, since some consumers need different copy.
+ * everything technical (search, getId, itemToString, itemSubTitle, errorTitle)
+ * is fixed by the concrete implementation and not overridable per call site.
  */
 export type EntitySearchSingleSelectProps<
   Entity extends Record<string, unknown>,
 > = Omit<
   AbstractEntitySearchSingleSelectProps<Entity>,
   "search" | "getId" | "itemToString" | "itemSubTitle" | "errorTitle"
-> &
-  Partial<Pick<AbstractEntitySearchSingleSelectProps<Entity>, "itemSubTitle">>;
+>;
 
 const EntitySearchSingleSelect = <Entity extends Record<string, unknown>>({
   search,

--- a/identity/client/src/components/form/EntitySearchSingleSelect.tsx
+++ b/identity/client/src/components/form/EntitySearchSingleSelect.tsx
@@ -59,6 +59,13 @@ const EntitySearchSingleSelect = <Entity extends Record<string, unknown>>({
   const { t } = useTranslate();
   const [selectedEntity, setSelectedEntity] = useState<Entity | null>(null);
 
+  // Only clears selectedEntity when value no longer matches it; it cannot
+  // resync to a new non-empty value set externally (e.g. a pre-filled owner
+  // in an edit flow), since there is no way to look up an Entity from just
+  // an id here. Safe today because every consumer is a create-only form
+  // where value only ever changes via this component's own onChange. If a
+  // future caller pre-fills value, pass the full Entity too so it can be
+  // set as the initial selectedEntity.
   useEffect(() => {
     setSelectedEntity((current) =>
       current && value && getId(current) === value ? current : null,

--- a/identity/client/src/components/form/entitySelection/GroupSelection.tsx
+++ b/identity/client/src/components/form/entitySelection/GroupSelection.tsx
@@ -22,7 +22,16 @@ const itemToString = (group: Group) => group.name || group.groupId;
 const itemSubTitle = (group: Group) => group.name;
 const search = (search: string) =>
   groupQueries.search(
-    search === "" ? {} : { filter: { groupId: { $like: `*${search}*` } } },
+    search === ""
+      ? {}
+      : {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { groupId: { $like: `*${search}*` } },
+            ],
+          },
+        },
   );
 
 export const GroupMultiSelect: FC<EntitySearchMultiSelectProps<Group>> = (

--- a/identity/client/src/components/form/entitySelection/MappingRuleSelection.tsx
+++ b/identity/client/src/components/form/entitySelection/MappingRuleSelection.tsx
@@ -23,7 +23,16 @@ const itemToString = (mappingRule: MappingRule) =>
 const itemSubTitle = (mappingRule: MappingRule) => mappingRule.name;
 const search = (search: string) =>
   mappingRuleQueries.search(
-    search.trim() ? { filter: { name: { $like: `*${search}*` } } } : {},
+    search.trim()
+      ? {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { mappingRuleId: { $like: `*${search}*` } },
+            ],
+          },
+        }
+      : {},
   );
 
 export const MappingRuleMultiSelect: FC<

--- a/identity/client/src/components/form/entitySelection/RoleSelection.tsx
+++ b/identity/client/src/components/form/entitySelection/RoleSelection.tsx
@@ -22,7 +22,16 @@ const itemToString = (role: Role) => role.name || role.roleId;
 const itemSubTitle = (role: Role) => role.name;
 const search = (search: string) =>
   roleQueries.search(
-    search === "" ? {} : { filter: { name: { $like: `*${search}*` } } },
+    search === ""
+      ? {}
+      : {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { roleId: { $like: `*${search}*` } },
+            ],
+          },
+        },
   );
 
 export const RoleMultiSelect: FC<EntitySearchMultiSelectProps<Role>> = (

--- a/identity/client/src/components/form/entitySelection/UserSelection.tsx
+++ b/identity/client/src/components/form/entitySelection/UserSelection.tsx
@@ -43,7 +43,7 @@ export const UserMultiSelect: FC<EntitySearchMultiSelectProps<User>> = (
       search={search}
       getId={getId}
       itemSubTitle={itemSubTitle}
-      placeholder={t("searchByUsername")}
+      placeholder={t("searchByNameOrEmail")}
       errorTitle={t("usersCouldNotLoad")}
       {...props}
     />

--- a/identity/client/src/components/form/entitySelection/UserSelection.tsx
+++ b/identity/client/src/components/form/entitySelection/UserSelection.tsx
@@ -27,6 +27,7 @@ const search = (search: string) =>
       : {
           filter: {
             $or: [
+              { username: { $like: `*${search}*` } },
               { name: { $like: `*${search}*` } },
               { email: { $like: `*${search}*` } },
             ],

--- a/identity/client/src/components/form/entitySelection/UserSelection.tsx
+++ b/identity/client/src/components/form/entitySelection/UserSelection.tsx
@@ -22,7 +22,16 @@ const itemToString = (user: User) => user.name || user.username;
 const itemSubTitle = (user: User) => user.email;
 const search = (search: string) =>
   userQueries.search(
-    search === "" ? {} : { filter: { username: { $like: `*${search}*` } } },
+    search === ""
+      ? {}
+      : {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { email: { $like: `*${search}*` } },
+            ],
+          },
+        },
   );
 
 export const UserMultiSelect: FC<EntitySearchMultiSelectProps<User>> = (

--- a/identity/client/src/components/formV2/EntitySearchMultiSelect.tsx
+++ b/identity/client/src/components/formV2/EntitySearchMultiSelect.tsx
@@ -30,9 +30,10 @@ type AbstractEntitySearchMultiSelectProps<
 
 /**
  * Public props for a concrete per-entity multi-select (e.g. UserMultiSelect):
- * everything technical (search, getId, errorTitle) is bound by the concrete
- * implementation. itemSubTitle/placeholder get concrete defaults but remain
- * overridable per call site, since some consumers need different copy.
+ * everything technical (search, getId, itemSubTitle, errorTitle) is fixed by
+ * the concrete implementation and not overridable per call site. placeholder
+ * gets a concrete default but remains overridable per call site, since some
+ * consumers need different copy.
  */
 export type EntitySearchMultiSelectProps<
   Entity extends Record<string, unknown>,
@@ -40,12 +41,7 @@ export type EntitySearchMultiSelectProps<
   AbstractEntitySearchMultiSelectProps<Entity>,
   "search" | "getId" | "itemSubTitle" | "placeholder" | "errorTitle"
 > &
-  Partial<
-    Pick<
-      AbstractEntitySearchMultiSelectProps<Entity>,
-      "itemSubTitle" | "placeholder"
-    >
-  >;
+  Partial<Pick<AbstractEntitySearchMultiSelectProps<Entity>, "placeholder">>;
 
 const EntitySearchMultiSelect = <Entity extends Record<string, unknown>>({
   search,

--- a/identity/client/src/components/formV2/EntitySearchSingleSelect.tsx
+++ b/identity/client/src/components/formV2/EntitySearchSingleSelect.tsx
@@ -33,17 +33,15 @@ type AbstractEntitySearchSingleSelectProps<
 
 /**
  * Public props for a concrete per-entity single-select (e.g. UserSingleSelect):
- * everything technical (search, getId, itemToString, errorTitle) is bound by
- * the concrete implementation. itemSubTitle gets a concrete default but
- * remains overridable per call site, since some consumers need different copy.
+ * everything technical (search, getId, itemToString, itemSubTitle, errorTitle)
+ * is fixed by the concrete implementation and not overridable per call site.
  */
 export type EntitySearchSingleSelectProps<
   Entity extends Record<string, unknown>,
 > = Omit<
   AbstractEntitySearchSingleSelectProps<Entity>,
   "search" | "getId" | "itemToString" | "itemSubTitle" | "errorTitle"
-> &
-  Partial<Pick<AbstractEntitySearchSingleSelectProps<Entity>, "itemSubTitle">>;
+>;
 
 const EntitySearchSingleSelect = <Entity extends Record<string, unknown>>({
   search,

--- a/identity/client/src/components/formV2/entitySelection/GroupSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/GroupSelection.tsx
@@ -22,7 +22,16 @@ const itemToString = (group: Group) => group.name || group.groupId;
 const itemSubTitle = (group: Group) => group.name;
 const search = (search: string) =>
   groupQueries.search(
-    search === "" ? {} : { filter: { groupId: { $like: `*${search}*` } } },
+    search === ""
+      ? {}
+      : {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { groupId: { $like: `*${search}*` } },
+            ],
+          },
+        },
   );
 
 export const GroupMultiSelect: FC<EntitySearchMultiSelectProps<Group>> = (

--- a/identity/client/src/components/formV2/entitySelection/MappingRuleSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/MappingRuleSelection.tsx
@@ -23,7 +23,16 @@ const itemToString = (mappingRule: MappingRule) =>
 const itemSubTitle = (mappingRule: MappingRule) => mappingRule.name;
 const search = (search: string) =>
   mappingRuleQueries.search(
-    search.trim() ? { filter: { name: { $like: `*${search}*` } } } : {},
+    search.trim()
+      ? {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { mappingRuleId: { $like: `*${search}*` } },
+            ],
+          },
+        }
+      : {},
   );
 
 export const MappingRuleMultiSelect: FC<

--- a/identity/client/src/components/formV2/entitySelection/RoleSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/RoleSelection.tsx
@@ -22,7 +22,16 @@ const itemToString = (role: Role) => role.name || role.roleId;
 const itemSubTitle = (role: Role) => role.name;
 const search = (search: string) =>
   roleQueries.search(
-    search === "" ? {} : { filter: { name: { $like: `*${search}*` } } },
+    search === ""
+      ? {}
+      : {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { roleId: { $like: `*${search}*` } },
+            ],
+          },
+        },
   );
 
 export const RoleMultiSelect: FC<EntitySearchMultiSelectProps<Role>> = (

--- a/identity/client/src/components/formV2/entitySelection/UserSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/UserSelection.tsx
@@ -22,7 +22,16 @@ const itemToString = (user: User) => user.name || user.username;
 const itemSubTitle = (user: User) => user.email;
 const search = (search: string) =>
   userQueries.search(
-    search === "" ? {} : { filter: { username: { $like: `*${search}*` } } },
+    search === ""
+      ? {}
+      : {
+          filter: {
+            $or: [
+              { name: { $like: `*${search}*` } },
+              { email: { $like: `*${search}*` } },
+            ],
+          },
+        },
   );
 
 export const UserMultiSelect: FC<EntitySearchMultiSelectProps<User>> = (
@@ -34,7 +43,7 @@ export const UserMultiSelect: FC<EntitySearchMultiSelectProps<User>> = (
       search={search}
       getId={getId}
       itemSubTitle={itemSubTitle}
-      placeholder={t("searchByUsername")}
+      placeholder={t("searchByNameOrEmail")}
       errorTitle={t("usersCouldNotLoad")}
       {...props}
     />

--- a/identity/client/src/components/formV2/entitySelection/UserSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/UserSelection.tsx
@@ -27,6 +27,7 @@ const search = (search: string) =>
       : {
           filter: {
             $or: [
+              { username: { $like: `*${search}*` } },
               { name: { $like: `*${search}*` } },
               { email: { $like: `*${search}*` } },
             ],

--- a/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
@@ -73,7 +73,6 @@ const AssignMembersModal: FC<
         value={selectedUsers}
         onChange={setSelectedUsers}
         excluded={assignedUsers}
-        itemSubTitle={({ name }) => name}
         placeholder={t("searchByUsernameOrName")}
         autoFocus
       />

--- a/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
@@ -73,7 +73,6 @@ const AssignMembersModal: FC<
         value={selectedUsers}
         onChange={setSelectedUsers}
         excluded={assignedUsers}
-        placeholder={t("searchByUsernameOrName")}
         autoFocus
       />
     </FormModal>

--- a/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
@@ -72,7 +72,6 @@ const AssignMembersModal: FC<
         value={selectedUsers}
         onChange={setSelectedUsers}
         excluded={assignedUsers}
-        itemSubTitle={({ name }) => name}
         placeholder={t("searchByUsernameOrName")}
         autoFocus
       />

--- a/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
@@ -72,7 +72,6 @@ const AssignMembersModal: FC<
         value={selectedUsers}
         onChange={setSelectedUsers}
         excluded={assignedUsers}
-        placeholder={t("searchByUsernameOrName")}
         autoFocus
       />
     </FormModal>

--- a/identity/client/src/utility/localization/en/entitySelection.json
+++ b/identity/client/src/utility/localization/en/entitySelection.json
@@ -3,7 +3,7 @@
   "groupsCouldNotLoad": "Groups could not be loaded.",
   "rolesCouldNotLoad": "Roles could not be loaded.",
   "mappingRulesCouldNotLoad": "Mapping rules could not be loaded.",
-  "searchByUsername": "Search by username",
+  "searchByNameOrEmail": "Search by name or email",
   "searchByGroupId": "Search by group ID",
   "searchByRoleId": "Search by role ID",
   "searchByMappingRuleId": "Search by mapping rule ID"

--- a/identity/client/src/utility/localization/en/entitySelection.json
+++ b/identity/client/src/utility/localization/en/entitySelection.json
@@ -3,7 +3,7 @@
   "groupsCouldNotLoad": "Groups could not be loaded.",
   "rolesCouldNotLoad": "Roles could not be loaded.",
   "mappingRulesCouldNotLoad": "Mapping rules could not be loaded.",
-  "searchByNameOrEmail": "Search by name or email",
+  "searchByNameOrEmail": "Search by name, email, or username",
   "searchByGroupId": "Search by group ID",
   "searchByRoleId": "Search by role ID",
   "searchByMappingRuleId": "Search by mapping rule ID"

--- a/identity/client/src/utility/localization/en/roles.json
+++ b/identity/client/src/utility/localization/en/roles.json
@@ -24,7 +24,6 @@
   "assignUser": "Assign user",
   "assigningUser": "Assigning user",
   "searchAndAssignUserToRole": "Search and assign user to role",
-  "searchByUsernameOrName": "Search by Username or Name",
   "usernameDescription": "Check the documentation for <2>how to reference users</2>.",
   "roleMemberRemoved": "Role member has been removed.",
   "removeUser": "Remove user",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsSearchIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class GroupsSearchIT {
+
+  private static CamundaClient camundaClient;
+
+  private static final String GROUP_ID_1 = Strings.newRandomValidIdentityId();
+  private static final String GROUP_NAME_1 = "AGroupName";
+  private static final String GROUP_ID_2 = Strings.newRandomValidIdentityId();
+  private static final String GROUP_NAME_2 = "BGroupName";
+
+  @BeforeAll
+  static void setup() {
+    createGroup(GROUP_ID_1, GROUP_NAME_1);
+    assertGroupCreated(GROUP_ID_1, GROUP_NAME_1);
+
+    createGroup(GROUP_ID_2, GROUP_NAME_2);
+    assertGroupCreated(GROUP_ID_2, GROUP_NAME_2);
+  }
+
+  @Test
+  void searchShouldReturnGroupFilteredByGroupName() {
+    final var groupSearchResponse =
+        camundaClient.newGroupsSearchRequest().filter(fn -> fn.name(GROUP_NAME_1)).send().join();
+
+    assertThat(groupSearchResponse.items())
+        .hasSize(1)
+        .map(Group::getName)
+        .containsExactly(GROUP_NAME_1);
+  }
+
+  @Test
+  void searchShouldReturnGroupsMatchingOrFilters() {
+    final var groupSearchResponse =
+        camundaClient
+            .newGroupsSearchRequest()
+            .filter(
+                fn ->
+                    fn.orFilters(
+                        List.of(f1 -> f1.groupId(GROUP_ID_1), f2 -> f2.groupId(GROUP_ID_2))))
+            .send()
+            .join();
+
+    assertThat(groupSearchResponse.items())
+        .extracting(Group::getGroupId)
+        .containsExactlyInAnyOrder(GROUP_ID_1, GROUP_ID_2);
+  }
+
+  private static void assertGroupCreated(final String groupId, final String groupName) {
+    Awaitility.await("Group is created and exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var group = camundaClient.newGroupGetRequest(groupId).send().join();
+              assertThat(group).isNotNull();
+              assertThat(group.getGroupId()).isEqualTo(groupId);
+              assertThat(group.getName()).isEqualTo(groupName);
+            });
+  }
+
+  private static void createGroup(final String groupId, final String groupName) {
+    camundaClient.newCreateGroupCommand().groupId(groupId).name(groupName).send().join();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesSearchIT.java
@@ -14,6 +14,7 @@ import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -123,6 +124,25 @@ public class MappingRulesSearchIT {
 
     assertThat(mappingRules).hasSizeGreaterThanOrEqualTo(2);
     assertThat(mappingRules).extracting(r -> r.getClaimName()).isSorted();
+  }
+
+  @Test
+  void searchShouldReturnMappingRulesMatchingOrFilters() {
+    final var mappingRuleSearchResponse =
+        camundaClient
+            .newMappingRulesSearchRequest()
+            .filter(
+                fn ->
+                    fn.orFilters(
+                        List.of(
+                            f1 -> f1.mappingRuleId(MAPPING_RULE_ID_1),
+                            f2 -> f2.mappingRuleId(MAPPING_RULE_ID_2))))
+            .send()
+            .join();
+
+    assertThat(mappingRuleSearchResponse.items())
+        .extracting(MappingRule::getMappingRuleId)
+        .containsExactlyInAnyOrder(MAPPING_RULE_ID_1, MAPPING_RULE_ID_2);
   }
 
   private static void createMappingRule(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.search.response.Role;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -98,6 +99,21 @@ public class RolesSearchIT {
         // IdentitySetupInitializer
         .filteredOn(r -> r.equals(ROLE_NAME_1) || r.equals(ROLE_NAME_2))
         .containsExactly(ROLE_NAME_2, ROLE_NAME_1);
+  }
+
+  @Test
+  void searchShouldReturnRolesMatchingOrFilters() {
+    final var roleSearchResponse =
+        camundaClient
+            .newRolesSearchRequest()
+            .filter(
+                fn -> fn.orFilters(List.of(f1 -> f1.roleId(ROLE_ID_1), f2 -> f2.roleId(ROLE_ID_2))))
+            .send()
+            .join();
+
+    assertThat(roleSearchResponse.items())
+        .extracting(Role::getRoleId)
+        .containsExactlyInAnyOrder(ROLE_ID_1, ROLE_ID_2);
   }
 
   private static void assertRoleCreated(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIT.java
@@ -17,6 +17,7 @@ import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -85,6 +86,23 @@ public class UsersSearchIT {
         .hasSize(1)
         .map(User::getUsername)
         .containsOnly(USERNAME_1);
+  }
+
+  @Test
+  void searchShouldReturnUsersMatchingOrFilters() {
+    final var userSearchResponse =
+        camundaClient
+            .newUsersSearchRequest()
+            .filter(
+                fn ->
+                    fn.orFilters(
+                        List.of(f1 -> f1.username(USERNAME_1), f2 -> f2.username(USERNAME_2))))
+            .send()
+            .join();
+
+    assertThat(userSearchResponse.items())
+        .extracting(User::getUsername)
+        .containsExactlyInAnyOrder(USERNAME_1, USERNAME_2);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -138,6 +138,32 @@ public class GroupSpecificFilterIT {
     assertThat(searchResult.items()).hasSize(expectedCount);
   }
 
+  @Test
+  public void shouldFindGroupsWithOrFilters() {
+    final var matchingGroup = createRandomized(b -> b);
+    final var otherMatchingGroup = createRandomized(b -> b);
+    final var nonMatchingGroup = createRandomized(b -> b);
+    createAndSaveGroup(rdbmsWriters, matchingGroup);
+    createAndSaveGroup(rdbmsWriters, otherMatchingGroup);
+    createAndSaveGroup(rdbmsWriters, nonMatchingGroup);
+
+    final var searchResult =
+        groupReader.search(
+            new GroupQuery(
+                new GroupFilter.Builder()
+                    .orFilters(
+                        List.of(
+                            new GroupFilter.Builder().groupIds(matchingGroup.groupId()).build(),
+                            new GroupFilter.Builder()
+                                .groupIds(otherMatchingGroup.groupId())
+                                .build()))
+                    .build(),
+                GroupSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(2);
+  }
+
   static List<GroupFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
         new GroupFilter.Builder().name("Group 1337").build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -24,6 +24,7 @@ import io.camunda.it.rdbms.db.fixtures.GroupMemberFixtures;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.filter.GroupFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.sort.GroupSort;
@@ -162,6 +163,29 @@ public class GroupSpecificFilterIT {
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
     assertThat(searchResult.total()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFilterGroupsByNameLike() {
+    final var matchingName = "like-test-name-" + java.util.UUID.randomUUID();
+    final var matchingGroup = createRandomized(b -> b.name(matchingName));
+    final var nonMatchingGroup = createRandomized(b -> b);
+    createAndSaveGroup(rdbmsWriters, matchingGroup);
+    createAndSaveGroup(rdbmsWriters, nonMatchingGroup);
+
+    final var searchResult =
+        groupReader.search(
+            new GroupQuery(
+                new GroupFilter.Builder()
+                    .nameOperations(Operation.like("like-test-name-*"))
+                    .build(),
+                GroupSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items())
+        .extracting(item -> item.groupId())
+        .containsExactly(matchingGroup.groupId());
   }
 
   static List<GroupFilter> shouldFindWithSpecificFilterParameters() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
@@ -32,8 +32,10 @@ import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.sort.MappingRuleSort;
+import io.camunda.zeebe.test.util.Strings;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -148,6 +150,33 @@ public class MappingRuleSpecificFilterIT {
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
     assertThat(mappingRules.total()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldFindMappingRulesWithOrFilters() {
+    final var matchingId = Strings.newRandomValidIdentityId();
+    final var otherMatchingId = Strings.newRandomValidIdentityId();
+    final var nonMatchingId = Strings.newRandomValidIdentityId();
+    createAndSaveMappingRule(
+        rdbmsWriters, MappingRuleFixtures.createRandomized(b -> b.mappingRuleId(matchingId)));
+    createAndSaveMappingRule(
+        rdbmsWriters, MappingRuleFixtures.createRandomized(b -> b.mappingRuleId(otherMatchingId)));
+    createAndSaveMappingRule(
+        rdbmsWriters, MappingRuleFixtures.createRandomized(b -> b.mappingRuleId(nonMatchingId)));
+
+    final var searchResult =
+        mappingRuleReader.search(
+            new MappingRuleQuery(
+                new MappingRuleFilter.Builder()
+                    .orFilters(
+                        List.of(
+                            new MappingRuleFilter.Builder().mappingRuleId(matchingId).build(),
+                            new MappingRuleFilter.Builder().mappingRuleId(otherMatchingId).build()))
+                    .build(),
+                MappingRuleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(2);
   }
 
   private void assignMappingRuleToGroup(final String groupId, final String mappingRuleId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mappingrules/MappingRuleSpecificFilterIT.java
@@ -29,6 +29,7 @@ import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.filter.MappingRuleFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.sort.MappingRuleSort;
@@ -177,6 +178,30 @@ public class MappingRuleSpecificFilterIT {
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
     assertThat(searchResult.total()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFilterMappingRulesByMappingRuleIdLike() {
+    final var matchingId = "like-test-" + Strings.newRandomValidIdentityId();
+    final var nonMatchingId = Strings.newRandomValidIdentityId();
+    createAndSaveMappingRule(
+        rdbmsWriters, MappingRuleFixtures.createRandomized(b -> b.mappingRuleId(matchingId)));
+    createAndSaveMappingRule(
+        rdbmsWriters, MappingRuleFixtures.createRandomized(b -> b.mappingRuleId(nonMatchingId)));
+
+    final var searchResult =
+        mappingRuleReader.search(
+            new MappingRuleQuery(
+                new MappingRuleFilter.Builder()
+                    .mappingRuleIdOperations(Operation.like("like-test-*"))
+                    .build(),
+                MappingRuleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items())
+        .extracting(MappingRuleEntity::mappingRuleId)
+        .containsExactly(matchingId);
   }
 
   private void assignMappingRuleToGroup(final String groupId, final String mappingRuleId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -30,6 +30,7 @@ import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsDataJdbcTest;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.RoleQuery;
@@ -277,6 +278,25 @@ public class RoleSpecificFilterIT {
     assertThat(searchResult.items())
         .extracting(RoleEntity::roleId)
         .containsExactly(roleIdMatchingBoth);
+  }
+
+  @Test
+  public void shouldFilterRolesByRoleIdLike() {
+    final var matchingRoleId = "like-test-" + Strings.newRandomValidIdentityId();
+    final var nonMatchingRoleId = Strings.newRandomValidIdentityId();
+    createAndSaveRole(rdbmsWriters, RoleFixtures.createRandomized(b -> b.roleId(matchingRoleId)));
+    createAndSaveRole(
+        rdbmsWriters, RoleFixtures.createRandomized(b -> b.roleId(nonMatchingRoleId)));
+
+    final var searchResult =
+        roleReader.search(
+            new RoleQuery(
+                new RoleFilter.Builder().roleIdOperations(Operation.like("like-test-*")).build(),
+                RoleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).extracting(RoleEntity::roleId).containsExactly(matchingRoleId);
   }
 
   static List<RoleFilter> shouldFindWithSpecificFilterParameters() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -234,6 +234,51 @@ public class RoleSpecificFilterIT {
         .containsExactlyInAnyOrder(matchingRoleId, otherMatchingRoleId);
   }
 
+  @Test
+  public void shouldFindRolesWithTopLevelFilterAndOrFiltersCombinedUsingAndSemantics() {
+    final var matchingDescription = "matching-description-" + nextStringId();
+    final var otherDescription = "other-description-" + nextStringId();
+
+    final var roleIdMatchingBoth = Strings.newRandomValidIdentityId();
+    final var roleIdMatchingOrOnly = Strings.newRandomValidIdentityId();
+    final var roleIdMatchingTopLevelOnly = Strings.newRandomValidIdentityId();
+
+    createAndSaveRole(
+        rdbmsWriters,
+        RoleFixtures.createRandomized(
+            b -> b.roleId(roleIdMatchingBoth).description(matchingDescription)));
+    createAndSaveRole(
+        rdbmsWriters,
+        RoleFixtures.createRandomized(
+            b -> b.roleId(roleIdMatchingOrOnly).description(otherDescription)));
+    createAndSaveRole(
+        rdbmsWriters,
+        RoleFixtures.createRandomized(
+            b -> b.roleId(roleIdMatchingTopLevelOnly).description(matchingDescription)));
+
+    final var searchResult =
+        roleReader.search(
+            new RoleQuery(
+                new RoleFilter.Builder()
+                    .description(matchingDescription)
+                    .orFilters(
+                        List.of(
+                            new RoleFilter.Builder().roleId(roleIdMatchingBoth).build(),
+                            new RoleFilter.Builder().roleId(roleIdMatchingOrOnly).build()))
+                    .build(),
+                RoleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    // then: only the role matching both the top-level description AND one of the $or branches is
+    // returned. roleIdMatchingOrOnly matches an $or branch but not the top-level description, and
+    // roleIdMatchingTopLevelOnly matches the top-level description but no $or branch, so both must
+    // be excluded.
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items())
+        .extracting(RoleEntity::roleId)
+        .containsExactly(roleIdMatchingBoth);
+  }
+
   static List<RoleFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
         new RoleFilter.Builder().roleId(ROLE_ID).build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -205,6 +205,35 @@ public class RoleSpecificFilterIT {
     assertThat(searchResult.items().getFirst().roleKey()).isEqualTo(ROLE_KEY);
   }
 
+  @Test
+  public void shouldFindRolesWithOrFilters() {
+    final var matchingRoleId = Strings.newRandomValidIdentityId();
+    final var otherMatchingRoleId = Strings.newRandomValidIdentityId();
+    final var nonMatchingRoleId = Strings.newRandomValidIdentityId();
+    createAndSaveRole(rdbmsWriters, RoleFixtures.createRandomized(b -> b.roleId(matchingRoleId)));
+    createAndSaveRole(
+        rdbmsWriters, RoleFixtures.createRandomized(b -> b.roleId(otherMatchingRoleId)));
+    createAndSaveRole(
+        rdbmsWriters, RoleFixtures.createRandomized(b -> b.roleId(nonMatchingRoleId)));
+
+    final var searchResult =
+        roleReader.search(
+            new RoleQuery(
+                new RoleFilter.Builder()
+                    .orFilters(
+                        List.of(
+                            new RoleFilter.Builder().roleId(matchingRoleId).build(),
+                            new RoleFilter.Builder().roleId(otherMatchingRoleId).build()))
+                    .build(),
+                RoleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(2);
+    assertThat(searchResult.items())
+        .extracting(RoleEntity::roleId)
+        .containsExactlyInAnyOrder(matchingRoleId, otherMatchingRoleId);
+  }
+
   static List<RoleFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
         new RoleFilter.Builder().roleId(ROLE_ID).build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -31,6 +31,7 @@ import io.camunda.search.filter.UserFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.UserSort;
+import io.camunda.zeebe.test.util.Strings;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Arrays;
 import java.util.List;
@@ -178,6 +179,33 @@ public class UserSpecificFilterIT {
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
     assertThat(searchResult.items().getFirst().userKey()).isEqualTo(1337L);
+  }
+
+  @Test
+  public void shouldFindUsersWithOrFilters() {
+    final var matchingUsername = Strings.newRandomValidUsername();
+    final var otherMatchingUsername = Strings.newRandomValidUsername();
+    final var nonMatchingUsername = Strings.newRandomValidUsername();
+    createAndSaveUser(
+        rdbmsWriters, UserFixtures.createRandomized(b -> b.username(matchingUsername)));
+    createAndSaveUser(
+        rdbmsWriters, UserFixtures.createRandomized(b -> b.username(otherMatchingUsername)));
+    createAndSaveUser(
+        rdbmsWriters, UserFixtures.createRandomized(b -> b.username(nonMatchingUsername)));
+
+    final var searchResult =
+        userReader.search(
+            new UserQuery(
+                new UserFilter.Builder()
+                    .orFilters(
+                        List.of(
+                            new UserFilter.Builder().usernames(matchingUsername).build(),
+                            new UserFilter.Builder().usernames(otherMatchingUsername).build()))
+                    .build(),
+                UserSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(2);
   }
 
   static List<UserFilter> shouldFindWithSpecificFilterParameters() {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -36,6 +36,17 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
     if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
       return createMultipleMemberTypeQuery(filter);
     }
+
+    final var queries = new ArrayList<>(toSearchQueryFields(filter));
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      queries.add(or(filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).toList()));
+    }
+
+    return and(queries);
+  }
+
+  private ArrayList<SearchQuery> toSearchQueryFields(final GroupFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     if (filter.groupIdOperations() != null && !filter.groupIdOperations().isEmpty()) {
       queries.addAll(stringOperations(GROUP_ID, filter.groupIdOperations()));
@@ -61,8 +72,7 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
               IdentityJoinRelationshipType.MEMBER.getType(),
               term(GroupIndex.MEMBER_TYPE, filter.childMemberType().name())));
     }
-
-    return and(queries);
+    return queries;
   }
 
   private SearchQuery createMultipleMemberTypeQuery(final GroupFilter filter) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -34,6 +34,7 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
   @Override
   public SearchQuery toSearchQuery(final GroupFilter filter) {
     final var queries = new ArrayList<>(toSearchQueryFields(filter));
+    queries.add(term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType()));
 
     if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
       queries.add(createMultipleMemberTypeQuery(filter));
@@ -65,7 +66,6 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
                   IdentityJoinRelationshipType.MEMBER.getType(),
                   stringTerms(MEMBER_ID, filter.memberIds())));
     }
-    queries.add(term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType()));
     if (filter.childMemberType() != null) {
       queries.add(
           hasChildQuery(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -33,11 +33,11 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
 
   @Override
   public SearchQuery toSearchQuery(final GroupFilter filter) {
-    if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
-      return createMultipleMemberTypeQuery(filter);
-    }
-
     final var queries = new ArrayList<>(toSearchQueryFields(filter));
+
+    if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
+      queries.add(createMultipleMemberTypeQuery(filter));
+    }
 
     if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
       queries.add(or(filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).toList()));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -51,8 +51,8 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
     if (filter.groupIdOperations() != null && !filter.groupIdOperations().isEmpty()) {
       queries.addAll(stringOperations(GROUP_ID, filter.groupIdOperations()));
     }
-    if (filter.name() != null) {
-      queries.add(term(NAME, filter.name()));
+    if (filter.nameOperations() != null && !filter.nameOperations().isEmpty()) {
+      queries.addAll(stringOperations(NAME, filter.nameOperations()));
     }
     if (filter.description() != null) {
       queries.add(term(GroupIndex.DESCRIPTION, filter.description()));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformer.java
@@ -32,6 +32,16 @@ public class MappingRuleFilterTransformer extends IndexFilterTransformer<Mapping
 
   @Override
   public SearchQuery toSearchQuery(final MappingRuleFilter filter) {
+    final var queries = new ArrayList<>(toSearchQueryFields(filter));
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      queries.add(or(filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).toList()));
+    }
+
+    return and(queries);
+  }
+
+  private ArrayList<SearchQuery> toSearchQueryFields(final MappingRuleFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     queries.add(stringTerms(CLAIM_NAME, filter.claimNames()));
     if (filter.claimName() != null) {
@@ -61,8 +71,7 @@ public class MappingRuleFilterTransformer extends IndexFilterTransformer<Mapping
               ? matchNone()
               : stringTerms(MAPPING_RULE_ID, filter.mappingRuleIds().stream().sorted().toList()));
     }
-
-    return and(queries);
+    return queries;
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformer.java
@@ -53,8 +53,8 @@ public class MappingRuleFilterTransformer extends IndexFilterTransformer<Mapping
     if (filter.nameOperations() != null && !filter.nameOperations().isEmpty()) {
       queries.addAll(stringOperations(NAME, filter.nameOperations()));
     }
-    if (filter.mappingRuleId() != null) {
-      queries.add(term(MAPPING_RULE_ID, filter.mappingRuleId()));
+    if (filter.mappingRuleIdOperations() != null && !filter.mappingRuleIdOperations().isEmpty()) {
+      queries.addAll(stringOperations(MAPPING_RULE_ID, filter.mappingRuleIdOperations()));
     }
     if (filter.claims() != null) {
       queries.add(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -31,6 +31,7 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
   @Override
   public SearchQuery toSearchQuery(final RoleFilter filter) {
     final var queries = new ArrayList<>(toSearchQueryFields(filter));
+    queries.add(term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType()));
 
     if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
       queries.add(createMultipleMemberTypeQuery(filter));
@@ -54,7 +55,6 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
     if (filter.description() != null) {
       queries.add(term(RoleIndex.DESCRIPTION, filter.description()));
     }
-    queries.add(term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType()));
     if (filter.memberIds() != null) {
       queries.add(
           filter.memberIds().isEmpty()

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -45,8 +45,8 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
 
   private ArrayList<SearchQuery> toSearchQueryFields(final RoleFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
-    if (filter.roleId() != null) {
-      queries.add(term(RoleIndex.ROLE_ID, filter.roleId()));
+    if (filter.roleIdOperations() != null && !filter.roleIdOperations().isEmpty()) {
+      queries.addAll(stringOperations(RoleIndex.ROLE_ID, filter.roleIdOperations()));
     }
     if (filter.nameOperations() != null && !filter.nameOperations().isEmpty()) {
       queries.addAll(stringOperations(RoleIndex.NAME, filter.nameOperations()));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -34,6 +34,16 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
       return createMultipleMemberTypeQuery(filter);
     }
 
+    final var queries = new ArrayList<>(toSearchQueryFields(filter));
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      queries.add(or(filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).toList()));
+    }
+
+    return and(queries);
+  }
+
+  private ArrayList<SearchQuery> toSearchQueryFields(final RoleFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     if (filter.roleId() != null) {
       queries.add(term(RoleIndex.ROLE_ID, filter.roleId()));
@@ -65,8 +75,7 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
               ? matchNone()
               : stringTerms(RoleIndex.ROLE_ID, filter.roleIds()));
     }
-
-    return and(queries);
+    return queries;
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -30,11 +30,11 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
 
   @Override
   public SearchQuery toSearchQuery(final RoleFilter filter) {
-    if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
-      return createMultipleMemberTypeQuery(filter);
-    }
-
     final var queries = new ArrayList<>(toSearchQueryFields(filter));
+
+    if (filter.memberIdsByType() != null && !filter.memberIdsByType().isEmpty()) {
+      queries.add(createMultipleMemberTypeQuery(filter));
+    }
 
     if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
       queries.add(or(filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).toList()));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.EMAIL;
@@ -28,11 +29,21 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
 
   @Override
   public SearchQuery toSearchQuery(final UserFilter filter) {
+    final var queries = new ArrayList<>(toSearchQueryFields(filter));
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      queries.add(or(filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).toList()));
+    }
+
+    return and(queries);
+  }
+
+  private ArrayList<SearchQuery> toSearchQueryFields(final UserFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     queries.addAll(stringOperations(USERNAME, filter.usernameOperations()));
     queries.addAll(stringOperations(NAME, filter.nameOperations()));
     queries.addAll(stringOperations(EMAIL, filter.emailOperations()));
-    return and(queries);
+    return queries;
   }
 
   @Override

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformerTest.java
@@ -14,10 +14,38 @@ import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
+import io.camunda.security.api.model.authz.EntityType;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class GroupFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldCombineMemberIdsByTypeQueryWithTopLevelFilterAndOrFilters() {
+    // given
+    final var filter =
+        FilterBuilders.group(
+            f ->
+                f.groupIds("group-top")
+                    .memberIdsByType(Map.of(EntityType.USER, Set.of("user-1")))
+                    .orFilters(List.of(FilterBuilders.group(f1 -> f1.groupIds("group-1")))));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    // memberIdsByType must not short-circuit the top-level groupId filter or the $or group —
+    // all criteria must be ANDed together, as they are for every other filter combination.
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              assertThat(bool.must()).hasSize(4);
+              assertThat(termValue(bool.must().get(0))).isEqualTo("group-top");
+            });
+  }
 
   @Test
   void shouldQueryByNameWithLikeOperation() {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformerTest.java
@@ -11,11 +11,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class GroupFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByNameWithLikeOperation() {
+    // given
+    final var filter = FilterBuilders.group(f -> f.nameOperations(Operation.like("Group*")));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              // must contains the wildcard query plus the unconditional JOIN term
+              assertThat(bool.must()).hasSize(2);
+              assertThat(bool.must().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchWildcardQuery.class,
+                      t -> {
+                        assertThat(t.field()).isEqualTo("name");
+                        assertThat(t.value()).isEqualTo("Group*");
+                      });
+            });
+  }
 
   @Test
   void shouldCombineOrFiltersWithOrLogic() {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GroupFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldCombineOrFiltersWithOrLogic() {
+    final var filter =
+        FilterBuilders.group(
+            f ->
+                f.orFilters(
+                    List.of(
+                        FilterBuilders.group(f1 -> f1.groupIds("group-1")),
+                        FilterBuilders.group(f2 -> f2.groupIds("group-2")))));
+
+    final var searchQuery = transformQuery(filter);
+
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              // must contains the unconditional JOIN term plus the appended OR group
+              assertThat(bool.must()).hasSize(2);
+              assertThat(bool.must().getLast().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      or -> {
+                        assertThat(or.should()).hasSize(2);
+                        assertThat(termValue(or.should().get(0))).isEqualTo("group-1");
+                        assertThat(termValue(or.should().get(1))).isEqualTo("group-2");
+                      });
+            });
+  }
+
+  /**
+   * Extracts the string value of the first {@link SearchTermQuery} found in {@code q} — either
+   * {@code q} itself is a term query, or it's a bool query and the term is one of its {@code must}
+   * clauses. and(queries) unwraps single-element lists instead of nesting a redundant one-element
+   * "must" bool around them (see SearchQueryBuilders.map()), so which shape shows up depends on how
+   * many conditions the given filter contributes — this helper handles both.
+   */
+  private static String termValue(final io.camunda.search.clients.query.SearchQuery q) {
+    if (q.queryOption() instanceof SearchTermQuery term) {
+      return term.value().stringValue();
+    }
+    final var bool = (SearchBoolQuery) q.queryOption();
+    return bool.must().stream()
+        .map(io.camunda.search.clients.query.SearchQuery::queryOption)
+        .filter(SearchTermQuery.class::isInstance)
+        .map(SearchTermQuery.class::cast)
+        .findFirst()
+        .orElseThrow()
+        .value()
+        .stringValue();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MappingRuleFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldCombineOrFiltersWithOrLogic() {
+    final var filter =
+        FilterBuilders.mappingRule(
+            f ->
+                f.orFilters(
+                    List.of(
+                        FilterBuilders.mappingRule(f1 -> f1.mappingRuleId("rule-1")),
+                        FilterBuilders.mappingRule(f2 -> f2.mappingRuleId("rule-2")))));
+
+    final var searchQuery = transformQuery(filter);
+
+    // filter.claimNames() is null, so stringTerms(CLAIM_NAME, null) evaluates to a literal `null`
+    // (see SearchQueryBuilders.stringTerms), which and(queries) strips out (withoutNull). With no
+    // other field set, the appended OR group is the only remaining element, and and(queries)
+    // returns single-element lists unwrapped (see SearchQueryBuilders.map()) instead of nesting a
+    // redundant one-element "must" bool around them.
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            or -> {
+              assertThat(or.should()).hasSize(2);
+              assertThat(termValue(or.should().get(0))).isEqualTo("rule-1");
+              assertThat(termValue(or.should().get(1))).isEqualTo("rule-2");
+            });
+  }
+
+  /**
+   * Extracts the string value of the first {@link SearchTermQuery} found in {@code q} — either
+   * {@code q} itself is a term query, or it's a bool query and the term is one of its {@code must}
+   * clauses. and(queries) unwraps single-element lists instead of nesting a redundant one-element
+   * "must" bool around them (see SearchQueryBuilders.map()), so which shape shows up depends on how
+   * many conditions the given filter contributes — this helper handles both.
+   */
+  private static String termValue(final io.camunda.search.clients.query.SearchQuery q) {
+    if (q.queryOption() instanceof SearchTermQuery term) {
+      return term.value().stringValue();
+    }
+    final var bool = (SearchBoolQuery) q.queryOption();
+    return bool.must().stream()
+        .map(io.camunda.search.clients.query.SearchQuery::queryOption)
+        .filter(SearchTermQuery.class::isInstance)
+        .map(SearchTermQuery.class::cast)
+        .findFirst()
+        .orElseThrow()
+        .value()
+        .stringValue();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MappingRuleFilterTransformerTest.java
@@ -11,11 +11,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class MappingRuleFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByMappingRuleIdWithLikeOperation() {
+    // given
+    final var filter =
+        FilterBuilders.mappingRule(f -> f.mappingRuleIdOperations(Operation.like("mapping-*")));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchWildcardQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("mappingRuleId");
+              assertThat(t.value()).isEqualTo("mapping-*");
+            });
+  }
 
   @Test
   void shouldCombineOrFiltersWithOrLogic() {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
@@ -14,10 +14,38 @@ import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
+import io.camunda.security.api.model.authz.EntityType;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class RoleFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldCombineMemberIdsByTypeQueryWithTopLevelFilterAndOrFilters() {
+    // given
+    final var filter =
+        FilterBuilders.role(
+            f ->
+                f.roleId("role-top")
+                    .memberIdsByType(Map.of(EntityType.USER, Set.of("user-1")))
+                    .orFilters(List.of(FilterBuilders.role(f1 -> f1.roleId("role-1")))));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    // memberIdsByType must not short-circuit the top-level roleId filter or the $or group —
+    // all criteria must be ANDed together, as they are for every other filter combination.
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              assertThat(bool.must()).hasSize(4);
+              assertThat(termValue(bool.must().get(0))).isEqualTo("role-top");
+            });
+  }
 
   @Test
   void shouldQueryByRoleIdWithLikeOperation() {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RoleFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldCombineOrFiltersWithOrLogic() {
+    final var filter =
+        FilterBuilders.role(
+            f ->
+                f.orFilters(
+                    List.of(
+                        FilterBuilders.role(f1 -> f1.roleId("role-1")),
+                        FilterBuilders.role(f2 -> f2.roleId("role-2")))));
+
+    final var searchQuery = transformQuery(filter);
+
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              // must contains the unconditional JOIN term plus the appended OR group
+              assertThat(bool.must()).hasSize(2);
+              assertThat(bool.must().getLast().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      or -> {
+                        assertThat(or.should()).hasSize(2);
+                        assertThat(termValue(or.should().get(0))).isEqualTo("role-1");
+                        assertThat(termValue(or.should().get(1))).isEqualTo("role-2");
+                      });
+            });
+  }
+
+  /**
+   * Extracts the string value of the first {@link SearchTermQuery} found in {@code q} — either
+   * {@code q} itself is a term query, or it's a bool query and the term is one of its {@code must}
+   * clauses. and(queries) unwraps single-element lists instead of nesting a redundant one-element
+   * "must" bool around them (see SearchQueryBuilders.map()), so which shape shows up depends on how
+   * many conditions the given filter contributes — this helper handles both.
+   */
+  private static String termValue(final io.camunda.search.clients.query.SearchQuery q) {
+    if (q.queryOption() instanceof SearchTermQuery term) {
+      return term.value().stringValue();
+    }
+    final var bool = (SearchBoolQuery) q.queryOption();
+    return bool.must().stream()
+        .map(io.camunda.search.clients.query.SearchQuery::queryOption)
+        .filter(SearchTermQuery.class::isInstance)
+        .map(SearchTermQuery.class::cast)
+        .findFirst()
+        .orElseThrow()
+        .value()
+        .stringValue();
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
@@ -11,11 +11,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class RoleFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByRoleIdWithLikeOperation() {
+    // given
+    final var filter = FilterBuilders.role(f -> f.roleIdOperations(Operation.like("role-*")));
+
+    // when
+    final var searchQuery = transformQuery(filter);
+
+    // then
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              // must contains the wildcard query plus the unconditional JOIN term
+              assertThat(bool.must()).hasSize(2);
+              assertThat(bool.must().getFirst().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchWildcardQuery.class,
+                      t -> {
+                        assertThat(t.field()).isEqualTo("roleId");
+                        assertThat(t.value()).isEqualTo("role-*");
+                      });
+            });
+  }
 
   @Test
   void shouldCombineOrFiltersWithOrLogic() {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformerTest.java
@@ -46,6 +46,38 @@ class RoleFilterTransformerTest extends AbstractTransformerTest {
             });
   }
 
+  @Test
+  void shouldCombineTopLevelFilterWithOrFiltersUsingAndLogic() {
+    final var filter =
+        FilterBuilders.role(
+            f ->
+                f.roleId("role-top")
+                    .orFilters(
+                        List.of(
+                            FilterBuilders.role(f1 -> f1.roleId("role-1")),
+                            FilterBuilders.role(f2 -> f2.roleId("role-2")))));
+
+    final var searchQuery = transformQuery(filter);
+
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            bool -> {
+              // the top-level field must AND with the unconditional JOIN term and the appended
+              // OR group, rather than merely coexisting with it
+              assertThat(bool.must()).hasSize(3);
+              assertThat(termValue(bool.must().get(0))).isEqualTo("role-top");
+              assertThat(bool.must().getLast().queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      or -> {
+                        assertThat(or.should()).hasSize(2);
+                        assertThat(termValue(or.should().get(0))).isEqualTo("role-1");
+                        assertThat(termValue(or.should().get(1))).isEqualTo("role-2");
+                      });
+            });
+  }
+
   /**
    * Extracts the string value of the first {@link SearchTermQuery} found in {@code q} — either
    * {@code q} itself is a term query, or it's a bool query and the term is one of its {@code must}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserFilterTransformerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UserFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldCombineOrFiltersWithOrLogic() {
+    final var filter =
+        FilterBuilders.user(
+            f ->
+                f.orFilters(
+                    List.of(
+                        FilterBuilders.user(f1 -> f1.usernames("user-1")),
+                        FilterBuilders.user(f2 -> f2.usernames("user-2")))));
+
+    final var searchQuery = transformQuery(filter);
+
+    // no other field is set: toSearchQueryFields(filter) contributes nothing, so the single
+    // remaining element (the OR group) is returned unwrapped by and(queries) — see
+    // SearchQueryBuilders.map(), which unwraps single-element lists instead of nesting a
+    // redundant one-element "must" bool around them.
+    assertThat(searchQuery.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            or -> {
+              assertThat(or.should()).hasSize(2);
+              assertThat(termValue(or.should().get(0))).isEqualTo("user-1");
+              assertThat(termValue(or.should().get(1))).isEqualTo("user-2");
+            });
+  }
+
+  /**
+   * Extracts the string value of the first {@link SearchTermQuery} found in {@code q} — either
+   * {@code q} itself is a term query, or it's a bool query and the term is one of its {@code must}
+   * clauses. and(queries) unwraps single-element lists instead of nesting a redundant one-element
+   * "must" bool around them (see SearchQueryBuilders.map()), so which shape shows up depends on how
+   * many conditions the given filter contributes — this helper handles both.
+   */
+  private static String termValue(final io.camunda.search.clients.query.SearchQuery q) {
+    if (q.queryOption() instanceof SearchTermQuery term) {
+      return term.value().stringValue();
+    }
+    final var bool = (SearchBoolQuery) q.queryOption();
+    return bool.must().stream()
+        .map(io.camunda.search.clients.query.SearchQuery::queryOption)
+        .filter(SearchTermQuery.class::isInstance)
+        .map(SearchTermQuery.class::cast)
+        .findFirst()
+        .orElseThrow()
+        .value()
+        .stringValue();
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -27,7 +27,8 @@ public record GroupFilter(
     String tenantId,
     EntityType childMemberType,
     String roleId,
-    Map<EntityType, Set<String>> memberIdsByType)
+    Map<EntityType, Set<String>> memberIdsByType,
+    List<GroupFilter> orFilters)
     implements FilterBase {
 
   public static GroupFilter of(
@@ -44,7 +45,8 @@ public record GroupFilter(
         .tenantId(tenantId)
         .childMemberType(childMemberType)
         .roleId(roleId)
-        .memberIdsByType(memberIdsByType);
+        .memberIdsByType(memberIdsByType)
+        .orFilters(orFilters);
   }
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
@@ -56,6 +58,7 @@ public record GroupFilter(
     private EntityType childMemberType;
     private String roleId;
     private Map<EntityType, Set<String>> memberIdsByType;
+    private List<GroupFilter> orFilters;
 
     public Builder groupIdOperations(final List<Operation<String>> operations) {
       if (operations != null) {
@@ -125,6 +128,19 @@ public record GroupFilter(
       return this;
     }
 
+    public Builder addOrOperation(final GroupFilter orOperation) {
+      if (orFilters == null) {
+        orFilters = new ArrayList<>();
+      }
+      orFilters.add(orOperation);
+      return this;
+    }
+
+    public Builder orFilters(final List<GroupFilter> orFilters) {
+      this.orFilters = orFilters;
+      return this;
+    }
+
     @Override
     public GroupFilter build() {
       return new GroupFilter(
@@ -135,7 +151,8 @@ public record GroupFilter(
           tenantId,
           childMemberType,
           roleId,
-          memberIdsByType);
+          memberIdsByType,
+          orFilters);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 public record GroupFilter(
     List<Operation<String>> groupIdOperations,
-    String name,
+    List<Operation<String>> nameOperations,
     String description,
     Set<String> memberIds,
     String tenantId,
@@ -39,7 +39,7 @@ public record GroupFilter(
   public Builder toBuilder() {
     return new Builder()
         .groupIdOperations(groupIdOperations)
-        .name(name)
+        .nameOperations(nameOperations)
         .description(description)
         .memberIds(memberIds)
         .tenantId(tenantId)
@@ -51,7 +51,7 @@ public record GroupFilter(
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
     private List<Operation<String>> groupIdOperations;
-    private String name;
+    private List<Operation<String>> nameOperations;
     private String description;
     private Set<String> memberIds;
     private String tenantId;
@@ -89,9 +89,33 @@ public record GroupFilter(
       return groupIdOperations(collectValues(operation, operations));
     }
 
-    public Builder name(final String value) {
-      name = value;
+    public Builder nameOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        nameOperations = addValuesToList(nameOperations, operations);
+      }
       return this;
+    }
+
+    public Builder names(final Set<String> value) {
+      final var vals = FilterUtil.mapDefaultToOperation(new ArrayList<>(value));
+      if (vals != null) {
+        return nameOperations(vals);
+      }
+      return this;
+    }
+
+    public Builder name(final String value, final String... values) {
+      final var vals = FilterUtil.mapDefaultToOperation(value, values);
+      if (vals != null) {
+        return nameOperations(vals);
+      }
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder nameOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return nameOperations(collectValues(operation, operations));
     }
 
     public Builder description(final String value) {
@@ -145,7 +169,7 @@ public record GroupFilter(
     public GroupFilter build() {
       return new GroupFilter(
           groupIdOperations,
-          name,
+          nameOperations,
           description,
           memberIds,
           tenantId,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingRuleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingRuleFilter.java
@@ -26,7 +26,8 @@ public record MappingRuleFilter(
     String tenantId,
     Set<String> mappingRuleIds,
     String groupId,
-    String roleId)
+    String roleId,
+    List<MappingRuleFilter> orFilters)
     implements FilterBase {
 
   public MappingRuleFilter.Builder toBuilder() {
@@ -40,7 +41,8 @@ public record MappingRuleFilter(
         .tenantId(tenantId)
         .mappingRuleIds(mappingRuleIds)
         .groupId(groupId)
-        .roleId(roleId);
+        .roleId(roleId)
+        .orFilters(orFilters);
   }
 
   public static final class Builder implements ObjectBuilder<MappingRuleFilter> {
@@ -54,6 +56,7 @@ public record MappingRuleFilter(
     private String tenantId;
     private String groupId;
     private String roleId;
+    private List<MappingRuleFilter> orFilters;
 
     public Builder mappingRuleId(final String value) {
       mappingRuleId = value;
@@ -129,6 +132,19 @@ public record MappingRuleFilter(
       return this;
     }
 
+    public Builder addOrOperation(final MappingRuleFilter orOperation) {
+      if (orFilters == null) {
+        orFilters = new ArrayList<>();
+      }
+      orFilters.add(orOperation);
+      return this;
+    }
+
+    public Builder orFilters(final List<MappingRuleFilter> orFilters) {
+      this.orFilters = orFilters;
+      return this;
+    }
+
     @Override
     public MappingRuleFilter build() {
       return new MappingRuleFilter(
@@ -141,7 +157,8 @@ public record MappingRuleFilter(
           tenantId,
           mappingRuleIds,
           groupId,
-          roleId);
+          roleId,
+          orFilters);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingRuleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingRuleFilter.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 public record MappingRuleFilter(
-    String mappingRuleId,
+    List<Operation<String>> mappingRuleIdOperations,
     String claimName,
     List<String> claimNames,
     String claimValue,
@@ -32,7 +32,7 @@ public record MappingRuleFilter(
 
   public MappingRuleFilter.Builder toBuilder() {
     return new Builder()
-        .mappingRuleId(mappingRuleId)
+        .mappingRuleIdOperations(mappingRuleIdOperations)
         .claimName(claimName)
         .claimNames(claimNames)
         .claimValue(claimValue)
@@ -46,7 +46,7 @@ public record MappingRuleFilter(
   }
 
   public static final class Builder implements ObjectBuilder<MappingRuleFilter> {
-    private String mappingRuleId;
+    private List<Operation<String>> mappingRuleIdOperations;
     private Set<String> mappingRuleIds;
     private String claimName;
     private List<String> claimNames;
@@ -58,9 +58,25 @@ public record MappingRuleFilter(
     private String roleId;
     private List<MappingRuleFilter> orFilters;
 
-    public Builder mappingRuleId(final String value) {
-      mappingRuleId = value;
+    public Builder mappingRuleIdOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        mappingRuleIdOperations = addValuesToList(mappingRuleIdOperations, operations);
+      }
       return this;
+    }
+
+    public Builder mappingRuleId(final String value, final String... values) {
+      final var vals = FilterUtil.mapDefaultToOperation(value, values);
+      if (vals != null) {
+        return mappingRuleIdOperations(vals);
+      }
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder mappingRuleIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return mappingRuleIdOperations(collectValues(operation, operations));
     }
 
     public Builder claimName(final String value) {
@@ -148,7 +164,7 @@ public record MappingRuleFilter(
     @Override
     public MappingRuleFilter build() {
       return new MappingRuleFilter(
-          mappingRuleId,
+          mappingRuleIdOperations,
           claimName,
           claimNames,
           claimValue,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 public record RoleFilter(
-    String roleId,
+    List<Operation<String>> roleIdOperations,
     List<Operation<String>> nameOperations,
     String description,
     Set<String> memberIds,
@@ -38,7 +38,7 @@ public record RoleFilter(
 
   public Builder toBuilder() {
     return new Builder()
-        .roleId(roleId)
+        .roleIdOperations(roleIdOperations)
         .nameOperations(nameOperations)
         .description(description)
         .memberIds(memberIds)
@@ -50,7 +50,7 @@ public record RoleFilter(
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
-    private String roleId;
+    private List<Operation<String>> roleIdOperations;
     private List<Operation<String>> nameOperations;
     private String description;
     private Set<String> memberIds;
@@ -60,9 +60,25 @@ public record RoleFilter(
     private Map<EntityType, Set<String>> memberIdsByType;
     private List<RoleFilter> orFilters;
 
-    public Builder roleId(final String value) {
-      roleId = value;
+    public Builder roleIdOperations(final List<Operation<String>> operations) {
+      if (operations != null) {
+        roleIdOperations = addValuesToList(roleIdOperations, operations);
+      }
       return this;
+    }
+
+    public Builder roleId(final String value, final String... values) {
+      final var vals = FilterUtil.mapDefaultToOperation(value, values);
+      if (vals != null) {
+        return roleIdOperations(vals);
+      }
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder roleIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return roleIdOperations(collectValues(operation, operations));
     }
 
     public Builder nameOperations(final List<Operation<String>> operations) {
@@ -147,7 +163,7 @@ public record RoleFilter(
         throw new IllegalArgumentException("If memberIds is set, childMemberType must be set too");
       }
       return new RoleFilter(
-          roleId,
+          roleIdOperations,
           nameOperations,
           description,
           memberIds,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -27,7 +27,8 @@ public record RoleFilter(
     Set<String> roleIds,
     EntityType childMemberType,
     String tenantId,
-    Map<EntityType, Set<String>> memberIdsByType)
+    Map<EntityType, Set<String>> memberIdsByType,
+    List<RoleFilter> orFilters)
     implements FilterBase {
 
   public static RoleFilter of(
@@ -44,7 +45,8 @@ public record RoleFilter(
         .roleIds(roleIds)
         .childMemberType(childMemberType)
         .tenantId(tenantId)
-        .memberIdsByType(memberIdsByType);
+        .memberIdsByType(memberIdsByType)
+        .orFilters(orFilters);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
@@ -56,6 +58,7 @@ public record RoleFilter(
     private EntityType childMemberType;
     private String tenantId;
     private Map<EntityType, Set<String>> memberIdsByType;
+    private List<RoleFilter> orFilters;
 
     public Builder roleId(final String value) {
       roleId = value;
@@ -125,6 +128,19 @@ public record RoleFilter(
       return this;
     }
 
+    public Builder addOrOperation(final RoleFilter orOperation) {
+      if (orFilters == null) {
+        orFilters = new ArrayList<>();
+      }
+      orFilters.add(orOperation);
+      return this;
+    }
+
+    public Builder orFilters(final List<RoleFilter> orFilters) {
+      this.orFilters = orFilters;
+      return this;
+    }
+
     @Override
     public RoleFilter build() {
       if (memberIds != null && childMemberType == null) {
@@ -138,7 +154,8 @@ public record RoleFilter(
           roleIds,
           childMemberType,
           tenantId,
-          memberIdsByType);
+          memberIdsByType,
+          orFilters);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
@@ -24,7 +24,8 @@ public record UserFilter(
     List<Operation<String>> emailOperations,
     String tenantId,
     String groupId,
-    String roleId)
+    String roleId,
+    List<UserFilter> orFilters)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -34,7 +35,8 @@ public record UserFilter(
         .emailOperations(emailOperations)
         .tenantId(tenantId)
         .groupId(groupId)
-        .roleId(roleId);
+        .roleId(roleId)
+        .orFilters(orFilters);
   }
 
   public static final class Builder implements ObjectBuilder<UserFilter> {
@@ -44,6 +46,7 @@ public record UserFilter(
     private String tenantId;
     private String groupId;
     private String roleId;
+    private List<UserFilter> orFilters;
 
     public Builder usernameOperations(final List<Operation<String>> operations) {
       usernameOperations = addValuesToList(usernameOperations, operations);
@@ -117,6 +120,19 @@ public record UserFilter(
       return this;
     }
 
+    public Builder addOrOperation(final UserFilter orOperation) {
+      if (orFilters == null) {
+        orFilters = new ArrayList<>();
+      }
+      orFilters.add(orOperation);
+      return this;
+    }
+
+    public Builder orFilters(final List<UserFilter> orFilters) {
+      this.orFilters = orFilters;
+      return this;
+    }
+
     @Override
     public UserFilter build() {
       return new UserFilter(
@@ -125,7 +141,8 @@ public record UserFilter(
           emailOperations,
           tenantId,
           groupId,
-          roleId);
+          roleId,
+          orFilters);
     }
   }
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/group.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/group.ts
@@ -7,7 +7,14 @@
  */
 
 import {z} from 'zod';
-import {API_VERSION, getQueryResponseBodySchema, getQueryRequestBodySchema, type Endpoint} from './common';
+import {
+	API_VERSION,
+	advancedStringFilterSchema,
+	getOrFilterSchema,
+	getQueryResponseBodySchema,
+	getQueryRequestBodySchema,
+	type Endpoint,
+} from './common';
 import {mappingRuleSchema, type MappingRule} from './mapping-rule';
 import {userSchema} from './user';
 import {groupSchema, type Group, roleSchema} from './group-role';
@@ -66,12 +73,12 @@ const deleteGroup = {
 
 const queryGroupsRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['name', 'groupId'] as const,
-	filter: groupSchema
-		.pick({
-			groupId: true,
-			name: true,
-		})
-		.partial(),
+	filter: getOrFilterSchema(
+		z.object({
+			groupId: advancedStringFilterSchema.optional(),
+			name: advancedStringFilterSchema.optional(),
+		}),
+	),
 });
 type QueryGroupsRequestBody = z.infer<typeof queryGroupsRequestBodySchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/mapping-rule.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/mapping-rule.ts
@@ -10,6 +10,7 @@ import {z} from 'zod';
 import {
 	API_VERSION,
 	advancedStringFilterSchema,
+	getOrFilterSchema,
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	type Endpoint,
@@ -41,12 +42,14 @@ type UpdateMappingRuleResponseBody = z.infer<typeof updateMappingRuleResponseBod
 
 const queryMappingRulesRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['mappingRuleId', 'claimName', 'claimValue', 'name'] as const,
-	filter: z.object({
-		mappingRuleId: z.string().optional(),
-		claimName: z.string().optional(),
-		claimValue: z.string().optional(),
-		name: advancedStringFilterSchema.optional(),
-	}),
+	filter: getOrFilterSchema(
+		z.object({
+			mappingRuleId: advancedStringFilterSchema.optional(),
+			claimName: z.string().optional(),
+			claimValue: z.string().optional(),
+			name: advancedStringFilterSchema.optional(),
+		}),
+	),
 });
 type QueryMappingRulesRequestBody = z.infer<typeof queryMappingRulesRequestBodySchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/role.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/role.ts
@@ -10,6 +10,7 @@ import {z} from 'zod';
 import {
 	API_VERSION,
 	advancedStringFilterSchema,
+	getOrFilterSchema,
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	type Endpoint,
@@ -35,10 +36,12 @@ type UpdateRoleResponseBody = z.infer<typeof updateRoleResponseBodySchema>;
 
 const queryRolesRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['name', 'roleId'] as const,
-	filter: z.object({
-		roleId: z.string().optional(),
-		name: advancedStringFilterSchema.optional(),
-	}),
+	filter: getOrFilterSchema(
+		z.object({
+			roleId: advancedStringFilterSchema.optional(),
+			name: advancedStringFilterSchema.optional(),
+		}),
+	),
 });
 type QueryRolesRequestBody = z.infer<typeof queryRolesRequestBodySchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/user.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/user.ts
@@ -9,6 +9,7 @@
 import {z} from 'zod';
 import {
 	API_VERSION,
+	getOrFilterSchema,
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	advancedStringFilterSchema,
@@ -52,11 +53,13 @@ type UpdateUserResponseBody = z.infer<typeof updateUserResponseBodySchema>;
 
 const queryUsersRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: ['username', 'name', 'email'] as const,
-	filter: z.object({
-		username: advancedStringFilterSchema.optional(),
-		name: advancedStringFilterSchema.optional(),
-		email: advancedStringFilterSchema.optional(),
-	}),
+	filter: getOrFilterSchema(
+		z.object({
+			username: advancedStringFilterSchema.optional(),
+			name: advancedStringFilterSchema.optional(),
+			email: advancedStringFilterSchema.optional(),
+		}),
+	),
 });
 type QueryUsersRequestBody = z.infer<typeof queryUsersRequestBodySchema>;
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -928,7 +928,8 @@ components:
             - $ref: "filters.yaml#/components/schemas/StringFilterProperty"
         name:
           description: The group name search filters.
-          type: string
+          allOf:
+            - $ref: "filters.yaml#/components/schemas/StringFilterProperty"
 
     GroupFilter:
       description: Group filter request

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -918,7 +918,7 @@ components:
             - $ref: '#/components/schemas/GroupFilter'
           description: The group search filters.
 
-    GroupFilter:
+    GroupFilterFields:
       description: Group filter request
       type: object
       properties:
@@ -929,6 +929,38 @@ components:
         name:
           description: The group name search filters.
           type: string
+
+    GroupFilter:
+      description: Group filter request
+      allOf:
+        - $ref: '#/components/schemas/GroupFilterFields'
+        - type: object
+          properties:
+            $or:
+              description: |
+                Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.
+
+                Top-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.
+                <br>
+                <em>Example:</em>
+
+                ```json
+                {
+                  "$or": [
+                    { "groupId": "group-1" },
+                    { "groupId": "group-2" }
+                  ]
+                }
+                ```
+                This matches groups whose <code>groupId</code> is <em>group-1</em> or <em>group-2</em>.
+                <br>
+                <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
+              type: array
+              items:
+                $ref: '#/components/schemas/GroupFilterFields'
+          x-properties-added-in-version:
+            - propertyName: "$or"
+              addedInVersion: "8.10"
 
     GroupSearchQueryResult:
       description: Group search response.

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -376,8 +376,8 @@ components:
           allOf:
             - $ref: '#/components/schemas/MappingRuleFilter'
 
-    MappingRuleFilter:
-      description: Mapping rule search filter.
+    MappingRuleFilterFields:
+      description: Mapping rule search filter fields.
       type: object
       properties:
         claimName:
@@ -394,3 +394,35 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/MappingRuleId'
           description: The ID of the mapping rule.
+
+    MappingRuleFilter:
+      description: Mapping rule search filter.
+      allOf:
+        - $ref: '#/components/schemas/MappingRuleFilterFields'
+        - type: object
+          properties:
+            $or:
+              description: |
+                Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.
+
+                Top-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.
+                <br>
+                <em>Example:</em>
+
+                ```json
+                {
+                  "$or": [
+                    { "mappingRuleId": "rule-1" },
+                    { "mappingRuleId": "rule-2" }
+                  ]
+                }
+                ```
+                This matches mapping rules whose <code>mappingRuleId</code> is <em>rule-1</em> or <em>rule-2</em>.
+                <br>
+                <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
+              type: array
+              items:
+                $ref: '#/components/schemas/MappingRuleFilterFields'
+          x-properties-added-in-version:
+            - propertyName: "$or"
+              addedInVersion: "8.10"

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -391,9 +391,9 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         mappingRuleId:
-          allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/MappingRuleId'
           description: The ID of the mapping rule.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
 
     MappingRuleFilter:
       description: Mapping rule search filter.

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -1015,7 +1015,7 @@ components:
         roleId:
           description: The role ID search filters.
           allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/RoleId'
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         name:
           description: The role name search filters.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -1008,7 +1008,7 @@ components:
             - $ref: '#/components/schemas/RoleFilter'
           description: The role search filters.
 
-    RoleFilter:
+    RoleFilterFields:
       description: Role filter request
       type: object
       properties:
@@ -1020,6 +1020,49 @@ components:
           description: The role name search filters.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+
+    RoleFilter:
+      description: Role filter request
+      allOf:
+        - $ref: '#/components/schemas/RoleFilterFields'
+        - type: object
+          properties:
+            $or:
+              description: |
+                Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.
+
+                Top-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.
+                <br>
+                <em>Example:</em>
+
+                ```json
+                {
+                  "name": "Admin",
+                  "$or": [
+                    { "roleId": "role-1" },
+                    { "roleId": "role-2" }
+                  ]
+                }
+                ```
+                This matches roles that:
+
+                <ul style="padding-left: 20px; margin-left: 20px;">
+                  <li style="list-style-type: disc;">have name equal to <em>Admin</em></li>
+                  <li style="list-style-type: disc;">and match either:
+                    <ul style="padding-left: 20px; margin-left: 20px;">
+                      <li style="list-style-type: circle;"><code>roleId</code> is <em>role-1</em>, or</li>
+                      <li style="list-style-type: circle;"><code>roleId</code> is <em>role-2</em></li>
+                    </ul>
+                  </li>
+                </ul>
+                <br>
+                <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
+              type: array
+              items:
+                $ref: '#/components/schemas/RoleFilterFields'
+          x-properties-added-in-version:
+            - propertyName: "$or"
+              addedInVersion: "8.10"
 
     RoleSearchQueryResult:
       description: Role search response.

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -376,8 +376,8 @@ components:
         - propertyName: "filter"
           addedInVersionOverride: "8.8"
 
-    UserFilter:
-      description: User search filter.
+    UserFilterFields:
+      description: User search filter fields.
       type: object
       properties:
         username:
@@ -399,6 +399,38 @@ components:
           addedInVersionOverride: "8.8"
         - propertyName: "email"
           addedInVersionOverride: "8.8"
+
+    UserFilter:
+      description: User search filter.
+      allOf:
+        - $ref: '#/components/schemas/UserFilterFields'
+        - type: object
+          properties:
+            $or:
+              description: |
+                Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.
+
+                Top-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.
+                <br>
+                <em>Example:</em>
+
+                ```json
+                {
+                  "$or": [
+                    { "username": "user-1" },
+                    { "username": "user-2" }
+                  ]
+                }
+                ```
+                This matches users whose <code>username</code> is <em>user-1</em> or <em>user-2</em>.
+                <br>
+                <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
+              type: array
+              items:
+                $ref: '#/components/schemas/UserFilterFields'
+          x-properties-added-in-version:
+            - propertyName: "$or"
+              addedInVersion: "8.10"
 
     UserSearchResult:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -20,6 +20,8 @@ import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.GroupFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GroupMemberQuery;
 import io.camunda.search.query.GroupQuery;
@@ -401,6 +403,75 @@ public class GroupQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(groupServices).search(eq(new GroupQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchGroupsWithOrOperator() {
+    // given
+    when(groupServices.search(any(GroupQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<GroupEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(new GroupEntity(111L, "group-top", "Group Top", "description 1")))
+                .build());
+
+    final var orFilters =
+        List.of(
+            new GroupFilter.Builder().groupIdOperations(Operation.eq("group-a")).build(),
+            new GroupFilter.Builder()
+                .groupIdOperations(Operation.eq("group-b"))
+                .name("group-b-name")
+                .build());
+
+    final var expectedFilter = new GroupFilter.Builder().name("group-top");
+    orFilters.forEach(expectedFilter::addOrOperation);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GROUP_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "name": "group-top",
+                "$or": [
+                  { "groupId": "group-a" },
+                  { "groupId": "group-b", "name": "group-b-name" }
+                ]
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "groupId": "group-top",
+                 "name": "Group Top",
+                 "description": "description 1"
+               }
+             ],
+             "page": {
+               "totalItems": 1,
+               "startCursor": "f",
+               "endCursor": "v",
+               "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
+
+    verify(groupServices)
+        .search(eq(new GroupQuery.Builder().filter(expectedFilter.build()).build()), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -475,6 +475,66 @@ public class GroupQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldSearchGroupsWithNameLikeFilter() {
+    // given
+    when(groupServices.search(any(GroupQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<GroupEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(new GroupEntity(111L, "group-top", "Group Top", "description 1")))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(GROUP_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "name": { "$like": "Group*" }
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "groupId": "group-top",
+                 "name": "Group Top",
+                 "description": "description 1"
+               }
+             ],
+             "page": {
+               "totalItems": 1,
+               "startCursor": "f",
+               "endCursor": "v",
+               "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
+
+    verify(groupServices)
+        .search(
+            eq(
+                new GroupQuery.Builder()
+                    .filter(
+                        new GroupFilter.Builder().nameOperations(Operation.like("Group*")).build())
+                    .build()),
+            any());
+  }
+
+  @Test
   void shouldSearchGroupsWithIdsWithEmptyQuery() throws JsonProcessingException {
     // given
     final var groupKey1 = 111L;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.MappingRuleFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -256,6 +257,72 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
 
     verify(mappingRuleServices)
         .search(eq(new MappingRuleQuery.Builder().filter(expectedFilter.build()).build()), any());
+  }
+
+  @Test
+  void shouldSearchMappingRulesWithMappingRuleIdLikeFilter() {
+    // given
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<MappingRuleEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(
+                    List.of(
+                        new MappingRuleEntity(
+                            "mapping-top", 100L, "Claim Name1", "Claim Value1", "Map Name1")))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(MAPPING_RULE_BASE_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "mappingRuleId": { "$like": "mapping-*" }
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "claimName": "Claim Name1",
+                 "claimValue": "Claim Value1",
+                 "name": "Map Name1",
+                 "mappingRuleId": "mapping-top"
+               }
+             ],
+             "page": {
+               "totalItems": 1,
+               "startCursor": "f",
+               "endCursor": "v",
+               "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
+
+    verify(mappingRuleServices)
+        .search(
+            eq(
+                new MappingRuleQuery.Builder()
+                    .filter(
+                        new MappingRuleFilter.Builder()
+                            .mappingRuleIdOperations(Operation.like("mapping-*"))
+                            .build())
+                    .build()),
+            any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingRuleQueryControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -185,6 +186,76 @@ public class MappingRuleQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(mappingRuleServices).search(eq(new MappingRuleQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchMappingRulesWithOrOperator() {
+    // given
+    when(mappingRuleServices.search(any(MappingRuleQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<MappingRuleEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(
+                    List.of(
+                        new MappingRuleEntity(
+                            "mapping-top", 100L, "Claim Name1", "Claim Value1", "Map Name1")))
+                .build());
+
+    final var orFilters =
+        List.of(
+            new MappingRuleFilter.Builder().claimName("claim-a").claimValue("value-a").build(),
+            new MappingRuleFilter.Builder().claimName("claim-b").build());
+
+    final var expectedFilter = new MappingRuleFilter.Builder().mappingRuleId("mapping-top");
+    orFilters.forEach(expectedFilter::addOrOperation);
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(MAPPING_RULE_BASE_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "mappingRuleId": "mapping-top",
+                "$or": [
+                  { "claimName": "claim-a", "claimValue": "value-a" },
+                  { "claimName": "claim-b" }
+                ]
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "claimName": "Claim Name1",
+                 "claimValue": "Claim Value1",
+                 "name": "Map Name1",
+                 "mappingRuleId": "mapping-top"
+               }
+             ],
+             "page": {
+               "totalItems": 1,
+               "startCursor": "f",
+               "endCursor": "v",
+               "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
+
+    verify(mappingRuleServices)
+        .search(eq(new MappingRuleQuery.Builder().filter(expectedFilter.build()).build()), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -17,6 +17,8 @@ import io.camunda.search.entities.MappingRuleEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingRuleQuery;
 import io.camunda.search.query.RoleMemberQuery;
@@ -189,6 +191,75 @@ public class RoleQueryControllerTest extends RestControllerTest {
             JsonCompareMode.STRICT);
 
     verify(roleServices).search(eq(new RoleQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchRolesWithOrOperator() {
+    // given
+    when(roleServices.search(any(RoleQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<RoleEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(new RoleEntity(100L, "role-top", "Role Top", "description 1")))
+                .build());
+
+    final var orFilters =
+        List.of(
+            new RoleFilter.Builder().nameOperations(Operation.eq("Role A")).build(),
+            new RoleFilter.Builder()
+                .nameOperations(Operation.eq("Role B"))
+                .roleId("role-b")
+                .build());
+
+    final var expectedFilter = new RoleFilter.Builder().roleId("role-top");
+    orFilters.forEach(expectedFilter::addOrOperation);
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(ROLE_BASE_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "roleId": "role-top",
+                "$or": [
+                  { "name": "Role A" },
+                  { "name": "Role B", "roleId": "role-b" }
+                ]
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "name": "Role Top",
+                 "roleId": "role-top",
+                 "description": "description 1"
+               }
+             ],
+             "page": {
+               "totalItems": 1,
+               "startCursor": "f",
+               "endCursor": "v",
+               "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
+
+    verify(roleServices)
+        .search(eq(new RoleQuery.Builder().filter(expectedFilter.build()).build()), any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -263,6 +263,66 @@ public class RoleQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldSearchRolesWithRoleIdLikeFilter() {
+    // given
+    when(roleServices.search(any(RoleQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<RoleEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(new RoleEntity(100L, "role-top", "Role Top", "description 1")))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(ROLE_BASE_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "roleId": { "$like": "role-*" }
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "name": "Role Top",
+                 "roleId": "role-top",
+                 "description": "description 1"
+               }
+             ],
+             "page": {
+               "totalItems": 1,
+               "startCursor": "f",
+               "endCursor": "v",
+               "hasMoreTotalItems": false
+             }
+           }""",
+            JsonCompareMode.STRICT);
+
+    verify(roleServices)
+        .search(
+            eq(
+                new RoleQuery.Builder()
+                    .filter(
+                        new RoleFilter.Builder().roleIdOperations(Operation.like("role-*")).build())
+                    .build()),
+            any());
+  }
+
+  @Test
   void shouldSortAndPaginateSearchResult() {
     // given
     when(roleServices.search(any(RoleQuery.class), any()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UserFilter;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.UserQuery;
@@ -192,6 +194,52 @@ public class UserQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(userServices).search(eq(new UserQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchUsersWithOrOperator() {
+    // given
+    when(userServices.search(any(UserQuery.class), any())).thenReturn(SEARCH_QUERY_RESULT);
+
+    final var orFilters =
+        List.of(
+            new UserFilter.Builder().nameOperations(Operation.eq("Name A")).build(),
+            new UserFilter.Builder()
+                .nameOperations(Operation.eq("Name B"))
+                .emailOperations(Operation.eq("b@example.com"))
+                .build());
+
+    final var expectedFilter =
+        new UserFilter.Builder().usernameOperations(Operation.eq("user-top"));
+    orFilters.forEach(expectedFilter::addOrOperation);
+
+    // when / then
+    webClient
+        .post()
+        .uri(USERS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "filter": {
+                "username": "user-top",
+                "$or": [
+                  { "name": "Name A" },
+                  { "name": "Name B", "email": "b@example.com" }
+                ]
+              }
+            }""")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(userServices)
+        .search(eq(new UserQuery.Builder().filter(expectedFilter.build()).build()), any());
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds `$or` support to the four identity entity search endpoints — `POST /v2/roles/search`, `/v2/groups/search`, `/v2/users/search`, `/v2/mapping-rules/search` — mirroring the OR-connected filter convention already established for `ProcessInstanceFilter`/`ElementInstanceFilter`/`ProcessDefinitionStatisticsFilter`.

Semantics: `(top-level filter fields) AND (any one of the $or groups)`, single level of nesting (an `$or` item cannot itself contain `$or`). Authorization/tenant checks are always applied once, outside the OR grouping.

For each entity, the same pattern is applied across all layers:
- `search-domain` filter record (`orFilters` field + `addOrOperation` builder)
- Elasticsearch/OpenSearch query transformer
- RDBMS MyBatis mapper (fragment split: pure field conditions vs. auth+OR wrapper)
- REST OpenAPI schema (`XFilterFields`/`XFilter` split) + REST-to-domain mapper
- Java client fluent interface (`XFilterBase`/`XFilter` with covariant overrides + `orFilters(...)`)

Design doc: `docs/superpowers/specs/2026-08-24-identity-search-or-filter-design.md` (local, not committed — gitignored per repo convention for scratch planning docs).

### Notes for reviewers

- The nested member-search endpoints that reuse these same request/filter types (e.g. `/groups/{groupId}/roles/search`, `/tenants/{tenantId}/users/search`) now also accept `$or` as a side effect of sharing the schema — not a separate implementation, but worth being aware of when reviewing scope.
- One pre-existing, unrelated test failure exists on this branch's starting commit (`SearchRolesByTenantTest.shouldIncludeFiltersInSearchRequestBody`, in `clients/java`) — confirmed via bisection to predate this PR entirely, not introduced by this change.
- Follow-ups identified but intentionally out of scope here: `$or` support for tenant search (the fifth identity search endpoint), empty-`$or`-item validation (same pre-existing gap already present for `ProcessInstanceFilter`), and zod schema support for the frontend API client.

## Checklist
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56453 