### PR TITLE
deps: change reference for response regeneration. Follow-up #61121

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/assert-json-body.config.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/assert-json-body.config.json
@@ -2,7 +2,7 @@
   "extract": {
     "repo": "https://github.com/camunda/camunda",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "ref": "main",
+    "ref": "stable/8.10",
     "outputDir": "json-body-assertions/_generated",
     "preserveCheckout": false,
     "dryRun": false,


### PR DESCRIPTION
## Description

This PR is a follow-up #61121 changing the referenced branch for response regeneration for tests.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
