### PR TITLE
ci: load-test: correctly detect changed load tests

### DIFF
--- a/.github/scripts/load-test-detect-versions-changed.sh
+++ b/.github/scripts/load-test-detect-versions-changed.sh
@@ -16,10 +16,17 @@ PARENT="origin/${GITHUB_BASE_REF}"
 
 # version orchestration-tag setup-path
 VERSIONS=(
-    "main SNAPSHOT load-tests/setup/main/"
-    "stable-89 8.9-SNAPSHOT load-tests/setup/stable-89/"
-    "stable-88 8.8-SNAPSHOT load-tests/setup/stable-88/"
-    "stable-87 8.7-SNAPSHOT load-tests/setup/stable-87/"
+    # version tag path
+    # `path` must be able to match files both in (for "stable-810"):
+    #
+    #   - load-tests/setup/stable-810/**
+    #   - load-tests/setup/test/golden/stable-810/**
+    #
+    "main SNAPSHOT load-tests/setup/.*main/"
+    "stable-810 8.10-SNAPSHOT load-tests/setup/.*stable-810/"
+    "stable-89 8.9-SNAPSHOT load-tests/setup/.*stable-89/"
+    "stable-88 8.8-SNAPSHOT load-tests/setup/.*stable-88/"
+    "stable-87 8.7-SNAPSHOT load-tests/setup/.*stable-87/"
 )
 
 echo "Finding versions changed compared to ${PARENT}..."
@@ -35,7 +42,7 @@ fi
 matrix_entries=()
 for entry in "${VERSIONS[@]}"; do
     read -r version tag path <<<"$entry"
-    if [[ "$run_all" == "true" ]] || grep -qF "$path" <<<"$changed"; then
+    if [[ "$run_all" == "true" ]] || grep -qE "$path" <<<"$changed"; then
         echo "⇒ Version '${version}' changed..."
         matrix_entries+=("{\"version\":\"${version}\",\"orchestration-tag\":\"${tag}\"}")
     fi

--- a/.github/scripts/load-test-detect-versions-changed.sh
+++ b/.github/scripts/load-test-detect-versions-changed.sh
@@ -34,8 +34,19 @@ echo "Finding versions changed compared to ${PARENT}..."
 changed="$(git diff --name-only "${PARENT}...HEAD")"
 
 run_all=false
+
+# Run all versions if the load-test workflow changed. This is a precaution
+# because the workflow may have changed in a way that affects all versions.
 if grep -qE '\.github/workflows/camunda-load-test' <<<"$changed"; then
     echo "⇒ Load-test workflow changed, running all versions..."
+    run_all=true
+fi
+
+# The load-test-setup Helm Chart is used by all the versions. It may or may not
+# affect the final output but as a precaution, we run all the versions if this
+# Helm Chart changed.
+if grep -qF 'load-tests/setup/charts/load-test-setup' <<<"$changed"; then
+    echo "⇒ load-test-setup Helm Chart changed, will run all the versions..."
     run_all=true
 fi
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -130,6 +130,7 @@
 
 # Performance + Load testing
 /.github/renovate/team-reliability-testing.json5 @camunda/reliability-testing
+/.github/scripts/load-test* @camunda/reliability-testing
 /.github/workflows/*load-test*.yml @camunda/reliability-testing
 /.tool-versions @camunda/reliability-testing
 /load-tests/ @camunda/reliability-testing


### PR DESCRIPTION
## Description

This should now detect:

1. changes both on the versioned configuration and the golden file tests themselves.
2. changes on the `load-test-setup` Helm Chart itself

The golden files can change without the versioned configuration if we update the Camunda Platform Helm Chart, versioned in `./load-tests/setup/newLoadTest.sh`.

This also enables the detection of stable-810 changes.

Tested with:

* Original detection:
  ```
  $ echo ./load-tests/setup/stable-810/values/values-stable.yaml | grep -E "load-tests/setup/.*stable-810/" && echo $?
  ./load-tests/setup/stable-810/values/values-stable.yaml
  0
  ```
* New detection:
  ```
  $ echo ./load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/namespace.yaml | grep -E "load-tests/setup/.*stable-810/" && echo $?
  ./load-tests/setup/test/golden/stable-810/max/load-test-setup/templates/namespace.yaml
  0
  ```


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Fix: #59988
