### PR TITLE
test: allow gaps in ZbColumnFamilies IDs

### DIFF
--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ZbColumnFamiliesTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ZbColumnFamiliesTest.java
@@ -18,26 +18,28 @@ package io.camunda.zeebe.protocol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 
 class ZbColumnFamiliesTest {
 
+  /**
+   * Column family IDs are RocksDB key prefixes. They must stay unique, and a given CF name must
+   * keep the same ID across versions so upgrades do not point at a different prefix. Gaps are
+   * allowed (e.g. when backporting a CF that was assigned a higher ID on a newer branch).
+   */
   @Test
   void shouldNotReuseEnumValues() {
     assertThat(Arrays.stream(ZbColumnFamilies.values()).map(ZbColumnFamilies::getValue))
         .doesNotHaveDuplicates();
   }
 
-  /** If this test case fails, you can update ZbColumnFamilies to include all known enum values. */
   @Test
-  void shouldNotSkipEnumValues() {
-    assertThat(
-            Arrays.stream(ZbColumnFamilies.values()).mapToInt(ZbColumnFamilies::getValue).toArray())
-        .describedAs("The enum values must be sequential")
-        .isEqualTo(IntStream.range(0, ZbColumnFamilies.values().length).toArray());
+  void shouldHaveSortedNonNegativeEnumValues() {
+    assertThat(Arrays.stream(ZbColumnFamilies.values()).map(ZbColumnFamilies::getValue))
+        .isSorted()
+        .allMatch(value -> value >= 0);
   }
 
   public static Stream<Arguments> values() {


### PR DESCRIPTION
Column family IDs are RocksDB key prefixes. A given CF must keep the same ID across versions; uniqueness is required. Dense sequential IDs are not: backports may keep a newer-branch ID and leave unused numbers on the stable branch.

Drop shouldNotSkipEnumValues so a gap (e.g. PENDING_PROCESS_DELETIONS at 159 after 141 on stable/8.9) does not fail CI. Keep the uniqueness check and document why gaps are allowed.

## Description

<!-- Describe the goal and purpose of this PR. -->

Loosens the UT for `ZbColumnFamiliesTest` so that column families that need to be backported but need to skip numbers are not stopped by the sequential test.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues
