### PR TITLE
test: remove unnecessary header for application/json content type in actuator

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
@@ -81,7 +81,7 @@ public interface ExportersActuator {
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("POST /{exporterId}/disable")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   PlannedOperationsResponse disableExporter(@Param final String exporterId);
 
   /**
@@ -91,7 +91,7 @@ public interface ExportersActuator {
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("POST /{exporterId}/disable?physicalTenant={physicalTenant}")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   PlannedOperationsResponse disableExporter(
       @Param final String exporterId, @Param final String physicalTenant);
 
@@ -111,7 +111,7 @@ public interface ExportersActuator {
   }
 
   @RequestLine("POST /{exporterId}/enable")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   PlannedOperationsResponse enableExporter(@Param final String exporterId);
 
   /**
@@ -121,7 +121,7 @@ public interface ExportersActuator {
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("POST /{exporterId}/enable?physicalTenant={physicalTenant}")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   PlannedOperationsResponse enableExporterForTenant(
       @Param final String exporterId, @Param final String physicalTenant);
 
@@ -131,7 +131,7 @@ public interface ExportersActuator {
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("DELETE /{exporterId}")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   PlannedOperationsResponse deleteExporter(@Param final String exporterId);
 
   /**
@@ -141,7 +141,7 @@ public interface ExportersActuator {
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("DELETE /{exporterId}?physicalTenant={physicalTenant}")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   PlannedOperationsResponse deleteExporter(
       @Param final String exporterId, @Param final String physicalTenant);
 
@@ -152,7 +152,7 @@ public interface ExportersActuator {
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("GET")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   List<ExporterStatus> getExporters();
 
   /**
@@ -162,7 +162,7 @@ public interface ExportersActuator {
    *     the physical tenant is unknown
    */
   @RequestLine("GET ?physicalTenant={physicalTenant}")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Headers("Accept: application/json")
   List<ExporterStatus> getExporters(@Param final String physicalTenant);
 
   @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
## Description
In ExportersActuator a lot of HTTP call were done with `Content-Type: application/json` even though there was no body at all. Removing it makes our tests more realistic

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
