### PR TITLE
fix: correctly handle optimize backup snapshot ordering

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/snapshot/BackupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/snapshot/BackupServiceIT.java
@@ -8,12 +8,13 @@
 package io.camunda.optimize.service.snapshot;
 
 import static io.camunda.optimize.dto.optimize.BackupState.INCOMPLETE;
-import static io.camunda.optimize.service.util.SnapshotUtil.getSnapshotNameForImportIndices;
+import static io.camunda.optimize.service.util.SnapshotUtil.getSnapshotName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.AbstractCCSMIT;
 import io.camunda.optimize.dto.optimize.rest.BackupInfoDto;
 import io.camunda.optimize.service.BackupService;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.util.configuration.db.DatabaseBackup;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ public class BackupServiceIT extends AbstractCCSMIT {
     databaseIntegrationTestExtension.createRepoSnapshot(VALID_REPOSITORY_NAME);
     databaseIntegrationTestExtension.createSnapshot(
         VALID_REPOSITORY_NAME,
-        getSnapshotNameForImportIndices(VALID_BACKUP_ID),
+        getSnapshotName(BackupPriority.PRIORITY1, VALID_BACKUP_ID),
         databaseIntegrationTestExtension.getIndexNames());
 
     final DatabaseBackup databaseBackup = new DatabaseBackup();

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/DatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/DatabaseTestService.java
@@ -193,8 +193,6 @@ public abstract class DatabaseTestService {
 
   public abstract void cleanSnapshots(final String snapshotRepositoryName);
 
-  public abstract List<String> getImportIndices();
-
   protected abstract <T extends OptimizeDto> List<T> getInstancesById(
       final String indexName,
       final List<String> instanceIds,

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
@@ -88,7 +88,6 @@ import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES
 import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
 import io.camunda.optimize.service.db.es.schema.ElasticSearchIndexSettingsBuilder;
 import io.camunda.optimize.service.db.es.schema.ElasticSearchMetadataService;
-import io.camunda.optimize.service.db.es.schema.ElasticSearchSchemaManager;
 import io.camunda.optimize.service.db.es.schema.index.ExternalProcessVariableIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessInstanceIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TerminatedUserSessionIndexES;
@@ -223,19 +222,6 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
                           .refresh(Refresh.True)));
     } catch (final IOException e) {
       throw new OptimizeIntegrationTestException("Unable to add an entry to elasticsearch", e);
-    }
-  }
-
-  @Override
-  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
-    try {
-      getOptimizeElasticClient()
-          .elasticsearchClient()
-          .index(
-              IndexRequest.of(
-                  i -> i.index(rawIndexName).id(id).document(entry).refresh(Refresh.True)));
-    } catch (final IOException e) {
-      throw new OptimizeIntegrationTestException("Unable to add a raw entry to elasticsearch", e);
     }
   }
 
@@ -406,39 +392,6 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
             .filter(indexName -> !indexName.contains(recordsToKeep))
             .toArray(String[]::new);
     deleteZeebeIndicesByName(indicesToDelete);
-  }
-
-  private String[] listZeebeIndicesForPrefix(final String prefix) {
-    try {
-      return getOptimizeElasticClient()
-          .elasticsearchClient()
-          .indices()
-          .get(
-              GetIndexRequest.of(
-                  r -> r.index(prefix + "*").ignoreUnavailable(true).allowNoIndices(true)))
-          .result()
-          .keySet()
-          .toArray(String[]::new);
-    } catch (final IOException e) {
-      throw new OptimizeRuntimeException(e);
-    }
-  }
-
-  private void deleteZeebeIndicesByName(final String... indices) {
-    if (indices.length == 0) {
-      return;
-    }
-    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
-    // that vanishes between listing and deletion does not fail the cleanup.
-    try {
-      getOptimizeElasticClient().deleteIndexByRawIndexNames(indices);
-    } catch (final ElasticsearchException e) {
-      if ("index_not_found_exception".equals(e.error().type())) {
-        LOG.debug("Some Zeebe indices already gone by delete time, ignoring: {}", e.getMessage());
-      } else {
-        throw e;
-      }
-    }
   }
 
   @Override
@@ -635,6 +588,19 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
   }
 
   @Override
+  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
+    try {
+      getOptimizeElasticClient()
+          .elasticsearchClient()
+          .index(
+              IndexRequest.of(
+                  i -> i.index(rawIndexName).id(id).document(entry).refresh(Refresh.True)));
+    } catch (final IOException e) {
+      throw new OptimizeIntegrationTestException("Unable to add a raw entry to elasticsearch", e);
+    }
+  }
+
+  @Override
   public void deleteProcessInstancesFromIndex(final String indexName, final String id) {
     final DeleteRequest request =
         OptimizeDeleteRequestBuilderES.of(
@@ -705,14 +671,6 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
     } catch (final Exception e) {
       LOG.warn("Delete failed, no snapshots to delete from repository {}", snapshotRepositoryName);
     }
-  }
-
-  @Override
-  public List<String> getImportIndices() {
-    return ElasticSearchSchemaManager.getAllNonDynamicMappings().stream()
-        .filter(IndexMappingCreator::isImportIndex)
-        .map(IndexMappingCreator::getIndexName)
-        .toList();
   }
 
   @Override
@@ -1123,6 +1081,39 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
   @Override
   public String[] getIndexNames() throws IOException {
     return getOptimizeElasticClient().getAllIndexNames().toArray(new String[0]);
+  }
+
+  private String[] listZeebeIndicesForPrefix(final String prefix) {
+    try {
+      return getOptimizeElasticClient()
+          .elasticsearchClient()
+          .indices()
+          .get(
+              GetIndexRequest.of(
+                  r -> r.index(prefix + "*").ignoreUnavailable(true).allowNoIndices(true)))
+          .result()
+          .keySet()
+          .toArray(String[]::new);
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException(e);
+    }
+  }
+
+  private void deleteZeebeIndicesByName(final String... indices) {
+    if (indices.length == 0) {
+      return;
+    }
+    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
+    // that vanishes between listing and deletion does not fail the cleanup.
+    try {
+      getOptimizeElasticClient().deleteIndexByRawIndexNames(indices);
+    } catch (final ElasticsearchException e) {
+      if ("index_not_found_exception".equals(e.error().type())) {
+        LOG.debug("Some Zeebe indices already gone by delete time, ignoring: {}", e.getMessage());
+      } else {
+        throw e;
+      }
+    }
   }
 
   public OptimizeIndexNameService getIndexNameService() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
@@ -903,8 +903,8 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
     if (indices.isEmpty()) {
       return;
     }
-    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
-    // that vanishes between listing and deletion does not fail the cleanup.
+    // Wrap in a catch so that indices that vanish between listing and deletion do not fail the
+    // cleanup.
     try {
       getOptimizeOpenSearchClient()
           .getOpenSearchClient()

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
@@ -36,7 +36,6 @@ import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
 import io.camunda.optimize.service.db.os.client.dsl.RequestDSL;
 import io.camunda.optimize.service.db.os.schema.OpenSearchIndexSettingsBuilder;
 import io.camunda.optimize.service.db.os.schema.OpenSearchMetadataService;
-import io.camunda.optimize.service.db.os.schema.OpenSearchSchemaManager;
 import io.camunda.optimize.service.db.os.schema.index.ExternalProcessVariableIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessInstanceIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TerminatedUserSessionIndexOS;
@@ -213,26 +212,6 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
   }
 
   @Override
-  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
-    try {
-      final IndexRequest.Builder<Object> request =
-          new IndexRequest.Builder<>()
-              .document(entry)
-              .index(rawIndexName)
-              .id(id)
-              .refresh(Refresh.True);
-      final IndexResponse response =
-          getOptimizeOpenSearchClient().getOpenSearchClient().index(request.build());
-      if (!response.shards().failures().isEmpty()) {
-        throw new OptimizeIntegrationTestException(
-            String.format("Could not add raw entry to index %s with id %s", rawIndexName, id));
-      }
-    } catch (final IOException e) {
-      throw new OptimizeIntegrationTestException("Unable to add a raw entry to OpenSearch", e);
-    }
-  }
-
-  @Override
   public void addEntriesToDatabase(final String indexName, final Map<String, Object> idToEntryMap) {
     StreamSupport.stream(Iterables.partition(idToEntryMap.entrySet(), 10_000).spliterator(), false)
         .forEach(
@@ -375,37 +354,6 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
     deleteZeebeIndicesByName(indicesToDelete);
   }
 
-  private List<String> listZeebeIndicesForPrefix(final String prefix) {
-    try {
-      return getOptimizeOpenSearchClient()
-          .getOpenSearchClient()
-          .indices()
-          .get(RequestDSL.getIndexRequestBuilder(prefix + "*").ignoreUnavailable(true).build())
-          .result()
-          .keySet()
-          .stream()
-          .toList();
-    } catch (final IOException e) {
-      return List.of(); // No indices exist — nothing to clean
-    }
-  }
-
-  private void deleteZeebeIndicesByName(final List<String> indices) {
-    if (indices.isEmpty()) {
-      return;
-    }
-    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
-    // that vanishes between listing and deletion does not fail the cleanup.
-    try {
-      getOptimizeOpenSearchClient()
-          .getOpenSearchClient()
-          .indices()
-          .delete(d -> d.index(indices).ignoreUnavailable(true));
-    } catch (final Exception e) {
-      LOG.debug("Some Zeebe indices already gone by delete time, ignoring: {}", e.getMessage());
-    }
-  }
-
   @Override
   public void updateZeebeRecordsForPrefix(
       final String zeebeRecordPrefix, final String indexName, final String updateScript) {
@@ -533,6 +481,26 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
   }
 
   @Override
+  public void addEntryWithRawIndex(final String rawIndexName, final String id, final Object entry) {
+    try {
+      final IndexRequest.Builder<Object> request =
+          new IndexRequest.Builder<>()
+              .document(entry)
+              .index(rawIndexName)
+              .id(id)
+              .refresh(Refresh.True);
+      final IndexResponse response =
+          getOptimizeOpenSearchClient().getOpenSearchClient().index(request.build());
+      if (!response.shards().failures().isEmpty()) {
+        throw new OptimizeIntegrationTestException(
+            String.format("Could not add raw entry to index %s with id %s", rawIndexName, id));
+      }
+    } catch (final IOException e) {
+      throw new OptimizeIntegrationTestException("Unable to add a raw entry to OpenSearch", e);
+    }
+  }
+
+  @Override
   public void deleteProcessInstancesFromIndex(final String indexName, final String id) {
     getOptimizeOpenSearchClient().getRichOpenSearchClient().doc().delete(indexName, id);
   }
@@ -594,14 +562,6 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
     } catch (final Exception e) {
       LOG.warn("Delete failed, no snapshots to delete from repository {}", snapshotRepositoryName);
     }
-  }
-
-  @Override
-  public List<String> getImportIndices() {
-    return OpenSearchSchemaManager.getAllNonDynamicMappings().stream()
-        .filter(IndexMappingCreator::isImportIndex)
-        .map(IndexMappingCreator::getIndexName)
-        .toList();
   }
 
   @Override
@@ -922,6 +882,37 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
   @Override
   public String[] getIndexNames() throws IOException {
     return getOptimizeOpenSearchClient().getAllIndexNames().toArray(new String[0]);
+  }
+
+  private List<String> listZeebeIndicesForPrefix(final String prefix) {
+    try {
+      return getOptimizeOpenSearchClient()
+          .getOpenSearchClient()
+          .indices()
+          .get(RequestDSL.getIndexRequestBuilder(prefix + "*").ignoreUnavailable(true).build())
+          .result()
+          .keySet()
+          .stream()
+          .toList();
+    } catch (final IOException e) {
+      return List.of(); // No indices exist — nothing to clean
+    }
+  }
+
+  private void deleteZeebeIndicesByName(final List<String> indices) {
+    if (indices.isEmpty()) {
+      return;
+    }
+    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
+    // that vanishes between listing and deletion does not fail the cleanup.
+    try {
+      getOptimizeOpenSearchClient()
+          .getOpenSearchClient()
+          .indices()
+          .delete(d -> d.index(indices).ignoreUnavailable(true));
+    } catch (final Exception e) {
+      LOG.debug("Some Zeebe indices already gone by delete time, ignoring: {}", e.getMessage());
+    }
   }
 
   private IndexSettings createIndexSettings(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/MappingMetadataRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/MappingMetadataRepository.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.optimize.service.db.repository;
 
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import java.util.Set;
 
 public interface MappingMetadataRepository {
-  String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex);
+  String[] getIndexAliasesWithBackupPriority(final BackupPriority backupPriority);
 
   /**
    * Returns the process definition keys that currently have an instance index, <strong>lowercased

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SnapshotRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SnapshotRepository.java
@@ -12,9 +12,6 @@ import java.util.concurrent.CompletableFuture;
 public interface SnapshotRepository {
   void deleteOptimizeSnapshots(final Long backupId);
 
-  /**
-   * The returned future always completes normally, even if snapshot creation fails - failures are
-   * logged internally.
-   */
+  /** The returned future always completes normally, even if snapshot creation fails. */
   CompletableFuture<Void> triggerSnapshot(final String snapshotName, final String[] indexNames);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SnapshotRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SnapshotRepository.java
@@ -12,5 +12,9 @@ import java.util.concurrent.CompletableFuture;
 public interface SnapshotRepository {
   void deleteOptimizeSnapshots(final Long backupId);
 
+  /**
+   * The returned future always completes normally, even if snapshot creation fails - failures are
+   * logged internally.
+   */
   CompletableFuture<Void> triggerSnapshot(final String snapshotName, final String[] indexNames);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SnapshotRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/SnapshotRepository.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.optimize.service.db.repository;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface SnapshotRepository {
   void deleteOptimizeSnapshots(final Long backupId);
 
-  void triggerSnapshot(final String snapshotName, final String[] indexNames);
+  CompletableFuture<Void> triggerSnapshot(final String snapshotName, final String[] indexNames);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/MappingMetadataRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/MappingMetadataRepositoryES.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.es;
 import io.camunda.optimize.service.db.es.MappingMetadataUtilES;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.util.Locale;
 import java.util.Set;
@@ -33,9 +34,9 @@ public class MappingMetadataRepositoryES implements MappingMetadataRepository {
   }
 
   @Override
-  public String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex) {
+  public String[] getIndexAliasesWithBackupPriority(final BackupPriority backupPriority) {
     return mappingUtil.getAllMappings(esClient.getIndexNameService().getIndexPrefix()).stream()
-        .filter(mapping -> isImportIndex == mapping.isImportIndex())
+        .filter(mapping -> backupPriority == mapping.getBackupPriority())
         .map(esClient.getIndexNameService()::getOptimizeIndexAliasForIndex)
         .toArray(String[]::new);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryES.java
@@ -78,47 +78,62 @@ public class SnapshotRepositoryES implements SnapshotRepository {
     return future.handle(
         (v, e) -> {
           if (e != null) {
-            final String reason;
-            if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
-              reason =
-                  String.format(
-                      "Could not create snapshot [%s] because of concurrent snapshot operations.",
-                      snapshotName);
-            } else if (ExceptionUtil.unwrapCompletionCause(e) instanceof IOException) {
-              reason =
-                  String.format(
-                      "Encountered an error connecting to Elasticsearch while attempting to create snapshot [%s].",
-                      snapshotName);
-            } else {
-              reason = String.format("Failed to take snapshot [%s]", snapshotName);
-            }
-            LOG.error(reason, e);
+            onCreateSnapshotError(snapshotName, e);
           } else {
-            final SnapshotInfo snapshotInfo = v.snapshot();
-            switch (SnapshotState.valueOf(snapshotInfo.state())) {
-              // should not be null as waitForCompletion is true on snapshot request
-              case SUCCESS:
-                LOG.info("Successfully taken snapshot [{}].", snapshotInfo.snapshot());
-                break;
-              case FAILED:
-              case INCOMPATIBLE:
-                String reason =
-                    String.format(
-                        "Snapshot execution failed for [%s], reason: %s",
-                        snapshotInfo.snapshot(), snapshotInfo.reason());
-                LOG.error(reason);
-                break;
-              case PARTIAL:
-              default:
-                reason =
-                    String.format(
-                        "Snapshot status [%s] for snapshot with ID [%s]",
-                        snapshotInfo.state(), snapshotInfo.snapshot());
-                LOG.warn(reason);
-            }
+            onCreateSnapshotCompletion(v);
           }
           return null;
         });
+  }
+
+  private static void onCreateSnapshotCompletion(final CreateSnapshotResponse response) {
+    // should not be null as waitForCompletion is true on snapshot request
+    final SnapshotInfo snapshotInfo = response.snapshot();
+    try {
+      final SnapshotState snapshotState = SnapshotState.valueOf(snapshotInfo.state());
+      switch (snapshotState) {
+        case SUCCESS:
+          LOG.info("Successfully taken snapshot [{}].", snapshotInfo.snapshot());
+          break;
+        case FAILED:
+        case INCOMPATIBLE:
+          LOG.error(
+              "Snapshot execution failed for [{}], reason: {}",
+              snapshotInfo.snapshot(),
+              snapshotInfo.reason());
+          break;
+        case PARTIAL:
+        default:
+          LOG.warn(
+              "Snapshot status [{}] for snapshot with ID [{}]",
+              snapshotInfo.state(),
+              snapshotInfo.snapshot());
+      }
+    } catch (final IllegalArgumentException ex) {
+      LOG.error(
+          "Snapshot state [{}] for snapshot with ID [{}] is not a valid SnapshotState enum value.",
+          snapshotInfo.state(),
+          snapshotInfo.snapshot(),
+          ex);
+    }
+  }
+
+  private static void onCreateSnapshotError(final String snapshotName, final Throwable e) {
+    final String reason;
+    if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
+      reason =
+          String.format(
+              "Could not create snapshot [%s] because of concurrent snapshot operations.",
+              snapshotName);
+    } else if (ExceptionUtil.unwrapCompletionCause(e) instanceof IOException) {
+      reason =
+          String.format(
+              "Encountered an error connecting to Elasticsearch while attempting to create snapshot [%s].",
+              snapshotName);
+    } else {
+      reason = String.format("Failed to take snapshot [%s]", snapshotName);
+    }
+    LOG.error(reason, e);
   }
 
   private void getDeleteSnapshotActionListener(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryES.java
@@ -82,15 +82,13 @@ public class SnapshotRepositoryES implements SnapshotRepository {
             if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
               reason =
                   String.format(
-                      "Could not create snapshot [%s] because because of concurrent snapshot operations.",
+                      "Could not create snapshot [%s] because of concurrent snapshot operations.",
                       snapshotName);
-              LOG.error(reason, e);
             } else if (ExceptionUtil.unwrapCompletionCause(e) instanceof IOException) {
               reason =
                   String.format(
                       "Encountered an error connecting to Elasticsearch while attempting to create snapshot [%s].",
                       snapshotName);
-              LOG.error(reason, e);
             } else {
               reason = String.format("Failed to take snapshot [%s]", snapshotName);
             }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryES.java
@@ -17,6 +17,7 @@ import co.elastic.clients.elasticsearch.snapshot.SnapshotInfo;
 import io.camunda.optimize.dto.optimize.rest.SnapshotState;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.repository.SnapshotRepository;
+import io.camunda.optimize.service.util.ExceptionUtil;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
@@ -54,7 +55,8 @@ public class SnapshotRepositoryES implements SnapshotRepository {
   }
 
   @Override
-  public void triggerSnapshot(final String snapshotName, final String[] indexNames) {
+  public CompletableFuture<Void> triggerSnapshot(
+      final String snapshotName, final String[] indexNames) {
     LOG.info("Triggering async snapshot {}.", snapshotName);
     final CreateSnapshotRequest createSnapshotRequest =
         CreateSnapshotRequest.of(
@@ -67,25 +69,32 @@ public class SnapshotRepositoryES implements SnapshotRepository {
                     .indices(Arrays.stream(indexNames).toList())
                     .includeGlobalState(false)
                     .waitForCompletion(true));
-    getCreateSnapshotActionListener(
+    return getCreateSnapshotActionListener(
         esClient.triggerSnapshotAsync(createSnapshotRequest), snapshotName);
   }
 
-  private void getCreateSnapshotActionListener(
+  private CompletableFuture<Void> getCreateSnapshotActionListener(
       final CompletableFuture<CreateSnapshotResponse> future, final String snapshotName) {
-    future.whenComplete(
+    return future.handle(
         (v, e) -> {
           if (e != null) {
-            if (e instanceof IOException) {
-              final String reason =
+            final String reason;
+            if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
+              reason =
+                  String.format(
+                      "Could not create snapshot [%s] because because of concurrent snapshot operations.",
+                      snapshotName);
+              LOG.error(reason, e);
+            } else if (ExceptionUtil.unwrapCompletionCause(e) instanceof IOException) {
+              reason =
                   String.format(
                       "Encountered an error connecting to Elasticsearch while attempting to create snapshot [%s].",
                       snapshotName);
               LOG.error(reason, e);
             } else {
-              final String reason = String.format("Failed to take snapshot [%s]", snapshotName);
-              LOG.error(reason, e);
+              reason = String.format("Failed to take snapshot [%s]", snapshotName);
             }
+            LOG.error(reason, e);
           } else {
             final SnapshotInfo snapshotInfo = v.snapshot();
             switch (SnapshotState.valueOf(snapshotInfo.state())) {
@@ -110,6 +119,7 @@ public class SnapshotRepositoryES implements SnapshotRepository {
                 LOG.warn(reason);
             }
           }
+          return null;
         });
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOS.java
@@ -121,7 +121,7 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
     if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
       reason =
           format(
-              "Could not create snapshot [%s] because because of concurrent snapshot operations.",
+              "Could not create snapshot [%s] because of concurrent snapshot operations.",
               snapshotName);
     } else if (ExceptionUtil.unwrapCompletionCause(e) instanceof IOException) {
       reason =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOS.java
@@ -77,10 +77,10 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
         .handle(
             (createSnapshotResponse, throwable) -> {
               if (createSnapshotResponse != null) {
-                onSnapshotCreated(createSnapshotResponse);
+                onCreateSnapshotCompletion(createSnapshotResponse);
               }
               if (throwable != null) {
-                onSnapshotCreationFailed(throwable, snapshotName);
+                onCreateSnapshotError(throwable, snapshotName);
               }
               return null;
             });
@@ -116,7 +116,7 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
     }
   }
 
-  private void onSnapshotCreationFailed(final Throwable e, final String snapshotName) {
+  private void onCreateSnapshotError(final Throwable e, final String snapshotName) {
     final String reason;
     if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
       reason =
@@ -134,10 +134,10 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
     LOG.error(reason, e);
   }
 
-  private void onSnapshotCreated(final CreateSnapshotResponse createSnapshotResponse) {
+  private void onCreateSnapshotCompletion(final CreateSnapshotResponse createSnapshotResponse) {
+    // should not be null as waitForCompletion is true on snapshot request
     final SnapshotInfo snapshotInfo = createSnapshotResponse.snapshot();
-    switch (snapshotInfo
-        .state()) { // should not be null as waitForCompletion is true on snapshot request
+    switch (snapshotInfo.state()) {
       case SUCCESS -> LOG.info("Successfully taken snapshot [{}].", snapshotInfo.snapshot());
       case FAILED -> {
         final String reason =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOS.java
@@ -14,10 +14,12 @@ import static java.lang.String.format;
 
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.SnapshotRepository;
+import io.camunda.optimize.service.util.ExceptionUtil;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
 import org.opensearch.client.opensearch.snapshot.DeleteSnapshotResponse;
 import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
@@ -60,9 +62,10 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
   }
 
   @Override
-  public void triggerSnapshot(final String snapshotName, final String[] indexNames) {
+  public CompletableFuture<Void> triggerSnapshot(
+      final String snapshotName, final String[] indexNames) {
     LOG.info("Triggering async snapshot {}.", snapshotName);
-    osClient
+    return osClient
         .getRichOpenSearchClient()
         .async()
         .snapshot()
@@ -71,7 +74,7 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
             snapshotName,
             Arrays.asList(indexNames),
             e -> format("Failed to send create snapshot %s request to Opensearch!", snapshotName))
-        .whenComplete(
+        .handle(
             (createSnapshotResponse, throwable) -> {
               if (createSnapshotResponse != null) {
                 onSnapshotCreated(createSnapshotResponse);
@@ -79,6 +82,7 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
               if (throwable != null) {
                 onSnapshotCreationFailed(throwable, snapshotName);
               }
+              return null;
             });
   }
 
@@ -113,16 +117,21 @@ public class SnapshotRepositoryOS implements SnapshotRepository {
   }
 
   private void onSnapshotCreationFailed(final Throwable e, final String snapshotName) {
-    if (e instanceof IOException) {
-      final String reason =
+    final String reason;
+    if (ExceptionUtil.isConcurrentSnapshotExecutionException(e)) {
+      reason =
+          format(
+              "Could not create snapshot [%s] because because of concurrent snapshot operations.",
+              snapshotName);
+    } else if (ExceptionUtil.unwrapCompletionCause(e) instanceof IOException) {
+      reason =
           format(
               "Encountered an error connecting to OpenSearch while attempting to create snapshot [%s].",
               snapshotName);
-      LOG.error(reason, e);
     } else {
-      final String reason = format("Failed to take snapshot [%s]", snapshotName);
-      LOG.error(reason, e);
+      reason = format("Failed to take snapshot [%s]", snapshotName);
     }
+    LOG.error(reason, e);
   }
 
   private void onSnapshotCreated(final CreateSnapshotResponse createSnapshotResponse) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/MappingMetadataRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/MappingMetadataRepositoryOS.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.os;
 import io.camunda.optimize.service.db.os.MappingMetadataUtilOS;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import java.util.Locale;
 import java.util.Set;
@@ -33,9 +34,9 @@ public class MappingMetadataRepositoryOS implements MappingMetadataRepository {
   }
 
   @Override
-  public String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex) {
+  public String[] getIndexAliasesWithBackupPriority(final BackupPriority backupPriority) {
     return mappingUtil.getAllMappings(osClient.getIndexNameService().getIndexPrefix()).stream()
-        .filter(mapping -> isImportIndex == mapping.isImportIndex())
+        .filter(mapping -> backupPriority == mapping.getBackupPriority())
         .map(osClient.getIndexNameService()::getOptimizeIndexAliasForIndex)
         .toArray(String[]::new);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BackupWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BackupWriter.java
@@ -30,16 +30,15 @@ public class BackupWriter {
     this.snapshotRepository = snapshotRepository;
   }
 
-  public void triggerSnapshotCreation(final Long backupId) {
+  public CompletableFuture<Void> triggerSnapshotCreation(final Long backupId) {
     final String snapshot1Name = getSnapshotNameForImportIndices(backupId);
     final String snapshot2Name = getSnapshotNameForNonImportIndices(backupId);
-    CompletableFuture.runAsync(
-        () -> {
-          snapshotRepository.triggerSnapshot(
-              snapshot1Name, getIndexAliasesWithImportIndexFlag(true));
-          snapshotRepository.triggerSnapshot(
-              snapshot2Name, getIndexAliasesWithImportIndexFlag(false));
-        });
+    return snapshotRepository
+        .triggerSnapshot(snapshot1Name, getIndexAliasesWithImportIndexFlag(true))
+        .thenComposeAsync(
+            ignored ->
+                snapshotRepository.triggerSnapshot(
+                    snapshot2Name, getIndexAliasesWithImportIndexFlag(false)));
   }
 
   public void deleteOptimizeSnapshots(final Long backupId) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BackupWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/BackupWriter.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.optimize.service.db.writer;
 
-import static io.camunda.optimize.service.util.SnapshotUtil.getSnapshotNameForImportIndices;
-import static io.camunda.optimize.service.util.SnapshotUtil.getSnapshotNameForNonImportIndices;
+import static io.camunda.optimize.service.util.SnapshotUtil.getSnapshotName;
 
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SnapshotRepository;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
@@ -31,21 +31,24 @@ public class BackupWriter {
   }
 
   public CompletableFuture<Void> triggerSnapshotCreation(final Long backupId) {
-    final String snapshot1Name = getSnapshotNameForImportIndices(backupId);
-    final String snapshot2Name = getSnapshotNameForNonImportIndices(backupId);
-    return snapshotRepository
-        .triggerSnapshot(snapshot1Name, getIndexAliasesWithImportIndexFlag(true))
+    final String snapshot1Name = getSnapshotName(BackupPriority.PRIORITY1, backupId);
+    final String snapshot2Name = getSnapshotName(BackupPriority.PRIORITY2, backupId);
+    return CompletableFuture.supplyAsync(
+            () -> getIndexAliasesWithBackupPriority(BackupPriority.PRIORITY1))
+        .thenCompose(aliases -> snapshotRepository.triggerSnapshot(snapshot1Name, aliases))
         .thenComposeAsync(
             ignored ->
-                snapshotRepository.triggerSnapshot(
-                    snapshot2Name, getIndexAliasesWithImportIndexFlag(false)));
+                CompletableFuture.supplyAsync(
+                        () -> getIndexAliasesWithBackupPriority(BackupPriority.PRIORITY2))
+                    .thenCompose(
+                        aliases -> snapshotRepository.triggerSnapshot(snapshot2Name, aliases)));
   }
 
   public void deleteOptimizeSnapshots(final Long backupId) {
     snapshotRepository.deleteOptimizeSnapshots(backupId);
   }
 
-  private String[] getIndexAliasesWithImportIndexFlag(final boolean isImportIndex) {
-    return mappingMetadataRepository.getIndexAliasesWithImportIndexFlag(isImportIndex);
+  private String[] getIndexAliasesWithBackupPriority(final BackupPriority backupPriority) {
+    return mappingMetadataRepository.getIndexAliasesWithBackupPriority(backupPriority);
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/SnapshotUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/SnapshotUtil.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.util;
 
 import static io.camunda.optimize.service.metadata.Version.VERSION;
 
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,12 +33,11 @@ public class SnapshotUtil {
   private static final String VERSION_PLACEHOLDER = "{version}";
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(SnapshotUtil.class);
 
-  public static String getSnapshotNameForImportIndices(final Long backupId) {
-    return getSnapshotName(SNAPSHOT_1_NAME_TEMPLATE, backupId);
-  }
-
-  public static String getSnapshotNameForNonImportIndices(final Long backupId) {
-    return getSnapshotName(SNAPSHOT_2_NAME_TEMPLATE, backupId);
+  public static String getSnapshotName(final BackupPriority priority, final Long backupId) {
+    return switch (priority) {
+      case PRIORITY1 -> getSnapshotName(SNAPSHOT_1_NAME_TEMPLATE, backupId);
+      case PRIORITY2 -> getSnapshotName(SNAPSHOT_2_NAME_TEMPLATE, backupId);
+    };
   }
 
   public static String getSnapshotPrefixWithBackupId(final Long backupId) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/backup/SnapshotUtilTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/backup/SnapshotUtilTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 public class SnapshotUtilTest {
   @Test
-  public void getSnapshotName() {
+  public void shouldGetSnapshotName() {
     // when/then
     assertThat(SnapshotUtil.getSnapshotName(BackupPriority.PRIORITY1, 123L))
         .isEqualTo(String.format("camunda_optimize_123_%s_part_1_of_2", VERSION));
@@ -25,13 +25,13 @@ public class SnapshotUtilTest {
   }
 
   @Test
-  public void getSnapshotPrefixWithBackupId() {
+  public void shouldGetSnapshotPrefixWithBackupId() {
     // when/then
     assertThat(SnapshotUtil.getSnapshotPrefixWithBackupId(123L)).isEqualTo("camunda_optimize_123_");
   }
 
   @Test
-  public void getBackupIdFromSnapshotName() {
+  public void shouldGetBackupIdFromSnapshotName() {
     // when/then
     assertThat(SnapshotUtil.getBackupIdFromSnapshotName("camunda_optimize_123_3.9.0_part_1_of_2"))
         .isEqualTo(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/backup/SnapshotUtilTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/backup/SnapshotUtilTest.java
@@ -10,21 +10,17 @@ package io.camunda.optimize.service.backup;
 import static io.camunda.optimize.service.metadata.Version.VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.util.SnapshotUtil;
 import org.junit.jupiter.api.Test;
 
 public class SnapshotUtilTest {
   @Test
-  public void getSnapshotNameForImportIndices() {
+  public void getSnapshotName() {
     // when/then
-    assertThat(SnapshotUtil.getSnapshotNameForImportIndices(123L))
+    assertThat(SnapshotUtil.getSnapshotName(BackupPriority.PRIORITY1, 123L))
         .isEqualTo(String.format("camunda_optimize_123_%s_part_1_of_2", VERSION));
-  }
-
-  @Test
-  public void getSnapshotNameForNonImportIndices() {
-    // when/then
-    assertThat(SnapshotUtil.getSnapshotNameForNonImportIndices(123L))
+    assertThat(SnapshotUtil.getSnapshotName(BackupPriority.PRIORITY2, 123L))
         .isEqualTo(String.format("camunda_optimize_123_%s_part_2_of_2", VERSION));
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryESTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotRequest;
+import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotResponse;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SnapshotRepositoryESTest {
+
+  private OptimizeElasticsearchClient esClient;
+  private SnapshotRepositoryES snapshotRepositoryES;
+
+  @BeforeEach
+  void init() {
+    esClient = mock(OptimizeElasticsearchClient.class);
+    final ConfigurationService configurationService =
+        ConfigurationServiceBuilder.createDefaultConfiguration();
+    snapshotRepositoryES = new SnapshotRepositoryES(esClient, configurationService);
+  }
+
+  @Test
+  void shouldCompleteReturnedFutureNormallyOnSuccessfulSnapshot() {
+    // given
+    final CreateSnapshotResponse response =
+        CreateSnapshotResponse.of(
+            b ->
+                b.snapshot(
+                    s ->
+                        s.snapshot("snap-1")
+                            .state("SUCCESS")
+                            .uuid("uuid")
+                            .indices(java.util.List.of("job-registry"))
+                            .dataStreams(java.util.List.of())));
+    when(esClient.triggerSnapshotAsync(any(CreateSnapshotRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final CompletableFuture<Void> result =
+        snapshotRepositoryES.triggerSnapshot("snap-1", new String[] {"job-registry"});
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteReturnedFutureNormallyEvenWhenSnapshotCreationFails() {
+    // given - a failed snapshot attempt must not block a subsequently chained snapshot request
+    when(esClient.triggerSnapshotAsync(any(CreateSnapshotRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new IOException("connection reset")));
+
+    // when
+    final CompletableFuture<Void> result =
+        snapshotRepositoryES.triggerSnapshot("snap-1", new String[] {"job-registry"});
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteReturnedFutureNormallyOnConcurrentSnapshotExecutionException() {
+    // given
+    final ElasticsearchException exception =
+        new ElasticsearchException(
+            "concurrent_snapshot_execution_exception",
+            ErrorResponse.of(
+                e ->
+                    e.error(
+                            ErrorCause.of(
+                                c ->
+                                    c.type("concurrent_snapshot_execution_exception")
+                                        .reason("a snapshot is already running")))
+                        .status(503)));
+    when(esClient.triggerSnapshotAsync(any(CreateSnapshotRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(exception));
+
+    // when
+    final CompletableFuture<Void> result =
+        snapshotRepositoryES.triggerSnapshot("snap-1", new String[] {"job-registry"});
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/es/SnapshotRepositoryOSTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.os.RichOpenSearchClient;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.ErrorResponse;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotRequest;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
+import org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotAsyncClient;
+
+class SnapshotRepositoryOSTest {
+
+  private OpenSearchSnapshotAsyncClient snapshotAsyncClient;
+  private SnapshotRepositoryOS snapshotRepositoryOS;
+
+  @BeforeEach
+  void init() throws IOException {
+    final OpenSearchAsyncClient openSearchAsyncClient = mock(OpenSearchAsyncClient.class);
+    snapshotAsyncClient = mock(OpenSearchSnapshotAsyncClient.class);
+    when(openSearchAsyncClient.snapshot()).thenReturn(snapshotAsyncClient);
+
+    final RichOpenSearchClient richOpenSearchClient =
+        new RichOpenSearchClient(
+            mock(OpenSearchClient.class),
+            openSearchAsyncClient,
+            new OptimizeIndexNameService("optimize"));
+    final OptimizeOpenSearchClient osClient = mock(OptimizeOpenSearchClient.class);
+    when(osClient.getRichOpenSearchClient()).thenReturn(richOpenSearchClient);
+
+    final ConfigurationService configurationService =
+        ConfigurationServiceBuilder.createDefaultConfiguration();
+    snapshotRepositoryOS = new SnapshotRepositoryOS(osClient, configurationService);
+  }
+
+  @Test
+  void shouldCompleteReturnedFutureNormallyOnSuccessfulSnapshot() throws IOException {
+    // given
+    final CreateSnapshotResponse response =
+        CreateSnapshotResponse.of(
+            b ->
+                b.snapshot(
+                    s ->
+                        s.snapshot("snap-1")
+                            .uuid("uuid")
+                            .state("SUCCESS")
+                            .indices("job-registry")));
+    when(snapshotAsyncClient.create(any(CreateSnapshotRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    final CompletableFuture<Void> result =
+        snapshotRepositoryOS.triggerSnapshot("snap-1", new String[] {"job-registry"});
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteReturnedFutureNormallyEvenWhenSnapshotCreationFails() throws IOException {
+    // given - a failed snapshot attempt must not block a subsequently chained snapshot request
+    when(snapshotAsyncClient.create(any(CreateSnapshotRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new IOException("connection reset")));
+
+    // when
+    final CompletableFuture<Void> result =
+        snapshotRepositoryOS.triggerSnapshot("snap-1", new String[] {"job-registry"});
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteReturnedFutureNormallyOnConcurrentSnapshotExecutionException()
+      throws IOException {
+    // given
+    final OpenSearchException exception =
+        new OpenSearchException(
+            new ErrorResponse.Builder()
+                .status(503)
+                .error(
+                    new ErrorCause.Builder()
+                        .type("concurrent_snapshot_execution_exception")
+                        .reason("a snapshot is already running")
+                        .build())
+                .build());
+    when(snapshotAsyncClient.create(any(CreateSnapshotRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(exception));
+
+    // when
+    final CompletableFuture<Void> result =
+        snapshotRepositoryOS.triggerSnapshot("snap-1", new String[] {"job-registry"});
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BackupWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BackupWriterTest.java
@@ -17,14 +17,15 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SnapshotRepository;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BackupWriterTest {
 
-  private static final String[] IMPORT_INDICES = new String[] {"job-registry"};
-  private static final String[] NON_IMPORT_INDICES = new String[] {"process-instance"};
+  private static final String[] PRIORITY1_INDICES = new String[] {"job-registry"};
+  private static final String[] PRIORITY2_INDICES = new String[] {"process-instance"};
 
   private SnapshotRepository snapshotRepository;
   private BackupWriter backupWriter;
@@ -34,33 +35,33 @@ class BackupWriterTest {
     final MappingMetadataRepository mappingMetadataRepository =
         mock(MappingMetadataRepository.class);
     snapshotRepository = mock(SnapshotRepository.class);
-    when(mappingMetadataRepository.getIndexAliasesWithImportIndexFlag(true))
-        .thenReturn(IMPORT_INDICES);
-    when(mappingMetadataRepository.getIndexAliasesWithImportIndexFlag(false))
-        .thenReturn(NON_IMPORT_INDICES);
+    when(mappingMetadataRepository.getIndexAliasesWithBackupPriority(BackupPriority.PRIORITY1))
+        .thenReturn(PRIORITY1_INDICES);
+    when(mappingMetadataRepository.getIndexAliasesWithBackupPriority(BackupPriority.PRIORITY2))
+        .thenReturn(PRIORITY2_INDICES);
     backupWriter = new BackupWriter(mappingMetadataRepository, snapshotRepository);
   }
 
   @Test
-  void shouldNotTriggerNonImportSnapshotUntilImportSnapshotFutureCompletes() {
+  void shouldNotTriggerPriority2SnapshotUntilPriority1SnapshotFutureCompletes() {
     // given
     final CompletableFuture<Void> importSnapshotFuture = new CompletableFuture<>();
-    when(snapshotRepository.triggerSnapshot(any(), eq(IMPORT_INDICES)))
+    when(snapshotRepository.triggerSnapshot(any(), eq(PRIORITY1_INDICES)))
         .thenReturn(importSnapshotFuture);
-    when(snapshotRepository.triggerSnapshot(any(), eq(NON_IMPORT_INDICES)))
+    when(snapshotRepository.triggerSnapshot(any(), eq(PRIORITY2_INDICES)))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
     final CompletableFuture<Void> result = backupWriter.triggerSnapshotCreation(1L);
 
-    // then - the non-import snapshot must not fire while the import snapshot is still pending
-    verify(snapshotRepository, never()).triggerSnapshot(any(), eq(NON_IMPORT_INDICES));
+    // then - the PRIORITY2 snapshot must not fire while the PRIORITY1 snapshot is still pending
+    verify(snapshotRepository, never()).triggerSnapshot(any(), eq(PRIORITY2_INDICES));
 
     // when the import snapshot resolves
     importSnapshotFuture.complete(null);
     result.join();
 
     // then the non-import snapshot is triggered afterward
-    verify(snapshotRepository, times(1)).triggerSnapshot(any(), eq(NON_IMPORT_INDICES));
+    verify(snapshotRepository, times(1)).triggerSnapshot(any(), eq(PRIORITY2_INDICES));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BackupWriterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/writer/BackupWriterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
+import io.camunda.optimize.service.db.repository.SnapshotRepository;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BackupWriterTest {
+
+  private static final String[] IMPORT_INDICES = new String[] {"job-registry"};
+  private static final String[] NON_IMPORT_INDICES = new String[] {"process-instance"};
+
+  private SnapshotRepository snapshotRepository;
+  private BackupWriter backupWriter;
+
+  @BeforeEach
+  void setUp() {
+    final MappingMetadataRepository mappingMetadataRepository =
+        mock(MappingMetadataRepository.class);
+    snapshotRepository = mock(SnapshotRepository.class);
+    when(mappingMetadataRepository.getIndexAliasesWithImportIndexFlag(true))
+        .thenReturn(IMPORT_INDICES);
+    when(mappingMetadataRepository.getIndexAliasesWithImportIndexFlag(false))
+        .thenReturn(NON_IMPORT_INDICES);
+    backupWriter = new BackupWriter(mappingMetadataRepository, snapshotRepository);
+  }
+
+  @Test
+  void shouldNotTriggerNonImportSnapshotUntilImportSnapshotFutureCompletes() {
+    // given
+    final CompletableFuture<Void> importSnapshotFuture = new CompletableFuture<>();
+    when(snapshotRepository.triggerSnapshot(any(), eq(IMPORT_INDICES)))
+        .thenReturn(importSnapshotFuture);
+    when(snapshotRepository.triggerSnapshot(any(), eq(NON_IMPORT_INDICES)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final CompletableFuture<Void> result = backupWriter.triggerSnapshotCreation(1L);
+
+    // then - the non-import snapshot must not fire while the import snapshot is still pending
+    verify(snapshotRepository, never()).triggerSnapshot(any(), eq(NON_IMPORT_INDICES));
+
+    // when the import snapshot resolves
+    importSnapshotFuture.complete(null);
+    result.join();
+
+    // then the non-import snapshot is triggered afterward
+    verify(snapshotRepository, times(1)).triggerSnapshot(any(), eq(NON_IMPORT_INDICES));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -70,6 +70,8 @@ public final class DatabaseConstants {
   public static final String INDEX_SUFFIX = "-000001";
   public static final String INDEX = "_index";
   public static final String TOO_MANY_BUCKETS_EXCEPTION_TYPE = "too_many_buckets_exception";
+  public static final String CONCURRENT_SNAPSHOT_EXECUTION_EXCEPTION_TYPE =
+      "concurrent_snapshot_execution_exception";
   public static final String INDEX_NOT_FOUND_EXCEPTION_TYPE = "index_not_found_exception";
   public static final String INDEX_ALREADY_EXISTS_EXCEPTION_TYPE =
       "resource_already_exists_exception";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/BackupPriority.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/BackupPriority.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema;
+
+/**
+ * Determines which of the two backup snapshot requests an index is captured in. {@code PRIORITY1}
+ * indices are snapshotted first and must complete before {@code PRIORITY2} indices are snapshotted,
+ * so that indices describing the state of other indices are never captured in a state newer than
+ * the data they describe.
+ */
+public enum BackupPriority {
+  PRIORITY1,
+  PRIORITY2
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexMappingCreator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexMappingCreator.java
@@ -31,8 +31,8 @@ public interface IndexMappingCreator<TBuilder> {
     return false;
   }
 
-  default boolean isImportIndex() {
-    return false;
+  default BackupPriority getBackupPriority() {
+    return BackupPriority.PRIORITY2;
   }
 
   int getVersion();

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
@@ -46,6 +46,11 @@ public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCrea
   }
 
   @Override
+  public boolean isImportIndex() {
+    return true;
+  }
+
+  @Override
   public int getVersion() {
     return VERSION;
   }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/JobRegistryIndex.java
@@ -12,6 +12,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FOR
 
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
 
 public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
@@ -46,8 +47,8 @@ public abstract class JobRegistryIndex<TBuilder> extends DefaultIndexMappingCrea
   }
 
   @Override
-  public boolean isImportIndex() {
-    return true;
+  public BackupPriority getBackupPriority() {
+    return BackupPriority.PRIORITY1;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/PositionBasedImportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/PositionBasedImportIndex.java
@@ -14,6 +14,7 @@ import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.index.ImportIndexDto;
 import io.camunda.optimize.dto.optimize.index.PositionBasedImportIndexDto;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
 
 public abstract class PositionBasedImportIndex<TBuilder>
@@ -41,8 +42,8 @@ public abstract class PositionBasedImportIndex<TBuilder>
   }
 
   @Override
-  public boolean isImportIndex() {
-    return true;
+  public BackupPriority getBackupPriority() {
+    return BackupPriority.PRIORITY1;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/TimestampBasedImportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/TimestampBasedImportIndex.java
@@ -14,6 +14,7 @@ import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.index.ImportIndexDto;
 import io.camunda.optimize.dto.optimize.index.TimestampBasedImportIndexDto;
+import io.camunda.optimize.service.db.schema.BackupPriority;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
 
 public abstract class TimestampBasedImportIndex<TBuilder>
@@ -34,8 +35,8 @@ public abstract class TimestampBasedImportIndex<TBuilder>
   }
 
   @Override
-  public boolean isImportIndex() {
-    return true;
+  public BackupPriority getBackupPriority() {
+    return BackupPriority.PRIORITY1;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/ExceptionUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/ExceptionUtil.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.util;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.CONCURRENT_SNAPSHOT_EXECUTION_EXCEPTION_TYPE;
 import static io.camunda.optimize.service.db.DatabaseConstants.DECISION_INSTANCE_INDEX_PREFIX;
 import static io.camunda.optimize.service.db.DatabaseConstants.DECISION_INSTANCE_MULTI_ALIAS;
 import static io.camunda.optimize.service.db.DatabaseConstants.INDEX_NOT_FOUND_EXCEPTION_TYPE;
@@ -18,12 +19,30 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.ErrorCause;
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 
 public class ExceptionUtil {
   public static boolean isTooManyBucketsException(final RuntimeException e) {
     return isDbExceptionWithMessage(e, msg -> msg.contains(TOO_MANY_BUCKETS_EXCEPTION_TYPE));
+  }
+
+  public static boolean isConcurrentSnapshotExecutionException(final Throwable t) {
+    final Throwable unwrapped = unwrapCompletionCause(t);
+    return unwrapped instanceof final RuntimeException runtimeException
+        && isDbExceptionWithMessage(
+            runtimeException, msg -> msg.contains(CONCURRENT_SNAPSHOT_EXECUTION_EXCEPTION_TYPE));
+  }
+
+  public static Throwable unwrapCompletionCause(final Throwable t) {
+    Throwable current = t;
+    while ((current instanceof CompletionException || current instanceof ExecutionException)
+        && current.getCause() != null) {
+      current = current.getCause();
+    }
+    return current;
   }
 
   public static boolean isInstanceIndexNotFoundException(final RuntimeException e) {

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/ExceptionUtilTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/ExceptionUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
+import java.io.IOException;
+import java.util.concurrent.CompletionException;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+
+class ExceptionUtilTest {
+
+  @Test
+  void shouldDetectConcurrentSnapshotExecutionExceptionFromElasticsearchException() {
+    // given
+    final ElasticsearchException exception =
+        new ElasticsearchException(
+            "snapshot",
+            ErrorResponse.of(
+                e ->
+                    e.error(
+                            ErrorCause.of(
+                                c ->
+                                    c.type("concurrent_snapshot_execution_exception")
+                                        .reason("a snapshot is already running")))
+                        .status(503)));
+
+    // when + then
+    assertThat(ExceptionUtil.isConcurrentSnapshotExecutionException(exception)).isTrue();
+  }
+
+  @Test
+  void shouldDetectConcurrentSnapshotExecutionExceptionFromOpenSearchException() {
+    // given
+    final OpenSearchException exception =
+        new OpenSearchException(
+            new org.opensearch.client.opensearch._types.ErrorResponse.Builder()
+                .status(503)
+                .error(
+                    new org.opensearch.client.opensearch._types.ErrorCause.Builder()
+                        .type("concurrent_snapshot_execution_exception")
+                        .reason("a snapshot is already running")
+                        .build())
+                .build());
+
+    // when + then
+    assertThat(ExceptionUtil.isConcurrentSnapshotExecutionException(exception)).isTrue();
+  }
+
+  @Test
+  void shouldDetectConcurrentSnapshotExecutionExceptionWrappedInCompletionException() {
+    // given
+    final OpenSearchException cause =
+        new OpenSearchException(
+            new org.opensearch.client.opensearch._types.ErrorResponse.Builder()
+                .status(503)
+                .error(
+                    new org.opensearch.client.opensearch._types.ErrorCause.Builder()
+                        .type("concurrent_snapshot_execution_exception")
+                        .reason("a snapshot is already running")
+                        .build())
+                .build());
+    final CompletionException wrapped = new CompletionException(cause);
+
+    // when + then
+    assertThat(ExceptionUtil.isConcurrentSnapshotExecutionException(wrapped)).isTrue();
+  }
+
+  @Test
+  void shouldNotDetectConcurrentSnapshotExecutionExceptionForUnrelatedElasticsearchException() {
+    // given
+    final ElasticsearchException exception =
+        new ElasticsearchException(
+            "too_many_buckets_exception",
+            ErrorResponse.of(
+                e ->
+                    e.error(
+                            ErrorCause.of(
+                                c ->
+                                    c.type("too_many_buckets_exception")
+                                        .reason("too many buckets")))
+                        .status(400)));
+
+    // when + then
+    assertThat(ExceptionUtil.isConcurrentSnapshotExecutionException(exception)).isFalse();
+  }
+
+  @Test
+  void shouldNotDetectConcurrentSnapshotExecutionExceptionForUnrelatedThrowable() {
+    // given
+    final IOException exception = new IOException("connection reset");
+
+    // when + then
+    assertThat(ExceptionUtil.isConcurrentSnapshotExecutionException(exception)).isFalse();
+  }
+
+  @Test
+  void shouldReturnRootThrowableUnchangedWhenNotACompletionOrExecutionException() {
+    // given
+    final IOException exception = new IOException("connection reset");
+
+    // when + then
+    assertThat(ExceptionUtil.unwrapCompletionCause(exception)).isSameAs(exception);
+  }
+
+  @Test
+  void shouldUnwrapNestedCompletionExceptions() {
+    // given
+    final IOException rootCause = new IOException("connection reset");
+    final CompletionException wrapped = new CompletionException(new CompletionException(rootCause));
+
+    // when + then
+    assertThat(ExceptionUtil.unwrapCompletionCause(wrapped)).isSameAs(rootCause);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Optimize backups split indices into two ES/OS snapshot requests, fired back-to-back with no ordering guarantee. The job-registry index landed in the second request alongside the data it describes, with no wait between the two. If a delete raced an in-progress backup, the registry and the data indices could be captured in inconsistent states, and a restore could silently resurrect deleted data with the registry showing `COMPLETED` (never retried), or vice versa.

- Move the job-registry index (and the other import-progress indices) into a  `PRIORITY1` snapshot bucket that is always taken *before* `PRIORITY2` (everything else), by making the second snapshot request wait on the first's completion future.
- Give `concurrent_snapshot_execution_exception` explicit detection and a distinct log message instead of falling through the generic failure branch.
- Replace the `isImportIndex()` boolean flag with a `BackupPriority` enum (`PRIORITY1`/`PRIORITY2`). The boolean conflated "this index holds imported data" with "this index must be snapshotted first for consistency". The job registry needs the latter but isn't the former, and reusing the flag mislabeled it as an import index it isn't.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59860 
