### PR TITLE
fix: upgrade micrometer to 1.16.7 to resolve CVE-2026-59295

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -340,7 +340,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>1.13.4</version>
+      <version>${micrometer.version}</version>
     </dependency>
 
     <!--Lucene dependencies-->

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -63,6 +63,11 @@
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.137.Final</netty.version>
     <log4j2.version>2.25.4</log4j2.version>
+    <!-- Override Spring Boot's micrometer version to address CVE-2026-59295.
+         The 1.15.x fix (1.15.13) is Spring Enterprise-only, so we move to the 1.16.x OSS line. -->
+    <micrometer.version>1.16.7</micrometer.version>
+    <!-- Must match what micrometer-registry-prometheus 1.16.x requires -->
+    <prometheus-metrics.version>1.4.3</prometheus-metrics.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.37</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -150,6 +155,21 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Must be declared before spring-boot-dependencies so this version wins -->
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>prometheus-metrics-bom</artifactId>
+        <version>${prometheus-metrics.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${micrometer.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -84,7 +84,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.5</version.protobuf>
     <version.protobuf-common>2.45.0</version.protobuf-common>
-    <version.micrometer>1.13.4</version.micrometer>
+    <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.1</version.sbe>
     <version.scala>2.13.15</version.scala>
@@ -1021,6 +1021,19 @@
         <scope>import</scope>
       </dependency>
 
+      <!--
+        Override Spring Boot's micrometer version to address CVE-2026-59295.
+        The 1.15.x fix (1.15.13) is Spring Enterprise-only, so we move to the 1.16.x OSS line.
+        Must be declared before spring-boot-dependencies so this version wins.
+      -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
@@ -1304,14 +1317,6 @@
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
         <version>${version.reactor-netty}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${version.micrometer}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

`MicrometerHttpClientInterceptor` leaks tracking state for async HTTP requests that fail before a response arrives (connection resets, timeouts), eventually exhausting the heap — CWE-401, CVSS 5.9 (`AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H`).

The 1.15.x fix (`1.15.13`) is **Spring Enterprise-only** and not published to Maven Central, so this moves to the 1.16.x OSS line (`1.16.7`).

Changes:

- **`parent/pom.xml`** — `version.micrometer` `1.13.4` → `1.16.7`, and the `micrometer-bom` import moved **before** `spring-boot-dependencies`. It previously sat after, so it never took effect and Spring Boot's `1.15.12` won. This matches the existing pattern for the netty and opentelemetry overrides.
- **`optimize/pom.xml`** — Optimize is a separate reactor root with its own Spring Boot BOM import, so it needs the same override. Also imports `prometheus-metrics-bom:1.4.3`: `micrometer-registry-prometheus:1.16.7` declares prometheus-metrics `1.4.3`, while Spring Boot 3.5.15 pins `1.3.10`, which would otherwise silently downgrade it.
- **`optimize/backend/pom.xml`** — hardcoded `micrometer-registry-prometheus:1.13.4` → `${micrometer.version}`.

Note: the vulnerable interceptor is not referenced anywhere in this repository (no `MicrometerHttpClientInterceptor`, `MicrometerHttpRequestExecutor`, or `ObservationExecChainHandler` usages), so the leaking path was not reachable in a default deployment. This is a dependency hygiene bump rather than an urgent fix.

## Related issues

Resolves CVE-2026-59295 — https://spring.io/security/cve-2026-59295

## Definition of Done

<!-- Please check off the boxes that apply. -->

### PR-specific

- [x] Descriptive title and description
- [x] No unrelated changes included

### Verification

- `dependency:tree` confirms `1.16.7` across `zeebe/broker`, `operate/common`, `dist`, `search/search-client-connect`, `clients/java` and `optimize/backend` — no `1.15.12` or `1.13.4` left.
- `micrometer-registry-prometheus-simpleclient:1.16.7` still binds `io.prometheus:simpleclient 0.16.0`, so zeebe/dist metrics are unchanged.
- `mvn compile` passes for broker, engine, stream-platform, gateway, operate common/importer, search-connect, clients/java, the Spring Boot SDK starter and all three ES/OS exporters.
- Micrometer API usage in the repo is limited to stable `micrometer-core` surface (`MeterRegistry`, `Counter`, `Gauge`, `Timer`, `Tags`, `MeterBinder`, the grpc/jvm/netty4 binders) plus `io.micrometer.prometheus.*` from the simpleclient registry — all still present in 1.16.7. No `micrometer-tracing` usage, so the Spring Boot-managed `1.5.12` is unaffected.
- The `optimize` modules and `dist`/`tasklist-webapp` were not compiled locally for reasons unrelated to this change (local JDK 25 vs. the repo's 21 breaks Lombok/spotless in `optimize`; `dist`/`tasklist-webapp` need `package` for the `tasklist-mvc-auth-commons` shade jar). Verified against a clean baseline — CI on JDK 21 covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)