### PR TITLE
feat: default Operate nav v2 to disabled on SaaS, enabled on Self-Managed

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -39,7 +39,7 @@ public class OperateProperties {
 
   private boolean enterprise = false;
 
-  private Boolean navV2Enabled = true;
+  private Boolean navV2Enabled;
 
   private String tasklistUrl = null;
 
@@ -157,6 +157,13 @@ public class OperateProperties {
 
   public void setNavV2Enabled(final Boolean navV2Enabled) {
     this.navV2Enabled = navV2Enabled;
+  }
+
+  public boolean resolveNavV2Enabled(final boolean isSaas) {
+    if (navV2Enabled != null) {
+      return navV2Enabled;
+    }
+    return !isSaas;
   }
 
   public IdentityProperties getIdentity() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -39,7 +39,7 @@ public class OperateProperties {
 
   private boolean enterprise = false;
 
-  private boolean navV2Enabled = true;
+  private Boolean navV2Enabled = true;
 
   private String tasklistUrl = null;
 
@@ -151,11 +151,11 @@ public class OperateProperties {
     this.enterprise = enterprise;
   }
 
-  public boolean isNavV2Enabled() {
+  public Boolean getNavV2Enabled() {
     return navV2Enabled;
   }
 
-  public void setNavV2Enabled(final boolean navV2Enabled) {
+  public void setNavV2Enabled(final Boolean navV2Enabled) {
     this.navV2Enabled = navV2Enabled;
   }
 

--- a/operate/common/src/test/java/io/camunda/operate/property/OperatePropertiesTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/property/OperatePropertiesTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.property;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class OperatePropertiesTest {
+
+  @Test
+  void shouldEnableNavV2ByDefaultForSelfManaged() {
+    // given
+    final var properties = new OperateProperties();
+
+    // when
+    final boolean result = properties.resolveNavV2Enabled(false);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldDisableNavV2ByDefaultForSaas() {
+    // given
+    final var properties = new OperateProperties();
+
+    // when
+    final boolean result = properties.resolveNavV2Enabled(true);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldEnableNavV2ForSaasWhenExplicitlyConfigured() {
+    // given
+    final var properties = new OperateProperties();
+    properties.setNavV2Enabled(true);
+
+    // when
+    final boolean result = properties.resolveNavV2Enabled(true);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldDisableNavV2ForSelfManagedWhenExplicitlyConfigured() {
+    // given
+    final var properties = new OperateProperties();
+    properties.setNavV2Enabled(false);
+
+    // when
+    final boolean result = properties.resolveNavV2Enabled(false);
+
+    // then
+    assertThat(result).isFalse();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
@@ -61,7 +61,7 @@ public class ClientConfig {
     multiTenancyEnabled = cslProperties.getMultiTenancy().isChecksEnabled();
     databaseType = environmentService.getDatabaseType();
     waitStatesEnabled = waitStatesEnabledProperty;
-    isNavV2Enabled = operateProperties.isNavV2Enabled();
+    isNavV2Enabled = operateProperties.getNavV2Enabled();
     try {
       return String.format(
           "window.clientConfig = %s;", new ObjectMapper().writeValueAsString(this));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ClientConfig.java
@@ -13,13 +13,18 @@ import io.camunda.operate.EnvironmentService;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ClientConfig {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClientConfig.class);
 
   public boolean isEnterprise;
   public boolean canLogout;
@@ -46,6 +51,16 @@ public class ClientConfig {
 
   @Autowired private ServletContext context;
 
+  @PostConstruct
+  public void logNavV2Resolution() {
+    final boolean isSaas = isSaas();
+    LOGGER.debug(
+        "Operate nav v2 resolved to {} (explicit override={}, isSaas={})",
+        operateProperties.resolveNavV2Enabled(isSaas),
+        operateProperties.getNavV2Enabled(),
+        isSaas);
+  }
+
   public String asJson() {
     isEnterprise = operateProperties.isEnterprise();
     clusterId = operateProperties.getCloud().getClusterId();
@@ -61,12 +76,16 @@ public class ClientConfig {
     multiTenancyEnabled = cslProperties.getMultiTenancy().isChecksEnabled();
     databaseType = environmentService.getDatabaseType();
     waitStatesEnabled = waitStatesEnabledProperty;
-    isNavV2Enabled = operateProperties.getNavV2Enabled();
+    isNavV2Enabled = operateProperties.resolveNavV2Enabled(isSaas());
     try {
       return String.format(
           "window.clientConfig = %s;", new ObjectMapper().writeValueAsString(this));
     } catch (final JsonProcessingException e) {
       return "window.clientConfig = {};";
     }
+  }
+
+  private boolean isSaas() {
+    return cslProperties.getSaas() != null && cslProperties.getSaas().getClusterId() != null;
   }
 }


### PR DESCRIPTION
## Description

Operate's nav v2 (Camunda Design System navigation) flag now defaults to enabled on Self-Managed, disabled on SaaS (previously enabled everywhere). Still overridable per deployment via `camunda.operate.nav-v2-enabled`, so a specific environment (e.g. preview) can opt in or out independent of the default.

SaaS is detected via the canonical `camunda.security.saas.*` config — the same signal already relied on elsewhere in this codebase for `canLogout` and for organization/cluster JWT validation — rather than the legacy Mixpanel-only `cloud.organizationId` field, which had never previously gated behavior.

Companion Admin change (same SM/SaaS default pattern): #61189

## Related issues

Related: #60649
