### PR TITLE
feat: add x-scope vendor extension to mark cluster-wide vs physical-tenant endpoints

### DIFF
--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -86,6 +86,7 @@ All descriptive text (summaries, descriptions, property docs) should follow the 
 - `tags` — exactly one tag matching the resource
 - `x-eventually-consistent` — explicitly `true` or `false` (see §2.5)
 - `x-added-in-version` — the Camunda version in which the operation was introduced, e.g., `"8.9"` (see §2.17)
+- `x-scope` — `cluster-wide` or `physical-tenant`, matching whether the endpoint is reachable via a physical-tenant-prefixed route (see §2.20)
 
 **Path patterns:**
 
@@ -1312,6 +1313,90 @@ correct deny shape — `4xx` for `reject`, `200` + target-absent for `filter`. S
 ADR decision **D8** for why static derivation of the deny outcome is unsound and
 the runtime oracle is authoritative.
 
+### 2.20 Scope annotation (`x-scope`)
+
+Every operation **must** declare `x-scope` as either `cluster-wide` or
+`physical-tenant`. This tells the docs API reference whether an operation acts
+on the whole cluster or on a single physical tenant, without having to
+fragment the existing tag-based grouping (`groupPathsBy: "tag"`) to express
+it. See
+[camunda-docs#8886 (comment)](https://github.com/camunda/camunda-docs/issues/8886#issuecomment-5414815612)
+for the motivating discussion and camunda/camunda#61157 for the annotation's
+introduction.
+
+```yaml
+/backups/runtime:
+  post:
+    operationId: takeRuntimeBackup
+    x-scope: physical-tenant
+    tags:
+      - Backup
+
+/cluster/v2/backups/runtime:
+  post:
+    operationId: takeClusterRuntimeBackup
+    x-scope: cluster-wide
+    tags:
+      - Backup
+```
+
+#### How to pick a value
+
+The value must match reachability — whether
+`PhysicalTenantRequestMappingHandlerMapping` actually registers a
+`/physical-tenants/{id}/...`-prefixed sibling route for the operation's
+controller — not a guess based on the path or tag:
+
+- `physical-tenant` — the default. A tenant-prefixed sibling route is
+  registered for the operation's controller, so it operates within a single
+  physical tenant's context (the default tenant when called without a
+  prefix).
+- `cluster-wide` — no tenant-prefixed sibling is registered; the operation
+  exists exactly once, cluster-wide. Today this is exactly the set of
+  `/cluster/v2/...` operations sourced from `cluster-admin.yaml`.
+
+The usual signal for `cluster-wide` is a controller annotated
+`@io.camunda.zeebe.gateway.rest.annotation.ClusterScoped`. That annotation is
+not, by itself, what makes a route unreachable per tenant, though: `prefix()`
+only builds a tenant-prefixed sibling when the path matches one of
+`PhysicalTenantRequestMappingHandlerMapping`'s `PREFIXABLE_ROOTS` (`/v2`,
+`/v3/api-docs`, `/post-logout`, `/custom.css`, the web apps). `/cluster/v2/...`
+paths match none of them, so they get no tenant-prefixed sibling whether or
+not their controller carries `@ClusterScoped` — the annotation and the
+prefixable-root check happen to agree for every controller today, but only
+the reachability check is the actual definition. When adding a new endpoint,
+verify reachability directly rather than relying on the annotation alone; if
+`@ClusterScoped` and reachability ever disagree, treat that as a bug to fix,
+not a reason to pick a value with `x-scope`.
+
+`x-scope` tracks reachability, not whether the returned data happens to be
+identical across tenants. Two known cases where reachability and semantics
+diverge:
+
+- `GET /license` is annotated `x-scope: physical-tenant` because it is
+  reachable under a `/physical-tenants/{id}/` prefix, even though the license
+  itself is a single cluster-wide fact that does not vary per tenant.
+- `GET /status` (`getStatus`) is annotated `x-scope: physical-tenant`, but it
+  is only reachable at the default physical tenant's prefix
+  (`/physical-tenants/default/v2/status`); every other physical tenant id
+  returns `404`. A two-valued reachability badge cannot express "default
+  tenant only," so the badge will read as "works for any physical tenant,"
+  which for this endpoint is not true.
+
+These are documented warts, not endpoints to imitate — most operations are
+either genuinely cluster-wide or genuinely usable at any physical tenant
+prefix.
+
+#### What the Spectral rule enforces
+
+The `require-scope` rule (severity `error`) checks every operation under
+`paths` (`get`, `post`, `put`, `patch`, `delete`) and fails the build if
+`x-scope` is missing, is not one of `cluster-wide` / `physical-tenant`, or
+disagrees with the path-derived expectation (`cluster-wide` for
+`/cluster/v2/...` paths, `physical-tenant` otherwise). The rule does not
+cross-check the value against the `@ClusterScoped` annotation in Java directly
+— that agreement is a reviewer responsibility.
+
 ---
 
 ## 3. Spectral linting & custom rules
@@ -1359,6 +1444,7 @@ The ruleset lives in `zeebe/gateway-protocol/.spectral.yaml`. Custom functions a
 | `valid-deprecated-enum-members`            | error    | `x-deprecated-enum-members` must be well-formed                                                   |
 | `require-added-in-version`                 | error    | Every operation must declare `x-added-in-version` (see §2.17)                                     |
 | `properties-added-in-version-shape`        | error    | `x-properties-added-in-version` entries must be `{propertyName, addedInVersion}` only (see §2.17) |
+| `require-scope`                            | error    | Every operation must declare `x-scope` as `cluster-wide` or `physical-tenant` (see §2.20)         |
 | `oas3-valid-schema-example`                | error    | Schemas must be valid per OpenAPI 3.0 JSON Schema rules                                           |
 
 ### 3.4 Adding new Spectral rules
@@ -1648,6 +1734,7 @@ Before opening a PR:
 - [ ] **Key properties are `type: string`**
 - [ ] **`x-eventually-consistent`** set correctly (`true` for queries, `false` for commands)
 - [ ] **`x-added-in-version`** field present on every new operation (see §2.17)
+- [ ] **`x-scope`** field present on every new operation, matching whether the endpoint is reachable via a physical-tenant-prefixed route (see §2.20)
 - [ ] **`x-properties-added-in-version`** entries added for properties whose intro version differs from their endpoint / nearest ancestor property, per Rules 1–3 in §2.17
 - [ ] **Response arrays** are `required` and not `nullable`
 - [ ] **`required` entries** all exist in `properties`

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -12,6 +12,7 @@ functions:
   - verifyResponsePropertiesRequired
   - verifyDeprecatedEnumMembers
   - verifyAddedInVersion
+  - verifyScope
   - verifySemanticKindsRegistered
   - verifyNoAmbiguousIdentifierProperty
   - verifySecurityDeclared
@@ -170,6 +171,19 @@ rules:
     message: "{{error}}"
     then:
       function: verifyAddedInVersion
+
+  # ── x-scope (camunda/camunda#61157) ──
+  # Marks whether an operation is cluster-wide or scoped to a single physical
+  # tenant, so the docs API reference can render a scope badge without
+  # fragmenting the existing tag-based grouping. See
+  # https://github.com/camunda/camunda-docs/issues/8886#issuecomment-5414815612.
+  require-scope:
+    description: "Every operation must have a valid `x-scope` (`cluster-wide` or `physical-tenant`)."
+    severity: error
+    given: $.paths[*][*]
+    message: "{{error}}"
+    then:
+      function: verifyScope
 
   # ── x-required-permissions (camunda/camunda#54727) ──
   # Canonical endpoint -> required-permission(s) binding. Two rules:

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -19,6 +19,7 @@ We use [Spectral CLI](https://docs.stoplight.io/docs/spectral/) to validate the 
   - Eventually-consistent annotation validation (command operations must not be marked as eventually consistent)
   - Required property existence validation (entries in required array must exist in properties)
   - Operation versioning annotation validation (every operation must declare `x-added-in-version`)
+  - Operation scope annotation validation (every operation must declare `x-scope` as `cluster-wide` or `physical-tenant`)
   - Property versioning annotation shape validation (`x-properties-added-in-version` entries must be `{propertyName, addedInVersion}` only)
   - Semantic graph annotation shape + cross-reference validation (`x-semantic-establishes`, `x-semantic-requires`, `semantic-kinds.json` registry)
 
@@ -186,6 +187,36 @@ ProcessInstanceModificationInstruction:
 Semantic correctness of these annotations (does the property actually exist? was it really introduced in that version?) is still validated in CI by the verifier under [`.github/scripts/x-added-in-version-check/`](../../.github/scripts/x-added-in-version-check/README.md) — the Spectral rule only checks shape.
 
 When a reviewer deliberately wants to publish a version other than the one the verifier computes, use `x-added-in-version-override` / `addedInVersionOverride` instead of just changing the annotation — see ["Overriding the computed version"](../../.github/scripts/x-added-in-version-check/README.md#overriding-the-computed-version) in the verifier's README.
+
+### Missing or invalid `x-scope`
+
+Every operation must declare `x-scope` as either `cluster-wide` or `physical-tenant`, marking whether it operates on the whole cluster or on a single physical tenant. The `require-scope` rule fails the build if this annotation is missing or has an unrecognised value.
+
+**Wrong:**
+
+```yaml
+paths:
+  /my-resources:
+    post:
+      operationId: createMyResource
+      summary: Create a my-resource
+      tags: [My resource]
+      # ❌ Missing x-scope
+```
+
+**Correct:**
+
+```yaml
+paths:
+  /my-resources:
+    post:
+      operationId: createMyResource
+      summary: Create a my-resource
+      x-scope: physical-tenant  # ✓ Scoped to a single physical tenant
+      tags: [My resource]
+```
+
+See §2.20 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md) for the full convention, including how this maps to the `@ClusterScoped` controller annotation.
 
 ### Semantic graph annotations (`x-semantic-establishes`, `x-semantic-requires`)
 

--- a/zeebe/gateway-protocol/spectral-functions/verifyScope.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyScope.js
@@ -1,0 +1,51 @@
+// Spectral custom function to verify that every operation declares a valid
+// x-scope, marking whether the endpoint is cluster-wide or scoped to a
+// single physical tenant. Consumed by the docs API reference to render a
+// scope badge on each operation (camunda/camunda#61157).
+//
+// Applied to each operation object under paths (get, post, put, patch, delete).
+
+// $.paths[*][*] matches all keys under a path item, including non-operation
+// entries like "parameters", "summary", "$ref", etc. Only check actual HTTP methods.
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
+const VALID_SCOPES = new Set(['cluster-wide', 'physical-tenant']);
+
+module.exports = (input, _opts, context) => {
+  const errors = [];
+
+  if (!context.path || context.path.length < 3) {
+    return errors;
+  }
+
+  const pathString = context.path[1];
+  const method = context.path[2];
+
+  if (!HTTP_METHODS.has(method)) {
+    return errors;
+  }
+
+  const operationId = input.operationId || '?';
+  const scope = input['x-scope'];
+
+  if (typeof scope !== 'string' || !VALID_SCOPES.has(scope)) {
+    errors.push({
+      message: `Operation "${operationId}" (${method.toUpperCase()} ${pathString}) is missing a valid x-scope. Every endpoint must declare whether it is "cluster-wide" or "physical-tenant" scoped.`,
+      path: [...context.path],
+    });
+    return errors;
+  }
+
+  // /cluster/v2/... path items override `servers` to drop the document's /v2
+  // base, and PhysicalTenantRequestMappingHandlerMapping never builds a
+  // physical-tenant-prefixed sibling for them, so they are structurally the
+  // only cluster-wide operations.
+  const expectedScope = pathString.startsWith('/cluster/v2/') ? 'cluster-wide' : 'physical-tenant';
+  if (scope !== expectedScope) {
+    errors.push({
+      message: `Operation "${operationId}" (${method.toUpperCase()} ${pathString}) declares x-scope: ${scope}, but its path implies x-scope: ${expectedScope}.`,
+      path: [...context.path],
+    });
+  }
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/scope/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/scope/rest-api.yaml
@@ -1,0 +1,32 @@
+# Entry point for require-scope rule tests.
+# Mirrors the real spec structure: paths $ref to domain files.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — require-scope
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+  # Endpoint with a valid x-scope
+  /valid/thing:
+    $ref: 'things.yaml#/paths/~1valid~1thing'
+
+  /cluster/v2/thing/{thingKey}:
+    $ref: 'things.yaml#/paths/~1cluster~1v2~1thing~1{thingKey}'
+
+  # ── Invalid cases ───────────────────────────────────────────
+  # Endpoint missing x-scope, or with an unrecognised value
+  /invalid/thing:
+    $ref: 'things.yaml#/paths/~1invalid~1thing'
+
+  /invalid/thing/{thingKey}:
+    $ref: 'things.yaml#/paths/~1invalid~1thing~1{thingKey}'
+
+  # x-scope disagrees with what the path implies
+  /mismatch/thing:
+    $ref: 'things.yaml#/paths/~1mismatch~1thing'
+
+  /cluster/v2/mismatch/thing:
+    $ref: 'things.yaml#/paths/~1cluster~1v2~1mismatch~1thing'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/scope/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/scope/things.yaml
@@ -1,0 +1,100 @@
+# Domain file for require-scope rule test fixture.
+openapi: "3.0.3"
+info:
+  title: Things domain (test fixture)
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid: operation has a valid x-scope ─────────────────────
+  /valid/thing:
+    post:
+      operationId: createThing
+      summary: Create a thing
+      description: Creates a new thing.
+      x-added-in-version: "8.6"
+      x-scope: physical-tenant
+      tags:
+        - Test
+      responses:
+        '200':
+          description: The thing was created.
+
+  /cluster/v2/thing/{thingKey}:
+    get:
+      operationId: getThing
+      summary: Get a thing
+      description: Gets a thing by key.
+      x-added-in-version: "8.7"
+      x-scope: cluster-wide
+      tags:
+        - Test
+      parameters:
+        - name: thingKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The thing.
+
+  # ── Invalid: x-scope disagrees with what the path implies ─────
+  /mismatch/thing:
+    post:
+      operationId: createMismatchThing
+      summary: Create a mismatched thing
+      description: Declares cluster-wide despite not living under /cluster/v2/.
+      x-added-in-version: "8.6"
+      x-scope: cluster-wide
+      tags:
+        - Test
+      responses:
+        '200':
+          description: The thing was created.
+
+  /cluster/v2/mismatch/thing:
+    post:
+      operationId: createClusterMismatchThing
+      summary: Create a mismatched cluster thing
+      description: Declares physical-tenant despite living under /cluster/v2/.
+      x-added-in-version: "8.6"
+      x-scope: physical-tenant
+      tags:
+        - Test
+      responses:
+        '200':
+          description: The thing was created.
+
+  # ── Invalid: operation missing x-scope, or with a bad value ──
+  /invalid/thing:
+    post:
+      operationId: createInvalidThing
+      summary: Create an invalid thing
+      description: Missing x-scope.
+      x-added-in-version: "8.6"
+      tags:
+        - Test
+      responses:
+        '200':
+          description: The thing was created.
+
+  /invalid/thing/{thingKey}:
+    get:
+      operationId: getInvalidThing
+      summary: Get an invalid thing
+      description: x-scope has an unrecognised value.
+      x-added-in-version: "8.7"
+      x-scope: global
+      tags:
+        - Test
+      parameters:
+        - name: thingKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The thing.

--- a/zeebe/gateway-protocol/spectral-tests/verifyScope.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyScope.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule } = require('./helpers');
+
+const RULE = 'require-scope';
+const FIXTURE = 'scope';
+
+describe('verifyScope', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: operation with a recognised x-scope', () => {
+    it('produces no violations for createThing (physical-tenant)', () => {
+      const v = violations.filter((e) => e.message.includes('createThing'));
+      assert.equal(v.length, 0);
+    });
+
+    it('produces no violations for getThing (cluster-wide)', () => {
+      const v = violations.filter(
+        (e) => e.message.includes('getThing') && !e.message.includes('Invalid'),
+      );
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: operation with missing or unrecognised x-scope', () => {
+    it('flags createInvalidThing (missing x-scope)', () => {
+      const v = violations.filter((e) => e.message.includes('createInvalidThing'));
+      assert.equal(v.length, 1);
+    });
+
+    it('flags getInvalidThing (unrecognised x-scope value)', () => {
+      const v = violations.filter((e) => e.message.includes('getInvalidThing'));
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = violations.filter((e) => e.message.includes('createInvalidThing'));
+      assert.match(v[0].message, /missing a valid x-scope/);
+    });
+  });
+
+  // ── Invalid: x-scope disagrees with what the path implies ────────
+
+  describe('invalid: x-scope disagrees with the path-derived scope', () => {
+    it('flags createMismatchThing (cluster-wide outside /cluster/v2/)', () => {
+      const v = violations.filter((e) => e.message.includes('createMismatchThing'));
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /implies x-scope: physical-tenant/);
+    });
+
+    it('flags createClusterMismatchThing (physical-tenant under /cluster/v2/)', () => {
+      const v = violations.filter((e) => e.message.includes('createClusterMismatchThing'));
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /implies x-scope: cluster-wide/);
+    });
+  });
+
+  it('produces exactly 4 violations total', () => {
+    assert.equal(violations.length, 4);
+  });
+});

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-definitions.yaml
@@ -37,6 +37,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /agent-definitions/{agentDefinitionKey}:
     get:
@@ -82,6 +83,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -54,6 +54,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /agent-instances/{agentInstanceKey}:
     get:
@@ -101,6 +102,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
     patch:
       x-eventually-consistent: false
@@ -154,6 +156,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /agent-instances/search:
     post:
@@ -191,6 +194,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /agent-instances/{agentInstanceKey}/history/search:
     post:
@@ -244,6 +248,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -36,6 +36,7 @@ paths:
         "500":
           description: An internal error occurred while processing the request.
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /audit-logs/{auditLogKey}:
     get:
@@ -77,6 +78,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -25,6 +25,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /authentication/me/authorizations/search:
     post:
@@ -59,6 +60,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -43,6 +43,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /authorizations/{authorizationKey}:
     put:
@@ -86,6 +87,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     get:
       x-eventually-consistent: true
@@ -126,6 +128,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -162,6 +165,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /authorizations/search:
     post:
@@ -198,6 +202,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/backups.yaml
@@ -55,6 +55,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
     get:
       x-eventually-consistent: false
       tags:
@@ -98,6 +99,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /backups/runtime/state:
     get:
@@ -132,6 +134,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
     delete:
       x-eventually-consistent: false
       tags:
@@ -159,6 +162,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /backups/runtime/state/sync:
     post:
@@ -198,6 +202,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /backups/runtime/{backupId}:
     get:
@@ -241,6 +246,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
     delete:
       x-eventually-consistent: false
       tags:
@@ -272,6 +278,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /backups/history:
     post:
@@ -328,6 +335,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
     get:
       x-eventually-consistent: false
       tags:
@@ -384,6 +392,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /backups/history/{backupId}:
     get:
@@ -430,6 +439,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
     delete:
       x-eventually-consistent: false
       tags:
@@ -471,6 +481,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 components:
   responses:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -43,6 +43,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /batch-operations/search:
     post:
@@ -80,6 +81,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /batch-operations/{batchOperationKey}/cancellation:
     post:
@@ -124,6 +126,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /batch-operations/{batchOperationKey}/suspension:
     post:
@@ -170,6 +173,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /batch-operations/{batchOperationKey}/resumption:
     post:
@@ -216,6 +220,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /batch-operation-items/search:
     post:
@@ -253,6 +258,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
@@ -36,6 +36,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /clock/reset:
     post:
@@ -64,6 +65,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -78,6 +78,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClusterStatusResponse'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/topology:
     servers:
@@ -126,6 +127,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/exporting:
     servers:
@@ -178,6 +180,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/exporting/pause:
     servers:
@@ -231,6 +234,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/exporting/resume:
     servers:
@@ -276,6 +280,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/mode:
     servers:
@@ -342,6 +347,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/restore:
     servers:
@@ -423,6 +429,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/backups/runtime:
     servers:
@@ -562,6 +569,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClusterTakeRuntimeBackupResponse'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     get:
       x-eventually-consistent: false
       tags:
@@ -629,6 +637,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/backups/runtime/state:
     servers:
@@ -694,6 +703,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     delete:
       x-eventually-consistent: false
       tags:
@@ -744,6 +754,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/backups/runtime/state/sync:
     servers:
@@ -816,6 +827,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/backups/runtime/{backupId}:
     servers:
@@ -891,6 +903,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     delete:
       x-eventually-consistent: false
       tags:
@@ -951,6 +964,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/backups/history:
     servers:
@@ -1044,6 +1058,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     get:
       x-eventually-consistent: false
       tags:
@@ -1124,6 +1139,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/backups/history/{backupId}:
     servers:
@@ -1201,6 +1217,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     delete:
       x-eventually-consistent: false
       tags:
@@ -1280,6 +1297,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
   /cluster/v2/rebalance:
     servers:
@@ -1374,6 +1392,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     get:
       x-eventually-consistent: false
       tags:
@@ -1425,6 +1444,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
     delete:
       x-eventually-consistent: false
       tags:
@@ -1480,6 +1500,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -46,6 +46,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
   /cluster-variables/tenants/{tenantId}:
     post:
       operationId: createTenantClusterVariable
@@ -109,6 +110,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
   /cluster-variables/search:
     post:
       tags:
@@ -151,6 +153,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
   /cluster-variables/global/{name}:
     get:
       operationId: getGlobalClusterVariable
@@ -197,6 +200,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
     put:
       operationId: updateGlobalClusterVariable
       x-required-permissions:
@@ -250,6 +254,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
     delete:
       operationId: deleteGlobalClusterVariable
       x-required-permissions:
@@ -291,6 +296,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
   /cluster-variables/tenants/{tenantId}/{name}:
     get:
       operationId: getTenantClusterVariable
@@ -344,6 +350,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
     put:
       operationId: updateTenantClusterVariable
       x-required-permissions:
@@ -404,6 +411,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
     delete:
       operationId: deleteTenantClusterVariable
       x-required-permissions:
@@ -452,6 +460,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -25,6 +25,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.5"
+      x-scope: physical-tenant
 
   /status:
     get:
@@ -56,6 +57,7 @@ paths:
         "503":
           description: The default physical tenant is DOWN and does not have any partition with a healthy leader.
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /mode:
     patch:
@@ -97,6 +99,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /restore:
     post:
@@ -141,6 +144,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
     get:
       x-eventually-consistent: false
       tags:
@@ -173,6 +177,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -71,6 +71,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -37,6 +37,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /decision-definitions/{decisionDefinitionKey}:
     get:
@@ -82,6 +83,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /decision-definitions/{decisionDefinitionKey}/xml:
     get:
@@ -127,6 +129,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /decision-definitions/evaluation:
     post:
@@ -182,6 +185,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -37,6 +37,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /decision-instances/{decisionEvaluationInstanceKey}:
     get:
@@ -82,6 +83,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /decision-instances/{decisionEvaluationKey}/deletion:
     post:
@@ -127,6 +129,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /decision-instances/deletion:
     post:
@@ -173,6 +176,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -37,6 +37,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /decision-requirements/{decisionRequirementsKey}:
     get:
@@ -82,6 +83,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /decision-requirements/{decisionRequirementsKey}/xml:
     get:
@@ -127,6 +129,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -48,6 +48,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /resources/{resourceKey}:
     get:
@@ -91,6 +92,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.7"
+      x-scope: physical-tenant
 
   /resources/{resourceKey}/content:
     get:
@@ -144,6 +146,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.7"
+      x-scope: physical-tenant
 
   /resources/{resourceKey}/content/binary:
     get:
@@ -188,6 +191,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /resources/search:
     post:
@@ -231,6 +235,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /resources/{resourceKey}/deletion:
     post:
@@ -303,6 +308,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -62,6 +62,7 @@ paths:
         "415":
           $ref: 'common-responses.yaml#/components/responses/UnsupportedMediaType'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /documents/batch:
     post:
@@ -150,6 +151,7 @@ paths:
         "415":
           $ref: 'common-responses.yaml#/components/responses/UnsupportedMediaType'
       x-added-in-version: "8.7"
+      x-scope: physical-tenant
 
   /documents/{documentId}:
     get:
@@ -206,6 +208,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -247,6 +250,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /documents/{documentId}/links:
     post:
@@ -302,6 +306,7 @@ paths:
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
       x-added-in-version: "8.7"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -37,6 +37,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /element-instances/wait-states/search:
     post:
@@ -75,6 +76,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /element-instances/{elementInstanceKey}:
     get:
@@ -120,6 +122,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /element-instances/{elementInstanceKey}/variables:
     put:
@@ -169,6 +172,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-added-in-version: "8.6"
       x-added-in-version-override: "8.6"
+      x-scope: physical-tenant
 
   /element-instances/{elementInstanceKey}/incidents/search:
     post:
@@ -225,6 +229,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation:
     post:
@@ -276,6 +281,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/exporting.yaml
@@ -37,6 +37,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /exporting/pause:
     post:
@@ -78,6 +79,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /exporting/resume:
     post:
@@ -105,6 +107,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -42,6 +42,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/forms.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/forms.yaml
@@ -44,3 +44,4 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -48,6 +48,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /global-task-listeners/{id}:
     get:
@@ -93,6 +94,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
     put:
       x-eventually-consistent: false
@@ -147,6 +149,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -191,6 +194,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /global-task-listeners/search:
     post:
@@ -227,6 +231,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -62,6 +62,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/search:
     post:
@@ -99,6 +100,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}:
     get:
@@ -144,6 +146,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     put:
       x-eventually-consistent: false
@@ -196,6 +199,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -236,6 +240,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/users/{username}:
     put:
@@ -295,6 +300,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -346,6 +352,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/users/search:
     post:
@@ -400,6 +407,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/clients/{clientId}:
     put:
@@ -459,6 +467,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -510,6 +519,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/clients/search:
     post:
@@ -564,6 +574,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/mapping-rules/{mappingRuleId}:
     put:
@@ -621,6 +632,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -670,6 +682,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/mapping-rules/search:
     post:
@@ -724,6 +737,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /groups/{groupId}/roles/search:
     post:
@@ -778,6 +792,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -38,6 +38,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /incidents/{incidentKey}:
     get:
@@ -82,6 +83,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /incidents/{incidentKey}/resolution:
     post:
@@ -135,6 +137,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /incidents/statistics/process-instances-by-error:
     post:
@@ -175,6 +178,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /incidents/statistics/process-instances-by-definition:
     post:
@@ -216,6 +220,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -58,6 +58,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /jobs/statistics/by-types:
     post:
@@ -96,6 +97,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /jobs/statistics/by-workers:
     post:
@@ -134,6 +136,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /jobs/statistics/time-series:
     post:
@@ -174,6 +177,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /jobs/statistics/errors:
     post:
@@ -212,6 +216,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -38,6 +38,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /jobs/search:
     post:
@@ -75,6 +76,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /jobs/{jobKey}/failure:
     post:
@@ -130,6 +132,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /jobs/{jobKey}/error:
     post:
@@ -183,6 +186,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /jobs/{jobKey}/completion:
     post:
@@ -235,6 +239,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /jobs/{jobKey}:
     patch:
@@ -286,6 +291,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /jobs/batch-update:
     post:
@@ -334,6 +340,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -24,6 +24,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -56,6 +56,7 @@ paths:
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
   /mapping-rules/{mappingRuleId}:
     put:
       x-eventually-consistent: false
@@ -114,6 +115,7 @@ paths:
         "503":
           $ref: "common-responses.yaml#/components/responses/ServiceUnavailable"
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
     delete:
       x-eventually-consistent: false
       tags:
@@ -154,6 +156,7 @@ paths:
         "503":
           $ref: "common-responses.yaml#/components/responses/ServiceUnavailable"
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
     get:
       x-eventually-consistent: true
       tags:
@@ -196,6 +199,7 @@ paths:
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
   /mapping-rules/search:
     post:
       x-eventually-consistent: true
@@ -232,6 +236,7 @@ paths:
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -39,6 +39,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /messages/correlation:
     post:
@@ -86,6 +87,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /message-subscriptions/search:
     post:
@@ -136,6 +138,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /correlated-message-subscriptions/search:
     post:
@@ -173,6 +176,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -37,6 +37,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-definitions/{processDefinitionKey}:
     get:
@@ -84,6 +85,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-definitions/{processDefinitionKey}/xml:
     get:
@@ -136,6 +138,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-definitions/{processDefinitionKey}/form:
     get:
@@ -183,6 +186,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-definitions/{processDefinitionKey}/statistics/element-instances:
     post:
@@ -227,6 +231,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-definitions/{processDefinitionKey}/variable-names/search:
     post:
@@ -271,6 +276,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-definitions/statistics/message-subscriptions:
     post:
@@ -309,6 +315,7 @@ paths:
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /process-definitions/statistics/process-instances:
     post:
@@ -347,6 +354,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /process-definitions/statistics/process-instances-by-version:
     post:
@@ -386,6 +394,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -72,6 +72,7 @@ paths:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}:
     get:
@@ -115,6 +116,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/sequence-flows:
     get:
@@ -152,6 +154,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/statistics/element-instances:
     get:
@@ -190,6 +193,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/statistics/wait-states:
     get:
@@ -228,6 +232,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-instances/search:
     post:
@@ -265,6 +270,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/incidents/search:
     post:
@@ -320,6 +326,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/incident-resolution:
     post:
@@ -363,6 +370,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/cancellation:
     post:
@@ -413,6 +421,7 @@ paths:
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /process-instances/cancellation:
     post:
@@ -461,6 +470,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/incident-resolution:
     post:
@@ -509,6 +519,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/migration:
     post:
@@ -557,6 +568,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/modification:
     post:
@@ -607,6 +619,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /process-instances/suspension:
     post:
@@ -655,6 +668,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-instances/resumption:
     post:
@@ -703,6 +717,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/deletion:
     post:
@@ -754,6 +769,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /process-instances/deletion:
     post:
@@ -801,6 +817,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/migration:
     post:
@@ -859,6 +876,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/business-id-assignment:
     post:
@@ -920,6 +938,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/modification:
     post:
@@ -969,6 +988,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/suspension:
     post:
@@ -1022,6 +1042,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/resumption:
     post:
@@ -1075,6 +1096,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /process-instances/{processInstanceKey}/call-hierarchy:
     get:
@@ -1120,6 +1142,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -47,6 +47,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/search:
     post:
@@ -84,6 +85,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}:
     get:
@@ -129,6 +131,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     put:
       x-eventually-consistent: false
@@ -181,6 +184,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -221,6 +225,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/users/{username}:
     put:
@@ -278,6 +283,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -327,6 +333,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/users/search:
     post:
@@ -381,6 +388,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/clients/{clientId}:
     put:
@@ -438,6 +446,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -487,6 +496,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/clients/search:
     post:
@@ -541,6 +551,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/groups/{groupId}:
     put:
@@ -604,6 +615,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -653,6 +665,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/groups/search:
     post:
@@ -707,6 +720,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/mapping-rules/{mappingRuleId}:
     put:
@@ -764,6 +778,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -813,6 +828,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /roles/{roleId}/mapping-rules/search:
     post:
@@ -867,6 +883,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -54,6 +54,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
   /secrets/list:
     post:
@@ -107,6 +108,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
+      x-scope: physical-tenant
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
@@ -45,3 +45,4 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant

--- a/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
@@ -41,6 +41,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -84,6 +84,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
   /system/configuration:
     get:
       tags:
@@ -133,6 +134,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 
 ## Schema definitions

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -52,6 +52,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/search:
     post:
@@ -95,6 +96,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}:
     get:
@@ -142,6 +144,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     put:
       x-eventually-consistent: false
@@ -194,6 +197,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -236,6 +240,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/users/{username}:
     put:
@@ -287,6 +292,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -338,6 +344,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/users/search:
     post:
@@ -378,6 +385,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantUserSearchResult'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/clients/{clientId}:
     put:
@@ -431,6 +439,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -482,6 +491,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/clients/search:
     post:
@@ -522,6 +532,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantClientSearchResult'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/groups/{groupId}:
     put:
@@ -581,6 +592,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -632,6 +644,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/groups/search:
     post:
@@ -672,6 +685,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantGroupSearchResult'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/roles/search:
     post:
@@ -712,6 +726,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantRoleSearchResult'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/roles/{roleId}:
     put:
@@ -765,6 +780,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -817,6 +833,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/mapping-rules/{mappingRuleId}:
     put:
@@ -868,6 +885,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -917,6 +935,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /tenants/{tenantId}/mapping-rules/search:
     post:
@@ -957,6 +976,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TenantMappingRuleSearchResult'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -61,6 +61,7 @@ paths:
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-added-in-version: "8.5"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}/assignment:
     post:
@@ -121,6 +122,7 @@ paths:
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-added-in-version: "8.5"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}:
     get:
@@ -166,6 +168,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     patch:
       x-eventually-consistent: false
@@ -224,6 +227,7 @@ paths:
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-added-in-version: "8.5"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}/form:
     get:
@@ -273,6 +277,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}/assignee:
     delete:
@@ -327,6 +332,7 @@ paths:
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
       x-added-in-version: "8.5"
+      x-scope: physical-tenant
 
   /user-tasks/search:
     post:
@@ -366,6 +372,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.6"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}/variables/search:
     post:
@@ -418,6 +425,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}/effective-variables/search:
     post:
@@ -470,6 +478,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
       x-added-in-version-override: "8.8"
+      x-scope: physical-tenant
 
   /user-tasks/{userTaskKey}/audit-logs/search:
     post:
@@ -511,6 +520,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.9"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -48,6 +48,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /users/search:
     post:
@@ -85,6 +86,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
       x-added-in-version-override: "8.8"
+      x-scope: physical-tenant
 
   /users/{username}:
     get:
@@ -130,6 +132,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     put:
       x-eventually-consistent: false
@@ -182,6 +185,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
     delete:
       x-eventually-consistent: false
@@ -222,6 +226,7 @@ paths:
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -53,6 +53,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
   /variables/{variableKey}:
     get:
@@ -101,6 +102,7 @@ paths:
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
+      x-scope: physical-tenant
 
 ## Schema definitions
 


### PR DESCRIPTION
## Summary
- Adds `x-scope: cluster-wide | physical-tenant` to every operation in the v2 REST API spec (`zeebe/gateway-protocol/src/main/proto/v2/*.yaml`), so docs can render a per-operation scope badge instead of re-tagging (which would fragment existing capability groups like `Backup`).
- The value tracks reachability, mirroring how `PhysicalTenantRequestMappingHandlerMapping` actually routes each operation's controller: `physical-tenant` is the default (the controller gets a `/physical-tenants/{id}/...` sibling route); `cluster-wide` applies only to `@ClusterScoped` controllers (today, the `/cluster/v2/...` operations from `cluster-admin.yaml`).
- `GET /license` is annotated `x-scope: physical-tenant` since its controller is reachable under the tenant prefix, even though the license itself is a single cluster-wide fact that doesn't vary per tenant — `x-scope` reflects reachability, not data-varies-per-tenant.
- Enforces the annotation going forward with a new `require-scope` Spectral rule (mirroring `require-added-in-version`), with tests.
- Documents the convention in `docs/rest-api-endpoint-guidelines.md` §2.20 and `zeebe/gateway-protocol/OPENAPI_VALIDATION.md`.

Closes #61157. See [camunda-docs#8886 (comment)](https://github.com/camunda/camunda-docs/issues/8886#issuecomment-5414815612) for the motivating discussion.

## Test plan
- [x] `npx spectral lint` on `rest-api.yaml` — clean, no errors
- [x] `node --test` in `zeebe/gateway-protocol` — 193 tests pass, including new `verifyScope` tests
- [x] `./mvnw verify -pl zeebe/gateway-protocol` — module build green
- [x] `./mvnw install -Dquickly -T1C` — full repo compiles
- [ ] Docs team confirms the `x-scope` shape matches what their renderer expects (tracked in the issue's acceptance criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)