### PR TITLE
feat: default Admin new design system to disabled on SaaS, enabled on Self-Managed

### DIFF
--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1653,6 +1653,7 @@ camunda: # Type: io.camunda.configuration.Camunda
 
     enterprise: null # Type: Boolean, Env: CAMUNDA_WEBAPP_ENTERPRISE
     login-delegated: null # Type: Boolean, Env: CAMUNDA_WEBAPP_LOGINDELEGATED
+    new-design-system-enabled: null # Type: Boolean, Env: CAMUNDA_WEBAPP_NEWDESIGNSYSTEMENABLED
 
   webapps: # Type: io.camunda.configuration.Webapps
     identity: # Type: io.camunda.configuration.Webapp

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminClientConfigController.java
@@ -12,11 +12,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.configuration.SaasConfigurationHelper;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import io.swagger.v3.oas.annotations.Hidden;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -33,20 +36,37 @@ public class AdminClientConfigController {
   private static final String ID_PATTERN = "idPattern";
   private static final String RESOURCE_PERMISSIONS = "resourcePermissions";
   private static final String DEFAULT_ROLE_IDS = "defaultRoleIds";
+  private static final String IS_NEW_DESIGN_SYSTEM_ENABLED = "isNewDesignSystemEnabled";
   private static final String FALLBACK_CONFIG_JS = "window.clientConfig = {};";
   private static final String CONFIG_JS_TEMPLATE = "window.clientConfig = %s;";
 
   private final String clientConfigAsJS;
   private final ObjectMapper objectMapper;
 
-  public AdminClientConfigController(final CamundaSecurityLibraryProperties cslProperties) {
+  public AdminClientConfigController(
+      final CamundaSecurityLibraryProperties cslProperties,
+      @Autowired(required = false) final WebappConfiguration webappConfiguration) {
+    final var resolvedWebappConfiguration =
+        webappConfiguration != null ? webappConfiguration : new WebappConfiguration();
+    final boolean isSaas = SaasConfigurationHelper.isSaas(cslProperties.getSaas());
+    final boolean isNewDesignSystemEnabled =
+        resolvedWebappConfiguration.resolveNewDesignSystemEnabled(isSaas);
+
+    LOG.info(
+        "Admin new design system resolved to {} (explicit override={}, isSaas={})",
+        isNewDesignSystemEnabled,
+        resolvedWebappConfiguration.getNewDesignSystemEnabled(),
+        isSaas);
+
     objectMapper = new ObjectMapper();
-    clientConfigAsJS = generateClientConfig(cslProperties);
+    clientConfigAsJS = generateClientConfig(cslProperties, isNewDesignSystemEnabled);
   }
 
-  private String generateClientConfig(final CamundaSecurityLibraryProperties cslProperties) {
+  private String generateClientConfig(
+      final CamundaSecurityLibraryProperties cslProperties,
+      final boolean isNewDesignSystemEnabled) {
     try {
-      final Map<String, Object> config = createConfigMap(cslProperties);
+      final Map<String, Object> config = createConfigMap(cslProperties, isNewDesignSystemEnabled);
       final String configJson = objectMapper.writeValueAsString(config);
       return String.format(CONFIG_JS_TEMPLATE, configJson);
     } catch (final JsonProcessingException e) {
@@ -56,7 +76,8 @@ public class AdminClientConfigController {
   }
 
   private Map<String, Object> createConfigMap(
-      final CamundaSecurityLibraryProperties cslProperties) {
+      final CamundaSecurityLibraryProperties cslProperties,
+      final boolean isNewDesignSystemEnabled) {
     final var config = new java.util.HashMap<String, Object>();
     final var saasConfiguration = cslProperties.getSaas();
 
@@ -69,6 +90,7 @@ public class AdminClientConfigController {
     config.put(ID_PATTERN, cslProperties.getIdValidationPattern());
     config.put(RESOURCE_PERMISSIONS, AuthorizationResourceType.buildResourcePermissionsMap());
     config.put(DEFAULT_ROLE_IDS, DefaultRole.ids());
+    config.put(IS_NEW_DESIGN_SYSTEM_ENABLED, String.valueOf(isNewDesignSystemEnabled));
 
     return config;
   }

--- a/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
+++ b/dist/src/test/java/io/camunda/webapps/controllers/AdminClientConfigControllerTest.java
@@ -25,6 +25,7 @@ import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.security.api.model.config.SaasConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -125,7 +126,7 @@ public class AdminClientConfigControllerTest {
             multiTenancyEnabled,
             expectedOrganizationId,
             expectedClusterId);
-    final var controller = new AdminClientConfigController(cslProperties);
+    final var controller = new AdminClientConfigController(cslProperties, null);
 
     // Setup MockMvc with the controller for this specific test
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
@@ -150,6 +151,30 @@ public class AdminClientConfigControllerTest {
         .containsEntry("isTenantsApiEnabled", expectedTenantsApi)
         .containsEntry("organizationId", expectedOrganizationId)
         .containsEntry("clusterId", expectedClusterId);
+  }
+
+  @Test
+  void shouldResolveNewDesignSystemFromDeploymentAndExplicitConfiguration() throws Exception {
+    // given
+    final var selfManagedProperties =
+        createCamundaSecurityLibraryProperties(AuthenticationMethod.BASIC, null, false, null, null);
+    final var saasProperties =
+        createCamundaSecurityLibraryProperties(
+            AuthenticationMethod.OIDC, null, false, "test-org", "test-cluster");
+    final var enabledConfiguration = new WebappConfiguration();
+    enabledConfiguration.setNewDesignSystemEnabled(true);
+    final var disabledConfiguration = new WebappConfiguration();
+    disabledConfiguration.setNewDesignSystemEnabled(false);
+
+    // when / then
+    assertThat(extractConfig(selfManagedProperties, null))
+        .containsEntry("isNewDesignSystemEnabled", "true");
+    assertThat(extractConfig(saasProperties, null))
+        .containsEntry("isNewDesignSystemEnabled", "false");
+    assertThat(extractConfig(saasProperties, enabledConfiguration))
+        .containsEntry("isNewDesignSystemEnabled", "true");
+    assertThat(extractConfig(selfManagedProperties, disabledConfiguration))
+        .containsEntry("isNewDesignSystemEnabled", "false");
   }
 
   private CamundaSecurityLibraryProperties createCamundaSecurityLibraryProperties(
@@ -193,7 +218,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -213,7 +239,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -232,7 +259,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -255,7 +283,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -281,7 +310,8 @@ public class AdminClientConfigControllerTest {
     final var controller =
         new AdminClientConfigController(
             createCamundaSecurityLibraryProperties(
-                AuthenticationMethod.BASIC, null, false, null, null));
+                AuthenticationMethod.BASIC, null, false, null, null),
+            null);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 
     // when
@@ -308,6 +338,17 @@ public class AdminClientConfigControllerTest {
 
     return objectMapper.readValue(
         response.substring(jsonConfigBodyStartIdx, jsonConfigBodyEndIdx + 1), Map.class);
+  }
+
+  private Map<String, Object> extractConfig(
+      final CamundaSecurityLibraryProperties cslProperties,
+      final WebappConfiguration webappConfiguration)
+      throws Exception {
+    final var controller = new AdminClientConfigController(cslProperties, webappConfiguration);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    final String response =
+        mockMvc.perform(get("/admin/config.js")).andReturn().getResponse().getContentAsString();
+    return extractConfigFromResponse(response);
   }
 
   @SuppressWarnings("unchecked")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public class WebappConfiguration {
 
@@ -16,6 +17,7 @@ public class WebappConfiguration {
   private boolean loginDelegated = false;
   private Cloud cloud = new Cloud();
   private List<String> activeComponents = new ArrayList<>();
+  private @Nullable Boolean newDesignSystemEnabled;
 
   public boolean isEnterprise() {
     return enterprise;
@@ -47,6 +49,18 @@ public class WebappConfiguration {
 
   public void setActiveComponents(final List<String> activeComponents) {
     this.activeComponents = activeComponents;
+  }
+
+  public @Nullable Boolean getNewDesignSystemEnabled() {
+    return newDesignSystemEnabled;
+  }
+
+  public void setNewDesignSystemEnabled(final @Nullable Boolean newDesignSystemEnabled) {
+    this.newDesignSystemEnabled = newDesignSystemEnabled;
+  }
+
+  public boolean resolveNewDesignSystemEnabled(final boolean isSaas) {
+    return newDesignSystemEnabled != null ? newDesignSystemEnabled : !isSaas;
   }
 
   public static class Cloud {


### PR DESCRIPTION
## Description

Admin's new-design-system flag (which also drives nav v2) was a hardcoded frontend constant, so changing it per environment needed a code change. It is now resolved in the backend and served through the Admin client config: enabled by default on Self-Managed, disabled on SaaS, with `camunda.webapp.new-design-system-enabled` overriding either default so a single environment (e.g. preview) can opt in while production stays unset.

Resolution lives on `WebappConfiguration` and is injected as a typed properties bean rather than a raw `@Value`, matching `WebappIndexController`/`SystemController`. This mirrors the Operate change in #61188, which puts the same resolution on `OperateProperties`.

SaaS detection treats either `organizationId` or `clusterId` as SaaS and ignores empty strings, rather than `clusterId != null` alone: misreading a SaaS cluster as Self-Managed would swap the whole Admin UI over, while the reverse only withholds a UI SaaS is not meant to get yet.

Backend only — the frontend still hardcodes the flag in `feature-flags.ts`.

## Checklist

- [x] Backports are not required — this targets `main` only.

## Related issues

Related to #61006, #60649
Companion Operate change: #61188
