### PR TITLE
fix: tasklist CI timeout on stable/8.7

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -42,7 +42,7 @@ jobs:
   integration-tests:
     name: Test
     runs-on: gcp-perf-core-16-default
-    timeout-minutes: 40
+    timeout-minutes: 50
     if: ${{ !startsWith(inputs.branch, 'fe-') && !startsWith(inputs.branch, 'renovate/') }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

The integration test suite normally completes in 36–38 minutes, leaving only 2–4 minutes of headroom against the 40-minute job limit. Under normal runner variance (e.g., a slow runner causing `VariableIT` to take 755s instead of the usual ~420s), the job is killed even though all tests pass and `BUILD SUCCESS` is logged. The Aug 20 OpenSearch run showed the same pattern.

Increasing to 50 minutes adds sufficient headroom for infrastructure variance without requiring test-suite restructuring (splitting the workflow was considered, but timeout increase determined to be sufficient for now - [ref](https://camunda.slack.com/archives/C0BSM9DLDGT/p1787756137246769)).



## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Closes INC-7449