### PR TITLE
ci: release the AlwaysGreen dispatch lock held by stale fix PRs

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -39,6 +39,11 @@ FIX_LABEL = os.environ.get("ALWAYSGREEN_FIX_LABEL", "alwaysgreen-fix")
 KEY_LABEL_PREFIX = "alwaysgreen-key:"
 #: How long a no-fix verdict keeps its fingerprints out of dispatch.
 NO_FIX_COOLDOWN_DAYS = int(os.environ.get("ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS", "7"))
+#: How long an open fix PR keeps holding its dispatch key; see
+#: planning.PR_LOCK_TTL_DAYS. Set to 0 to restore the old never-expiring lock.
+PR_LOCK_TTL_DAYS = int(
+    os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_DAYS", str(planning.PR_LOCK_TTL_DAYS))
+)
 #: Cap on artifact downloads while reading past verdicts, so a burst of agent runs
 #: cannot make triage slow.
 NO_FIX_MAX_RUNS = 20
@@ -350,17 +355,22 @@ def open_fix_pr_keys() -> tuple[set[str], bool]:
     stamps, not from the PR body: the body's coverage block is written by the agent
     and cannot be relied on to exist.
 
+    A PR past PR_LOCK_TTL_DAYS stops holding its key, so a fix PR left unreviewed
+    cannot wedge its surface shut for good; `covered_fingerprints` still suppresses a
+    repeat of the specs it already claims.
+
     Returns (keys, ok). As with `inflight_keys`, a failed lookup makes the caller
     suppress rather than risk a duplicate PR.
     """
     out: set[str] = set()
     ok = True
+    now = datetime.now(timezone.utc)
     for repo in FIX_PR_REPOS:
         prs, err = gh_json_ex(
             [
                 "pr", "list", "--repo", repo,
                 "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "labels",
+                "--limit", "100", "--json", "labels,number,createdAt",
             ],
             None,
         )
@@ -369,12 +379,24 @@ def open_fix_pr_keys() -> tuple[set[str], bool]:
             ok = False
             continue
         for pr in prs if isinstance(prs, list) else []:
+            keys: set[str] = set()
             for label in pr.get("labels") or []:
                 name = (label.get("name") or "").strip()
                 if name.startswith(KEY_LABEL_PREFIX):
                     key = name[len(KEY_LABEL_PREFIX) :].strip()
                     if key:
-                        out.add(key)
+                        keys.add(key)
+            if not keys:
+                continue
+            if planning.pr_lock_expired(
+                pr.get("createdAt") or "", now, PR_LOCK_TTL_DAYS
+            ):
+                log(
+                    f"lock expired after {PR_LOCK_TTL_DAYS}d: {repo}#{pr.get('number')} "
+                    f"no longer holds {', '.join(sorted(keys))}"
+                )
+                continue
+            out |= keys
     return out, ok
 
 
@@ -631,6 +653,9 @@ def serialise(result: planning.Plan, blame: classify.Blame, run_id: str) -> dict
                 "surface": c.surface,
                 "dispatch_key": c.key,
                 "job_name": classify.job_leaf_name(c.job_name),
+                "also_failing_jobs": [
+                    classify.job_leaf_name(n) for n in c.also_failing_jobs
+                ],
                 "evidence_run_url": c.evidence_run_url,
                 "evidence_repo": c.evidence_repo,
                 "job_level": c.job_level,

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -57,13 +57,16 @@ PR_LOCK_TTL_DAYS = 2
 
 
 def pr_lock_expired(
-    created_at: str, now: datetime, ttl_days: int = PR_LOCK_TTL_DAYS
+    created_at: str | None, now: datetime, ttl_days: int = PR_LOCK_TTL_DAYS
 ) -> bool:
     """Whether an open fix PR is too old to keep holding its dispatch key.
 
     A missing or unparseable timestamp keeps the lock, and `ttl_days <= 0` disables
     expiry altogether: the bias matches the `ok` flags in discover's key lookups,
     where an unproven state suppresses rather than risks a duplicate PR.
+
+    Either timestamp is read as UTC when it carries no offset, so a naive `now` does
+    not raise against GitHub's offset-aware `createdAt`.
     """
     if ttl_days <= 0:
         return False
@@ -76,6 +79,8 @@ def pr_lock_expired(
         return False
     if created.tzinfo is None:
         created = created.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     return now - created > timedelta(days=ttl_days)
 
 

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -18,6 +18,7 @@ Two levels of identity are used, for different jobs:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 
 import classify
 
@@ -41,6 +42,41 @@ SUPPRESSED_CAP = "per-run-cap-reached"
 #: fail on the agent's first step, which is what happened to run 31115770750 on
 #: `ci/alwaysgreen-helm-live-check`.
 SUPPORTED_BASE_REFS = frozenset({"main", "stable/8.7", "stable/8.8", "stable/8.9"})
+
+
+#: How long an open fix PR's key label keeps holding its dispatch key. The lock is
+#: there to win the race described above, but nothing ever released it: the label
+#: stops matching `is:open` only when a human merges or closes the PR, so the agent's
+#: own output locked the agent out of its own surface. camunda-platform-helm#6927
+#: claimed `main:sm-smoke-e2e` on 2026-08-20 and then sat unreviewed, and every `main`
+#: triage for the following six days reported `open-fix-pr-for-surface` and dispatched
+#: nothing. Past the TTL this coarse per-surface lock lifts and the per-spec coverage
+#: block takes over: a repeat of the same failure is still suppressed as
+#: `open-pr-covers-all-specs`, while a genuinely new one gets an agent.
+PR_LOCK_TTL_DAYS = 2
+
+
+def pr_lock_expired(
+    created_at: str, now: datetime, ttl_days: int = PR_LOCK_TTL_DAYS
+) -> bool:
+    """Whether an open fix PR is too old to keep holding its dispatch key.
+
+    A missing or unparseable timestamp keeps the lock, and `ttl_days <= 0` disables
+    expiry altogether: the bias matches the `ok` flags in discover's key lookups,
+    where an unproven state suppresses rather than risks a duplicate PR.
+    """
+    if ttl_days <= 0:
+        return False
+    text = (created_at or "").strip()
+    if not text:
+        return False
+    try:
+        created = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    return now - created > timedelta(days=ttl_days)
 
 
 def spec_suite(spec_file: str) -> str | None:
@@ -109,10 +145,18 @@ class Candidate:
     evidence_repo: str = ""
     #: Set when the surface produced no per-spec detail (job-level failure).
     job_level: bool = False
+    #: Further jobs of the same surface, folded in by `merge_by_key`. Kept so a merged
+    #: job-level dispatch still claims a fingerprint per job and leaves none of them
+    #: uncovered and re-dispatchable on the next run.
+    also_failing_jobs: list[str] = field(default_factory=list)
 
     @property
     def key(self) -> str:
         return dispatch_key(self.base_ref, self.surface)
+
+    @property
+    def job_names(self) -> list[str]:
+        return [self.job_name, *self.also_failing_jobs]
 
     @property
     def spec_fingerprints(self) -> list[str]:
@@ -125,7 +169,12 @@ class Candidate:
     def fingerprints(self) -> list[str]:
         """Every fingerprint this candidate would claim in a PR coverage block."""
         if self.job_level or not self.specs:
-            return [classify.job_fingerprint(self.base_ref, self.surface, self.job_name)]
+            return list(
+                dict.fromkeys(
+                    classify.job_fingerprint(self.base_ref, self.surface, n)
+                    for n in self.job_names
+                )
+            )
         return self.spec_fingerprints
 
     @property
@@ -146,6 +195,35 @@ class Plan:
     suppressed: list[Suppression] = field(default_factory=list)
     #: Failing jobs dropped by the noise prefilter, for the summary only.
     noise: list[tuple[str, str]] = field(default_factory=list)
+
+
+def merge_by_key(candidates: list[Candidate]) -> list[Candidate]:
+    """Collapse candidates sharing a dispatch key into one, keeping input order.
+
+    Candidates are built per failing job while a key is one agent's remit, and one
+    surface routinely fails as several jobs: `Playwright e2e full after install` and
+    `Playwright e2e smoke after install` are both `sm-smoke-e2e`, and a multi-cell
+    matrix yields one `helm-install` job per cell. `plan_dispatches` reads
+    `open_pr_keys` and `inflight_keys` once up front and never adds a key it has just
+    planned, so same-key candidates could not see each other and both dispatched —
+    two agents, then two PRs stamping the one key label.
+    c8-cross-component-e2e-tests#3071 and #3073 are such a pair, and freeing
+    `stable/8.9:saas-smoke-e2e` needed two merges instead of one.
+    """
+    merged: dict[str, Candidate] = {}
+    for cand in candidates:
+        first = merged.get(cand.key)
+        if first is None:
+            merged[cand.key] = cand
+            continue
+        first.specs.extend(cand.specs)
+        for name in cand.job_names:
+            if name and name not in first.job_names:
+                first.also_failing_jobs.append(name)
+        first.evidence_run_url = first.evidence_run_url or cand.evidence_run_url
+        first.evidence_repo = first.evidence_repo or cand.evidence_repo
+        first.job_level = first.job_level or cand.job_level
+    return list(merged.values())
 
 
 def plan_dispatches(
@@ -178,7 +256,7 @@ def plan_dispatches(
     no_fix = recent_no_fix_fingerprints or set()
     fixed_upstream = fixed_upstream_fingerprints or set()
 
-    for cand in candidates:
+    for cand in merge_by_key(candidates):
         # Before anything reads .specs or derives fingerprints from them.
         cand.specs = dedupe_specs(cand.specs)
 

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import classify
 import plan
 
@@ -11,11 +13,17 @@ def _spec(name="t", file="tests/SM-8.10/smoke-tests.spec.ts", deterministic=True
     return classify.FailingSpec(file=file, test_name=name, statuses=statuses)
 
 
-def _cand(surface=classify.SURFACE_SM_E2E, base_ref="main", specs=None, job_level=False):
+def _cand(
+    surface=classify.SURFACE_SM_E2E,
+    base_ref="main",
+    specs=None,
+    job_level=False,
+    job_name="Playwright e2e after install - install on gke - agrn (1 of 1)",
+):
     return plan.Candidate(
         base_ref=base_ref,
         surface=surface,
-        job_name="Playwright e2e after install - install on gke - agrn (1 of 1)",
+        job_name=job_name,
         specs=list(specs if specs is not None else [_spec()]),
         job_level=job_level,
     )
@@ -467,3 +475,124 @@ def test_open_fix_pr_blocks_even_when_the_body_claims_nothing():
     cand = _cand(surface=classify.SURFACE_SM_E2E)
     result = _plan([cand], covered_fingerprints=set(), open_pr_keys={"main:sm-smoke-e2e"})
     assert result.dispatches == []
+
+
+# ---------------------------------------------------------------------------
+# PR lock expiry
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _ago(**kw):
+    return (NOW - timedelta(**kw)).isoformat().replace("+00:00", "Z")
+
+
+def test_fresh_fix_pr_keeps_holding_its_key():
+    assert plan.pr_lock_expired(_ago(hours=6), NOW, 2) is False
+
+
+def test_fix_pr_past_the_ttl_releases_its_key():
+    # camunda-platform-helm#6927 held main:sm-smoke-e2e unreviewed from 2026-08-20,
+    # and every main triage for six days dispatched nothing.
+    assert plan.pr_lock_expired("2026-08-20T14:56:44Z", NOW, 2) is True
+
+
+def test_ttl_boundary_is_inclusive_of_the_lock():
+    assert plan.pr_lock_expired(_ago(days=2), NOW, 2) is False
+    assert plan.pr_lock_expired(_ago(days=2, minutes=1), NOW, 2) is True
+
+
+def test_unreadable_timestamp_keeps_the_lock():
+    for value in ("", None, "yesterday", "2026-13-45T00:00:00Z"):
+        assert plan.pr_lock_expired(value, NOW, 2) is False
+
+
+def test_naive_timestamp_is_read_as_utc():
+    assert plan.pr_lock_expired("2026-08-20T14:56:44", NOW, 2) is True
+
+
+def test_zero_ttl_restores_the_never_expiring_lock():
+    assert plan.pr_lock_expired("2026-01-01T00:00:00Z", NOW, 0) is False
+
+
+# ---------------------------------------------------------------------------
+# Same-key merge
+# ---------------------------------------------------------------------------
+
+
+def test_two_jobs_of_one_surface_dispatch_a_single_agent():
+    # The 2026-08-26 shape: "Playwright e2e full after install" and "Playwright e2e
+    # smoke after install" are both sm-smoke-e2e, so triage reported them as x2 and
+    # would have dispatched two agents onto one key.
+    result = _plan([
+        _cand(job_name="Playwright e2e full after install - agrn (1 of 1)"),
+        _cand(job_name="Playwright e2e smoke after install - agrn (1 of 1)"),
+    ])
+    assert len(result.dispatches) == 1
+    assert result.suppressed == []
+
+
+def test_merge_unions_specs_across_jobs_without_duplicating_them():
+    merged = plan.merge_by_key([
+        _cand(job_name="full", specs=[_spec("flow"), _spec("shared")]),
+        _cand(job_name="smoke", specs=[_spec("shared"), _spec("connector")]),
+    ])
+    assert len(merged) == 1
+    result = _plan(merged)
+    names = [s.test_name for s in result.dispatches[0].specs]
+    assert names == ["flow", "shared", "connector"]
+
+
+def test_merge_records_the_folded_in_job_names():
+    merged = plan.merge_by_key([_cand(job_name="full"), _cand(job_name="smoke")])
+    assert merged[0].job_names == ["full", "smoke"]
+
+
+def test_merged_job_level_candidate_claims_a_fingerprint_per_job():
+    # One helm-install job per matrix cell: a merged dispatch must still cover both,
+    # or the uncovered one is re-dispatched on the next failing run.
+    merged = plan.merge_by_key([
+        _cand(surface=classify.SURFACE_HELM_INSTALL, specs=[], job_level=True,
+              job_name="install for install on gke - agrn"),
+        _cand(surface=classify.SURFACE_HELM_INSTALL, specs=[], job_level=True,
+              job_name="install for install on gke - esss"),
+    ])
+    assert merged[0].fingerprints == [
+        classify.job_fingerprint("main", classify.SURFACE_HELM_INSTALL, n)
+        for n in ("install for install on gke - agrn", "install for install on gke - esss")
+    ]
+
+
+def test_merge_leaves_distinct_keys_alone_and_keeps_order():
+    merged = plan.merge_by_key([
+        _cand(surface=classify.SURFACE_SAAS_E2E),
+        _cand(surface=classify.SURFACE_SM_E2E),
+        _cand(surface=classify.SURFACE_SM_E2E, base_ref="stable/8.9"),
+    ])
+    assert [c.key for c in merged] == [
+        "main:saas-smoke-e2e", "main:sm-smoke-e2e", "stable/8.9:sm-smoke-e2e"
+    ]
+
+
+def test_merged_candidate_is_suppressed_once_not_per_job():
+    result = _plan(
+        [_cand(job_name="full"), _cand(job_name="smoke")],
+        open_pr_keys={"main:sm-smoke-e2e"},
+    )
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_PR_OPEN]
+
+
+def test_merged_candidate_consumes_one_slot_of_the_cap():
+    result = _plan(
+        [
+            _cand(job_name="full"),
+            _cand(job_name="smoke"),
+            _cand(surface=classify.SURFACE_SAAS_E2E),
+        ],
+        max_dispatches=2,
+    )
+    assert [c.surface for c in result.dispatches] == [
+        classify.SURFACE_SM_E2E, classify.SURFACE_SAAS_E2E
+    ]
+    assert result.suppressed == []

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -508,8 +508,14 @@ def test_unreadable_timestamp_keeps_the_lock():
         assert plan.pr_lock_expired(value, NOW, 2) is False
 
 
-def test_naive_timestamp_is_read_as_utc():
+def test_naive_created_at_is_read_as_utc():
     assert plan.pr_lock_expired("2026-08-20T14:56:44", NOW, 2) is True
+
+
+def test_naive_now_does_not_raise_against_an_offset_aware_created_at():
+    naive_now = NOW.replace(tzinfo=None)
+    assert plan.pr_lock_expired("2026-08-20T14:56:44Z", naive_now, 2) is True
+    assert plan.pr_lock_expired(_ago(hours=6), naive_now, 2) is False
 
 
 def test_zero_ttl_restores_the_never_expiring_lock():


### PR DESCRIPTION
## Description

The AlwaysGreen fix agent stopped producing PRs because triage stopped dispatching it. Two defects in the dispatch-suppression logic, both fixed here.

**1. The per-surface lock never expired.** The fix workflow stamps every PR it opens with `alwaysgreen-key:<branch>:<surface>`, and `open_fix_pr_keys()` treats that label on any open PR as "this key is taken", suppressing dispatch before any evidence is read. The only filter was `is:open`, so the label released the key only when a human merged or closed the PR — the agent's own output locked it out of its own surface.

`camunda-platform-helm#6927` claimed `main:sm-smoke-e2e` on 2026-08-20 and then sat unreviewed (mergeable, checks green). Every `main` triage for the next six days reported `open-fix-pr-for-surface` and dispatched nothing — e.g. [run 32957300536](https://github.com/camunda/camunda/actions/runs/32957300536), [32960128209](https://github.com/camunda/camunda/actions/runs/32960128209), [32960650627](https://github.com/camunda/camunda/actions/runs/32960650627). The same had happened on the SaaS keys: `stable/8.9:saas-smoke-e2e` (#3071, #3073), `stable/8.8:saas-smoke-e2e` (#3072), `stable/8.8:saas-ci` (#3039), all unreviewed 5–7 days. Every dispatchable SM/SaaS key except `stable/8.7` was locked at once.

The lock now has a TTL — 2 days, overridable with `ALWAYSGREEN_PR_LOCK_TTL_DAYS`, `0` restores the old never-expiring behaviour. Past the TTL the coarse per-surface lock lifts, and the finer per-spec coverage block keeps doing its job: a repeat of the specs an open PR already claims is still suppressed as `open-pr-covers-all-specs`, so only a genuinely new failure gets an agent. That the no-fix cooldown already expires (`NO_FIX_COOLDOWN_DAYS = 7`), and that the sibling OC nightly agent ships `c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml`, is what makes the missing expiry here a gap rather than a policy.

**2. One surface could lock itself twice.** Candidates are built per failing job while a dispatch key is one agent's remit, so a surface failing as several jobs produced several same-key candidates — `Playwright e2e full after install` and `Playwright e2e smoke after install` are both `sm-smoke-e2e` (this is the `x2` in the Slack summaries), and a multi-cell matrix gives one `helm-install` job per cell. `plan_dispatches` reads `open_pr_keys`/`inflight_keys` once up front and never adds a key it has just planned, so these could not see each other and all dispatched: two agents, then two PRs stamping the one key label. `c8-cross-component-e2e-tests#3071` and `#3073` are such a pair — freeing that key needed two merges instead of one, which fed defect 1.

`merge_by_key` now collapses same-key candidates before planning. It also unions their evidence, which matters when only one of the jobs yielded a Playwright report, and keeps every job name so a merged job-level dispatch still claims one fingerprint per job rather than leaving one uncovered and re-dispatchable.

### Verification

- `pytest .github/scripts` — 162 passed (14 new tests: TTL boundary/unparseable/naive-timestamp/disabled, and the merge behaviour incl. the cap and suppression-count effects).
- Ran the patched `open_fix_pr_keys()` against the live PR state: all five stale locks release, no key still held.
- Replayed the real failing run through the patched `discover.py`:
  - before — 2 candidates, both suppressed `open-fix-pr-for-surface`;
  - after — 1 merged candidate, correctly suppressed as `fixed-upstream-after-run-started` (the SM-8.10 test code had changed after the run started, via c8-cross-component-e2e-tests#3138). A real, self-expiring reason instead of a permanent lock.

Not backported: `.github/scripts/alwaysgreen` and the triage workflow live only on `main` — triage pins its tooling checkout to `main` precisely because the stable branches do not carry these files.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

No tracking issue — found from the `#alwaysgreen-reliability` triage thread [2026-08-26 13:05 CEST](https://camunda.slack.com/archives/C0AK0AVKRL0/p1787742352579809).
