### PR TITLE
refactor: migrate cluster variables page in Admin to new design-system

### DIFF
--- a/identity/client/src/components/formV2/JSONEditor.tsx
+++ b/identity/client/src/components/formV2/JSONEditor.tsx
@@ -44,12 +44,11 @@ const JSONEditor: FC<JSONEditorProps> = observer(
   }) => {
     return (
       <Editor
+        className="w-full h-86"
         options={{ ...options, readOnly }}
         language="json"
         theme={themeStore.actualTheme === "dark" ? "vs-dark" : "light"}
         value={value}
-        height="32vh"
-        width="100%"
         onChange={(value) => {
           onChange?.(value ?? "");
         }}

--- a/identity/client/src/components/formV2/JSONEditor.tsx
+++ b/identity/client/src/components/formV2/JSONEditor.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import Editor from "@monaco-editor/react";
+import { Button, FormLabel, Stack } from "@carbon/react";
+import { observer } from "mobx-react-lite";
+import { ComponentProps, FC, useEffect, useRef, useState } from "react";
+import { beautify as beautifyJSON } from "src/utility/components/editor/jsonUtils.ts";
+import { options } from "src/utility/components/editor/options.ts";
+import useTranslate from "src/utility/localization";
+import { Copy, Edit } from "@carbon/react/icons";
+// TODO: Replace with Tailwind
+import Flex from "src/components/layout/Flex.tsx";
+import { useNotifications } from "src/components/notifications";
+import { themeStore } from "src/common/theme/theme.ts";
+
+type EditorFirstParam = Parameters<
+  NonNullable<ComponentProps<typeof JSONEditor>["onMount"]>
+>[0];
+
+type JSONEditorProps = {
+  value: string;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
+  onValidate?: (isValid: boolean) => void;
+  onMount?: (editor: {
+    showMarkers: () => void;
+    hideMarkers: () => void;
+  }) => void;
+};
+
+const JSONEditor: FC<JSONEditorProps> = observer(
+  ({
+    value,
+    onChange,
+    readOnly = false,
+    onValidate = () => {},
+    onMount = () => {},
+  }) => {
+    return (
+      <Editor
+        options={{ ...options, readOnly }}
+        language="json"
+        theme={themeStore.actualTheme === "dark" ? "vs-dark" : "light"}
+        value={value}
+        height="32vh"
+        width="100%"
+        onChange={(value) => {
+          onChange?.(value ?? "");
+        }}
+        onMount={(editor, monaco) => {
+          editor.focus();
+
+          onMount({
+            showMarkers: () => {
+              editor.trigger("", "editor.action.marker.next", undefined);
+              editor.trigger("", "editor.action.marker.prev", undefined);
+            },
+            hideMarkers: () => {
+              editor.trigger("", "closeMarkersNavigation", undefined);
+            },
+          });
+
+          monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+            ...monaco.languages.json.jsonDefaults.diagnosticsOptions,
+            schemaValidation: "error",
+            schemaRequest: "error",
+          });
+        }}
+        onValidate={(markers) => {
+          onValidate(markers.length === 0);
+        }}
+      />
+    );
+  },
+);
+
+type JSONEditorFieldProps = {
+  label: string;
+  value: string;
+  errors?: string[] | string;
+  readOnly?: boolean;
+  onChange?: (newValue: string) => void;
+  beautify?: boolean;
+  copy?: boolean;
+  copyProps?: { notificationText?: string; onClick?: () => void };
+};
+
+const JSONEditorField: FC<JSONEditorFieldProps> = ({
+  label,
+  value,
+  errors = [],
+  readOnly = false,
+  onChange,
+  beautify = false,
+  copy = false,
+  copyProps,
+}) => {
+  const { t } = useTranslate();
+  const { enqueueNotification } = useNotifications();
+
+  const [isValid, setIsValid] = useState(true);
+  const editorRef = useRef<EditorFirstParam | null>(null);
+
+  useEffect(() => {
+    if (isValid) {
+      // This will hide the problems dialog if the user has it opened. This does not hide by
+      // default even after the problems are resolved. If the json becomes invalid again, the user
+      // can reopen this dialog to see details.
+      editorRef.current?.hideMarkers();
+    }
+  }, [isValid]);
+
+  const onCopy = async () => {
+    await navigator.clipboard.writeText(value);
+
+    if (copyProps?.notificationText) {
+      enqueueNotification({
+        kind: "info",
+        title: copyProps.notificationText,
+      });
+    }
+
+    copyProps?.onClick?.();
+  };
+
+  return (
+    <Stack gap="3">
+      <Flex align="start">
+        <Flex
+          direction="column"
+          align="start"
+          spacing="small"
+          style={{ flex: 1, minHeight: "36px" }}
+        >
+          <FormLabel>{label}</FormLabel>
+          {errors?.length > 0 && (
+            <FormLabel style={{ color: "var(--cds-support-error)" }}>
+              {errors}
+            </FormLabel>
+          )}
+        </Flex>
+        <Flex spacing="small" style={{ alignSelf: "end" }}>
+          {beautify && (
+            <Button
+              onClick={() => onChange?.(beautifyJSON(value))}
+              size="sm"
+              kind="ghost"
+              renderIcon={Edit}
+            >
+              {t("format")}
+            </Button>
+          )}
+          {copy && (
+            <Button onClick={onCopy} size="sm" kind="ghost" renderIcon={Copy}>
+              {t("copy")}
+            </Button>
+          )}
+        </Flex>
+      </Flex>
+      <JSONEditor
+        value={value}
+        onChange={onChange}
+        readOnly={readOnly}
+        onValidate={setIsValid}
+        onMount={(editor) => {
+          editorRef.current = editor;
+        }}
+      />
+    </Stack>
+  );
+};
+
+export default JSONEditorField;

--- a/identity/client/src/components/formV2/JSONEditor.tsx
+++ b/identity/client/src/components/formV2/JSONEditor.tsx
@@ -7,15 +7,13 @@
  */
 
 import Editor from "@monaco-editor/react";
-import { Button, FormLabel, Stack } from "@carbon/react";
+import { Button, Label, Text } from "@camunda/design-system";
 import { observer } from "mobx-react-lite";
 import { ComponentProps, FC, useEffect, useRef, useState } from "react";
+import { Copy, Pencil } from "lucide-react";
 import { beautify as beautifyJSON } from "src/utility/components/editor/jsonUtils.ts";
 import { options } from "src/utility/components/editor/options.ts";
 import useTranslate from "src/utility/localization";
-import { Copy, Edit } from "@carbon/react/icons";
-// TODO: Replace with Tailwind
-import Flex from "src/components/layout/Flex.tsx";
 import { useNotifications } from "src/components/notifications";
 import { themeStore } from "src/common/theme/theme.ts";
 
@@ -130,39 +128,41 @@ const JSONEditorField: FC<JSONEditorFieldProps> = ({
   };
 
   return (
-    <Stack gap="3">
-      <Flex align="start">
-        <Flex
-          direction="column"
-          align="start"
-          spacing="small"
-          style={{ flex: 1, minHeight: "36px" }}
-        >
-          <FormLabel>{label}</FormLabel>
+    <div className="flex flex-col">
+      <div className="flex items-start gap-3">
+        <div className="flex min-h-9 flex-1 flex-col items-start gap-1">
+          <Label>{label}</Label>
           {errors?.length > 0 && (
-            <FormLabel style={{ color: "var(--cds-support-error)" }}>
+            <Text
+              as="p"
+              variant="helper"
+              role="alert"
+              className="text-danger-action-default"
+            >
               {errors}
-            </FormLabel>
+            </Text>
           )}
-        </Flex>
-        <Flex spacing="small" style={{ alignSelf: "end" }}>
+        </div>
+        <div className="flex items-center gap-1 self-end">
           {beautify && (
             <Button
+              type="button"
               onClick={() => onChange?.(beautifyJSON(value))}
               size="sm"
-              kind="ghost"
-              renderIcon={Edit}
+              variant="ghost"
             >
+              <Pencil aria-hidden="true" />
               {t("format")}
             </Button>
           )}
           {copy && (
-            <Button onClick={onCopy} size="sm" kind="ghost" renderIcon={Copy}>
+            <Button type="button" onClick={onCopy} size="sm" variant="ghost">
+              <Copy aria-hidden="true" />
               {t("copy")}
             </Button>
           )}
-        </Flex>
-      </Flex>
+        </div>
+      </div>
       <JSONEditor
         value={value}
         onChange={onChange}
@@ -172,7 +172,7 @@ const JSONEditorField: FC<JSONEditorFieldProps> = ({
           editorRef.current = editor;
         }}
       />
-    </Stack>
+    </div>
   );
 };
 

--- a/identity/client/src/components/formV2/JSONEditor.tsx
+++ b/identity/client/src/components/formV2/JSONEditor.tsx
@@ -25,6 +25,7 @@ type JSONEditorProps = {
   value: string;
   onChange?: (value: string) => void;
   readOnly?: boolean;
+  autoFocus?: boolean;
   onValidate?: (isValid: boolean) => void;
   onMount?: (editor: {
     showMarkers: () => void;
@@ -37,6 +38,7 @@ const JSONEditor: FC<JSONEditorProps> = observer(
     value,
     onChange,
     readOnly = false,
+    autoFocus = false,
     onValidate = () => {},
     onMount = () => {},
   }) => {
@@ -52,7 +54,9 @@ const JSONEditor: FC<JSONEditorProps> = observer(
           onChange?.(value ?? "");
         }}
         onMount={(editor, monaco) => {
-          editor.focus();
+          if (autoFocus) {
+            editor.focus();
+          }
 
           onMount({
             showMarkers: () => {
@@ -83,6 +87,7 @@ type JSONEditorFieldProps = {
   value: string;
   errors?: string[] | string;
   readOnly?: boolean;
+  autoFocus?: boolean;
   onChange?: (newValue: string) => void;
   beautify?: boolean;
   copy?: boolean;
@@ -94,6 +99,7 @@ const JSONEditorField: FC<JSONEditorFieldProps> = ({
   value,
   errors = [],
   readOnly = false,
+  autoFocus = false,
   onChange,
   beautify = false,
   copy = false,
@@ -167,6 +173,7 @@ const JSONEditorField: FC<JSONEditorFieldProps> = ({
         value={value}
         onChange={onChange}
         readOnly={readOnly}
+        autoFocus={autoFocus}
         onValidate={setIsValid}
         onMount={(editor) => {
           editorRef.current = editor;

--- a/identity/client/src/pages/cluster-variables/ListV2.tsx
+++ b/identity/client/src/pages/cluster-variables/ListV2.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import useTranslate from "src/utility/localization";
+import Page, { PageHeader } from "src/components/layoutV2/Page";
+import EntityList from "src/components/entityListV2";
+import {
+  InlineNotification,
+  TranslatedErrorInlineNotification,
+} from "src/components/notificationsV2/InlineNotification";
+import useModal, { useEntityModal } from "src/components/modalV2/useModal";
+import { usePagination } from "src/utility/api";
+import { useQuery } from "@tanstack/react-query";
+import { clusterVariableQueries } from "src/utility/api/cluster-variables/queries";
+import PageEmptyState from "src/components/layoutV2/PageEmptyState";
+import { AddModal } from "./modalsV2/add-modal";
+import DeleteModal from "./modalsV2/DeleteModal";
+import DetailsModal from "./modalsV2/DetailsModal";
+import EditModal from "./modalsV2/EditModal";
+import { usePollingReload } from "src/utility/hooks/usePollingReload";
+import { type QueryClusterVariablesResponseBody } from "@camunda/camunda-api-zod-schemas/8.10";
+import { useCallback } from "react";
+
+export default function List({ isSaaS }: { isSaaS: boolean }) {
+  const { t } = useTranslate("clusterVariables");
+  const { pageParams, page, search, ...paginationCallbacks } = usePagination();
+  const {
+    data: clusterVariables,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery(clusterVariableQueries.search(pageParams));
+
+  const compareClusterVariables = useCallback(
+    (current: QueryClusterVariablesResponseBody) => {
+      const previous = clusterVariables?.items ?? [];
+      if (previous.length !== current.items.length) {
+        return true;
+      }
+
+      return previous.some((prev) => {
+        const match = current.items.find(
+          (curr) =>
+            curr.name === prev.name &&
+            curr.scope === prev.scope &&
+            curr.tenantId === prev.tenantId,
+        );
+        if (!match) {
+          return true;
+        }
+        return JSON.stringify(prev.value) !== JSON.stringify(match.value);
+      });
+    },
+    [clusterVariables],
+  );
+
+  const { startPolling, pollingStatus, resetPollingStatus, isPolling } =
+    usePollingReload<QueryClusterVariablesResponseBody>(
+      reload,
+      compareClusterVariables,
+    );
+
+  const isInitialLoad = loading && !isPolling;
+
+  const reloadWithPolling = () => {
+    startPolling();
+  };
+
+  const [addClusterVariable, addClusterVariableModal] = useModal(
+    AddModal,
+    reloadWithPolling,
+    { isSaaS },
+  );
+  const [deleteClusterVariable, deleteClusterVariableModal] = useEntityModal(
+    DeleteModal,
+    reloadWithPolling,
+  );
+  const [viewClusterVariable, viewClusterVariableModal] = useEntityModal(
+    DetailsModal,
+    () => {},
+  );
+  const [editClusterVariable, editClusterVariableModal] = useEntityModal(
+    EditModal,
+    reloadWithPolling,
+  );
+
+  const shouldShowEmptyState =
+    success && !search && !clusterVariables?.items.length;
+
+  const pageHeader = (
+    <PageHeader
+      title={t("clusterVariables")}
+      linkText={t("clusterVariables").toLowerCase()}
+      docsLinkPath="/components/modeler/feel/cluster-variable/cluster-variable-overview/"
+      shouldShowDocumentationLink={!shouldShowEmptyState}
+    />
+  );
+
+  if (shouldShowEmptyState) {
+    return (
+      <Page>
+        {pageHeader}
+        <PageEmptyState
+          resourceTypeTranslationKey={"clusterVariable"}
+          docsLinkPath="/components/modeler/feel/cluster-variable/cluster-variable-overview/"
+          handleClick={addClusterVariable}
+        />
+        {addClusterVariableModal}
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      {pageHeader}
+      <EntityList
+        data={
+          clusterVariables?.items.map((clusterVar) => {
+            return {
+              ...clusterVar,
+              id: `${clusterVar.name}__${clusterVar.tenantId}`,
+              value: clusterVar.value,
+              scopeValue:
+                clusterVar.scope === "GLOBAL"
+                  ? t("clusterVariableScopeTypeGlobal")
+                  : `${t("clusterVariableScopeTypeTenant")}: ${clusterVar.tenantId}`,
+            };
+          }) || []
+        }
+        headers={[
+          { header: t("name"), key: "name", isSortable: true },
+          { header: t("value"), key: "value" },
+          { header: t("scope"), key: "scopeValue" },
+        ]}
+        addEntityLabel={t("createClusterVariable")}
+        onAddEntity={addClusterVariable}
+        loading={isInitialLoad}
+        menuItems={[
+          {
+            label: t("view"),
+            onClick: ({ name, value }) => {
+              viewClusterVariable({
+                name,
+                value,
+              });
+            },
+          },
+          {
+            label: t("edit"),
+            onClick: ({ name, value, scope, tenantId }) => {
+              editClusterVariable({
+                name,
+                value,
+                scope,
+                tenantId,
+              });
+            },
+          },
+          {
+            label: t("delete"),
+            isDangerous: true,
+            onClick: ({ name, scope, tenantId }) => {
+              deleteClusterVariable({
+                name,
+                scope,
+                tenantId,
+              });
+            },
+          },
+        ]}
+        searchPlaceholder={t("searchByClusterVariableName")}
+        searchKey="name"
+        page={{ ...page, ...clusterVariables?.page }}
+        {...paginationCallbacks}
+      />
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("clusterVariablesCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+      {pollingStatus === "timeout" && (
+        <InlineNotification
+          kind="warning"
+          title={t("clusterVariableUpdateTakingLonger")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              resetPollingStatus();
+              void reload();
+            },
+          }}
+        />
+      )}
+      {addClusterVariableModal}
+      {deleteClusterVariableModal}
+      {viewClusterVariableModal}
+      {editClusterVariableModal}
+    </Page>
+  );
+}

--- a/identity/client/src/pages/cluster-variables/index.tsx
+++ b/identity/client/src/pages/cluster-variables/index.tsx
@@ -8,9 +8,13 @@
 
 import { FC, lazy, Suspense } from "react";
 import { ListPageFallback } from "src/components/fallbacks";
+import { ListPageFallback as ListPageFallbackV2 } from "src/components/fallbacksV2";
 import PageRoutes from "src/components/router/PageRoutes.tsx";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "src/feature-flags";
 
-const List = lazy(() => import("./List"));
+const List = lazy(() =>
+  IS_NEW_DESIGN_SYSTEM_ENABLED ? import("./ListV2") : import("./List"),
+);
 
 type ClusterVariablesProps = {
   isSaaS: boolean;
@@ -19,7 +23,15 @@ type ClusterVariablesProps = {
 const ClusterVariables: FC<ClusterVariablesProps> = ({ isSaaS }) => (
   <PageRoutes
     indexElement={
-      <Suspense fallback={<ListPageFallback />}>
+      <Suspense
+        fallback={
+          IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+            <ListPageFallbackV2 />
+          ) : (
+            <ListPageFallback />
+          )
+        }
+      >
         <List isSaaS={isSaaS} />
       </Suspense>
     }

--- a/identity/client/src/pages/cluster-variables/modalsV2/DeleteModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/DeleteModal.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useNotifications } from "src/components/notifications";
+import {
+  DeleteModal as Modal,
+  UseEntityModalProps,
+} from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { clusterVariableMutations } from "src/utility/api/cluster-variables/mutations";
+import type { ClusterVariable } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const DeleteModal: FC<
+  UseEntityModalProps<Pick<ClusterVariable, "scope" | "tenantId" | "name">>
+> = ({ open, onClose, onSuccess, entity: deleteClusterVariableParams }) => {
+  const { t, Translate } = useTranslate("clusterVariables");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    clusterVariableMutations.delete(qc),
+  );
+
+  const handleSubmit = () => {
+    mutate(deleteClusterVariableParams, {
+      onSuccess: () => {
+        enqueueNotification({
+          kind: "success",
+          title: t("clusterVariableHasBeenDeleted"),
+          subtitle: t("deleteClusterVariableSuccess", {
+            name: deleteClusterVariableParams.name,
+          }),
+        });
+        onSuccess();
+      },
+    });
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("deleteClusterVariable")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("deletingClusterVariable")}
+      onClose={onClose}
+      confirmLabel={t("deleteClusterVariable")}
+    >
+      <p>
+        <Translate
+          i18nKey="deleteClusterVariableConfirmation"
+          values={{ name: deleteClusterVariableParams.name }}
+        />
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/cluster-variables/modalsV2/DetailsModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/DetailsModal.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import Modal, { UseEntityModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { beautify } from "src/utility/components/editor/jsonUtils.ts";
+import JSONEditor from "src/components/formV2/JSONEditor.tsx";
+
+const DetailsModal: FC<
+  UseEntityModalProps<{ name: string; value: string }>
+> = ({ open, onClose, entity: clusterVariable }) => {
+  const { t } = useTranslate("clusterVariables");
+
+  return (
+    <Modal
+      passiveModal
+      preventCloseOnClickOutside
+      open={open}
+      onClose={onClose}
+      headline={clusterVariable.name}
+      size="md"
+    >
+      <JSONEditor
+        readOnly
+        label={t("clusterVariableDetailsValue")}
+        value={beautify(clusterVariable.value)}
+        copy
+        copyProps={{
+          notificationText: t("copiedClusterVariableValue", {
+            name: clusterVariable.name,
+          }),
+        }}
+      />
+    </Modal>
+  );
+};
+
+export default DetailsModal;

--- a/identity/client/src/pages/cluster-variables/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/EditModal.tsx
@@ -108,6 +108,7 @@ const EditModal: FC<UseEntityModalProps<ClusterVariable>> = ({
             label={t("clusterVariableDetailsValue")}
             errors={fieldState.error?.message}
             beautify
+            autoFocus
           />
         )}
       />

--- a/identity/client/src/pages/cluster-variables/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/EditModal.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { FormModal, UseEntityModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { beautify, isValid } from "src/utility/components/editor/jsonUtils.ts";
+import JSONEditor from "src/components/formV2/JSONEditor.tsx";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { clusterVariableMutations } from "src/utility/api/cluster-variables/mutations";
+import { useNotifications } from "src/components/notifications";
+import type { ClusterVariable } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type FormData = {
+  value: string;
+};
+
+const EditModal: FC<UseEntityModalProps<ClusterVariable>> = ({
+  open,
+  onClose,
+  onSuccess,
+  entity: clusterVariable,
+}) => {
+  const { t } = useTranslate("clusterVariables");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(clusterVariableMutations.update(qc));
+  const initialValue = beautify(clusterVariable.value);
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    formState: { isValid: isFormValid },
+  } = useForm<FormData>({
+    defaultValues: {
+      value: initialValue,
+    },
+    mode: "all",
+  });
+
+  const currentValue = watch("value");
+  const hasChanged = currentValue !== initialValue;
+  const isSubmitDisabled = !isFormValid || !hasChanged;
+
+  const handleSave = (data: FormData) => {
+    mutate(
+      {
+        name: clusterVariable.name,
+        scope: clusterVariable.scope,
+        tenantId: clusterVariable.tenantId,
+        value: JSON.parse(data.value.trim()),
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("clusterVariableUpdated"),
+            subtitle: t("clusterVariableUpdatedSuccessfully", {
+              name: clusterVariable.name,
+            }),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <FormModal
+      open={open}
+      onClose={onClose}
+      headline={t("editClusterVariable", { name: clusterVariable.name })}
+      onSubmit={handleSubmit(handleSave)}
+      confirmLabel={t("save")}
+      submitDisabled={isSubmitDisabled}
+      loading={loading}
+      loadingDescription={t("updatingClusterVariable")}
+      error={error}
+    >
+      <Controller
+        name="value"
+        control={control}
+        rules={{
+          validate: (value) => {
+            if (!value || !value.trim()) {
+              return t("clusterVariableValueRequired");
+            } else if (!isValid(value.trim())) {
+              return t("clusterVariableValueInvalid");
+            }
+
+            return true;
+          },
+        }}
+        render={({ field, fieldState }) => (
+          <JSONEditor
+            {...field}
+            label={t("clusterVariableDetailsValue")}
+            errors={fieldState.error?.message}
+            beautify
+          />
+        )}
+      />
+    </FormModal>
+  );
+};
+
+export default EditModal;

--- a/identity/client/src/pages/cluster-variables/modalsV2/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/add-modal/AddModal.tsx
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC } from "react";
+import { FC, useId } from "react";
 import type { ClusterVariableScope } from "@camunda/camunda-api-zod-schemas/8.10";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { clusterVariableMutations } from "src/utility/api/cluster-variables/mutations";
-import { RadioButton, RadioButtonGroup, Stack } from "@carbon/react";
+import { Label, RadioGroup, RadioGroupItem } from "@camunda/design-system";
 import { Controller, useForm } from "react-hook-form";
 import { useNotifications } from "src/components/notifications";
 import { FormModal, UseModalProps } from "src/components/modalV2";
@@ -36,6 +36,7 @@ export const AddModal: FC<AddModalProps> = ({
   isSaaS,
 }) => {
   const { t } = useTranslate("clusterVariables");
+  const scopeLabelId = useId();
   const { enqueueNotification } = useNotifications();
   const qc = useQueryClient();
   const {
@@ -91,86 +92,83 @@ export const AddModal: FC<AddModalProps> = ({
       loadingDescription={t("creatingClusterVariable")}
       confirmLabel={t("createClusterVariable")}
     >
-      <Stack orientation="vertical" gap="6">
-        <Controller
-          name="name"
-          control={control}
-          rules={{
-            required: t("clusterVariableNameRequired"),
-          }}
-          render={({ field, fieldState }) => (
-            <TextField
-              {...field}
-              label={t("name")}
-              placeholder={t("clusterVariableNamePlaceholder")}
-              errors={fieldState.error?.message}
-              autoFocus
-            />
-          )}
-        />
-        <Controller
-          name="scope"
-          control={control}
-          render={({ field }) => (
-            <RadioButtonGroup
-              name="scopeType"
-              legendText={t("scope")}
-              orientation="horizontal"
-            >
-              <RadioButton
-                value={"GLOBAL"}
-                checked={field.value === "GLOBAL"}
-                onClick={() => field.onChange("GLOBAL")}
-                labelText={<span>{t("clusterVariableScopeTypeGlobal")}</span>}
-                type="radio"
-              />
-              <RadioButton
-                value={"TENANT"}
-                checked={field.value === "TENANT"}
-                onClick={() => field.onChange("TENANT")}
-                labelText={<span>{t("clusterVariableScopeTypeTenant")}</span>}
-                disabled={isSaaS}
-                type="radio"
-              />
-            </RadioButtonGroup>
-          )}
-        />
-        {isTenantScoped && (
-          <Controller
-            name="tenantId"
-            control={control}
-            render={({ field }) => (
-              <ClusterVariableTenantDropdown
-                tenantId={field.value}
-                onChange={(tenantId) => field.onChange(tenantId)}
-              />
-            )}
+      <Controller
+        name="name"
+        control={control}
+        rules={{
+          required: t("clusterVariableNameRequired"),
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("name")}
+            placeholder={t("clusterVariableNamePlaceholder")}
+            errors={fieldState.error?.message}
+            autoFocus
           />
         )}
-        <Controller
-          name="value"
-          control={control}
-          rules={{
-            validate: (value) => {
-              if (!value || !value.trim()) {
-                return t("clusterVariableValueRequired");
-              } else if (!isValid(value.trim())) {
-                return t("clusterVariableValueInvalid");
+      />
+      <Controller
+        name="scope"
+        control={control}
+        render={({ field }) => (
+          <div className="flex flex-col gap-1.5">
+            <Label id={scopeLabelId}>{t("scope")}</Label>
+            <RadioGroup
+              aria-labelledby={scopeLabelId}
+              value={field.value}
+              onValueChange={(value) =>
+                field.onChange(value as ClusterVariableScope)
               }
-
-              return true;
-            },
-          }}
-          render={({ field, fieldState }) => (
-            <JSONEditor
-              {...field}
-              label={t("clusterVariableCreateValue")}
-              errors={fieldState.error?.message}
-              beautify
+              className="flex flex-row gap-4"
+            >
+              <Label className="flex items-center gap-2">
+                <RadioGroupItem value="GLOBAL" />
+                {t("clusterVariableScopeTypeGlobal")}
+              </Label>
+              <Label className="flex items-center gap-2">
+                <RadioGroupItem value="TENANT" disabled={isSaaS} />
+                {t("clusterVariableScopeTypeTenant")}
+              </Label>
+            </RadioGroup>
+          </div>
+        )}
+      />
+      {isTenantScoped && (
+        <Controller
+          name="tenantId"
+          control={control}
+          render={({ field }) => (
+            <ClusterVariableTenantDropdown
+              tenantId={field.value}
+              onChange={(tenantId) => field.onChange(tenantId)}
             />
           )}
         />
-      </Stack>
+      )}
+      <Controller
+        name="value"
+        control={control}
+        rules={{
+          validate: (value) => {
+            if (!value || !value.trim()) {
+              return t("clusterVariableValueRequired");
+            } else if (!isValid(value.trim())) {
+              return t("clusterVariableValueInvalid");
+            }
+
+            return true;
+          },
+        }}
+        render={({ field, fieldState }) => (
+          <JSONEditor
+            {...field}
+            label={t("clusterVariableCreateValue")}
+            errors={fieldState.error?.message}
+            beautify
+          />
+        )}
+      />
     </FormModal>
   );
 };

--- a/identity/client/src/pages/cluster-variables/modalsV2/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/add-modal/AddModal.tsx
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import type { ClusterVariableScope } from "@camunda/camunda-api-zod-schemas/8.10";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { clusterVariableMutations } from "src/utility/api/cluster-variables/mutations";
+import { RadioButton, RadioButtonGroup, Stack } from "@carbon/react";
+import { Controller, useForm } from "react-hook-form";
+import { useNotifications } from "src/components/notifications";
+import { FormModal, UseModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import TextField from "src/components/formV2/TextField.tsx";
+import JSONEditor from "src/components/formV2/JSONEditor.tsx";
+import { isValid } from "src/utility/components/editor/jsonUtils.ts";
+import ClusterVariableTenantDropdown from "./ClusterVariableTenantDropdown.tsx";
+
+type FormData = {
+  name: string;
+  value: string;
+  scope: ClusterVariableScope;
+  tenantId?: string;
+};
+
+type AddModalProps = UseModalProps & { isSaaS: boolean };
+
+export const AddModal: FC<AddModalProps> = ({
+  open,
+  onClose,
+  onSuccess,
+  isSaaS,
+}) => {
+  const { t } = useTranslate("clusterVariables");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(clusterVariableMutations.create(qc));
+
+  const { control, handleSubmit, watch } = useForm<FormData>({
+    defaultValues: {
+      name: "",
+      value: "",
+      scope: "GLOBAL",
+      tenantId: "",
+    },
+    mode: "all",
+  });
+
+  const watchedScope = watch("scope");
+  const isTenantScoped = watchedScope === "TENANT";
+
+  const onSubmit = (data: FormData) => {
+    mutate(
+      {
+        name: data.name.trim(),
+        value: JSON.parse(data.value.trim()),
+        scope: data.scope,
+        tenantId: isTenantScoped ? (data.tenantId ?? null) : "",
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("clusterVariableCreated"),
+            subtitle: t("clusterVariableCreatedSuccessfully", {
+              clusterVariableName: data.name,
+            }),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("createClusterVariable")}
+      onClose={onClose}
+      onSubmit={handleSubmit(onSubmit)}
+      loading={loading}
+      error={error}
+      loadingDescription={t("creatingClusterVariable")}
+      confirmLabel={t("createClusterVariable")}
+    >
+      <Stack orientation="vertical" gap="6">
+        <Controller
+          name="name"
+          control={control}
+          rules={{
+            required: t("clusterVariableNameRequired"),
+          }}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label={t("name")}
+              placeholder={t("clusterVariableNamePlaceholder")}
+              errors={fieldState.error?.message}
+              autoFocus
+            />
+          )}
+        />
+        <Controller
+          name="scope"
+          control={control}
+          render={({ field }) => (
+            <RadioButtonGroup
+              name="scopeType"
+              legendText={t("scope")}
+              orientation="horizontal"
+            >
+              <RadioButton
+                value={"GLOBAL"}
+                checked={field.value === "GLOBAL"}
+                onClick={() => field.onChange("GLOBAL")}
+                labelText={<span>{t("clusterVariableScopeTypeGlobal")}</span>}
+                type="radio"
+              />
+              <RadioButton
+                value={"TENANT"}
+                checked={field.value === "TENANT"}
+                onClick={() => field.onChange("TENANT")}
+                labelText={<span>{t("clusterVariableScopeTypeTenant")}</span>}
+                disabled={isSaaS}
+                type="radio"
+              />
+            </RadioButtonGroup>
+          )}
+        />
+        {isTenantScoped && (
+          <Controller
+            name="tenantId"
+            control={control}
+            render={({ field }) => (
+              <ClusterVariableTenantDropdown
+                tenantId={field.value}
+                onChange={(tenantId) => field.onChange(tenantId)}
+              />
+            )}
+          />
+        )}
+        <Controller
+          name="value"
+          control={control}
+          rules={{
+            validate: (value) => {
+              if (!value || !value.trim()) {
+                return t("clusterVariableValueRequired");
+              } else if (!isValid(value.trim())) {
+                return t("clusterVariableValueInvalid");
+              }
+
+              return true;
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <JSONEditor
+              {...field}
+              label={t("clusterVariableCreateValue")}
+              errors={fieldState.error?.message}
+              beautify
+            />
+          )}
+        />
+      </Stack>
+    </FormModal>
+  );
+};

--- a/identity/client/src/pages/cluster-variables/modalsV2/add-modal/ClusterVariableTenantDropdown.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/add-modal/ClusterVariableTenantDropdown.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { usePagination } from "src/utility/api";
+import { tenantQueries } from "src/utility/api/tenants/queries";
+import { Dropdown } from "@carbon/react";
+import useTranslate from "src/utility/localization";
+import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.10";
+
+export type TenantDropdownProps = {
+  tenantId: string | undefined;
+  onChange: (tenantId: string | undefined) => void;
+};
+
+const ClusterVariableTenantDropdown: FC<TenantDropdownProps> = ({
+  tenantId,
+  onChange,
+}) => {
+  const { t } = useTranslate("clusterVariables");
+
+  const { pageParams } = usePagination();
+  const { data: tenants, isLoading: tenantLoading } = useQuery(
+    tenantQueries.search(pageParams),
+  );
+
+  // Set tenantId to first tenant if not set
+  useEffect(() => {
+    if (
+      tenants?.items?.length &&
+      (!tenantId ||
+        !tenants.items.some((tenant) => tenant.tenantId === tenantId))
+    ) {
+      onChange(tenants.items[0].tenantId);
+    }
+  }, [tenants, tenantId, onChange]);
+
+  return (
+    <Dropdown
+      id="cluster-variable-tenant-id-dropdown"
+      label={t(
+        tenantLoading
+          ? "clusterVariableTenantIdLoadingPlaceholder"
+          : "clusterVariableTenantIdPlaceholder",
+      )}
+      titleText={t("clusterVariableTenantId")}
+      items={tenants?.items || []}
+      onChange={({ selectedItem }) => onChange(selectedItem?.tenantId)}
+      itemToString={(item: Tenant) => item.name || ""}
+      selectedItem={tenants?.items.find(
+        (tenant) => tenant.tenantId === tenantId,
+      )}
+    />
+  );
+};
+
+export default ClusterVariableTenantDropdown;

--- a/identity/client/src/pages/cluster-variables/modalsV2/add-modal/ClusterVariableTenantDropdown.tsx
+++ b/identity/client/src/pages/cluster-variables/modalsV2/add-modal/ClusterVariableTenantDropdown.tsx
@@ -10,9 +10,15 @@ import { FC, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { usePagination } from "src/utility/api";
 import { tenantQueries } from "src/utility/api/tenants/queries";
-import { Dropdown } from "@carbon/react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@camunda/design-system";
+import FormField from "src/components/formV2/FormField";
 import useTranslate from "src/utility/localization";
-import type { Tenant } from "@camunda/camunda-api-zod-schemas/8.10";
 
 export type TenantDropdownProps = {
   tenantId: string | undefined;
@@ -42,21 +48,35 @@ const ClusterVariableTenantDropdown: FC<TenantDropdownProps> = ({
   }, [tenants, tenantId, onChange]);
 
   return (
-    <Dropdown
-      id="cluster-variable-tenant-id-dropdown"
-      label={t(
-        tenantLoading
-          ? "clusterVariableTenantIdLoadingPlaceholder"
-          : "clusterVariableTenantIdPlaceholder",
+    <FormField label={t("clusterVariableTenantId")}>
+      {({ id }) => (
+        <Select
+          value={
+            tenants?.items.some((tenant) => tenant.tenantId === tenantId)
+              ? tenantId
+              : ""
+          }
+          onValueChange={(value) => onChange(value || undefined)}
+        >
+          <SelectTrigger id={id} className="w-full">
+            <SelectValue
+              placeholder={t(
+                tenantLoading
+                  ? "clusterVariableTenantIdLoadingPlaceholder"
+                  : "clusterVariableTenantIdPlaceholder",
+              )}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {(tenants?.items ?? []).map((tenant) => (
+              <SelectItem key={tenant.tenantId} value={tenant.tenantId}>
+                {tenant.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       )}
-      titleText={t("clusterVariableTenantId")}
-      items={tenants?.items || []}
-      onChange={({ selectedItem }) => onChange(selectedItem?.tenantId)}
-      itemToString={(item: Tenant) => item.name || ""}
-      selectedItem={tenants?.items.find(
-        (tenant) => tenant.tenantId === tenantId,
-      )}
-    />
+    </FormField>
   );
 };
 

--- a/identity/client/src/pages/cluster-variables/modalsV2/add-modal/index.ts
+++ b/identity/client/src/pages/cluster-variables/modalsV2/add-modal/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export { AddModal } from "./AddModal";


### PR DESCRIPTION
## Description

This PR migrates the cluster-variables page to the new design system. The migration is split into 2 commits:
- First commit duplicates the required components and guards them behind a feature flag
- Second commit migrates the duplicated components if they need migration.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60631
