### PR TITLE
fix: wait for variable import before asserting in VariableIT on stable/8.7

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/VariableIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/VariableIT.java
@@ -797,6 +797,8 @@ public class VariableIT extends TasklistZeebeIntegrationTest {
             .waitUntil()
             .taskIsCreated("subProcessTask")
             .and()
+            .taskVariableExists("processVar")
+            .and()
             .getAllTasks();
     final String taskId = response.get("$.data.tasks[0].id");
 


### PR DESCRIPTION
## Description

`VariableIT.shouldReturnEventSubprocessVariable` failed in 4 of 6 recent CI runs on `stable/8.7` with:

```
expected: <2> but was: <0>
at VariableIT.java:808
```

**Root cause:** The test waited for the task to be created (`taskIsCreated`), then immediately called `getTaskById` and asserted that 2 variables were present. Zeebe variable import is asynchronous — the task record can be indexed before its variables have been processed by the importer. This caused the variables array to be empty on a fast or normally-loaded runner.

**Fix:** Add `.taskVariableExists("processVar")` before `getAllTasks()` to ensure the importer has processed at least one variable before the assertion runs.

## Checklist

- [x] for CI changes: N/A (test-only change)

## Related issues

Related to INC-7449