### PR TITLE
fix: search process instances by error message of process level incidents

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/incidents/ProcessLevelIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/incidents/ProcessLevelIncidentSearchTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration.incidents;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An incident can be raised at the process level, without any element instance to attach to, for
+ * example by a process level execution listener. Such an incident must still be reachable when
+ * searching process instances by error message.
+ */
+@MultiDbTest
+public class ProcessLevelIncidentSearchTest {
+
+  private static final String PROCESS_ID = "process_level_incident";
+  private static final String LISTENER_JOB_TYPE = "processLevelListener";
+
+  private static CamundaClient camundaClient;
+  private static long processInstanceKey;
+  private static String errorMessage;
+
+  @BeforeAll
+  static void beforeAll() {
+    deployResource(camundaClient, "process/process_level_incident.bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    processInstanceKey = startProcessInstance(camundaClient, PROCESS_ID).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, 1);
+
+    final var job =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(LISTENER_JOB_TYPE)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+    errorMessage = "process level listener failed for " + processInstanceKey;
+    camundaClient.newFailCommand(job.getKey()).retries(0).errorMessage(errorMessage).send().join();
+
+    waitUntilIncidentsAreActive(camundaClient, 1);
+    waitUntilProcessInstanceHasIncidents(camundaClient, 1);
+  }
+
+  @Test
+  void shouldFindProcessInstanceByProcessLevelIncidentErrorMessage() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.errorMessage(m -> m.eq(errorMessage)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items())
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactly(processInstanceKey);
+  }
+
+  @Test
+  void shouldFindProcessInstanceByExistingProcessLevelIncidentErrorMessage() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.errorMessage(m -> m.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items())
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactly(processInstanceKey);
+  }
+
+  @Test
+  void shouldNotFindProcessInstanceByAnotherErrorMessage() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.errorMessage(m -> m.eq("some other error message")))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldNotFindProcessInstanceWithoutAnyErrorMessage() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.errorMessage(m -> m.exists(false)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+}

--- a/qa/acceptance-tests/src/test/resources/process/process_level_incident.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_level_incident.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_process_level_incident" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process_level_incident" name="Process Level Incident" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" type="processLevelListener" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="taskA" />
+    <bpmn:serviceTask id="taskA" name="Task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="taskA" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="taskA" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_level_incident">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="taskA_di" bpmnElement="taskA">
+        <dc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -540,8 +540,18 @@ public final class SearchQueryBuilders {
         .toList();
   }
 
-  public static <C extends List<Operation<String>>> SearchQuery stringMatchPhraseInSingleHasChild(
-      final String field, final C operations, final String childType) {
+  /**
+   * Matches the given field against all operations, either on a single child document of the given
+   * type or on the document itself.
+   *
+   * <p>The document itself is included because a value is not always carried by a child: an
+   * incident error message, for instance, lives on the flow node child document, unless the
+   * incident was raised at the process level (e.g. by a process level execution listener), in which
+   * case it lives on the process instance document.
+   */
+  public static <C extends List<Operation<String>>>
+      SearchQuery stringMatchPhraseInSingleHasChildOrSelf(
+          final String field, final C operations, final String childType) {
 
     if (operations == null || operations.isEmpty()) {
       return null;
@@ -560,7 +570,8 @@ public final class SearchQueryBuilders {
                             .mustNot(List.of(matchPhrase(field, op.value()))))
                     .toSearchQuery());
         case EXISTS -> innerClauses.add(bool(b -> b.must(List.of(exists(field)))).toSearchQuery());
-        case NOT_EXISTS -> allClauses.add(not(hasChildQuery(childType, exists(field))));
+        case NOT_EXISTS ->
+            allClauses.add(and(not(hasChildQuery(childType, exists(field))), not(exists(field))));
         case IN ->
             innerClauses.add(
                 or(op.values().stream().map(value -> matchPhrase(field, value)).toList()));
@@ -572,7 +583,8 @@ public final class SearchQueryBuilders {
     }
 
     if (!innerClauses.isEmpty()) {
-      allClauses.add(hasChildQuery(childType, bool(b -> b.must(innerClauses)).toSearchQuery()));
+      final var matchingClauses = bool(b -> b.must(innerClauses)).toSearchQuery();
+      allClauses.add(or(hasChildQuery(childType, matchingClauses), matchingClauses));
     }
 
     return and(allClauses);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
@@ -13,7 +13,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
-import static io.camunda.search.clients.query.SearchQueryBuilders.stringMatchPhraseInSingleHasChild;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringMatchPhraseInSingleHasChildOrSelf;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
@@ -128,7 +128,7 @@ public class ProcessDefinitionStatisticsFilterTransformer
     Optional.of(stringOperations(TENANT_ID, filter.tenantIdOperations()))
         .ifPresent(queries::addAll);
     Optional.ofNullable(
-            stringMatchPhraseInSingleHasChild(
+            stringMatchPhraseInSingleHasChildOrSelf(
                 ERROR_MSG, filter.errorMessageOperations(), ACTIVITIES_JOIN_RELATION))
         .ifPresent(queries::add);
     ofNullable(getProcessVariablesQuery(filter.variableFilters())).ifPresent(queries::add);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -85,7 +85,7 @@ public final class ProcessInstanceFilterTransformer
 
     if (filter.errorMessageOperations() != null && !filter.errorMessageOperations().isEmpty()) {
       queries.add(
-          stringMatchPhraseInSingleHasChild(
+          stringMatchPhraseInSingleHasChildOrSelf(
               ERROR_MSG, filter.errorMessageOperations(), ACTIVITIES_JOIN_RELATION));
     }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchExistsQuery;
 import io.camunda.search.clients.query.SearchHasChildQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
 import io.camunda.search.clients.query.SearchMatchPhraseQuery;
@@ -410,7 +411,7 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
   }
 
   @Test
-  public void shouldQueryByErrorMessage() {
+  public void shouldQueryByErrorMessageOfFlowNodeOrProcessLevelIncident() {
     // given
     final String expectedError = "expected error";
     final ProcessInstanceFilter filter =
@@ -432,24 +433,85 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
     assertIsSearchTermQuery(
         boolQuery.must().get(0).queryOption(), "joinRelation", "processInstance");
 
+    // Second must clause: the error message either on a flow node child, or, for a process level
+    // incident, on the process instance document itself.
     assertThat(boolQuery.must().get(1).queryOption())
-        .isInstanceOf(SearchHasChildQuery.class)
-        .satisfies(
-            queryOption -> {
-              final SearchHasChildQuery hasChildQuery = (SearchHasChildQuery) queryOption;
-              assertThat(hasChildQuery.type()).isEqualTo("activity");
-              assertThat(hasChildQuery.query().queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            errorMessageQuery -> {
+              assertThat(errorMessageQuery.should()).hasSize(2);
+
+              assertThat(errorMessageQuery.should().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchHasChildQuery.class,
+                      hasChildQuery -> {
+                        assertThat(hasChildQuery.type()).isEqualTo("activity");
+                        assertIsErrorMessageMatch(
+                            hasChildQuery.query().queryOption(), expectedError);
+                      });
+
+              assertIsErrorMessageMatch(
+                  errorMessageQuery.should().get(1).queryOption(), expectedError);
+            });
+  }
+
+  @Test
+  public void shouldQueryByMissingErrorMessage() {
+    // given
+    final ProcessInstanceFilter filter =
+        FilterBuilders.processInstance(
+            f -> f.errorMessageOperations(List.of(Operation.exists(false))));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then: neither a flow node child nor the process instance itself may carry an error message
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    final SearchBoolQuery boolQuery = (SearchBoolQuery) queryVariant;
+    assertThat(boolQuery.must()).hasSize(2);
+
+    assertThat(boolQuery.must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            errorMessageQuery -> {
+              assertThat(errorMessageQuery.must()).hasSize(2);
+
+              assertThat(errorMessageQuery.must().get(0).queryOption())
                   .isInstanceOfSatisfying(
                       SearchBoolQuery.class,
-                      innerBool -> {
-                        assertThat(innerBool.must()).hasSize(1);
-                        assertThat(innerBool.must().get(0).queryOption())
-                            .isInstanceOfSatisfying(
-                                SearchMatchPhraseQuery.class,
-                                searchMatchQuery -> {
-                                  assertThat(searchMatchQuery.field()).isEqualTo("errorMessage");
-                                  assertThat(searchMatchQuery.query()).isEqualTo(expectedError);
-                                });
+                      notHasChild ->
+                          assertThat(notHasChild.mustNot().get(0).queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchHasChildQuery.class,
+                                  hasChildQuery ->
+                                      assertThat(hasChildQuery.type()).isEqualTo("activity")));
+
+              assertThat(errorMessageQuery.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchBoolQuery.class,
+                      notExists ->
+                          assertThat(notExists.mustNot().get(0).queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchExistsQuery.class,
+                                  existsQuery ->
+                                      assertThat(existsQuery.field()).isEqualTo("errorMessage")));
+            });
+  }
+
+  private void assertIsErrorMessageMatch(
+      final SearchQueryOption queryOption, final String expectedError) {
+    assertThat(queryOption)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            innerBool -> {
+              assertThat(innerBool.must()).hasSize(1);
+              assertThat(innerBool.must().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchMatchPhraseQuery.class,
+                      searchMatchQuery -> {
+                        assertThat(searchMatchQuery.field()).isEqualTo("errorMessage");
+                        assertThat(searchMatchQuery.query()).isEqualTo(expectedError);
                       });
             });
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -74,6 +74,17 @@ public class ProcessInstanceForListViewEntity
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime suspendedDate;
 
+  /**
+   * Message of an incident raised at the process level, i.e. one that is not attached to any flow
+   * node. Incidents attached to a flow node carry their message on the corresponding {@link
+   * FlowNodeInstanceForListViewEntity} instead.
+   *
+   * <p>Attention! This field will be filled in only for data imported after v. 8.11.0.
+   */
+  @SinceVersion(value = "8.11.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String errorMessage;
+
   @JsonIgnore private Object[] sortValues;
 
   @Override
@@ -310,6 +321,15 @@ public class ProcessInstanceForListViewEntity
     return this;
   }
 
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public ProcessInstanceForListViewEntity setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -335,7 +355,8 @@ public class ProcessInstanceForListViewEntity
         tags,
         rootProcessInstanceKey,
         businessId,
-        suspendedDate);
+        suspendedDate,
+        errorMessage);
   }
 
   @Override
@@ -369,6 +390,7 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(position, that.position)
         && Objects.equals(tags, that.tags)
         && Objects.equals(businessId, that.businessId)
-        && Objects.equals(suspendedDate, that.suspendedDate);
+        && Objects.equals(suspendedDate, that.suspendedDate)
+        && Objects.equals(errorMessage, that.errorMessage);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -48,6 +48,7 @@ import io.camunda.exporter.handlers.ListViewFlowNodeFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromJobHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler;
+import io.camunda.exporter.handlers.ListViewProcessInstanceFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.ListViewVariableFromVariableHandler;
 import io.camunda.exporter.handlers.MappingRuleCreatedUpdatedHandler;
@@ -270,6 +271,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromIncidentHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+            new ListViewProcessInstanceFromIncidentHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromJobHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ERROR_MSG;
+
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keeps the error message of a process level incident on the process instance list view document.
+ *
+ * <p>Most incidents belong to a flow node, and {@link ListViewFlowNodeFromIncidentHandler} stores
+ * their message on the corresponding flow node document. An incident raised at the process level
+ * (e.g. by a process level execution listener) has no flow node to attach to, so its message is
+ * stored on the process instance document itself, which is what searching process instances by
+ * error message falls back to.
+ */
+public class ListViewProcessInstanceFromIncidentHandler
+    implements OrdinalIndexExportHandler<ProcessInstanceForListViewEntity, IncidentRecordValue> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ListViewProcessInstanceFromIncidentHandler.class);
+
+  private static final Set<IncidentIntent> SUPPORTED_INTENTS =
+      EnumSet.of(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
+
+  private final String indexName;
+
+  public ListViewProcessInstanceFromIncidentHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.INCIDENT;
+  }
+
+  @Override
+  public Class<ProcessInstanceForListViewEntity> getEntityType() {
+    return ProcessInstanceForListViewEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<IncidentRecordValue> record) {
+    if (!SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent())) {
+      return false;
+    }
+    return isProcessLevelIncident(record.getValue());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<IncidentRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getProcessInstanceKey()));
+  }
+
+  @Override
+  public ProcessInstanceForListViewEntity createNewEntity(final String id) {
+    return new ProcessInstanceForListViewEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<IncidentRecordValue> record, final ProcessInstanceForListViewEntity entity) {
+
+    final IncidentRecordValue recordValue = record.getValue();
+    final long processInstanceKey = recordValue.getProcessInstanceKey();
+
+    entity
+        .setId(String.valueOf(processInstanceKey))
+        .setKey(processInstanceKey)
+        .setProcessInstanceKey(processInstanceKey)
+        .setPartitionId(record.getPartitionId())
+        .setTenantId(tenantOrDefault(recordValue.getTenantId()));
+
+    if (record.getIntent() == IncidentIntent.CREATED) {
+      entity.setErrorMessage(trimWhitespace(recordValue.getErrorMessage()));
+    } else {
+      entity.setErrorMessage(null);
+    }
+  }
+
+  @Override
+  public void flush(
+      final TargetIndex index,
+      final ProcessInstanceForListViewEntity entity,
+      final BatchRequest batchRequest) {
+
+    LOGGER.debug("Process instance for list view: id {}", entity.getId());
+    final Map<String, Object> updateFields = new LinkedHashMap<>();
+    updateFields.put(ERROR_MSG, entity.getErrorMessage());
+
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private String trimWhitespace(final String str) {
+    return (str == null) ? null : str.strip();
+  }
+
+  private boolean isProcessLevelIncident(final IncidentRecordValue recordValue) {
+    return recordValue.getProcessInstanceKey() == recordValue.getElementInstanceKey();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
@@ -33,6 +33,12 @@ import org.slf4j.LoggerFactory;
  * (e.g. by a process level execution listener) has no flow node to attach to, so its message is
  * stored on the process instance document itself, which is what searching process instances by
  * error message falls back to.
+ *
+ * <p>A single message field is enough, and cannot lose one incident to another, because a process
+ * element instance holds at most one incident at a time: the engine keys non-job process incidents
+ * by element instance key and rejects a duplicate, execution listeners run strictly one after
+ * another, and an open incident blocks the element instance either way. Records therefore always
+ * reach this handler as created/resolved pairs.
  */
 public class ListViewProcessInstanceFromIncidentHandler
     implements OrdinalIndexExportHandler<ProcessInstanceForListViewEntity, IncidentRecordValue> {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandlerTest.java
@@ -36,12 +36,12 @@ public class ListViewProcessInstanceFromIncidentHandlerTest {
       new ListViewProcessInstanceFromIncidentHandler(indexName);
 
   @Test
-  public void testGetHandledValueType() {
+  public void shouldHandleIncidentValueType() {
     assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.INCIDENT);
   }
 
   @Test
-  public void testGetEntityType() {
+  public void shouldHandleProcessInstanceForListViewEntityType() {
     assertThat(underTest.getEntityType()).isEqualTo(ProcessInstanceForListViewEntity.class);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandlerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ERROR_MSG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.handlers.ExportHandler.IdAndIndex;
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.index.TargetIndexLocator;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class ListViewProcessInstanceFromIncidentHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-list-view";
+  private final ListViewProcessInstanceFromIncidentHandler underTest =
+      new ListViewProcessInstanceFromIncidentHandler(indexName);
+
+  @Test
+  public void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.INCIDENT);
+  }
+
+  @Test
+  public void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(ProcessInstanceForListViewEntity.class);
+  }
+
+  @Test
+  void shouldExtractIdAndIndexes() {
+    // given
+    final TargetIndexLocator indexLocator = mock(TargetIndexLocator.class);
+    final TargetIndex index = TargetIndex.mainIndex(indexName);
+    when(indexLocator.locateOrdinalIndex(eq(indexName), any())).thenReturn(index);
+    final Record<IncidentRecordValue> incidentRecord =
+        createProcessLevelIncidentRecord(IncidentIntent.CREATED, 123L);
+
+    // when - then
+    assertThat(underTest.extractIdAndIndexes(indexLocator, incidentRecord))
+        .containsExactly(new IdAndIndex("123", index));
+  }
+
+  @Test
+  public void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  public void shouldUpsertEntityOnFlush() {
+    // given
+    final ProcessInstanceForListViewEntity inputEntity =
+        new ProcessInstanceForListViewEntity()
+            .setId("111")
+            .setKey(111L)
+            .setProcessInstanceKey(111L)
+            .setPartitionId(3)
+            .setTenantId("tenantId")
+            .setErrorMessage("error");
+
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
+    expectedUpdateFields.put(ERROR_MSG, "error");
+
+    // when
+    underTest.flush(index, inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
+  }
+
+  @Test
+  public void shouldUpdateEntityFromRecord() {
+    // given
+    final var processInstanceKey = 123L;
+    final Record<IncidentRecordValue> incidentRecord =
+        createProcessLevelIncidentRecord(IncidentIntent.CREATED, processInstanceKey);
+
+    // when
+    final var entity = new ProcessInstanceForListViewEntity();
+    underTest.updateEntity(incidentRecord, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(String.valueOf(processInstanceKey));
+    assertThat(entity.getKey()).isEqualTo(processInstanceKey);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(entity.getPartitionId()).isEqualTo(incidentRecord.getPartitionId());
+    assertThat(entity.getTenantId()).isEqualTo(incidentRecord.getValue().getTenantId());
+    assertThat(entity.getErrorMessage()).isEqualTo(incidentRecord.getValue().getErrorMessage());
+  }
+
+  @Test
+  public void shouldTrimErrorMessage() {
+    // given
+    final var processInstanceKey = 123L;
+    final Record<IncidentRecordValue> incidentRecord =
+        createProcessLevelIncidentRecord(
+            IncidentIntent.CREATED, processInstanceKey, "  padded error\n");
+
+    // when
+    final var entity = new ProcessInstanceForListViewEntity();
+    underTest.updateEntity(incidentRecord, entity);
+
+    // then
+    assertThat(entity.getErrorMessage()).isEqualTo("padded error");
+  }
+
+  @Test
+  public void shouldRemoveErrorMessageForResolvedIncident() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        createProcessLevelIncidentRecord(IncidentIntent.RESOLVED, 123L);
+
+    // when
+    final var entity = new ProcessInstanceForListViewEntity().setErrorMessage("error");
+    underTest.updateEntity(incidentRecord, entity);
+
+    // then
+    assertThat(entity.getErrorMessage()).isNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"CREATED", "RESOLVED"})
+  void shouldHandleProcessLevelIncidentWithSupportedIntent(final IncidentIntent intent) {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        createProcessLevelIncidentRecord(intent, 123L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = IncidentIntent.class,
+      names = {"RESOLVE", "MIGRATED"})
+  void shouldNotHandleRecordWithUnsupportedIntent(final IncidentIntent intent) {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        createProcessLevelIncidentRecord(intent, 123L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleFlowNodeLevelIncidentRecords() {
+    // given
+    final var recordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .withProcessInstanceKey(123L)
+            .withElementInstanceKey(456L)
+            .build();
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.CREATED).withValue(recordValue));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
+  }
+
+  private Record<IncidentRecordValue> createProcessLevelIncidentRecord(
+      final IncidentIntent intent, final long processInstanceKey) {
+    return createProcessLevelIncidentRecord(intent, processInstanceKey, "error");
+  }
+
+  private Record<IncidentRecordValue> createProcessLevelIncidentRecord(
+      final IncidentIntent intent, final long processInstanceKey, final String errorMessage) {
+    final var recordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementInstanceKey(processInstanceKey)
+            .withErrorMessage(errorMessage)
+            .build();
+    return factory.generateRecord(
+        ValueType.INCIDENT, r -> r.withIntent(intent).withValue(recordValue));
+  }
+}


### PR DESCRIPTION
## Description

Searching process instances by incident error message never returned instances whose incident was raised at the process level — a failing process level execution listener, for example — even though the incident is visible on the
instance itself.

A process level incident has `elementInstanceKey == processInstanceKey`, so writing it as a flow node child of the list view index would collide with the process instance document. The exporter therefore skips it:

https://github.com/camunda/camunda/blob/20b221b31081d55561ae1e2b3c9f93ce005891f7/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java#L127-L131

The message ended up stored nowhere, while the filter only searched flow node children — so the two sides never met on a common field.

Following the solution idea in the issue, the message is now stored on the process instance document, and the filter matches a single child **or** the document itself. `NOT_EXISTS` stays conjunctive so it does not start matching
every instance through the parent branch.

No index mapping change is needed: the list view is a single index with a join field, so `errorMessage` is already mapped for every document in it.

## Related issues

closes #44398 
