### PR TITLE
feat: default Admin new design system to disabled on SaaS, enabled on Self-Managed

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
@@ -12,12 +12,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.api.model.config.SaasConfiguration;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.swagger.v3.oas.annotations.Hidden;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -33,13 +36,19 @@ public class AdminClientConfigController {
   private static final String ID_PATTERN = "idPattern";
   private static final String RESOURCE_PERMISSIONS = "resourcePermissions";
   private static final String DEFAULT_ROLE_IDS = "defaultRoleIds";
+  private static final String IS_NEW_DESIGN_SYSTEM_ENABLED = "isNewDesignSystemEnabled";
   private static final String FALLBACK_CONFIG_JS = "window.clientConfig = {};";
   private static final String CONFIG_JS_TEMPLATE = "window.clientConfig = %s;";
 
   private final String clientConfigAsJS;
   private final ObjectMapper objectMapper;
+  private final Boolean newDesignSystemEnabledOverride;
 
-  public AdminClientConfigController(final CamundaSecurityLibraryProperties cslProperties) {
+  public AdminClientConfigController(
+      final CamundaSecurityLibraryProperties cslProperties,
+      @Value("${camunda.identity.new-design-system-enabled:#{null}}")
+          final Boolean newDesignSystemEnabledOverride) {
+    this.newDesignSystemEnabledOverride = newDesignSystemEnabledOverride;
     objectMapper = new ObjectMapper();
     clientConfigAsJS = generateClientConfig(cslProperties);
   }
@@ -69,8 +78,23 @@ public class AdminClientConfigController {
     config.put(ID_PATTERN, cslProperties.getIdValidationPattern());
     config.put(RESOURCE_PERMISSIONS, AuthorizationResourceType.buildResourcePermissionsMap());
     config.put(DEFAULT_ROLE_IDS, DefaultRole.ids());
+    config.put(
+        IS_NEW_DESIGN_SYSTEM_ENABLED,
+        String.valueOf(resolveNewDesignSystemEnabled(saasConfiguration)));
 
     return config;
+  }
+
+  /**
+   * Effective value of the new design system flag: an explicit {@code
+   * camunda.identity.new-design-system-enabled} always wins, otherwise it's enabled for
+   * Self-Managed and disabled for SaaS.
+   */
+  private boolean resolveNewDesignSystemEnabled(final SaasConfiguration saasConfiguration) {
+    if (newDesignSystemEnabledOverride != null) {
+      return newDesignSystemEnabledOverride;
+    }
+    return saasConfiguration == null || !StringUtils.hasText(saasConfiguration.getOrganizationId());
   }
 
   private boolean isOidcAuthentication(final CamundaSecurityLibraryProperties cslProperties) {

--- a/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
@@ -125,7 +125,7 @@ public class AdminClientConfigControllerTest {
             multiTenancyEnabled,
             expectedOrganizationId,
             expectedClusterId);
-    final var controller = new AdminClientConfigController(cslProperties);
+    final var controller = new AdminClientConfigController(cslProperties, null);
 
     // Setup MockMvc with the controller for this specific test
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
@@ -193,7 +193,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -213,7 +214,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -232,7 +234,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -255,7 +258,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -281,7 +285,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -297,6 +302,82 @@ public class AdminClientConfigControllerTest {
                     "permissions for resource type %s should be sorted alphabetically",
                     resourceType)
                 .isSortedAccordingTo(String::compareTo));
+  }
+
+  @Test
+  void shouldEnableNewDesignSystemByDefaultForSelfManaged() throws Exception {
+    // given
+    final var controller =
+        new AdminClientConfigController(
+            createCamundaSecurityLibraryProperties(
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final String response =
+        mockMvc.perform(get("/admin/config.js")).andReturn().getResponse().getContentAsString();
+    final var config = extractConfigFromResponse(response);
+
+    // then
+    assertThat(config).containsEntry("isNewDesignSystemEnabled", "true");
+  }
+
+  @Test
+  void shouldDisableNewDesignSystemByDefaultForSaas() throws Exception {
+    // given
+    final var controller =
+        new AdminClientConfigController(
+            createCamundaSecurityLibraryProperties(
+                AuthenticationMethod.BASIC, null, false, "test-org", "test-cluster"),
+            null);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final String response =
+        mockMvc.perform(get("/admin/config.js")).andReturn().getResponse().getContentAsString();
+    final var config = extractConfigFromResponse(response);
+
+    // then
+    assertThat(config).containsEntry("isNewDesignSystemEnabled", "false");
+  }
+
+  @Test
+  void shouldEnableNewDesignSystemForSaasWhenExplicitlyConfigured() throws Exception {
+    // given
+    final var controller =
+        new AdminClientConfigController(
+            createCamundaSecurityLibraryProperties(
+                AuthenticationMethod.BASIC, null, false, "test-org", "test-cluster"),
+            true);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final String response =
+        mockMvc.perform(get("/admin/config.js")).andReturn().getResponse().getContentAsString();
+    final var config = extractConfigFromResponse(response);
+
+    // then
+    assertThat(config).containsEntry("isNewDesignSystemEnabled", "true");
+  }
+
+  @Test
+  void shouldDisableNewDesignSystemForSelfManagedWhenExplicitlyConfigured() throws Exception {
+    // given
+    final var controller =
+        new AdminClientConfigController(
+            createCamundaSecurityLibraryProperties(
+                AuthenticationMethod.BASIC, null, false, null, null),
+            false);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+    // when
+    final String response =
+        mockMvc.perform(get("/admin/config.js")).andReturn().getResponse().getContentAsString();
+    final var config = extractConfigFromResponse(response);
+
+    // then
+    assertThat(config).containsEntry("isNewDesignSystemEnabled", "false");
   }
 
   @SuppressWarnings("unchecked")

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -30,6 +30,11 @@ export const docsUrl = "https://docs.camunda.io/docs/next";
 
 export const isSaaS = Boolean(getClientConfigString("organizationId"));
 
+export const isNewDesignSystemEnabled = getClientConfigBoolean(
+  "isNewDesignSystemEnabled",
+  true,
+);
+
 export const resourcePermissions = getClientConfigObject(
   "resourcePermissions",
   {} as Record<ResourceType, PermissionType[]>,

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -6,7 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import { isNewDesignSystemEnabled } from "./configuration";
+
 export const featureFlags = [];
 
-export const IS_NEW_DESIGN_SYSTEM_ENABLED = false;
+export const IS_NEW_DESIGN_SYSTEM_ENABLED = isNewDesignSystemEnabled;
 export const IS_NAV_V2_ENABLED = IS_NEW_DESIGN_SYSTEM_ENABLED;

--- a/identity/client/src/types/global.d.ts
+++ b/identity/client/src/types/global.d.ts
@@ -16,6 +16,7 @@ export declare global {
     idPattern?: string;
     resourcePermissions?: Record<string, string[]>;
     defaultRoleIds?: string[];
+    isNewDesignSystemEnabled?: string;
   }
 
   interface Window {


### PR DESCRIPTION
## Description

Admin's new-design-system flag (also driving nav v2) is currently a hardcoded frontend constant with no way to change it per environment without a code PR. Same pattern just applied to Operate (#61145): enabled by default on Self-Managed, disabled by default on SaaS, still overridable per deployment via `camunda.identity.new-design-system-enabled`.

`AdminClientConfigController` already builds the client config served to the frontend and already has `CamundaSecurityLibraryProperties`, so the resolution lives there — no new dependency needed. `feature-flags.ts` now reads the resolved value from `clientConfig` instead of a hardcoded `false`.

Related: #61006 (this closes the exact gap flagged in its review — "make it configurable through the clientConfig?"), #60649

## Open question

Same caveat as #61145: SaaS is detected via presence of an organization ID. If that's not reliably set on every real SaaS cluster, this silently defaults to *enabled* there instead of disabled — needs the same confirmation from whoever owns SaaS deployment config.
