### PR TITLE
refactor: prepare roles page for design-system migration

### DIFF
--- a/identity/client/src/components/formV2/DropdownSearch.tsx
+++ b/identity/client/src/components/formV2/DropdownSearch.tsx
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Search } from "@carbon/react";
+import ListBox from "@carbon/react/es/components/ListBox";
+import useDebounce from "react-debounced";
+// TODO: Replace with design-system and Tailwind
+import { SecondaryText } from "src/components/form/Text";
+import styled from "styled-components";
+import Fuse from "fuse.js";
+
+type DropdownSearchProps<Item extends Record<string, unknown>> = {
+  items: Item[];
+  keyAttribute?: string;
+  itemTitle: (item: Item) => string;
+  itemSubTitle?: (item: Item) => string;
+  placeholder: string;
+  onChange?: (search: string) => void;
+  onSelect: (item: Item) => unknown;
+  filter?: (item: Item) => boolean;
+  autoFocus?: boolean;
+  invalid?: boolean;
+};
+
+type ItemWithTitleAndSubTitle<Item> = Item & {
+  title: string;
+  subTitle?: string;
+};
+
+const InvalidSearchWrapper = styled.div<{ $invalid: boolean }>`
+  ${({ $invalid }) =>
+    $invalid &&
+    `
+    .cds--search-input {
+      outline: 2px solid var(--cds-support-error, #da1e28);
+      outline-offset: -2px;
+    }
+  `}
+`;
+
+const ListStyleWrapper = styled.div`
+  & .cds--list-box__menu-item,
+  & .cds--list-box__menu-item__option {
+    height: auto;
+  }
+`;
+
+const MenuItemWrapper = styled.div<{ $isSelected: boolean }>`
+  & .cds--list-box__menu-item {
+    ${({ $isSelected }) =>
+      $isSelected
+        ? "background-color: var(--cds-layer-selected) !important"
+        : ""};
+  }
+`;
+const DropdownSearch = <Item extends Record<string, unknown>>({
+  placeholder,
+  onChange = () => {},
+  keyAttribute = "title",
+  items: rawItems,
+  itemTitle,
+  itemSubTitle,
+  onSelect,
+  filter = () => true, // We require a filter to allow the parent to remove items with accumulated state. See comment below for details.
+  autoFocus = false,
+  invalid = false,
+}: DropdownSearchProps<Item>) => {
+  const debounce = useDebounce();
+  const [search, setSearch] = useState("");
+  const [selectedResult, setSelectedResult] = useState<number>(-1);
+  const [filteredItems, setFilteredItems] = useState<
+    ItemWithTitleAndSubTitle<Item>[]
+  >([]);
+
+  const [allItems, setAllItems] = useState<ItemWithTitleAndSubTitle<Item>[]>(
+    [],
+  );
+
+  // We are accumulating all itemsm even if the `items` prop changes.
+  // This allows the parent component to pass new items into the dropdown, e.g.
+  // when the user types in the search field.
+  //
+  // === THIS IS A WORKAROUND ===
+  // Ideally, we can use the response from the server directly and don't need to
+  // keep state here. However, as some endpoints only allow for exact matches,
+  // this would invalidate the use case of a dropdown search.
+  // We should refactor this component to use the server response directly.
+  //
+  // Related to https://github.com/camunda/camunda/issues/36493
+  useEffect(() => {
+    setAllItems((prevItems) => {
+      const allKeys = prevItems.map((item) => item[keyAttribute] as string);
+
+      const newItems = rawItems
+        .map((item) => ({
+          ...item,
+          title: itemTitle(item),
+          subTitle: itemSubTitle ? itemSubTitle(item) : undefined,
+        }))
+        .filter((item) => !allKeys.includes(item[keyAttribute] as string));
+      return [...prevItems, ...newItems];
+    });
+  }, [rawItems, itemTitle, itemSubTitle, keyAttribute]);
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(allItems, {
+        keys: ["title", "subTitle"],
+        threshold: 0.3,
+      }),
+    [allItems],
+  );
+
+  useEffect(() => {
+    if (search) {
+      setFilteredItems(fuse.search(search).map((result) => result.item));
+    } else {
+      setFilteredItems(allItems);
+    }
+  }, [search, allItems, fuse]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setSearch(value);
+    debounce(() => onChange(value));
+    setSelectedResult(-1);
+  };
+
+  const handleClear = () => {
+    setSearch("");
+    onChange("");
+    setSelectedResult(-1);
+  };
+
+  const handleSelect = (item: Item) => {
+    onSelect(item);
+    setSearch("");
+    onChange("");
+    setSelectedResult(-1);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (
+      event.key === "ArrowDown" &&
+      selectedResult < filteredItems.length - 1
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      setSelectedResult(selectedResult + 1);
+    }
+
+    if (event.key === "ArrowUp" && selectedResult > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      setSelectedResult(selectedResult - 1);
+    }
+
+    if (
+      event.key === "Enter" &&
+      selectedResult >= 0 &&
+      selectedResult < filteredItems.length
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      handleSelect(filteredItems[selectedResult]);
+    }
+  };
+
+  useEffect(() => {
+    if (filteredItems.length > 0) setSelectedResult(0);
+  }, [filteredItems.length]);
+
+  return (
+    <ListBox disabled={false} type="inline" isOpen>
+      <InvalidSearchWrapper $invalid={invalid}>
+        <Search
+          labelText={placeholder}
+          placeholder={placeholder}
+          onChange={handleChange}
+          onClear={handleClear}
+          value={search}
+          autoFocus={autoFocus}
+          onKeyDown={handleKeyDown}
+        />
+      </InvalidSearchWrapper>
+      {search && (
+        <ListStyleWrapper>
+          <ListBox.Menu id="list-box">
+            {filteredItems.filter(filter).map((item, index) => {
+              const { title, subTitle } = item;
+
+              return (
+                <MenuItemWrapper
+                  key={item[keyAttribute] as string}
+                  $isSelected={index === selectedResult}
+                >
+                  <ListBox.MenuItem
+                    title={title}
+                    onClick={() => handleSelect(item)}
+                  >
+                    {title}
+                    {subTitle && <SecondaryText>{subTitle}</SecondaryText>}
+                  </ListBox.MenuItem>
+                </MenuItemWrapper>
+              );
+            })}
+          </ListBox.Menu>
+        </ListStyleWrapper>
+      )}
+    </ListBox>
+  );
+};
+
+export default DropdownSearch;

--- a/identity/client/src/components/formV2/DropdownSearch.tsx
+++ b/identity/client/src/components/formV2/DropdownSearch.tsx
@@ -13,7 +13,6 @@ import useDebounce from "react-debounced";
 // TODO: Replace with design-system and Tailwind
 import { SecondaryText } from "src/components/form/Text";
 import styled from "styled-components";
-import Fuse from "fuse.js";
 
 type DropdownSearchProps<Item extends Record<string, unknown>> = {
   items: Item[];
@@ -63,67 +62,29 @@ const DropdownSearch = <Item extends Record<string, unknown>>({
   placeholder,
   onChange = () => {},
   keyAttribute = "title",
-  items: rawItems,
+  items,
   itemTitle,
   itemSubTitle,
   onSelect,
-  filter = () => true, // We require a filter to allow the parent to remove items with accumulated state. See comment below for details.
+  filter = () => true,
   autoFocus = false,
   invalid = false,
 }: DropdownSearchProps<Item>) => {
   const debounce = useDebounce();
   const [search, setSearch] = useState("");
   const [selectedResult, setSelectedResult] = useState<number>(-1);
-  const [filteredItems, setFilteredItems] = useState<
-    ItemWithTitleAndSubTitle<Item>[]
-  >([]);
 
-  const [allItems, setAllItems] = useState<ItemWithTitleAndSubTitle<Item>[]>(
-    [],
-  );
-
-  // We are accumulating all itemsm even if the `items` prop changes.
-  // This allows the parent component to pass new items into the dropdown, e.g.
-  // when the user types in the search field.
-  //
-  // === THIS IS A WORKAROUND ===
-  // Ideally, we can use the response from the server directly and don't need to
-  // keep state here. However, as some endpoints only allow for exact matches,
-  // this would invalidate the use case of a dropdown search.
-  // We should refactor this component to use the server response directly.
-  //
-  // Related to https://github.com/camunda/camunda/issues/36493
-  useEffect(() => {
-    setAllItems((prevItems) => {
-      const allKeys = prevItems.map((item) => item[keyAttribute] as string);
-
-      const newItems = rawItems
-        .map((item) => ({
-          ...item,
-          title: itemTitle(item),
-          subTitle: itemSubTitle ? itemSubTitle(item) : undefined,
-        }))
-        .filter((item) => !allKeys.includes(item[keyAttribute] as string));
-      return [...prevItems, ...newItems];
-    });
-  }, [rawItems, itemTitle, itemSubTitle, keyAttribute]);
-
-  const fuse = useMemo(
+  // `items` is already the server's search result for the current `search`
+  // text, so it's rendered directly rather than accumulated/re-filtered here.
+  const filteredItems: ItemWithTitleAndSubTitle<Item>[] = useMemo(
     () =>
-      new Fuse(allItems, {
-        keys: ["title", "subTitle"],
-        threshold: 0.3,
-      }),
-    [allItems],
+      items.map((item) => ({
+        ...item,
+        title: itemTitle(item),
+        subTitle: itemSubTitle ? itemSubTitle(item) : undefined,
+      })),
+    [items, itemTitle, itemSubTitle],
   );
-
-  useEffect(() => {
-    if (search) {
-      setFilteredItems(fuse.search(search).map((result) => result.item));
-    } else {
-      setFilteredItems(allItems);
-    }
-  }, [search, allItems, fuse]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/identity/client/src/components/formV2/EntitySearchDropdown.tsx
+++ b/identity/client/src/components/formV2/EntitySearchDropdown.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import DropdownSearch from "src/components/formV2/DropdownSearch";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+
+export type EntitySearchQuery<Entity> = {
+  queryKey: readonly unknown[];
+  // The generated query builders type their queryFn's context param more
+  // narrowly per entity; `any` here just needs to accept whatever they pass.
+  queryFn?: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    context: any,
+  ) => Promise<{ items: Entity[] }> | { items: Entity[] };
+};
+
+type EntitySearchDropdownProps<Entity extends Record<string, unknown>> = {
+  search: (search: string) => EntitySearchQuery<Entity>;
+  itemTitle: (entity: Entity) => string;
+  itemSubTitle?: (entity: Entity) => string;
+  onSelect: (entity: Entity) => void;
+  filter?: (entity: Entity) => boolean;
+  placeholder: string;
+  autoFocus?: boolean;
+  invalid?: boolean;
+  errorTitle: string;
+  retryLabel: string;
+};
+
+/**
+ * Generic search dropdown for any entity: fetches items via the given
+ * search query as the user types, and renders them through DropdownSearch.
+ */
+const EntitySearchDropdown = <Entity extends Record<string, unknown>>({
+  search: buildSearchQuery,
+  itemTitle,
+  itemSubTitle,
+  onSelect,
+  filter,
+  placeholder,
+  autoFocus = false,
+  invalid = false,
+  errorTitle,
+  retryLabel,
+}: EntitySearchDropdownProps<Entity>) => {
+  const [search, setSearch] = useState("");
+
+  const {
+    data: searchResults,
+    isLoading: loading,
+    refetch: reload,
+    error,
+  } = useQuery<{ items: Entity[] }>({
+    ...buildSearchQuery(search),
+    enabled: search !== "",
+  });
+
+  return (
+    <>
+      <DropdownSearch
+        autoFocus={autoFocus}
+        items={searchResults?.items || []}
+        itemTitle={itemTitle}
+        itemSubTitle={itemSubTitle}
+        placeholder={placeholder}
+        onSelect={onSelect}
+        onChange={setSearch}
+        filter={filter}
+        invalid={invalid}
+      />
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={errorTitle}
+          actionButton={{
+            label: retryLabel,
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default EntitySearchDropdown;

--- a/identity/client/src/components/formV2/EntitySearchMultiSelect.tsx
+++ b/identity/client/src/components/formV2/EntitySearchMultiSelect.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useCallback } from "react";
+import { Tag } from "@carbon/react";
+import styled from "styled-components";
+import useTranslate from "src/utility/localization";
+import EntitySearchDropdown, {
+  type EntitySearchQuery,
+} from "src/components/formV2/EntitySearchDropdown";
+
+const SelectedEntities = styled.div`
+  margin-top: 0;
+`;
+
+type AbstractEntitySearchMultiSelectProps<
+  Entity extends Record<string, unknown>,
+> = {
+  search: (search: string) => EntitySearchQuery<Entity>;
+  itemSubTitle?: (entity: Entity) => string;
+  getId: (entity: Entity) => string;
+  value: Entity[];
+  onChange: (entities: Entity[]) => void;
+  excluded?: Entity[];
+  placeholder: string;
+  errorTitle: string;
+  autoFocus?: boolean;
+};
+
+/**
+ * Public props for a concrete per-entity multi-select (e.g. UserMultiSelect):
+ * everything technical (search, getId, errorTitle) is bound by the concrete
+ * implementation. itemSubTitle/placeholder get concrete defaults but remain
+ * overridable per call site, since some consumers need different copy.
+ */
+export type EntitySearchMultiSelectProps<
+  Entity extends Record<string, unknown>,
+> = Omit<
+  AbstractEntitySearchMultiSelectProps<Entity>,
+  "search" | "getId" | "itemSubTitle" | "placeholder" | "errorTitle"
+> &
+  Partial<
+    Pick<
+      AbstractEntitySearchMultiSelectProps<Entity>,
+      "itemSubTitle" | "placeholder"
+    >
+  >;
+
+const EntitySearchMultiSelect = <Entity extends Record<string, unknown>>({
+  search,
+  itemSubTitle,
+  getId,
+  value,
+  onChange,
+  excluded = [],
+  placeholder,
+  errorTitle,
+  autoFocus = false,
+}: AbstractEntitySearchMultiSelectProps<Entity>) => {
+  const { t } = useTranslate();
+
+  const isAlreadyPicked = useCallback(
+    (entity: Entity) =>
+      excluded.some((picked) => getId(picked) === getId(entity)) ||
+      value.some((picked) => getId(picked) === getId(entity)),
+    [excluded, value, getId],
+  );
+
+  const handleSelect = (entity: Entity) => {
+    onChange([...value, entity]);
+  };
+
+  const handleUnselect = (entity: Entity) => () => {
+    onChange(value.filter((picked) => getId(picked) !== getId(entity)));
+  };
+
+  return (
+    <>
+      {value.length > 0 && (
+        <SelectedEntities>
+          {value.map((entity) => (
+            <Tag
+              key={getId(entity)}
+              onClose={handleUnselect(entity)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {getId(entity)}
+            </Tag>
+          ))}
+        </SelectedEntities>
+      )}
+      <EntitySearchDropdown
+        search={search}
+        itemTitle={getId}
+        itemSubTitle={itemSubTitle}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        onSelect={handleSelect}
+        filter={(entity) => !isAlreadyPicked(entity)}
+        errorTitle={errorTitle}
+        retryLabel={t("retry")}
+      />
+    </>
+  );
+};
+
+export default EntitySearchMultiSelect;

--- a/identity/client/src/components/formV2/EntitySearchSingleSelect.tsx
+++ b/identity/client/src/components/formV2/EntitySearchSingleSelect.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useEffect, useState } from "react";
+import { FormLabel, Tag } from "@carbon/react";
+import useTranslate from "src/utility/localization";
+import EntitySearchDropdown, {
+  type EntitySearchQuery,
+} from "src/components/formV2/EntitySearchDropdown";
+
+type AbstractEntitySearchSingleSelectProps<
+  Entity extends Record<string, unknown>,
+> = {
+  search: (search: string) => EntitySearchQuery<Entity>;
+  itemSubTitle?: (entity: Entity) => string;
+  getId: (entity: Entity) => string;
+  itemToString: (entity: Entity) => string;
+  label: string;
+  placeholder: string;
+  errorTitle: string;
+  requiredText: string;
+  onChange: (id: string) => void;
+  value?: string;
+  isEmpty?: boolean;
+};
+
+/**
+ * Public props for a concrete per-entity single-select (e.g. UserSingleSelect):
+ * everything technical (search, getId, itemToString, errorTitle) is bound by
+ * the concrete implementation. itemSubTitle gets a concrete default but
+ * remains overridable per call site, since some consumers need different copy.
+ */
+export type EntitySearchSingleSelectProps<
+  Entity extends Record<string, unknown>,
+> = Omit<
+  AbstractEntitySearchSingleSelectProps<Entity>,
+  "search" | "getId" | "itemToString" | "itemSubTitle" | "errorTitle"
+> &
+  Partial<Pick<AbstractEntitySearchSingleSelectProps<Entity>, "itemSubTitle">>;
+
+const EntitySearchSingleSelect = <Entity extends Record<string, unknown>>({
+  search,
+  itemSubTitle,
+  getId,
+  itemToString,
+  label,
+  placeholder,
+  errorTitle,
+  requiredText,
+  onChange,
+  value,
+  isEmpty = false,
+}: AbstractEntitySearchSingleSelectProps<Entity>) => {
+  const { t } = useTranslate();
+  const [selectedEntity, setSelectedEntity] = useState<Entity | null>(null);
+
+  useEffect(() => {
+    setSelectedEntity((current) =>
+      current && value && getId(current) === value ? current : null,
+    );
+  }, [value, getId]);
+
+  const handleSelect = (entity: Entity) => {
+    setSelectedEntity(entity);
+    onChange(getId(entity));
+  };
+
+  const handleClear = () => {
+    setSelectedEntity(null);
+    onChange("");
+  };
+
+  return (
+    <div>
+      <FormLabel>{label}</FormLabel>
+      {selectedEntity ? (
+        <div style={{ marginTop: "0.5rem" }}>
+          <Tag filter onClose={handleClear} type="blue" size="md">
+            {itemToString(selectedEntity)}
+          </Tag>
+        </div>
+      ) : (
+        <EntitySearchDropdown
+          search={search}
+          itemTitle={getId}
+          itemSubTitle={itemSubTitle}
+          placeholder={placeholder}
+          onSelect={handleSelect}
+          errorTitle={errorTitle}
+          retryLabel={t("retry")}
+          invalid={isEmpty}
+        />
+      )}
+      {isEmpty && (
+        <p
+          style={{
+            color: "var(--cds-text-error, #da1e28)",
+            fontSize: "0.75rem",
+            marginTop: "0.25rem",
+          }}
+        >
+          {requiredText}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default EntitySearchSingleSelect;

--- a/identity/client/src/components/formV2/entitySelection/GroupSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/GroupSelection.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import EntitySearchMultiSelect, {
+  type EntitySearchMultiSelectProps,
+} from "src/components/formV2/EntitySearchMultiSelect";
+import EntitySearchSingleSelect, {
+  type EntitySearchSingleSelectProps,
+} from "src/components/formV2/EntitySearchSingleSelect";
+import { groupQueries } from "src/utility/api/groups/queries";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const getId = (group: Group) => group.groupId;
+const itemToString = (group: Group) => group.name || group.groupId;
+const itemSubTitle = (group: Group) => group.name;
+const search = (search: string) =>
+  groupQueries.search(
+    search === "" ? {} : { filter: { groupId: { $like: `*${search}*` } } },
+  );
+
+export const GroupMultiSelect: FC<EntitySearchMultiSelectProps<Group>> = (
+  props,
+) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchMultiSelect
+      search={search}
+      getId={getId}
+      itemSubTitle={itemSubTitle}
+      placeholder={t("searchByGroupId")}
+      errorTitle={t("groupsCouldNotLoad")}
+      {...props}
+    />
+  );
+};
+
+export const GroupSingleSelect: FC<EntitySearchSingleSelectProps<Group>> = (
+  props,
+) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchSingleSelect
+      search={search}
+      getId={getId}
+      itemToString={itemToString}
+      itemSubTitle={itemSubTitle}
+      errorTitle={t("groupsCouldNotLoad")}
+      {...props}
+    />
+  );
+};

--- a/identity/client/src/components/formV2/entitySelection/MappingRuleSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/MappingRuleSelection.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import EntitySearchMultiSelect, {
+  type EntitySearchMultiSelectProps,
+} from "src/components/formV2/EntitySearchMultiSelect";
+import EntitySearchSingleSelect, {
+  type EntitySearchSingleSelectProps,
+} from "src/components/formV2/EntitySearchSingleSelect";
+import { mappingRuleQueries } from "src/utility/api/mapping-rules/queries";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const getId = (mappingRule: MappingRule) => mappingRule.mappingRuleId;
+const itemToString = (mappingRule: MappingRule) =>
+  mappingRule.name || mappingRule.mappingRuleId;
+const itemSubTitle = (mappingRule: MappingRule) => mappingRule.name;
+const search = (search: string) =>
+  mappingRuleQueries.search(
+    search.trim() ? { filter: { name: { $like: `*${search}*` } } } : {},
+  );
+
+export const MappingRuleMultiSelect: FC<
+  EntitySearchMultiSelectProps<MappingRule>
+> = (props) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchMultiSelect
+      search={search}
+      getId={getId}
+      itemSubTitle={itemSubTitle}
+      placeholder={t("searchByMappingRuleId")}
+      errorTitle={t("mappingRulesCouldNotLoad")}
+      {...props}
+    />
+  );
+};
+
+export const MappingRuleSingleSelect: FC<
+  EntitySearchSingleSelectProps<MappingRule>
+> = (props) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchSingleSelect
+      search={search}
+      getId={getId}
+      itemToString={itemToString}
+      itemSubTitle={itemSubTitle}
+      errorTitle={t("mappingRulesCouldNotLoad")}
+      {...props}
+    />
+  );
+};

--- a/identity/client/src/components/formV2/entitySelection/RoleSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/RoleSelection.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import EntitySearchMultiSelect, {
+  type EntitySearchMultiSelectProps,
+} from "src/components/formV2/EntitySearchMultiSelect";
+import EntitySearchSingleSelect, {
+  type EntitySearchSingleSelectProps,
+} from "src/components/formV2/EntitySearchSingleSelect";
+import { roleQueries } from "src/utility/api/roles/queries";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const getId = (role: Role) => role.roleId;
+const itemToString = (role: Role) => role.name || role.roleId;
+const itemSubTitle = (role: Role) => role.name;
+const search = (search: string) =>
+  roleQueries.search(
+    search === "" ? {} : { filter: { name: { $like: `*${search}*` } } },
+  );
+
+export const RoleMultiSelect: FC<EntitySearchMultiSelectProps<Role>> = (
+  props,
+) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchMultiSelect
+      search={search}
+      getId={getId}
+      itemSubTitle={itemSubTitle}
+      placeholder={t("searchByRoleId")}
+      errorTitle={t("rolesCouldNotLoad")}
+      {...props}
+    />
+  );
+};
+
+export const RoleSingleSelect: FC<EntitySearchSingleSelectProps<Role>> = (
+  props,
+) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchSingleSelect
+      search={search}
+      getId={getId}
+      itemToString={itemToString}
+      itemSubTitle={itemSubTitle}
+      errorTitle={t("rolesCouldNotLoad")}
+      {...props}
+    />
+  );
+};

--- a/identity/client/src/components/formV2/entitySelection/UserSelection.tsx
+++ b/identity/client/src/components/formV2/entitySelection/UserSelection.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import EntitySearchMultiSelect, {
+  type EntitySearchMultiSelectProps,
+} from "src/components/formV2/EntitySearchMultiSelect";
+import EntitySearchSingleSelect, {
+  type EntitySearchSingleSelectProps,
+} from "src/components/formV2/EntitySearchSingleSelect";
+import { userQueries } from "src/utility/api/users/queries";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const getId = (user: User) => user.username;
+const itemToString = (user: User) => user.name || user.username;
+const itemSubTitle = (user: User) => user.email;
+const search = (search: string) =>
+  userQueries.search(
+    search === "" ? {} : { filter: { username: { $like: `*${search}*` } } },
+  );
+
+export const UserMultiSelect: FC<EntitySearchMultiSelectProps<User>> = (
+  props,
+) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchMultiSelect
+      search={search}
+      getId={getId}
+      itemSubTitle={itemSubTitle}
+      placeholder={t("searchByUsername")}
+      errorTitle={t("usersCouldNotLoad")}
+      {...props}
+    />
+  );
+};
+
+export const UserSingleSelect: FC<EntitySearchSingleSelectProps<User>> = (
+  props,
+) => {
+  const { t } = useTranslate("entitySelection");
+  return (
+    <EntitySearchSingleSelect
+      search={search}
+      getId={getId}
+      itemToString={itemToString}
+      itemSubTitle={itemSubTitle}
+      errorTitle={t("usersCouldNotLoad")}
+      {...props}
+    />
+  );
+};

--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -19,8 +19,10 @@ import type {
   Group,
 } from "@camunda/camunda-api-zod-schemas/8.10";
 
+type GroupWithId = Group & { id: string };
+
 type UseEnrichedGroupsResult = {
-  groups: Group[];
+  groups: GroupWithId[];
   loading: boolean;
   success: boolean;
   reload: () => void;
@@ -69,11 +71,12 @@ export function useEnrichedGroups<P>(
     enabled: isCamundaGroupsEnabled && groupIds.length > 0,
   });
 
-  const groups = useMemo<Group[]>(() => {
+  const groups = useMemo<GroupWithId[]>(() => {
     const items = membersQuery.data?.items ?? [];
     if (items.length === 0) return [];
     if (!isCamundaGroupsEnabled) {
       return items.map(({ groupId }) => ({
+        id: groupId,
         groupId,
         name: "",
         description: "",
@@ -83,6 +86,7 @@ export function useEnrichedGroups<P>(
     return items.map((member) => {
       const group = fullGroups.find((g) => g.groupId === member.groupId);
       return {
+        id: member.groupId,
         groupId: member.groupId,
         name: group?.name || "",
         description: group?.description || "",

--- a/identity/client/src/components/global/useEnrichUsers.tsx
+++ b/identity/client/src/components/global/useEnrichUsers.tsx
@@ -19,8 +19,10 @@ import { usePagination } from "src/utility/api";
 import { getApiBaseUrl } from "src/configuration/urlConfig";
 import { mergeParams } from "src/utility/api/hooks/utils";
 
+type UserWithId = User & { id: string };
+
 type UseEnrichedUsersResult = {
-  users: User[];
+  users: UserWithId[];
   loading: boolean;
   success: boolean;
   reload: () => void;
@@ -68,11 +70,12 @@ export function useEnrichedUsers<P>(
     enabled: !isOIDC && usernames.length > 0,
   });
 
-  const users = useMemo<User[]>(() => {
+  const users = useMemo<UserWithId[]>(() => {
     const items = membersQuery.data?.items ?? [];
     if (items.length === 0) return [];
     if (isOIDC) {
       return items.map(({ username }) => ({
+        id: username,
         username,
         name: "",
         email: "",
@@ -82,6 +85,7 @@ export function useEnrichedUsers<P>(
     return items.map((member) => {
       const user = fullUsers.find((u) => u.username === member.username);
       return {
+        id: member.username,
         username: member.username,
         name: user?.name || "",
         email: user?.email || "",

--- a/identity/client/src/components/layoutV2/DetailsPageDescription.tsx
+++ b/identity/client/src/components/layoutV2/DetailsPageDescription.tsx
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from "styled-components";
+
+/** @deprecated Use `PageHeader.description` from `@camunda/design-system` instead. */
+export const Description = styled.p`
+  color: var(--cds-text-secondary);
+`;

--- a/identity/client/src/components/layoutV2/TabEmptyState.tsx
+++ b/identity/client/src/components/layoutV2/TabEmptyState.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+// TODO: Replace with design system empty state
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { Add } from "@carbon/react/icons";
+import { useDocsUrl } from "../documentation/DocsUrlContext";
+import { documentationHref } from "src/components/documentationV2";
+import useTranslate from "src/utility/localization";
+
+type TabEmptyStateProps = {
+  childResourceTypeTranslationKey: string;
+  parentResourceTypeTranslationKey: string;
+  description?: string;
+  docsLinkPath?: string;
+  handleClick: () => void;
+};
+
+const TabEmptyState: FC<TabEmptyStateProps> = ({
+  childResourceTypeTranslationKey,
+  parentResourceTypeTranslationKey,
+  description,
+  docsLinkPath = "",
+  handleClick,
+}) => {
+  const { t } = useTranslate();
+  const docsUrl = useDocsUrl();
+
+  const childResourceTypeText = t(
+    childResourceTypeTranslationKey,
+  ).toLowerCase();
+  const parentResourceTypeText = t(
+    parentResourceTypeTranslationKey,
+  ).toLowerCase();
+
+  return (
+    <C3EmptyState
+      heading={t("emptyStateTitleAssign", {
+        childResourceType: childResourceTypeText,
+        parentResourceType: parentResourceTypeText,
+      })}
+      description={
+        description
+          ? description
+          : t("emptyStateSubtitleAssign", {
+              childResourceType: childResourceTypeText,
+            })
+      }
+      button={{
+        label: t("emptyStateButtonAssign", {
+          childResourceType: childResourceTypeText,
+        }),
+        onClick: handleClick,
+        icon: Add,
+      }}
+      link={{
+        href: documentationHref(docsUrl, docsLinkPath),
+        label: t("emptyStateLearnText", {
+          resourceType: childResourceTypeText,
+        }),
+      }}
+    />
+  );
+};
+
+export default TabEmptyState;

--- a/identity/client/src/pages/roles/ListV2.tsx
+++ b/identity/client/src/pages/roles/ListV2.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Edit, TrashCan } from "@carbon/react/icons";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { roleQueries } from "src/utility/api/roles/queries";
+import Page, { PageHeader } from "src/components/layoutV2/Page";
+import EntityList from "src/components/entityListV2";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import useModal, { useEntityModal } from "src/components/modalV2/useModal";
+import AddModal from "src/pages/roles/modalsV2/AddModal";
+import DeleteModal from "src/pages/roles/modalsV2/DeleteModal";
+import EditModal from "src/pages/roles/modalsV2/EditModal";
+import PageEmptyState from "src/components/layoutV2/PageEmptyState";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type ListProps = {
+  defaultRoleIds: string[];
+};
+
+const List: FC<ListProps> = ({ defaultRoleIds }) => {
+  const { t } = useTranslate("roles");
+  const navigate = useNavigate();
+  const noop = () => {};
+
+  const { pageParams, page, search, ...paginationCallbacks } = usePagination();
+  const {
+    data: roles,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...roleQueries.search(pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((role) => ({ ...role, id: role.roleId })),
+    }),
+  });
+
+  const [addRole, addRoleModal] = useModal(AddModal, noop);
+  const [editRole, editRoleModal] = useEntityModal(EditModal, noop);
+  const [deleteRole, deleteRoleModal] = useEntityModal(DeleteModal, noop);
+
+  const showDetails = ({ roleId }: Role) => navigate(roleId);
+
+  const shouldShowEmptyState = success && !search && !roles?.items.length;
+
+  const pageHeader = (
+    <PageHeader
+      title={t("roles")}
+      linkText={t("roles").toLowerCase()}
+      docsLinkPath="/components/admin/role/"
+      shouldShowDocumentationLink={!shouldShowEmptyState}
+    />
+  );
+
+  if (shouldShowEmptyState) {
+    return (
+      <Page>
+        {pageHeader}
+        <PageEmptyState
+          resourceTypeTranslationKey={"role"}
+          docsLinkPath="/components/admin/role/"
+          handleClick={addRole}
+        />
+        {addRoleModal}
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      {pageHeader}
+      <EntityList
+        data={roles?.items ?? []}
+        headers={[
+          { header: t("roleId"), key: "roleId", isSortable: true },
+          { header: t("roleName"), key: "name", isSortable: true },
+        ]}
+        onEntityClick={showDetails}
+        addEntityLabel={t("createRole")}
+        onAddEntity={addRole}
+        loading={loading}
+        menuItems={[
+          {
+            label: t("editRole"),
+            icon: Edit,
+            onClick: editRole,
+            disabled: ({ roleId }: Role) => defaultRoleIds.includes(roleId),
+          },
+          {
+            label: t("delete"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: deleteRole,
+            disabled: ({ roleId }: Role) => defaultRoleIds.includes(roleId),
+          },
+        ]}
+        searchPlaceholder={t("searchByRoleId")}
+        searchKey="roleId"
+        page={{ ...page, ...roles?.page }}
+        {...paginationCallbacks}
+      />
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("rolesCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+      {addRoleModal}
+      {editRoleModal}
+      {deleteRoleModal}
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/roles/detailV2/clients/AssignClientsModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/clients/AssignClientsModal.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import FormModal from "src/components/modalV2/FormModal";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import TextField from "src/components/formV2/TextField";
+import { UseEntityModalProps } from "src/components/modalV2";
+import type { Role, TenantClient } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignClientsModal: FC<UseEntityModalProps<Role["roleId"]>> = ({
+  entity: roleId,
+  onSuccess,
+  open,
+  onClose,
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const [clientId, setClientId] = useState<TenantClient["clientId"]>("");
+  const qc = useQueryClient();
+  const { mutate, isPending: loadingAssignClient } = useMutation(
+    roleMutations.assignClient(qc),
+  );
+
+  const canSubmit = roleId && clientId.length;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    mutate({ clientId, roleId }, { onSuccess });
+  };
+
+  useEffect(() => {
+    if (open) {
+      setClientId("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignClient")}
+      confirmLabel={t("assignClient")}
+      loading={loadingAssignClient}
+      loadingDescription={t("assigningClient")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>
+        <Translate i18nKey="assignClientToRole">
+          Assign client to this role
+        </Translate>
+      </p>
+
+      <TextField
+        label={t("clientId")}
+        placeholder={t("enterClientId")}
+        onChange={setClientId}
+        value={clientId}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignClientsModal;

--- a/identity/client/src/pages/roles/detailV2/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/clients/DeleteModal.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import type { Role, TenantClient } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveRoleClientModalProps = UseEntityModalCustomProps<
+  TenantClient,
+  {
+    roleId: Role["roleId"];
+  }
+>;
+
+const DeleteModal: FC<RemoveRoleClientModalProps> = ({
+  entity: client,
+  open,
+  onClose,
+  onSuccess,
+  roleId,
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    roleMutations.unassignClient(qc),
+  );
+
+  const handleSubmit = () => {
+    if (roleId && client) {
+      mutate(
+        { roleId, clientId: client.clientId },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("roleClientRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeClient")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingClient")}
+      onClose={onClose}
+      confirmLabel={t("removeClient")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeClientFromRole"
+          values={{ clientId: client.clientId }}
+        >
+          Are you sure you want to remove <strong>{client.clientId}</strong>{" "}
+          from this role?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/roles/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/clients/index.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+// TODO: Replace with design system empty state
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { roleQueries } from "src/utility/api/roles/queries";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import DeleteModal from "src/pages/roles/detailV2/clients/DeleteModal";
+import AssignClientsModal from "src/pages/roles/detailV2/clients/AssignClientsModal";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type ClientsProps = {
+  roleId: Role["roleId"];
+};
+
+const Clients: FC<ClientsProps> = ({ roleId }) => {
+  const { t } = useTranslate("roles");
+  const noop = () => {};
+
+  const { pageParams, page, ...paginationCallbacks } = usePagination();
+  const {
+    data: clients,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...roleQueries.clients(roleId, pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((client) => ({ ...client, id: client.clientId })),
+    }),
+  });
+
+  const assignedClients =
+    clients && Array.isArray(clients.items) ? clients.items : [];
+
+  const [assignClient, assignClientModal] = useEntityModal(
+    AssignClientsModal,
+    noop,
+  );
+  const openAssignModal = () => assignClient(roleId);
+  const [unassignClient, unassignClientModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    { roleId },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("client").toLowerCase(),
+        })}
+        button={{
+          label: t("retry"),
+          onClick: () => {
+            void reload();
+          },
+        }}
+      />
+    );
+
+  if (success && assignedClients.length === 0)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"client"}
+          parentResourceTypeTranslationKey={"role"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/client/"
+        />
+        {assignClientModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={clients?.items}
+        headers={[{ header: t("clientId"), key: "clientId", isSortable: true }]}
+        loading={loading}
+        addEntityLabel={t("assignClient")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByClientId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignClient,
+          },
+        ]}
+        page={{ ...page, ...clients?.page }}
+        {...paginationCallbacks}
+      />
+      {assignClientModal}
+      {unassignClientModal}
+    </>
+  );
+};
+
+export default Clients;

--- a/identity/client/src/pages/roles/detailV2/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/AssignGroupModal.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import useTranslate from "src/utility/localization";
+import FormModal from "src/components/modalV2/FormModal";
+import TextField from "src/components/formV2/TextField";
+import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignGroupModal: FC<
+  UseEntityModalCustomProps<
+    { roleId: Role["roleId"] },
+    { assignedGroups: Group[] }
+  >
+> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("roles");
+  const [groupId, setGroupId] = useState("");
+  const qc = useQueryClient();
+  const { mutate, isPending: loadingAssignGroup } = useMutation(
+    roleMutations.assignGroup(qc),
+  );
+
+  const canSubmit = roleId && groupId;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    mutate({ groupId, roleId }, { onSuccess });
+  };
+
+  useEffect(() => {
+    if (open) {
+      setGroupId("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignGroup")}
+      confirmLabel={t("assignGroup")}
+      loading={loadingAssignGroup}
+      loadingDescription={t("assigningGroup")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("assignGroupsToRole")}</p>
+      <TextField
+        label={t("groupId")}
+        placeholder={t("typeGroup")}
+        onChange={setGroupId}
+        value={groupId}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignGroupModal;

--- a/identity/client/src/pages/roles/detailV2/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/AssignGroupsModal.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { groupQueries } from "src/utility/api/groups/queries";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import DropdownSearch from "src/components/formV2/DropdownSearch";
+import FormModal from "src/components/modalV2/FormModal";
+import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const SelectedGroups = styled.div`
+  margin-top: 0;
+`;
+
+const AssignGroupsModal: FC<
+  UseEntityModalCustomProps<
+    { roleId: Role["roleId"] },
+    { assignedGroups: Group[] }
+  >
+> = ({ entity: { roleId }, assignedGroups, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("roles");
+  const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
+  const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
+  const [currentInputValue, setCurrentInputValue] = useState("");
+
+  const [search, setSearch] = useState<Record<string, unknown>>({});
+  useEffect(() => {
+    if (currentInputValue === "") {
+      setSearch({});
+      return;
+    }
+    setSearch({ filter: { groupId: { $like: `*${currentInputValue}*` } } });
+  }, [currentInputValue]);
+
+  const {
+    data: groupSearchResults,
+    isLoading: loading,
+    refetch: reload,
+    error,
+  } = useQuery(groupQueries.search(search));
+
+  const qc = useQueryClient();
+  const { mutateAsync: callAssignGroup } = useMutation(
+    roleMutations.assignGroup(qc),
+  );
+
+  const unassignedFilter = useCallback(
+    ({ groupId }: Group) =>
+      !assignedGroups.some((group) => group.groupId === groupId) &&
+      !selectedGroups.some((group) => group.groupId === groupId),
+    [assignedGroups, selectedGroups],
+  );
+
+  const handleDropdownChange = (value: string) => {
+    setCurrentInputValue(value);
+  };
+
+  const onSelectGroup = (group: Group) => {
+    setSelectedGroups([...selectedGroups, group]);
+    setCurrentInputValue("");
+  };
+
+  const onUnselectGroup =
+    ({ groupId }: Group) =>
+    () => {
+      setSelectedGroups(
+        selectedGroups.filter((group) => group.groupId !== groupId),
+      );
+    };
+
+  const canSubmit = roleId && selectedGroups.length && !loadingAssignGroup;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignGroup(true);
+    try {
+      await Promise.all(
+        selectedGroups.map(({ groupId }) =>
+          callAssignGroup({ groupId, roleId }),
+        ),
+      );
+      onSuccess();
+    } catch {
+      // error handled globally
+    } finally {
+      setLoadingAssignGroup(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedGroups([]);
+      setCurrentInputValue("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignGroup")}
+      confirmLabel={t("assignGroup")}
+      loading={loadingAssignGroup}
+      loadingDescription={t("assigningGroup")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("searchAndAssignGroupToRole")}</p>
+      {selectedGroups.length > 0 && (
+        <SelectedGroups>
+          {selectedGroups.map((group) => (
+            <Tag
+              key={group.groupId}
+              onClose={onUnselectGroup(group)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {group.groupId}
+            </Tag>
+          ))}
+        </SelectedGroups>
+      )}
+      <DropdownSearch
+        autoFocus
+        items={groupSearchResults?.items || []}
+        itemTitle={({ groupId }) => groupId}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByGroupId")}
+        onSelect={onSelectGroup}
+        onChange={handleDropdownChange}
+        filter={unassignedFilter}
+      />
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("groupsCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignGroupsModal;

--- a/identity/client/src/pages/roles/detailV2/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/AssignGroupsModal.tsx
@@ -6,22 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useCallback, useEffect, useState } from "react";
-import styled from "styled-components";
-import { Tag } from "@carbon/react";
+import { FC, useEffect, useState } from "react";
 import { UseEntityModalCustomProps } from "src/components/modalV2";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
-import { groupQueries } from "src/utility/api/groups/queries";
 import { roleMutations } from "src/utility/api/roles/mutations";
-import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
-import DropdownSearch from "src/components/formV2/DropdownSearch";
+import { GroupMultiSelect } from "src/components/formV2/entitySelection/GroupSelection";
 import FormModal from "src/components/modalV2/FormModal";
 import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
-
-const SelectedGroups = styled.div`
-  margin-top: 0;
-`;
 
 const AssignGroupsModal: FC<
   UseEntityModalCustomProps<
@@ -32,52 +24,11 @@ const AssignGroupsModal: FC<
   const { t } = useTranslate("roles");
   const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
   const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
-  const [currentInputValue, setCurrentInputValue] = useState("");
-
-  const [search, setSearch] = useState<Record<string, unknown>>({});
-  useEffect(() => {
-    if (currentInputValue === "") {
-      setSearch({});
-      return;
-    }
-    setSearch({ filter: { groupId: { $like: `*${currentInputValue}*` } } });
-  }, [currentInputValue]);
-
-  const {
-    data: groupSearchResults,
-    isLoading: loading,
-    refetch: reload,
-    error,
-  } = useQuery(groupQueries.search(search));
 
   const qc = useQueryClient();
   const { mutateAsync: callAssignGroup } = useMutation(
     roleMutations.assignGroup(qc),
   );
-
-  const unassignedFilter = useCallback(
-    ({ groupId }: Group) =>
-      !assignedGroups.some((group) => group.groupId === groupId) &&
-      !selectedGroups.some((group) => group.groupId === groupId),
-    [assignedGroups, selectedGroups],
-  );
-
-  const handleDropdownChange = (value: string) => {
-    setCurrentInputValue(value);
-  };
-
-  const onSelectGroup = (group: Group) => {
-    setSelectedGroups([...selectedGroups, group]);
-    setCurrentInputValue("");
-  };
-
-  const onUnselectGroup =
-    ({ groupId }: Group) =>
-    () => {
-      setSelectedGroups(
-        selectedGroups.filter((group) => group.groupId !== groupId),
-      );
-    };
 
   const canSubmit = roleId && selectedGroups.length && !loadingAssignGroup;
 
@@ -102,7 +53,6 @@ const AssignGroupsModal: FC<
   useEffect(() => {
     if (open) {
       setSelectedGroups([]);
-      setCurrentInputValue("");
     }
   }, [open]);
 
@@ -118,42 +68,12 @@ const AssignGroupsModal: FC<
       onClose={onClose}
     >
       <p>{t("searchAndAssignGroupToRole")}</p>
-      {selectedGroups.length > 0 && (
-        <SelectedGroups>
-          {selectedGroups.map((group) => (
-            <Tag
-              key={group.groupId}
-              onClose={onUnselectGroup(group)}
-              size="md"
-              type="blue"
-              filter
-            >
-              {group.groupId}
-            </Tag>
-          ))}
-        </SelectedGroups>
-      )}
-      <DropdownSearch
+      <GroupMultiSelect
+        value={selectedGroups}
+        onChange={setSelectedGroups}
+        excluded={assignedGroups}
         autoFocus
-        items={groupSearchResults?.items || []}
-        itemTitle={({ groupId }) => groupId}
-        itemSubTitle={({ name }) => name}
-        placeholder={t("searchByGroupId")}
-        onSelect={onSelectGroup}
-        onChange={handleDropdownChange}
-        filter={unassignedFilter}
       />
-      {!loading && error && (
-        <TranslatedErrorInlineNotification
-          title={t("groupsCouldNotLoad")}
-          actionButton={{
-            label: t("retry"),
-            onClick: () => {
-              void reload();
-            },
-          }}
-        />
-      )}
     </FormModal>
   );
 };

--- a/identity/client/src/pages/roles/detailV2/groups/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/DeleteModal.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveRoleGroupModalProps = UseEntityModalCustomProps<
+  Group,
+  {
+    role: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveRoleGroupModalProps> = ({
+  entity: group,
+  open,
+  onClose,
+  onSuccess,
+  role,
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    roleMutations.unassignGroup(qc),
+  );
+
+  const handleSubmit = () => {
+    if (role && group) {
+      mutate(
+        { roleId: role, groupId: group.groupId },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("roleGroupRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeGroup")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingGroup")}
+      onClose={onClose}
+      confirmLabel={t("removeGroup")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeGroupFromRole"
+          values={{ groupId: group.groupId }}
+        >
+          Are you sure you want to remove <strong>{group.groupId}</strong> from
+          this role?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/roles/detailV2/groups/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/index.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { TrashCan } from "@carbon/react/icons";
+// TODO: Replace with design system empty state
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import useTranslate from "src/utility/localization";
+import { getGroupsByRoleId } from "src/utility/api/roles";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import AssignGroupsModal from "src/pages/roles/detailV2/groups/AssignGroupsModal";
+import AssignGroupModal from "src/pages/roles/detailV2/groups/AssignGroupModal";
+import DeleteModal from "src/pages/roles/detailV2/groups/DeleteModal";
+import { GroupKeys } from "src/utility/api/groups";
+import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+
+type GroupsProps = {
+  roleId: string;
+  isCamundaGroupsEnabled: boolean;
+};
+
+const Groups: FC<GroupsProps> = ({ roleId, isCamundaGroupsEnabled }) => {
+  const { t } = useTranslate("roles");
+
+  const { groups, loading, success, reload, paginationProps } =
+    useEnrichedGroups(
+      "roles",
+      getGroupsByRoleId,
+      {
+        roleId,
+      },
+      isCamundaGroupsEnabled,
+    );
+
+  const isGroupsEmpty = !groups || groups.length === 0;
+  const noop = () => {};
+  const [assignGroups, assignGroupsModal] = useEntityModal(
+    isCamundaGroupsEnabled ? AssignGroupsModal : AssignGroupModal,
+    noop,
+    {
+      assignedGroups: groups,
+    },
+  );
+  const openAssignModal = () => assignGroups({ roleId });
+  const [unassignGroup, unassignGroupModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    {
+      role: roleId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("group").toLowerCase(),
+        })}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && isGroupsEmpty)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"group"}
+          parentResourceTypeTranslationKey={"role"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/group/"
+        />
+        {assignGroupsModal}
+      </>
+    );
+
+  type GroupsListHeaders = {
+    header: string;
+    key: GroupKeys;
+    isSortable?: boolean;
+  }[];
+
+  const groupsListHeaders: GroupsListHeaders = isCamundaGroupsEnabled
+    ? [
+        { header: t("groupId"), key: "groupId", isSortable: true },
+        { header: t("groupName"), key: "name" },
+      ]
+    : [{ header: t("groupId"), key: "groupId", isSortable: true }];
+
+  return (
+    <>
+      <EntityList
+        data={groups}
+        headers={groupsListHeaders}
+        loading={loading}
+        addEntityLabel={t("assignGroup")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByGroupId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignGroup,
+          },
+        ]}
+        {...paginationProps}
+      />
+      {assignGroupsModal}
+      {unassignGroupModal}
+    </>
+  );
+};
+
+export default Groups;

--- a/identity/client/src/pages/roles/detailV2/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/index.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { OverflowMenu, OverflowMenuItem, Section, Stack } from "@carbon/react";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { roleQueries } from "src/utility/api/roles/queries";
+import NotFound from "src/pages/not-foundV2";
+import { Breadcrumbs, StackPage } from "src/components/layoutV2/Page";
+import { DetailPageHeaderFallback } from "src/components/fallbacksV2";
+// TODO: Replace with Tailwind
+import Flex from "src/components/layout/Flex";
+import PageHeadline from "src/components/layoutV2/PageHeadline";
+// TODO: Overhaul to work with `PageHeader`. Implementation reference users/detailV2/index.tsx for example.
+import { Tabs, TabsContent, TabsHeaderList } from "src/components/tabsV2";
+import { useEntityModal } from "src/components/modalV2";
+import DeleteModal from "src/pages/roles/modalsV2/DeleteModal";
+import EditModal from "src/pages/roles/modalsV2/EditModal";
+// TODO: Use `PageHeader` description directly?
+import { Description } from "src/components/layoutV2/DetailsPageDescription";
+import Members from "src/pages/roles/detailV2/members";
+import Groups from "src/pages/roles/detailV2/groups";
+import MappingRules from "src/pages/roles/detailV2/mapping-rules";
+import Clients from "src/pages/roles/detailV2/clients";
+
+type DetailsProps = {
+  isOIDC: boolean;
+  isCamundaGroupsEnabled: boolean;
+  defaultRoleIds: string[];
+};
+
+const Details: FC<DetailsProps> = ({
+  isOIDC,
+  isCamundaGroupsEnabled,
+  defaultRoleIds,
+}) => {
+  const navigate = useNavigate();
+  const { t } = useTranslate("roles");
+  const { id = "", tab = "details" } = useParams<{
+    id: string;
+    tab: string;
+  }>();
+
+  const { data: role, isLoading: loading } = useQuery(roleQueries.detail(id));
+
+  const [editRole, editModal] = useEntityModal(EditModal, () => {});
+  const [deleteRole, deleteModal] = useEntityModal(DeleteModal, () =>
+    navigate("..", { replace: true }),
+  );
+
+  if (!loading && !role) return <NotFound />;
+
+  return (
+    <StackPage>
+      <>
+        <Stack gap="2">
+          <Breadcrumbs items={[{ href: "/roles", title: t("roles") }]} />
+          {loading && !role ? (
+            <DetailPageHeaderFallback hasOverflowMenu={false} />
+          ) : (
+            <Flex>
+              {role && (
+                <Stack gap="3">
+                  <Stack orientation="horizontal" gap="1">
+                    <PageHeadline>{role.name}</PageHeadline>
+                    {!defaultRoleIds.includes(role.roleId) && (
+                      <OverflowMenu ariaLabel={t("openRoleContextMenu")}>
+                        <OverflowMenuItem
+                          itemText={t("editRole")}
+                          onClick={() => editRole(role)}
+                        />
+                        <OverflowMenuItem
+                          itemText={t("delete")}
+                          isDelete
+                          onClick={() => {
+                            deleteRole(role);
+                          }}
+                        />
+                      </OverflowMenu>
+                    )}
+                  </Stack>
+                  <p>
+                    {t("roleId")}: {role.roleId}
+                  </p>
+                  {role?.description && (
+                    <Description>
+                      {t("description")}: {role.description}
+                    </Description>
+                  )}
+                </Stack>
+              )}
+            </Flex>
+          )}
+        </Stack>
+        {role && (
+          <Section>
+            <Tabs
+              tabs={[
+                {
+                  key: "users",
+                  label: t("users"),
+                  content: <Members roleId={role.roleId} isOIDC={isOIDC} />,
+                },
+                {
+                  key: "groups",
+                  label: t("groups"),
+                  content: (
+                    <Groups
+                      roleId={role.roleId}
+                      isCamundaGroupsEnabled={isCamundaGroupsEnabled}
+                    />
+                  ),
+                },
+                ...(isOIDC
+                  ? [
+                      {
+                        key: "mapping-rules",
+                        label: t("mappingRules"),
+                        content: <MappingRules roleId={role.roleId} />,
+                      },
+                      {
+                        key: "clients",
+                        label: t("clients"),
+                        content: <Clients roleId={role.roleId} />,
+                      },
+                    ]
+                  : []),
+              ]}
+              selectedTabKey={tab}
+              path={`../${id}`}
+            >
+              <TabsHeaderList />
+              <TabsContent />
+            </Tabs>
+          </Section>
+        )}
+      </>
+      {editModal}
+      {deleteModal}
+    </StackPage>
+  );
+};
+
+export default Details;

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx
@@ -6,22 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useCallback, useEffect, useState } from "react";
-import styled from "styled-components";
-import { Tag } from "@carbon/react";
+import { FC, useEffect, useState } from "react";
 import { UseEntityModalCustomProps } from "src/components/modalV2";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
-import { mappingRuleQueries } from "src/utility/api/mapping-rules/queries";
 import { roleMutations } from "src/utility/api/roles/mutations";
-import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
-import DropdownSearch from "src/components/formV2/DropdownSearch";
+import { MappingRuleMultiSelect } from "src/components/formV2/entitySelection/MappingRuleSelection";
 import FormModal from "src/components/modalV2/FormModal";
 import type { MappingRule, Role } from "@camunda/camunda-api-zod-schemas/8.10";
-
-const SelectedMappingRules = styled.div`
-  margin-top: 0;
-`;
 
 const AssignMappingRulesModal: FC<
   UseEntityModalCustomProps<
@@ -36,51 +28,10 @@ const AssignMappingRulesModal: FC<
   const [loadingAssignMappingRule, setLoadingAssignMappingRule] =
     useState(false);
 
-  const [mappingRuleFilter, setMappingRuleFilter] = useState({});
-  const handleMappingRuleFilterChange = (search: string) => {
-    if (!search.trim()) {
-      setMappingRuleFilter({});
-      return;
-    }
-    setMappingRuleFilter({ filter: { name: search } });
-  };
-
-  const {
-    data: mappingRuleSearchResults,
-    isLoading: loading,
-    refetch: reload,
-    error,
-  } = useQuery(mappingRuleQueries.search(mappingRuleFilter));
-
   const qc = useQueryClient();
   const { mutateAsync: callAssignMappingRule } = useMutation(
     roleMutations.assignMappingRule(qc),
   );
-
-  const unassignedFilter = useCallback(
-    ({ mappingRuleId }: MappingRule) =>
-      !assignedMappingRules.some(
-        (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
-      ) &&
-      !selectedMappingRules.some(
-        (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
-      ),
-    [assignedMappingRules, selectedMappingRules],
-  );
-
-  const onSelectMappingRule = (mappingRule: MappingRule) => {
-    setSelectedMappingRules([...selectedMappingRules, mappingRule]);
-  };
-
-  const onUnselectMappingRule =
-    ({ mappingRuleId }: MappingRule) =>
-    () => {
-      setSelectedMappingRules(
-        selectedMappingRules.filter(
-          (mappingRule) => mappingRule.mappingRuleId !== mappingRuleId,
-        ),
-      );
-    };
 
   const canSubmit = role && selectedMappingRules.length;
 
@@ -127,42 +78,12 @@ const AssignMappingRulesModal: FC<
           Search and assign mapping rule to role
         </Translate>
       </p>
-      {selectedMappingRules.length > 0 && (
-        <SelectedMappingRules>
-          {selectedMappingRules.map((mappingRule) => (
-            <Tag
-              key={mappingRule.mappingRuleId}
-              onClose={onUnselectMappingRule(mappingRule)}
-              size="md"
-              type="blue"
-              filter
-            >
-              {mappingRule.mappingRuleId}
-            </Tag>
-          ))}
-        </SelectedMappingRules>
-      )}
-      <DropdownSearch
+      <MappingRuleMultiSelect
+        value={selectedMappingRules}
+        onChange={setSelectedMappingRules}
+        excluded={assignedMappingRules}
         autoFocus
-        items={mappingRuleSearchResults?.items || []}
-        itemTitle={({ mappingRuleId }) => mappingRuleId}
-        itemSubTitle={({ name }) => name}
-        placeholder={t("searchByMappingRuleId")}
-        onSelect={onSelectMappingRule}
-        onChange={handleMappingRuleFilterChange}
-        filter={unassignedFilter}
       />
-      {!loading && error && (
-        <TranslatedErrorInlineNotification
-          title={t("mappingRulesCouldNotLoad")}
-          actionButton={{
-            label: t("retry"),
-            onClick: () => {
-              void reload();
-            },
-          }}
-        />
-      )}
     </FormModal>
   );
 };

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { mappingRuleQueries } from "src/utility/api/mapping-rules/queries";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import DropdownSearch from "src/components/formV2/DropdownSearch";
+import FormModal from "src/components/modalV2/FormModal";
+import type { MappingRule, Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const SelectedMappingRules = styled.div`
+  margin-top: 0;
+`;
+
+const AssignMappingRulesModal: FC<
+  UseEntityModalCustomProps<
+    { id: Role["roleId"] },
+    { assignedMappingRules: MappingRule[] }
+  >
+> = ({ entity: role, assignedMappingRules, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("roles");
+  const [selectedMappingRules, setSelectedMappingRules] = useState<
+    MappingRule[]
+  >([]);
+  const [loadingAssignMappingRule, setLoadingAssignMappingRule] =
+    useState(false);
+
+  const [mappingRuleFilter, setMappingRuleFilter] = useState({});
+  const handleMappingRuleFilterChange = (search: string) => {
+    if (!search.trim()) {
+      setMappingRuleFilter({});
+      return;
+    }
+    setMappingRuleFilter({ filter: { name: search } });
+  };
+
+  const {
+    data: mappingRuleSearchResults,
+    isLoading: loading,
+    refetch: reload,
+    error,
+  } = useQuery(mappingRuleQueries.search(mappingRuleFilter));
+
+  const qc = useQueryClient();
+  const { mutateAsync: callAssignMappingRule } = useMutation(
+    roleMutations.assignMappingRule(qc),
+  );
+
+  const unassignedFilter = useCallback(
+    ({ mappingRuleId }: MappingRule) =>
+      !assignedMappingRules.some(
+        (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
+      ) &&
+      !selectedMappingRules.some(
+        (mappingRule) => mappingRule.mappingRuleId === mappingRuleId,
+      ),
+    [assignedMappingRules, selectedMappingRules],
+  );
+
+  const onSelectMappingRule = (mappingRule: MappingRule) => {
+    setSelectedMappingRules([...selectedMappingRules, mappingRule]);
+  };
+
+  const onUnselectMappingRule =
+    ({ mappingRuleId }: MappingRule) =>
+    () => {
+      setSelectedMappingRules(
+        selectedMappingRules.filter(
+          (mappingRule) => mappingRule.mappingRuleId !== mappingRuleId,
+        ),
+      );
+    };
+
+  const canSubmit = role && selectedMappingRules.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignMappingRule(true);
+    try {
+      await Promise.all(
+        selectedMappingRules.map(({ mappingRuleId }) =>
+          callAssignMappingRule({
+            mappingRuleId: mappingRuleId,
+            roleId: role.id,
+          }),
+        ),
+      );
+      onSuccess();
+    } catch {
+      // error handled globally
+    } finally {
+      setLoadingAssignMappingRule(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedMappingRules([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignMappingRule")}
+      confirmLabel={t("assignMappingRule")}
+      loading={loadingAssignMappingRule}
+      loadingDescription={t("assigningMappingRule")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>
+        <Translate i18nKey="searchAndAssignMappingRuleToRole">
+          Search and assign mapping rule to role
+        </Translate>
+      </p>
+      {selectedMappingRules.length > 0 && (
+        <SelectedMappingRules>
+          {selectedMappingRules.map((mappingRule) => (
+            <Tag
+              key={mappingRule.mappingRuleId}
+              onClose={onUnselectMappingRule(mappingRule)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {mappingRule.mappingRuleId}
+            </Tag>
+          ))}
+        </SelectedMappingRules>
+      )}
+      <DropdownSearch
+        autoFocus
+        items={mappingRuleSearchResults?.items || []}
+        itemTitle={({ mappingRuleId }) => mappingRuleId}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByMappingRuleId")}
+        onSelect={onSelectMappingRule}
+        onChange={handleMappingRuleFilterChange}
+        filter={unassignedFilter}
+      />
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("mappingRulesCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignMappingRulesModal;

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/DeleteModal.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveRoleMappingRuleModalProps = UseEntityModalCustomProps<
+  MappingRule,
+  {
+    roleId: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveRoleMappingRuleModalProps> = ({
+  entity: mappingRule,
+  open,
+  onClose,
+  onSuccess,
+  roleId,
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    roleMutations.unassignMappingRule(qc),
+  );
+
+  const handleSubmit = () => {
+    if (roleId && mappingRule) {
+      mutate(
+        { roleId, mappingRuleId: mappingRule.mappingRuleId },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("roleMappingRuleRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeMappingRule")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingMappingRule")}
+      onClose={onClose}
+      confirmLabel={t("removeMappingRule")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeMappingRuleFromRole"
+          values={{ mappingRuleId: mappingRule.mappingRuleId }}
+        >
+          Are you sure you want to remove{" "}
+          <strong>{mappingRule.mappingRuleId}</strong> from this role?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/index.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+// TODO: Replace with design system empty state
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { roleQueries } from "src/utility/api/roles/queries";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import DeleteModal from "src/pages/roles/detailV2/mapping-rules/DeleteModal";
+import AssignMappingRulesModal from "src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+
+type MappingRulesProps = {
+  roleId: string;
+};
+
+const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
+  const { t } = useTranslate("roles");
+  const noop = () => {};
+
+  const { pageParams, page, ...paginationCallbacks } = usePagination();
+  const {
+    data: mappingRules,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...roleQueries.mappingRules(roleId, pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((rule) => ({ ...rule, id: rule.mappingRuleId })),
+    }),
+  });
+
+  const isMappingRulesListEmpty =
+    !mappingRules || mappingRules.items?.length === 0;
+
+  const [assignMappingRules, assignMappingRulesModal] = useEntityModal(
+    AssignMappingRulesModal,
+    noop,
+    {
+      assignedMappingRules: mappingRules?.items || [],
+    },
+  );
+  const openAssignModal = () => assignMappingRules({ id: roleId });
+  const [unassignMappingRule, unassignMappingRuleModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    {
+      roleId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("mappingRule").toLowerCase(),
+        })}
+        button={{
+          label: t("retry"),
+          onClick: () => {
+            void reload();
+          },
+        }}
+      />
+    );
+
+  if (success && isMappingRulesListEmpty)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"mappingRule"}
+          parentResourceTypeTranslationKey={"role"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/mapping-rules/"
+        />
+        {assignMappingRulesModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={mappingRules?.items}
+        headers={[
+          {
+            header: t("mappingRuleId"),
+            key: "mappingRuleId",
+            isSortable: true,
+          },
+          { header: t("mappingRuleName"), key: "name", isSortable: true },
+          { header: t("claimName"), key: "claimName", isSortable: true },
+          { header: t("claimValue"), key: "claimValue", isSortable: true },
+        ]}
+        loading={loading}
+        addEntityLabel={t("assignMappingRule")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByMappingRuleId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignMappingRule,
+          },
+        ]}
+        page={{ ...page, ...mappingRules?.page }}
+        {...paginationCallbacks}
+      />
+      {assignMappingRulesModal}
+      {unassignMappingRuleModal}
+    </>
+  );
+};
+
+export default MappingRules;

--- a/identity/client/src/pages/roles/detailV2/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMemberModal.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { membershipMutations } from "src/utility/api/membership/mutations";
+import useTranslate from "src/utility/localization";
+import FormModal from "src/components/modalV2/FormModal";
+import TextField from "src/components/formV2/TextField";
+// TODO: Remove. Don't import from different page!
+import { Caption } from "src/pages/authorizations/modals/components.tsx";
+import { DocumentationLink } from "src/components/documentationV2";
+import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignMemberModal: FC<
+  UseEntityModalCustomProps<
+    { roleId: Role["roleId"] },
+    { assignedUsers: User[] }
+  >
+> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("roles");
+  const [username, setUsername] = useState("");
+  const qc = useQueryClient();
+  const { mutate, isPending: loadingAssignUser } = useMutation(
+    membershipMutations.assignRoleMember(qc),
+  );
+
+  const canSubmit = roleId && username;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    mutate(
+      { username, roleId },
+      {
+        onSuccess: () => {
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (open) {
+      setUsername("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignUser")}
+      confirmLabel={t("assignUser")}
+      loading={loadingAssignUser}
+      loadingDescription={t("assigningUser")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("assignUsersToRole")}</p>
+      <TextField
+        label={t("username")}
+        placeholder={t("typeUsername")}
+        onChange={setUsername}
+        helperText={
+          <Caption>
+            <Translate i18nKey="usernameDescription">
+              Check the documentation for{" "}
+              <DocumentationLink
+                path="/components/admin/role/#assign-users-to-a-role"
+                withIcon
+              >
+                how to reference users
+              </DocumentationLink>{" "}
+              .
+            </Translate>
+          </Caption>
+        }
+        value={username}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignMemberModal;

--- a/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
@@ -6,23 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useCallback, useEffect, useState } from "react";
-import { Tag } from "@carbon/react";
+import { FC, useEffect, useState } from "react";
 import { UseEntityModalCustomProps } from "src/components/modalV2";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { membershipMutations } from "src/utility/api/membership/mutations";
 import useTranslate from "src/utility/localization";
-import { useQuery } from "@tanstack/react-query";
-import { userQueries } from "src/utility/api/users/queries";
-import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
-import styled from "styled-components";
-import DropdownSearch from "src/components/formV2/DropdownSearch";
+import { UserMultiSelect } from "src/components/formV2/entitySelection/UserSelection";
 import FormModal from "src/components/modalV2/FormModal";
 import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
-
-const SelectedUsers = styled.div`
-  margin-top: 0;
-`;
 
 const AssignMembersModal: FC<
   UseEntityModalCustomProps<
@@ -34,45 +25,10 @@ const AssignMembersModal: FC<
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [loadingAssignUser, setLoadingAssignUser] = useState(false);
 
-  const [search, setSearch] = useState<Record<string, unknown>>({});
-  const handleSearchChange = (search: string) => {
-    if (search === "") {
-      setSearch({});
-      return;
-    }
-    setSearch({ filter: { username: { $like: `*${search}*` } } });
-  };
-
-  const {
-    data: userSearchResults,
-    isLoading: loading,
-    refetch: reload,
-    error,
-  } = useQuery(userQueries.search(search));
-
   const qc = useQueryClient();
   const { mutateAsync: callAssignUser } = useMutation(
     membershipMutations.assignRoleMember(qc),
   );
-
-  const unassignedFilter = useCallback(
-    ({ username }: User) =>
-      !assignedUsers.some((user) => user.username === username) &&
-      !selectedUsers.some((user) => user.username === username),
-    [assignedUsers, selectedUsers],
-  );
-
-  const onSelectUser = (user: User) => {
-    setSelectedUsers([...selectedUsers, user]);
-  };
-
-  const onUnselectUser =
-    ({ username }: User) =>
-    () => {
-      setSelectedUsers(
-        selectedUsers.filter((user) => user.username !== username),
-      );
-    };
 
   const canSubmit = roleId && selectedUsers.length;
 
@@ -112,42 +68,14 @@ const AssignMembersModal: FC<
       onClose={onClose}
     >
       <p>{t("searchAndAssignUserToRole")}</p>
-      {selectedUsers.length > 0 && (
-        <SelectedUsers>
-          {selectedUsers.map((user) => (
-            <Tag
-              key={user.username}
-              onClose={onUnselectUser(user)}
-              size="md"
-              type="blue"
-              filter
-            >
-              {user.username}
-            </Tag>
-          ))}
-        </SelectedUsers>
-      )}
-      <DropdownSearch
-        autoFocus
-        items={userSearchResults?.items || []}
-        itemTitle={({ username }) => username}
+      <UserMultiSelect
+        value={selectedUsers}
+        onChange={setSelectedUsers}
+        excluded={assignedUsers}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByUsernameOrName")}
-        onSelect={onSelectUser}
-        onChange={handleSearchChange}
-        filter={unassignedFilter}
+        autoFocus
       />
-      {!loading && error && (
-        <TranslatedErrorInlineNotification
-          title={t("usersCouldNotLoad")}
-          actionButton={{
-            label: t("retry"),
-            onClick: () => {
-              void reload();
-            },
-          }}
-        />
-      )}
     </FormModal>
   );
 };

--- a/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useCallback, useEffect, useState } from "react";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { membershipMutations } from "src/utility/api/membership/mutations";
+import useTranslate from "src/utility/localization";
+import { useQuery } from "@tanstack/react-query";
+import { userQueries } from "src/utility/api/users/queries";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import styled from "styled-components";
+import DropdownSearch from "src/components/formV2/DropdownSearch";
+import FormModal from "src/components/modalV2/FormModal";
+import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const SelectedUsers = styled.div`
+  margin-top: 0;
+`;
+
+const AssignMembersModal: FC<
+  UseEntityModalCustomProps<
+    { roleId: Role["roleId"] },
+    { assignedUsers: User[] }
+  >
+> = ({ entity: { roleId }, assignedUsers, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("roles");
+  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
+  const [loadingAssignUser, setLoadingAssignUser] = useState(false);
+
+  const [search, setSearch] = useState<Record<string, unknown>>({});
+  const handleSearchChange = (search: string) => {
+    if (search === "") {
+      setSearch({});
+      return;
+    }
+    setSearch({ filter: { username: { $like: `*${search}*` } } });
+  };
+
+  const {
+    data: userSearchResults,
+    isLoading: loading,
+    refetch: reload,
+    error,
+  } = useQuery(userQueries.search(search));
+
+  const qc = useQueryClient();
+  const { mutateAsync: callAssignUser } = useMutation(
+    membershipMutations.assignRoleMember(qc),
+  );
+
+  const unassignedFilter = useCallback(
+    ({ username }: User) =>
+      !assignedUsers.some((user) => user.username === username) &&
+      !selectedUsers.some((user) => user.username === username),
+    [assignedUsers, selectedUsers],
+  );
+
+  const onSelectUser = (user: User) => {
+    setSelectedUsers([...selectedUsers, user]);
+  };
+
+  const onUnselectUser =
+    ({ username }: User) =>
+    () => {
+      setSelectedUsers(
+        selectedUsers.filter((user) => user.username !== username),
+      );
+    };
+
+  const canSubmit = roleId && selectedUsers.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignUser(true);
+    try {
+      await Promise.all(
+        selectedUsers.map(({ username }) =>
+          callAssignUser({ username, roleId }),
+        ),
+      );
+      onSuccess();
+    } catch {
+      // error handled globally
+    } finally {
+      setLoadingAssignUser(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedUsers([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignUser")}
+      confirmLabel={t("assignUser")}
+      loading={loadingAssignUser}
+      loadingDescription={t("assigningUser")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("searchAndAssignUserToRole")}</p>
+      {selectedUsers.length > 0 && (
+        <SelectedUsers>
+          {selectedUsers.map((user) => (
+            <Tag
+              key={user.username}
+              onClose={onUnselectUser(user)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {user.username}
+            </Tag>
+          ))}
+        </SelectedUsers>
+      )}
+      <DropdownSearch
+        autoFocus
+        items={userSearchResults?.items || []}
+        itemTitle={({ username }) => username}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByUsernameOrName")}
+        onSelect={onSelectUser}
+        onChange={handleSearchChange}
+        filter={unassignedFilter}
+      />
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("usersCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignMembersModal;

--- a/identity/client/src/pages/roles/detailV2/members/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/DeleteModal.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { membershipMutations } from "src/utility/api/membership/mutations";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveRoleMemberModalProps = UseEntityModalCustomProps<
+  User,
+  {
+    roleId: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveRoleMemberModalProps> = ({
+  entity: user,
+  open,
+  onClose,
+  onSuccess,
+  roleId,
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    membershipMutations.unassignRoleMember(qc),
+  );
+
+  const handleSubmit = () => {
+    if (roleId && user) {
+      mutate(
+        { roleId, username: user.username },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("roleMemberRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeUser")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingUser")}
+      onClose={onClose}
+      confirmLabel={t("removeUser")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeUserConfirmation"
+          values={{ username: user.username }}
+        >
+          Are you sure you want to remove <strong>{user.username}</strong> from
+          this role?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/roles/detailV2/members/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/index.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { TrashCan } from "@carbon/react/icons";
+// TODO: Replace with design system empty state
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import useTranslate from "src/utility/localization";
+import { getMembersByRole } from "src/utility/api/membership";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import AssignMembersModal from "src/pages/roles/detailV2/members/AssignMembersModal";
+import AssignMemberModal from "src/pages/roles/detailV2/members/AssignMemberModal";
+import DeleteModal from "src/pages/roles/detailV2/members/DeleteModal";
+import { UserKeys } from "src/utility/api/users";
+import { useEnrichedUsers } from "src/components/global/useEnrichUsers";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+
+type MembersProps = {
+  roleId: string;
+  isOIDC: boolean;
+};
+
+const Members: FC<MembersProps> = ({ roleId, isOIDC }) => {
+  const { t } = useTranslate("roles");
+
+  const { users, loading, success, reload, paginationProps } = useEnrichedUsers(
+    "roles",
+    getMembersByRole,
+    {
+      roleId,
+    },
+    isOIDC,
+  );
+  const noop = () => {};
+
+  const isUsersListEmpty = !users || users?.length === 0;
+  const [assignUsers, assignUsersModal] = useEntityModal(
+    isOIDC ? AssignMemberModal : AssignMembersModal,
+    noop,
+    { assignedUsers: users },
+  );
+  const openAssignModal = () => assignUsers({ roleId });
+  const [unassignMember, unassignMemberModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    {
+      roleId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("user").toLowerCase(),
+        })}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && isUsersListEmpty)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"user"}
+          parentResourceTypeTranslationKey={"role"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/user/"
+        />
+        {assignUsersModal}
+      </>
+    );
+
+  type MembersListHeaders = {
+    header: string;
+    key: UserKeys;
+    isSortable?: boolean;
+  }[];
+
+  const membersListHeaders: MembersListHeaders = isOIDC
+    ? [{ header: t("username"), key: "username", isSortable: true }]
+    : [
+        { header: t("username"), key: "username", isSortable: true },
+        { header: t("name"), key: "name" },
+        { header: t("email"), key: "email" },
+      ];
+
+  return (
+    <>
+      <EntityList
+        data={users}
+        headers={membersListHeaders}
+        loading={loading}
+        addEntityLabel={t("assignUser")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByUsername")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignMember,
+          },
+        ]}
+        {...paginationProps}
+      />
+      {assignUsersModal}
+      {unassignMemberModal}
+    </>
+  );
+};
+
+export default Members;

--- a/identity/client/src/pages/roles/index.tsx
+++ b/identity/client/src/pages/roles/index.tsx
@@ -8,10 +8,15 @@
 
 import { FC, lazy, Suspense } from "react";
 import { ListPageFallback } from "src/components/fallbacks";
+import { ListPageFallback as ListPageFallbackV2 } from "src/components/fallbacksV2";
 import PageRoutes from "src/components/router/PageRoutes";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "src/feature-flags";
 import Detail from "src/pages/roles/detail";
+import DetailV2 from "src/pages/roles/detailV2";
 
-const List = lazy(() => import("./List"));
+const List = lazy(() =>
+  IS_NEW_DESIGN_SYSTEM_ENABLED ? import("./ListV2") : import("./List"),
+);
 
 type RolesProps = {
   isOIDC: boolean;
@@ -26,16 +31,32 @@ const Roles: FC<RolesProps> = ({
 }) => (
   <PageRoutes
     indexElement={
-      <Suspense fallback={<ListPageFallback />}>
+      <Suspense
+        fallback={
+          IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+            <ListPageFallbackV2 />
+          ) : (
+            <ListPageFallback />
+          )
+        }
+      >
         <List defaultRoleIds={defaultRoleIds} />
       </Suspense>
     }
     detailElement={
-      <Detail
-        isOIDC={isOIDC}
-        isCamundaGroupsEnabled={isCamundaGroupsEnabled}
-        defaultRoleIds={defaultRoleIds}
-      />
+      IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+        <DetailV2
+          isOIDC={isOIDC}
+          isCamundaGroupsEnabled={isCamundaGroupsEnabled}
+          defaultRoleIds={defaultRoleIds}
+        />
+      ) : (
+        <Detail
+          isOIDC={isOIDC}
+          isCamundaGroupsEnabled={isCamundaGroupsEnabled}
+          defaultRoleIds={defaultRoleIds}
+        />
+      )
     }
   />
 );

--- a/identity/client/src/pages/roles/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/roles/modalsV2/AddModal.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FormModal, UseModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import TextField from "src/components/formV2/TextField";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import { useNotifications } from "src/components/notifications";
+import { isValidId, getIdPattern } from "src/utility/validate";
+
+type FormData = {
+  roleName: string;
+  roleId: string;
+  description: string;
+};
+
+const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
+  const { t } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(roleMutations.create(qc));
+
+  const { control, handleSubmit } = useForm<FormData>({
+    defaultValues: {
+      roleName: "",
+      roleId: "",
+      description: "",
+    },
+    mode: "all",
+  });
+
+  const onSubmit = (data: FormData) => {
+    mutate(
+      {
+        name: data.roleName,
+        description: data.description,
+        roleId: data.roleId,
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("roleCreated"),
+            subtitle: t("createRoleSuccess", {
+              roleName: data.roleName,
+            }),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("createRole")}
+      loading={loading}
+      error={error}
+      loadingDescription={t("creatingRole")}
+      confirmLabel={t("createRole")}
+      onClose={onClose}
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <Controller
+        name="roleId"
+        control={control}
+        rules={{
+          validate: (value) =>
+            isValidId(value) ||
+            t("pleaseEnterValidRoleId", {
+              pattern: getIdPattern(),
+            }),
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("roleId")}
+            placeholder={t("roleIdPlaceholder")}
+            errors={fieldState.error?.message}
+            helperText={t("roleIdHelperText")}
+            autoFocus
+          />
+        )}
+      />
+      <Controller
+        name="roleName"
+        control={control}
+        rules={{
+          required: t("roleNameRequired"),
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("roleName")}
+            placeholder={t("roleNamePlaceholder")}
+            errors={fieldState.error?.message}
+          />
+        )}
+      />
+      <Controller
+        name="description"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            label={t("description")}
+            placeholder={t("roleDescriptionPlaceholder")}
+            cols={2}
+            enableCounter
+          />
+        )}
+      />
+    </FormModal>
+  );
+};
+
+export default AddModal;

--- a/identity/client/src/pages/roles/modalsV2/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/modalsV2/DeleteModal.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalProps,
+} from "src/components/modalV2";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import { useNotifications } from "src/components/notifications";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const DeleteModal: FC<UseEntityModalProps<Role>> = ({
+  open,
+  onClose,
+  onSuccess,
+  entity: { roleId, name },
+}) => {
+  const { t, Translate } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(roleMutations.delete(qc));
+
+  const handleSubmit = () => {
+    mutate(
+      { roleId },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("roleHasBeenDeleted"),
+            subtitle: t("deleteRoleSuccess", { name }),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("deleteRole")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("deletingRole")}
+      onClose={onClose}
+      confirmLabel={t("deleteRole")}
+    >
+      <p>
+        <Translate i18nKey="deleteRoleConfirmation" values={{ roleId }}>
+          Are you sure you want to delete <strong>{roleId}</strong>?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/roles/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/roles/modalsV2/EditModal.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FormModal, UseEntityModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useNotifications } from "src/components/notifications";
+import { roleMutations } from "src/utility/api/roles/mutations";
+import TextField from "src/components/formV2/TextField";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const EditModal: FC<UseEntityModalProps<Role>> = ({
+  entity: role,
+  open,
+  onClose,
+  onSuccess,
+}) => {
+  const { t } = useTranslate("roles");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(roleMutations.update(qc));
+
+  const [roleName, setRoleName] = useState(role.name ?? "");
+  const [description, setDescription] = useState(role.description ?? "");
+
+  const handleSubmit = () => {
+    mutate(
+      { roleId: role.roleId, name: roleName, description },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("roleHasBeenUpdated"),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("editRole")}
+      onSubmit={handleSubmit}
+      onClose={onClose}
+      loading={loading}
+      error={error}
+      loadingDescription={t("updatingRole")}
+      confirmLabel={t("editRole")}
+      submitDisabled={!roleName}
+    >
+      <TextField label={t("roleId")} value={role.roleId} readOnly />
+      <TextField
+        label={t("roleName")}
+        value={roleName}
+        placeholder={t("roleNamePlaceholder")}
+        onChange={setRoleName}
+        autoFocus
+      />
+      <TextField
+        label={t("description")}
+        value={description}
+        placeholder={t("roleDescriptionPlaceholder")}
+        onChange={setDescription}
+        cols={2}
+        enableCounter
+      />
+    </FormModal>
+  );
+};
+
+export default EditModal;


### PR DESCRIPTION
## Description

This PR duplicates the relevant components in the roles page and missing shared components. Some things to note:

- `EntityTableV2` requires an `id` by design. I had to add a `select` mapping to various queries to satisfy that requirement.
- Modal V1 has a `overflowVisible` which I did not carry over to V2. Role details modals used it to have the `DropdownSearch` component suggestions overflow the modal content. I expect/hope that a migrated `DropdownSearch` overflows automatically, and we do not need to introduce that prop.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #60634
