### PR TITLE
ci: cover stable/8.10 in the E2E responses regeneration

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -1,6 +1,6 @@
 # description: Regenerates two OpenAPI-derived, checked-in artifacts for the C8
 #              Orchestration Cluster E2E test suite across all supported refs
-#              (main, stable/8.9, stable/8.8) via a matrix:
+#              (main, stable/8.10, stable/8.9, stable/8.8) via a matrix:
 #                - json-body-assertions/_generated/responses.json, via
 #                  `npm run responses:regenerate`
 #                - utils/_generated/apiPaths.ts (the `ApiPath` union consumed by
@@ -47,13 +47,15 @@ jobs:
         include:
           - ref: main
             safe: main
+          - ref: stable/8.10
+            safe: stable-8.10
           - ref: stable/8.9
             safe: stable-8.9
           - ref: stable/8.8
             safe: stable-8.8
 
     # Serialise per ref (not across the whole matrix), so two runs of the same
-    # branch never collide but the three refs still run in parallel.
+    # branch never collide but the refs still run in parallel.
     concurrency:
       group: responses-regenerate-${{ matrix.safe }}
       cancel-in-progress: false

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -45,14 +45,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # paths_expected declares whether this ref carries the typed buildUrl
+          # generator. Quoted so the value reaches the shell as plain text,
+          # with no YAML boolean coercion in between.
           - ref: main
             safe: main
+            paths_expected: 'true'
           - ref: stable/8.10
             safe: stable-8.10
+            paths_expected: 'true'
           - ref: stable/8.9
             safe: stable-8.9
+            paths_expected: 'false'
           - ref: stable/8.8
             safe: stable-8.8
+            paths_expected: 'false'
 
     # Serialise per ref (not across the whole matrix), so two runs of the same
     # branch never collide but the refs still run in parallel.
@@ -68,6 +75,7 @@ jobs:
       # instead of interpolating ${{ matrix.* }} directly (injection-safe).
       TARGET_REF: ${{ matrix.ref }}
       SAFE: ${{ matrix.safe }}
+      PATHS_EXPECTED: ${{ matrix.paths_expected }}
 
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
@@ -138,11 +146,17 @@ jobs:
             echo '{"responses":null}' > /tmp/responses.before.json
           fi
 
-      # Only main has the typed buildUrl and its generator script, and that is
-      # deliberate: a rename on a released stable branch would itself be a
-      # breaking change. Gating each apiPaths.ts step on the script being
-      # present lets the other refs skip that half instead of failing, and
-      # starts working on its own if the script ever reaches them.
+      # Not every ref carries the typed buildUrl and its generator script: the
+      # refs predating it do without, and that is deliberate — a rename on a
+      # released stable branch would itself be a breaking change. Gating each
+      # apiPaths.ts step on the script being present lets those refs skip that
+      # half instead of failing.
+      #
+      # Which refs are supposed to have it is declared per matrix row
+      # (paths_expected) rather than matched on a branch name here, so a new
+      # release branch states its answer where it is added. The probe treats a
+      # disagreement between that flag and package.json as fatal, which is what
+      # keeps the flag from going stale in silence.
       - name: Check API paths feature availability
         id: paths-feature
         working-directory: ${{ env.SUITE_DIR }}
@@ -169,14 +183,22 @@ jobs:
               ;;
             3)
               echo "available=false" >> "$GITHUB_OUTPUT"
-              echo "No paths:regenerate script on ${TARGET_REF} — typed buildUrl is main-only, skipping apiPaths.ts regeneration."
+              # The flag says this ref has the generator and package.json says
+              # otherwise. Either the flag is wrong or the branch lost the
+              # script; both leave apiPaths.ts unmaintained, so neither may pass
+              # quietly.
+              if [ "$PATHS_EXPECTED" = "true" ]; then
+                echo "::error::Matrix declares paths_expected=true for ${TARGET_REF}, but ${SUITE_DIR}/package.json has no paths:regenerate script. Fix the flag or the branch."
+                exit 1
+              fi
+              echo "No paths:regenerate script on ${TARGET_REF} — this ref predates the typed buildUrl, skipping apiPaths.ts regeneration."
               ;;
             *)
               echo "available=false" >> "$GITHUB_OUTPUT"
-              # On main the script is expected, so a broken probe is a real
-              # fault and should stop the paths half loudly. On stable refs the
-              # script is absent by design, so warn rather than fail the job.
-              if [ "$TARGET_REF" = "main" ]; then
+              # Where the script is expected, a broken probe is a real fault
+              # and should stop the paths half loudly. Where it is absent by
+              # design, warn rather than fail the job.
+              if [ "$PATHS_EXPECTED" = "true" ]; then
                 echo "::error::Could not probe ${SUITE_DIR}/package.json on ${TARGET_REF} (node exit ${rc}). Path detection is disabled until this is fixed."
                 exit 1
               fi
@@ -544,7 +566,7 @@ jobs:
             echo "## API paths regeneration — \`${TARGET_REF}\`"
             echo ""
             if [ "${PATHS_FEATURE_AVAILABLE:-false}" != "true" ]; then
-              echo ":fast_forward: No \`paths:regenerate\` on this ref (typed \`buildUrl\` is main-only) — skipped."
+              echo ":fast_forward: No \`paths:regenerate\` on this ref (it predates the typed \`buildUrl\`) — skipped."
             elif [ "${CHANGED_PATHS:-false}" = "true" ]; then
               echo ":white_check_mark: API path changes detected."
               if [ -n "${PR_URL_PATHS:-}" ]; then


### PR DESCRIPTION
Covers `stable/8.10` in the nightly C8 Orchestration Cluster responses
regeneration, and makes the API-paths probe's strictness declarative rather
than branch-name-matched.

`stable/8.10` was cut on 2026-08-24 and was not in the matrix, so its
`responses.json` and `apiPaths.ts` would go stale unnoticed.

### Why the second commit

The probe that decides whether to regenerate `apiPaths.ts` hard-failed only
when the target ref was `main`, because the typed `buildUrl` and its
`paths:regenerate` generator were main-only when the job was written.
`stable/8.10` is the first stable branch carrying both — so on that ref a
broken probe would warn, skip regeneration, and leave the job green: the
silent staleness this workflow exists to catch.

Availability is now declared per matrix row (`paths_expected`), so a new
release branch answers in the same place it is added and the shell holds no
branch names. A mismatch between the flag and `package.json` is fatal, which
keeps the hand-maintained flag from going stale in silence.

Extending the `TARGET_REF = main` test to also match `stable/8.10` was the
smaller diff, but it puts the decision 130 lines from the row that implies it
and needs editing at every branch cut.

### Verification

- `actionlint` clean.
- `paths_expected` checked against all four refs: `main` and `stable/8.10`
  have `paths:regenerate`, `stable/8.9` and `stable/8.8` do not — matching the
  matrix.
- Probe case statement simulated in isolation across all `rc` x flag
  combinations; each takes the intended branch. No current ref changes
  behaviour.
- `conftest` and `act` were not run (neither installed locally). The job needs
  Vault secrets, a GitHub App token and live `gh` PR operations, so `act`
  gives no useful signal here regardless.

### Required follow-up — separate PR against `stable/8.10`

`assert-json-body.config.json` on `stable/8.10` still carries `"ref": "main"`,
inherited from `main` at branch time, where `stable/8.9` and `stable/8.8` each
pin to their own branch:

https://github.com/camunda/camunda/blob/e47c85684507b819b93e3cdc86dd21b3e7f318ad/qa/c8-orchestration-cluster-e2e-test-suite/assert-json-body.config.json#L5

Once this merges, `npm run responses:regenerate` for `stable/8.10` fetches the
spec from **main**, so the nightly job will open PRs against `stable/8.10`
proposing `responses.json` generated from main's spec — the cross-branch drift
the job exists to prevent. It is latent only because the two specs' path sets
are still identical; it becomes wrong PRs as soon as main's spec moves ahead.

Fix on the `stable/8.10` branch: `"ref": "main"` -> `"ref": "stable/8.10"`,
then run `npm run responses:regenerate` there and commit the result. The
`apiPaths.ts` half is unaffected — its generator reads the spec from the local
checkout by design.

### Backport

None. The workflow is `schedule`/`workflow_dispatch`-triggered, so GitHub only
ever runs the copy on the default branch.

### Workflow run
[was successful](https://github.com/camunda/camunda/actions/runs/32951662263)
