### PR TITLE
ci: let the AlwaysGreen fix agent run against stable/8.10

### DIFF
--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -41,7 +41,9 @@ SUPPRESSED_CAP = "per-run-cap-reached"
 #: statement in alwaysgreen-fix.yml: dispatching anything else spends a runner only to
 #: fail on the agent's first step, which is what happened to run 31115770750 on
 #: `ci/alwaysgreen-helm-live-check`.
-SUPPORTED_BASE_REFS = frozenset({"main", "stable/8.7", "stable/8.8", "stable/8.9"})
+SUPPORTED_BASE_REFS = frozenset(
+    {"main", "stable/8.7", "stable/8.8", "stable/8.9", "stable/8.10"}
+)
 
 
 #: How long an open fix PR's key label keeps holding its dispatch key. The lock is

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -215,9 +215,13 @@ def test_supported_base_refs_match_the_fix_workflow_whitelist():
         / "workflows"
         / "alwaysgreen-fix.yml"
     ).read_text()
-    match = re.search(r"^\s*(main\|stable[^)]*)\)\s*;;", workflow, re.M)
+    # Tolerant of formatting so this fails on drift and not on a reflow: `[^)]` spans
+    # newlines for a wrapped list, whitespace is allowed around each `|`, and every
+    # token is stripped before comparing.
+    match = re.search(r"^\s*(main\s*\|[^)]*)\)\s*;;", workflow, re.M)
     assert match, "no base_ref case statement found in alwaysgreen-fix.yml"
-    assert set(match.group(1).split("|")) == set(plan.SUPPORTED_BASE_REFS)
+    refs = {token.strip() for token in match.group(1).split("|")} - {""}
+    assert refs == set(plan.SUPPORTED_BASE_REFS)
 
 
 def test_unsupported_ref_is_reported_before_any_other_reason():

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pathlib
+import re
 from datetime import datetime, timedelta, timezone
 
 import classify
@@ -201,6 +203,21 @@ def test_every_supported_base_ref_is_dispatchable():
     for ref in plan.SUPPORTED_BASE_REFS:
         result = _plan([_cand(base_ref=ref)])
         assert len(result.dispatches) == 1, ref
+
+
+def test_supported_base_refs_match_the_fix_workflow_whitelist():
+    # These two lists drifted the moment stable/8.10 was cut: the branch got the whole
+    # pipeline and started running AlwaysGreen, while both whitelists still ended at
+    # stable/8.9, so every 8.10 failure was withheld. Assert them equal rather than
+    # trusting a comment to keep them in step.
+    workflow = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "workflows"
+        / "alwaysgreen-fix.yml"
+    ).read_text()
+    match = re.search(r"^\s*(main\|stable[^)]*)\)\s*;;", workflow, re.M)
+    assert match, "no base_ref case statement found in alwaysgreen-fix.yml"
+    assert set(match.group(1).split("|")) == set(plan.SUPPORTED_BASE_REFS)
 
 
 def test_unsupported_ref_is_reported_before_any_other_reason():

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -120,15 +120,17 @@ jobs:
         run: |
           set -euo pipefail
           case "$BASE_REF" in
-            main|stable/8.7|stable/8.8|stable/8.9) ;;
+            main|stable/8.7|stable/8.8|stable/8.9|stable/8.10) ;;
             *) echo "::error::unsupported base_ref '$BASE_REF'"; exit 1 ;;
           esac
           case "$SURFACE" in
             sm-smoke-e2e|saas-smoke-e2e|saas-ci|helm-install) ;;
             *) echo "::error::unsupported surface '$SURFACE'"; exit 1 ;;
           esac
-          # main carries the next unreleased minor; stable/X.Y carries X.Y. Bump this
-          # when main moves to 8.11.
+          # The version is the suite and chart the branch's pipeline exercises, not the
+          # branch's pom version: main became 8.11.0-SNAPSHOT when stable/8.10 was cut,
+          # while docker-build-helm-integration still deploys camunda-platform-8.10 and
+          # the e2e repo tops out at tests/SM-8.10. Bump when an 8.11 chart and suite exist.
           if [ "$BASE_REF" = "main" ]; then version=8.10; else version="${BASE_REF#stable/}"; fi
           # The e2e suite directory. SM specs live under an SM- prefix, SaaS specs under
           # the bare version, and pages/ mirrors tests/ exactly.


### PR DESCRIPTION
## Description

`stable/8.10` was cut on 2026-08-26 and carries the whole pipeline, so
`docker-build-helm-integration.yml` and `alwaysgreen-triage.yml` now run on it. Both
base_ref whitelists still ended at `stable/8.9`, so **every AlwaysGreen failure on the
new release branch was withheld from the fix agent** — the planner reported
`base-ref-not-supported-by-fix-agent`, and before that check existed the agent spent a
runner only to fail on its first step (that is what run
[31115770750](https://github.com/camunda/camunda/actions/runs/31115770750) was).

Adds `stable/8.10` to both whitelists. `${BASE_REF#stable/}` resolves it to `8.10`, and
`tests/SM-8.10/`, `tests/8.10/` and `charts/camunda-platform-8.10/` all exist, so nothing
else needs to change for it to work.

### The version mapping deliberately stays at 8.10

`main` became `8.11.0-SNAPSHOT` when the branch was cut, so the comment saying *"bump this
when main moves to 8.11"* now reads as an instruction to bump — which would be wrong:

| | |
|---|---|
| `docker-build-helm-integration.yml` on main | still deploys `camunda-platform-8.10`, reports `"c8Version": "8.10"` |
| `c8-cross-component-e2e-tests` | `tests/` tops out at `8.10` / `SM-8.10` — no 8.11 |
| `camunda-platform-helm` | `charts/` tops out at `camunda-platform-8.10` — no 8.11 |

So `main → 8.10` is still correct. Bumping it would point the agent at directories that do
not exist. The comment now says the version follows the suite and chart the branch's
pipeline exercises, not the branch's pom version, and to bump when an 8.11 chart and suite
exist.

### Drift guard

The two whitelists — `plan.SUPPORTED_BASE_REFS` and the `case` statement in
`alwaysgreen-fix.yml` — drifting apart is exactly what silently withheld 8.10, so
`test_supported_base_refs_match_the_fix_workflow_whitelist` now asserts them equal by
parsing the workflow. Verified it fails when either side is changed alone.

### No backport needed

Triage checks its scripts out of `main`
(`ref: ${{ inputs.tooling_ref || (inputs.run_id && github.ref_name) || 'main' }}`) and
dispatches the fix workflow with `FIX_AGENT_REF: main`. A stable branch is handled through
the `base_ref` *input*, never by running its own copy of the tooling — `stable/8.10`'s
copies of these files are inert leftovers from being branched off main. `stable/8.7`,
`stable/8.8` and `stable/8.9` have no AlwaysGreen tooling at all.

### Validation

- `pytest .github/scripts` — 164 passed. `test_every_supported_base_ref_is_dispatchable`
  iterates the set, so it now covers `stable/8.10`.
- `actionlint -shellcheck=shellcheck` clean on the changed workflow.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follows [#60161](https://github.com/camunda/camunda/pull/60161), which added the
`base-ref-not-supported-by-fix-agent` check that surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
