### PR TITLE
refactor: resolve webapp-enabled from configuration instead of the caller

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -17,13 +17,11 @@ import io.camunda.authentication.config.spi.WebAppProviderAdapter;
 import io.camunda.authentication.pt.PhysicalTenantSecurityConfiguration;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.core.port.out.AdminUserPresencePort;
 import io.camunda.security.core.port.out.BasicAuthUserDetailsPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
-import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
 import io.camunda.security.spring.security.OidcResourceServerCustomizer;
 import io.camunda.security.spring.spi.WebAppProviderPort;
 import io.camunda.service.RoleServices;
@@ -73,18 +71,10 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
 })
 public class WebSecurityConfig {
 
-  /**
-   * The host's path declarations. {@code webapp-enabled} is read here with CSL's own property key
-   * and default, so this gate cannot drift from the cluster webapp chains' conditions, which read
-   * the same key from the same {@link Environment}.
-   */
+  /** The host's path declarations. */
   @Bean
   public SecurityPathPort securityPathPort(final Environment environment) {
-    return new SecurityPathAdapter(
-        environment.getProperty(
-            CamundaSecurityFilterChainConstants.WEBAPP_ENABLED_PROPERTY,
-            Boolean.class,
-            AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED));
+    return SecurityPathAdapter.fromEnvironment(environment);
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -9,57 +9,20 @@ package io.camunda.authentication.config.spi;
 
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.core.port.out.SecurityPathPort;
+import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.core.env.Environment;
 
 /**
  * Host-supplied {@link SecurityPathPort} declaring the path patterns OC's filter chains operate on.
- * These values were previously inlined in {@code WebSecurityConfig}; they are lifted here so the
- * central library-owned chains can consume them.
+ * The configuration-independent sets live in {@link SecurityPaths}; the ones kept here are either
+ * gated on configuration or read only through this port.
+ *
+ * <p>Construct only via {@link #fromEnvironment(Environment)}, so {@link #webappPaths()} always
+ * reports the gate as configuration resolves it rather than as a caller asserts it.
  */
-public class SecurityPathAdapter implements SecurityPathPort {
-
-  /**
-   * Shared instance for callers outside the Spring context. It reports the default {@code
-   * webapp-enabled} state, so read {@link #webappPaths()} from the configured bean instead.
-   */
-  public static final SecurityPathAdapter INSTANCE = new SecurityPathAdapter();
-
-  // Tenant-prefixed paths (/physical-tenants/<id>/...) are deliberately NOT listed here. They are
-  // owned exclusively by the per-tenant scoped security chains that PhysicalTenantScopeProvider
-  // contributes (CSL derives each scope's matcher as basePath + these apiPaths, e.g.
-  // /physical-tenants/<id>/v2/**). The cluster chain and a scoped chain share ORDER_API, so
-  // listing the tenant prefix here would let the cluster chain also match a tenant request and, if
-  // it wins the same-order tie-break, validate the token against the cluster's providers instead of
-  // the tenant's — breaking per-tenant audience isolation. Keep this list cluster-only.
-  private static final Set<String> API_PATHS =
-      Set.of("/api/**", "/v1/**", "/v2/**", "/mcp/**", "/.well-known/oauth-protected-resource/**");
-
-  private static final Set<String> UNPROTECTED_API_PATHS =
-      Set.of(
-          "/v2/license",
-          "/v2/setup/user",
-          "/v2/status",
-          "/v1/external/process/**",
-          "/.well-known/oauth-protected-resource/**");
-
-  // Served by CSL's unprotected-paths chain, which sits ahead of every authenticated chain and
-  // installs no authentication filter at all. That is what /cluster/v2/status needs and what
-  // listing it in UNPROTECTED_API_PATHS could not give it: a `permitAll` inside an authenticated
-  // chain still lets the Basic or bearer filter reject a credential it does not recognise, and the
-  // cluster-admin chain recognises only cluster-admin credentials — so a client migrating here from
-  // /v2/status, which sends its ordinary API credentials on every request, would be answered 401 by
-  // a health endpoint. Here the Authorization header is never inspected. The exact path is listed,
-  // so the rest of /cluster/v2/** stays with the cluster-admin chains.
-  private static final Set<String> UNPROTECTED_PATHS =
-      Set.of(
-          "/error",
-          "/actuator/**",
-          "/ready",
-          "/health",
-          "/startup",
-          "/favicon.ico",
-          "/cluster/v2/status");
+public final class SecurityPathAdapter implements SecurityPathPort {
 
   private static final Set<String> WEBAPP_PATHS =
       Set.of(
@@ -125,27 +88,41 @@ public class SecurityPathAdapter implements SecurityPathPort {
 
   private final boolean webappEnabled;
 
-  public SecurityPathAdapter() {
-    this(AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED);
+  private SecurityPathAdapter(final boolean webappEnabled) {
+    this.webappEnabled = webappEnabled;
   }
 
-  public SecurityPathAdapter(final boolean webappEnabled) {
-    this.webappEnabled = webappEnabled;
+  /**
+   * Reads {@code webapp-enabled} with CSL's own property key and default, so this gate cannot drift
+   * from the cluster webapp chains' conditions, which read the same key from the same {@link
+   * Environment}.
+   *
+   * <p>The only way to build the adapter, so the gate is always resolved from configuration rather
+   * than asserted by the caller. Note an {@link Environment} without the property resolves CSL's
+   * default of enabled — a test that means to exercise a webapp-disabled cluster must set the
+   * property, not merely pass a bare environment.
+   */
+  public static SecurityPathAdapter fromEnvironment(final Environment environment) {
+    return new SecurityPathAdapter(
+        environment.getProperty(
+            CamundaSecurityFilterChainConstants.WEBAPP_ENABLED_PROPERTY,
+            Boolean.class,
+            AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED));
   }
 
   @Override
   public Set<String> apiPaths() {
-    return API_PATHS;
+    return SecurityPaths.API_PATHS;
   }
 
   @Override
   public Set<String> unprotectedApiPaths() {
-    return UNPROTECTED_API_PATHS;
+    return SecurityPaths.UNPROTECTED_API_PATHS;
   }
 
   @Override
   public Set<String> unprotectedPaths() {
-    return UNPROTECTED_PATHS;
+    return SecurityPaths.UNPROTECTED_PATHS;
   }
 
   /**

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config.spi;
+
+import java.util.Set;
+
+/**
+ * OC's path patterns that no configuration can change, readable without a {@link
+ * SecurityPathAdapter} instance. Configuration-dependent sets stay private to the adapter, so the
+ * {@code webapp-enabled} gate can only be read from the configured bean.
+ */
+public final class SecurityPaths {
+
+  // Tenant-prefixed paths (/physical-tenants/<id>/...) are deliberately NOT listed here. They are
+  // owned exclusively by the per-tenant scoped security chains that PhysicalTenantScopeProvider
+  // contributes (CSL derives each scope's matcher as basePath + these apiPaths, e.g.
+  // /physical-tenants/<id>/v2/**). The cluster chain and a scoped chain share ORDER_API, so
+  // listing the tenant prefix here would let the cluster chain also match a tenant request and, if
+  // it wins the same-order tie-break, validate the token against the cluster's providers instead of
+  // the tenant's — breaking per-tenant audience isolation. Keep this list cluster-only.
+  public static final Set<String> API_PATHS =
+      Set.of("/api/**", "/v1/**", "/v2/**", "/mcp/**", "/.well-known/oauth-protected-resource/**");
+
+  public static final Set<String> UNPROTECTED_API_PATHS =
+      Set.of(
+          "/v2/license",
+          "/v2/setup/user",
+          "/v2/status",
+          "/v1/external/process/**",
+          "/.well-known/oauth-protected-resource/**");
+
+  // Served by CSL's unprotected-paths chain, which sits ahead of every authenticated chain and
+  // installs no authentication filter at all. That is what /cluster/v2/status needs and what
+  // listing it in UNPROTECTED_API_PATHS could not give it: a `permitAll` inside an authenticated
+  // chain still lets the Basic or bearer filter reject a credential it does not recognise, and the
+  // cluster-admin chain recognises only cluster-admin credentials — so a client migrating here from
+  // /v2/status, which sends its ordinary API credentials on every request, would be answered 401 by
+  // a health endpoint. Here the Authorization header is never inspected. The exact path is listed,
+  // so the rest of /cluster/v2/** stays with the cluster-admin chains.
+  public static final Set<String> UNPROTECTED_PATHS =
+      Set.of(
+          "/error",
+          "/actuator/**",
+          "/ready",
+          "/health",
+          "/startup",
+          "/favicon.ico",
+          "/cluster/v2/status");
+
+  private SecurityPaths() {}
+}

--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.csrf;
 
-import io.camunda.authentication.config.spi.SecurityPathAdapter;
+import io.camunda.authentication.config.spi.SecurityPaths;
 import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
@@ -70,8 +70,8 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
 
   private Pattern getAllowedPathsPattern() {
     final Set<String> paths = new HashSet<>();
-    paths.addAll(SecurityPathAdapter.INSTANCE.unprotectedPaths());
-    paths.addAll(SecurityPathAdapter.INSTANCE.unprotectedApiPaths());
+    paths.addAll(SecurityPaths.UNPROTECTED_PATHS);
+    paths.addAll(SecurityPaths.UNPROTECTED_API_PATHS);
     paths.add(CamundaSecurityFilterChainConstants.LOGIN_URL);
     paths.add(CamundaSecurityFilterChainConstants.LOGOUT_URL);
     final String patternAsString =

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -10,10 +10,14 @@ package io.camunda.authentication.config.spi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 class SecurityPathAdapterTest {
 
-  private final SecurityPathAdapter port = new SecurityPathAdapter();
+  // No webapp-enabled property set, so the adapter resolves CSL's default (enabled) and the
+  // webappPaths() assertion below pins the enabled set.
+  private final SecurityPathAdapter port =
+      SecurityPathAdapter.fromEnvironment(new MockEnvironment());
 
   @Test
   void shouldExposeApiPaths() {
@@ -113,5 +117,19 @@ class SecurityPathAdapterTest {
     assertThat(port.adminFilterBypassPaths())
         .containsExactlyInAnyOrder(
             "/login", "/logout", "/sso-callback", "/post-logout", "/admin/setup", "/admin/assets");
+  }
+
+  @Test
+  void shouldReportNoWebappPathsWhenWebappDisabled() {
+    // given
+    final var environment =
+        new MockEnvironment()
+            .withProperty("camunda.security.authentication.webapp-enabled", "false");
+
+    // when
+    final var disabledPort = SecurityPathAdapter.fromEnvironment(environment);
+
+    // then
+    assertThat(disabledPort.webappPaths()).isEmpty();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
@@ -11,7 +11,7 @@ import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.common.net.HttpHeaders.REFERER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.authentication.config.spi.SecurityPathAdapter;
+import io.camunda.authentication.config.spi.SecurityPaths;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
 import java.util.HashSet;
@@ -176,16 +176,16 @@ class CsrfProtectionRequestMatcherTest {
 
   private static Stream<Arguments> unprotectedPaths() {
     final Set<String> allowedPaths = new HashSet<>();
-    allowedPaths.addAll(SecurityPathAdapter.INSTANCE.unprotectedPaths());
-    allowedPaths.addAll(SecurityPathAdapter.INSTANCE.unprotectedApiPaths());
+    allowedPaths.addAll(SecurityPaths.UNPROTECTED_PATHS);
+    allowedPaths.addAll(SecurityPaths.UNPROTECTED_API_PATHS);
     allowedPaths.add(CamundaSecurityFilterChainConstants.LOGIN_URL);
     allowedPaths.add(CamundaSecurityFilterChainConstants.LOGOUT_URL);
     return Stream.of(allowedPaths.stream().map(Arguments::of).toArray(Arguments[]::new));
   }
 
   private static Stream<Arguments> protectedPaths() {
-    final Set<String> protectedPaths = new HashSet<>(SecurityPathAdapter.INSTANCE.apiPaths());
-    protectedPaths.removeAll(SecurityPathAdapter.INSTANCE.unprotectedApiPaths());
+    final Set<String> protectedPaths = new HashSet<>(SecurityPaths.API_PATHS);
+    protectedPaths.removeAll(SecurityPaths.UNPROTECTED_API_PATHS);
     return Stream.of(protectedPaths.stream().map(Arguments::of).toArray(Arguments[]::new));
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/pt/OcPathsConfig.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/OcPathsConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.security.core.port.out.SecurityPathPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Shared {@link SecurityPathPort} for PT tests, built from production wiring so the {@code
+ * webapp-enabled} gate under test is the real thing, not a copy. Reads the context {@link
+ * Environment} — not a test's hand-rolled {@link MockEnvironment}, which is a separate consumer
+ * ({@link PhysicalTenantScopeProvider}'s).
+ */
+@Configuration
+class OcPathsConfig {
+
+  @Bean
+  SecurityPathPort securityPathPort(final Environment environment) {
+    return new WebSecurityConfig().securityPathPort(environment);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -671,14 +672,16 @@ class PhysicalTenantApiChainIsolationIT {
 
   /**
    * Provides the OC host's {@link SecurityPathPort} so CSL's chain builder knows which paths to
-   * protect ({@code /v2/**} among others).
+   * protect ({@code /v2/**} among others). Built from the context {@link Environment} — the same
+   * consumer CSL's properties bean reads, not the {@link MockEnvironment} that {@link
+   * #buildChainsFromProvider} hands to the scope provider.
    */
   @Configuration
   static class OcPathsConfig {
 
     @Bean
-    SecurityPathPort securityPathPort() {
-      return new SecurityPathAdapter();
+    SecurityPathPort securityPathPort(final Environment environment) {
+      return SecurityPathAdapter.fromEnvironment(environment);
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -10,9 +10,7 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
-import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityConfiguration;
 import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
 import io.camunda.security.spring.oidc.JWSKeySelectorFactory;
@@ -31,7 +29,6 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -667,21 +664,6 @@ class PhysicalTenantApiChainIsolationIT {
     @Bean
     ObjectMapper objectMapper() {
       return new ObjectMapper();
-    }
-  }
-
-  /**
-   * Provides the OC host's {@link SecurityPathPort} so CSL's chain builder knows which paths to
-   * protect ({@code /v2/**} among others). Built from the context {@link Environment} — the same
-   * consumer CSL's properties bean reads, not the {@link MockEnvironment} that {@link
-   * #buildChainsFromProvider} hands to the scope provider.
-   */
-  @Configuration
-  static class OcPathsConfig {
-
-    @Bean
-    SecurityPathPort securityPathPort(final Environment environment) {
-      return SecurityPathAdapter.fromEnvironment(environment);
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantBasicAuthAdminSetupRedirectIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantBasicAuthAdminSetupRedirectIT.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -170,8 +171,8 @@ class PhysicalTenantBasicAuthAdminSetupRedirectIT {
     }
 
     @Bean
-    SecurityPathPort securityPathPort() {
-      return new SecurityPathAdapter();
+    SecurityPathPort securityPathPort(final Environment environment) {
+      return SecurityPathAdapter.fromEnvironment(environment);
     }
 
     @Bean

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantBasicAuthAdminSetupRedirectIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantBasicAuthAdminSetupRedirectIT.java
@@ -15,13 +15,11 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.config.spi.AdminUserPresenceAdapter;
-import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
 import io.camunda.security.core.port.out.AdminUserPresencePort;
-import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityConfiguration;
 import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
 import io.camunda.security.spring.security.AdminUserCheckFilterConfiguration;
@@ -38,7 +36,6 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.Environment;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -145,7 +142,7 @@ class PhysicalTenantBasicAuthAdminSetupRedirectIT {
 
   private WebApplicationContextRunner buildRunner() {
     return new WebApplicationContextRunner()
-        .withUserConfiguration(TestBeansConfig.class)
+        .withUserConfiguration(TestBeansConfig.class, OcPathsConfig.class)
         .withConfiguration(
             AutoConfigurations.of(
                 CamundaSecurityConfiguration.class,
@@ -168,11 +165,6 @@ class PhysicalTenantBasicAuthAdminSetupRedirectIT {
     @Bean
     ObjectMapper objectMapper() {
       return new ObjectMapper();
-    }
-
-    @Bean
-    SecurityPathPort securityPathPort(final Environment environment) {
-      return SecurityPathAdapter.fromEnvironment(environment);
     }
 
     @Bean

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -10,10 +10,8 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
-import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityConfiguration;
 import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
 import io.camunda.security.spring.oidc.JWSKeySelectorFactory;
@@ -35,7 +33,6 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -214,20 +211,6 @@ class PhysicalTenantDefaultAliasChainIT {
     @Bean
     ObjectMapper objectMapper() {
       return new ObjectMapper();
-    }
-  }
-
-  /**
-   * The OC host's {@link SecurityPathPort}, so CSL knows {@code /v2/**} is an API path. Built from
-   * the context {@link Environment} — the same consumer CSL's properties bean reads, not the {@link
-   * MockEnvironment} that {@link #rootOnlyEnv()} hands to the scope provider.
-   */
-  @Configuration
-  static class OcPathsConfig {
-
-    @Bean
-    SecurityPathPort securityPathPort(final Environment environment) {
-      return SecurityPathAdapter.fromEnvironment(environment);
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -216,13 +217,17 @@ class PhysicalTenantDefaultAliasChainIT {
     }
   }
 
-  /** The OC host's {@link SecurityPathPort}, so CSL knows {@code /v2/**} is an API path. */
+  /**
+   * The OC host's {@link SecurityPathPort}, so CSL knows {@code /v2/**} is an API path. Built from
+   * the context {@link Environment} — the same consumer CSL's properties bean reads, not the {@link
+   * MockEnvironment} that {@link #rootOnlyEnv()} hands to the scope provider.
+   */
   @Configuration
   static class OcPathsConfig {
 
     @Bean
-    SecurityPathPort securityPathPort() {
-      return new SecurityPathAdapter();
+    SecurityPathPort securityPathPort(final Environment environment) {
+      return SecurityPathAdapter.fromEnvironment(environment);
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
@@ -10,8 +10,6 @@ package io.camunda.authentication.pt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.authentication.config.WebSecurityConfig;
-import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityConfiguration;
 import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
 import io.camunda.security.spring.scope.ScopedSecurityChainConfiguration;
@@ -27,7 +25,6 @@ import org.springframework.boot.test.context.assertj.AssertableWebApplicationCon
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -148,19 +145,6 @@ class PhysicalTenantScopedChainStartupIT {
     @Bean
     ObjectMapper objectMapper() {
       return new ObjectMapper();
-    }
-  }
-
-  /**
-   * Builds the path port exactly as production does, so the {@code webapp-enabled} gate under test
-   * is the real wiring and not a copy of it.
-   */
-  @Configuration
-  static class OcPathsConfig {
-
-    @Bean
-    SecurityPathPort securityPathPort(final Environment environment) {
-      return new WebSecurityConfig().securityPathPort(environment);
     }
   }
 }


### PR DESCRIPTION
`SecurityPathAdapter` could report `webappPaths()` without consulting configuration two ways: the static INSTANCE, and the public no-arg constructor defaulting to enabled. Three scoped-chain ITs already built it that way — exactly how a future test silently asserts the enabled paths on a webapp-disabled cluster.

INSTANCE existed only to give `CsrfProtectionRequestMatcher` a static reader, so the sets it reads move to `SecurityPaths`; a set belongs there iff something outside the package reads it statically. WEBAPP_PATHS stays private, since a public constant carries no caveat at the read site. Construction now requires an Environment, so the gate is resolved from configuration rather than asserted by the caller.

Note this narrows the bypass rather than eliminating it: an `Environment` without the property resolves CSL's default of enabled, so a test meaning to exercise a webapp-disabled cluster must set the property, not merely pass a bare environment. The javadoc on `fromEnvironment` says so.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #60862
