### PR TITLE
deps: bump micrometer to 1.16.7 for CVE-2026-59295

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,7 +85,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.31.1</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.15.12</version.micrometer>
+    <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
## Description

Bumps `version.micrometer` in `parent/pom.xml` from `1.15.12` to `1.16.7` to clear [CVE-2026-59295](https://nvd.nist.gov/vuln/detail/CVE-2026-59295) (CWE-401, CVSS 5.9, `AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H`).

The `micrometer-bom` import at `parent/pom.xml:1100` comes before `spring-boot-dependencies` at line 1139, so this moves every micrometer artifact we consume together: `micrometer-core`, `micrometer-commons`, `micrometer-registry-prometheus`, `micrometer-registry-otlp`. `micrometer-tracing` is not used in this repository, so no sibling bump is needed.

### Why a minor bump on a maintenance branch

Per the [Spring advisory](https://spring.io/security/cve-2026-59295), the fix for the 1.15.x line is `1.15.13` — **Enterprise Support Only**. It is not on Maven Central, and it is not in `artifacts.camunda.com/artifactory/internal` either:

```
Could not find artifact io.micrometer:micrometer-core:jar:1.15.13
  in camunda-nexus (https://artifacts.camunda.com/artifactory/internal)
```

Our extended-support channel on `stable/8.7` is HeroDevs (`herodevs-nes`, `bom/pom.xml:231`), which covers Spring Boot / Framework / Security but not micrometer. The only OSS fixed versions are `1.16.7` and `1.17.1`, so `1.16.7` is the smallest step available.

This conflicts with the `.github/renovate.json` rule that restricts `stable/*` to patch updates, which is why this is a manual PR rather than a renovate one.

### Runtime exposure: none

The vulnerable code path is `MicrometerHttpClientInterceptor` / `MicrometerHttpRequestExecutor`. Neither has any usage in this repository — micrometer is used for `MeterRegistry`, counters, the Prometheus/OTLP registries and job worker metrics. Apache HttpAsyncClient *is* used (`clients/java/.../HttpClientFactory.java`, `operate/common/.../ElasticsearchConnector.java`, `OpensearchConnector.java`), but no micrometer interceptor is registered on any of those clients. So this bump is scanner hygiene, not a live fix.

## Verification

`./mvnw install -Dquickly -T1C` locally: 132 modules SUCCESS, including every micrometer consumer — `Zeebe Util`, `Operate Common`, `Operate Webapp`, `Tasklist Webapp`, all `Camunda Search Client*`.

The local run then failed in `Zeebe Distribution` with a `401` from the `herodevs-nes` repository while resolving `spring-boot-maven-plugin:3.5.16-spring-boot-3.5.18`. That is a missing-credentials issue on my machine, reproduced independently of this change, not a regression — CI has those credentials.

Two things this local run does **not** cover, and which CI should be watched for:

- `-Dquickly` skips tests. `zeebe/util/pom.xml:147` pulls `io.prometheus:prometheus-metrics-model` at the version managed by the Spring Boot 3.5 BOM while `micrometer-registry-prometheus` moves to 1.16 — the metrics tests in `zeebe/util`, `operate/webapp` and `tasklist/webapp` are the interesting ones.
- Boot 3.5 + micrometer 1.16 is not the upstream-supported pairing (1.16 targets Boot 4.0), so actuator/metrics endpoint behavior deserves a look.

## Related issues

n/a — CVE triage, no tracking issue yet.
