### PR TITLE
fix: unblock `yarn start` for the Optimize client under CSL

### DIFF
--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -168,7 +168,7 @@ async function setupEnvironment() {
 function buildBackend() {
   return new Promise((resolve, reject) => {
     buildBackendProcess = spawnWithArgs(
-      'mvn -f optimize/pom.xml clean install -T1C -DskipTests -Dskip.docker -pl backend -am',
+      './mvnw -f optimize/pom.xml clean install -T1C -DskipTests -Dskip.docker -pl backend -am',
       {
         cwd: _resolve(__dirname, '..', '..', '..'),
         shell: true,

--- a/optimize/client/vite.config.ts
+++ b/optimize/client/vite.config.ts
@@ -14,6 +14,9 @@ import sbom from 'rollup-plugin-sbom';
 
 const outDir = 'dist';
 
+const backend = 'http://localhost:8090';
+let sessionRejected = false;
+
 const plugins: PluginOption[] = [
   {
     name: 'treat-js-files-as-jsx',
@@ -77,22 +80,26 @@ export default defineConfig(({mode}) => ({
     open: true,
     proxy: {
       '^/(api|external/api|external/static)': {
-        target: 'http://localhost:8090',
+        target: backend,
+        configure: (proxy) => {
+          proxy.on('proxyRes', (proxyRes) => {
+            sessionRejected = proxyRes.statusCode === 401;
+          });
+        },
       },
       '^/': {
-        target: 'http://localhost:8090',
+        target: backend,
         bypass: (req) => {
           const path = req.url;
           if (path?.includes('/sso-callback') || path?.includes('/logout')) {
             return;
           }
 
-          // CSL mints `X-CSRF-TOKEN` on login, so it means authenticated; `camunda-session` exists
-          // before login too (it holds the OIDC authorization request) and cannot stand in for it.
           if (
-            req.headers.cookie?.includes('X-CSRF-TOKEN') ||
-            req.headers.cookie?.includes('X-Optimize-Authorization_0') ||
-            req.headers.cookie?.includes('X-Optimize-Refresh-Token')
+            !sessionRejected &&
+            (req.headers.cookie?.includes('X-CSRF-TOKEN') ||
+              req.headers.cookie?.includes('X-Optimize-Authorization_0') ||
+              req.headers.cookie?.includes('X-Optimize-Refresh-Token'))
           ) {
             return path;
           }

--- a/optimize/client/vite.config.ts
+++ b/optimize/client/vite.config.ts
@@ -83,11 +83,14 @@ export default defineConfig(({mode}) => ({
         target: 'http://localhost:8090',
         bypass: (req) => {
           const path = req.url;
-          if (path?.includes('/sso-callback')) {
+          if (path?.includes('/sso-callback') || path?.includes('/logout')) {
             return;
           }
 
+          // CSL mints `X-CSRF-TOKEN` on login, so it means authenticated; `camunda-session` exists
+          // before login too (it holds the OIDC authorization request) and cannot stand in for it.
           if (
+            req.headers.cookie?.includes('X-CSRF-TOKEN') ||
             req.headers.cookie?.includes('X-Optimize-Authorization_0') ||
             req.headers.cookie?.includes('X-Optimize-Refresh-Token')
           ) {


### PR DESCRIPTION
## Description

Two independent things break `yarn start` in `optimize/client` against a backend on 8.10 defaults.
Both are local-development only.

### 1. The dev server never serves the app

Every navigation was proxied to `:8090`, so you developed against the backend's bundled frontend —
no HMR, and source edits did not appear.

The proxy serves the app shell from Vite only when it recognises the browser as authenticated, and
it looked for `X-Optimize-Authorization_0` / `X-Optimize-Refresh-Token`. Those are minted by a
successful login on the **legacy** security path, and since CSL became the default in #58483 they
are no longer issued, so the check never matched.

It now also recognises **`X-CSRF-TOKEN`**, which CSL mints on login
([`shouldSetCsrfCookiesOnLogin`](https://github.com/camunda/camunda/blob/main/qa/acceptance-tests/src/test/java/io/camunda/it/csrf/CsrfTokenIT.java)).

**Why not `camunda-session`?** It looks like the obvious candidate and it is a trap. Optimize reuses
CSL's *stateful* OIDC webapp chain (ADR-0038), which creates the session **before** authentication
to hold the authorization request across the IdP round trip. So the session cookie is present while
the browser is still anonymous. Keying on it serves the shell to an anonymous browser, whose 401 the
SPA answers with `window.location.reload()` — which Vite serves again, looping forever, with the
backend never reached to issue its login redirect. This was tried and reverted.

The legacy cookies stay alongside it: `optimize.security.csl.enabled=false` still selects the legacy
path through 8.10, so a developer may be pointed at either backend.

`/logout` is also no longer claimed by Vite — it has to reach the backend for the session to be
invalidated, and once the CSRF cookie matches it would otherwise be served the shell.

### 2. The backend build shells out to a bare `mvn`

`yarn start` builds the backend before booting it. Developers who manage toolchains with asdf and
have its maven plugin installed get no build at all, only `No version is set for command mvn`,
because `.tool-versions` declares no maven version.

Rather than adding one there — which would duplicate a pin the wrapper already owns — the script now
calls `./mvnw`, as the rest of the repository does. The spawn already runs with the repository root
as its working directory. The two would have diverged immediately in any case: the wrapper pins
**3.9.16**, and the asdf maven plugin does not offer that version at all (it goes from `3.9.9` to
`3.9.17-SNAPSHOT`).

## Verification

The proxy change is verified by hand against a running CSL backend: logged in serves Vite with HMR,
logged out reaches the backend and completes the login flow, and logging out invalidates the session.

Neither change is reachable from a production build — `server.proxy` and `scripts/start-backend.js`
are both dev-only — so there is nothing for CI to cover. Prettier clean.

### Known limitation

The check is cookie presence, not validity. If a session expires server-side while `X-CSRF-TOKEN`
is still in the browser, the shell is served to what is effectively an anonymous browser and the
401-reload loop returns until the cookie is cleared. Robustly distinguishing the two states means
asking the backend on every navigation, which is more machinery than a dev proxy warrants.

## Checklist

- [ ] No backport label set. Developer-facing only, so nothing ships to users — but `stable/8.10`
      has both problems, so anyone developing off that branch hits them. Happy to add
      `backport stable/8.10` if a reviewer wants it.

## Related issues

None; both found while developing Optimize locally against a CSL backend.
