### PR TITLE
ci: retry setup-java to survive transient infra blips

### DIFF
--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -35,29 +35,12 @@ runs:
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
     - name: Authenticate to GCS via WIF
-      # wretry retries WIF auth through transient network/STS failures (INC-7417). Same pattern as
-      # build-platform-docker; `_js_action` pin lets the *_context inputs be blanked (auth has no
-      # `${{ }}` defaults). Each attempt mints a fresh OIDC token, so retrying is side-effect-free.
+      # Not wrapped in wretry: it blanks INPUT_SERVICE_ACCOUNT before auth reads it, dropping SA
+      # impersonation so gcloud runs as the bare WIF identity and every storage call 403s (INC-7417).
       if: steps.is-fork.outputs.is-fork != 'true'
-      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
-        # Full semver (not `# v3`) so the wretry-wrapped-action Renovate regex manager tracks it.
-        action: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        attempt_limit: 3
-        attempt_delay: 10000
-        github_token: ${{ github.token }}
-        github_context: '{}'
-        env_context: '{}'
-        job_context: '{}'
-        matrix_context: '{}'
-        with: |
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-    # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
-    - name: Clear auth inputs leaked into the job environment by wretry
-      if: always() && steps.is-fork.outputs.is-fork != 'true'
-      shell: bash
-      run: |
-        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
+        workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+        service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
     - if: steps.is-fork.outputs.is-fork != 'true'
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -35,10 +35,29 @@ runs:
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
     - name: Authenticate to GCS via WIF
+      # wretry retries WIF auth through transient network/STS failures (INC-7417). Same pattern as
+      # build-platform-docker; `_js_action` pin lets the *_context inputs be blanked (auth has no
+      # `${{ }}` defaults). Each attempt mints a fresh OIDC token, so retrying is side-effect-free.
       if: steps.is-fork.outputs.is-fork != 'true'
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
-        workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-        service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+        # Full semver (not `# v3`) so the wretry-wrapped-action Renovate regex manager tracks it.
+        action: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        attempt_limit: 3
+        attempt_delay: 10000
+        github_token: ${{ github.token }}
+        github_context: '{}'
+        env_context: '{}'
+        job_context: '{}'
+        matrix_context: '{}'
+        with: |
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+    # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
+    - name: Clear auth inputs leaked into the job environment by wretry
+      if: always() && steps.is-fork.outputs.is-fork != 'true'
+      shell: bash
+      run: |
+        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
     - if: steps.is-fork.outputs.is-fork != 'true'
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -155,10 +155,29 @@ runs:
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
-    uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+    # wretry retries setup-java through transient network/setup failures (INC-7417). Same pattern
+    # as build-platform-docker; `_js_action` pin lets the *_context inputs be overridden.
+    # `token` is passed explicitly since github_context is blanked (setup-java defaults it from it).
+    uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
     with:
-      distribution: ${{ inputs.java-distribution }}
-      java-version: ${{ inputs.java-version }}
+      action: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      attempt_limit: 3
+      attempt_delay: 10000
+      github_token: ${{ github.token }}
+      github_context: '{}'
+      env_context: '{}'
+      job_context: '{}'
+      matrix_context: '{}'
+      with: |
+        distribution: ${{ inputs.java-distribution }}
+        java-version: ${{ inputs.java-version }}
+        token: ${{ github.token }}
+  # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
+  - name: Clear setup-java inputs leaked into the job environment by wretry
+    if: always()
+    shell: bash
+    run: |
+      env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
   - name: Register Maven problem matcher
     shell: bash
     run: echo "::add-matcher::.github/maven-matcher.json"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -199,7 +199,6 @@
       matchFileNames: [
         ".github/actions/build-platform-docker/action.yml",
         ".github/actions/setup-build/action.yml",
-        ".github/actions/gcs-build-cache-auth/action.yml",
       ],
       matchPackageNames: [
         "Wandalen/wretry.action",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -198,6 +198,8 @@
       description: "Wandalen/wretry.action releases a `vX.Y.Z` composite tag and a paired `vX.Y.Z_js_action` tag together (the composite's own dependency); we pin the latter (see PR #60406). Renovate's versioning strips the `_js_action` suffix and can't tell the two tags apart, so digest updates resolve to the composite's commit instead. Scope this dependency to only consider `_js_action`-suffixed tags.",
       matchFileNames: [
         ".github/actions/build-platform-docker/action.yml",
+        ".github/actions/setup-build/action.yml",
+        ".github/actions/gcs-build-cache-auth/action.yml",
       ],
       matchPackageNames: [
         "Wandalen/wretry.action",


### PR DESCRIPTION
> **Update (scope narrowed to `setup-java` only):** the `google-github-actions/auth`
> wrap was reverted. wretry blanks `INPUT_SERVICE_ACCOUNT` / `INPUT_WORKLOAD_IDENTITY_PROVIDER`
> before `auth` reads them, so `auth` fell back to direct WIF and dropped `monorepo-build-cache-sa`
> impersonation — every downstream `gcloud storage` call then 403'd (authenticated as the bare
> `…svc.id.goog` pool identity). This PR now wraps **only `setup-java`**, which reads its inputs
> before wretry blanks them and is unaffected. Auth stays as the plain step.

---

## Problem

A single GitHub-/GCP-side network blip on 2026-08-25 opened **11 CI incidents**
(INC-7417 and its merged cluster) in a 15-minute window across `main` and
`stable/8.10`. The failing jobs shared no logic — the common cause was that each
failed at an early **setup** step that has no retry:

- `Setup Java` at archive download — `Name or service not known (internal-api.service.iad.github.net)`
- `Authenticate to GCS via WIF` at the STS token exchange

A plain rerun went green with no code change, but this failure class recurs and
each recurrence pages one incident per affected job.

## Change

Wrap both steps in `Wandalen/wretry.action` (`attempt_limit: 3`,
`attempt_delay: 10000`), mirroring the existing `build-platform-docker` pattern —
the repo's established way to retry an external call made through a `uses:` step,
which `nick-fields/retry` (shell-command only) cannot wrap. Each wrap gets the
same `Clear … inputs` follow-up, because wretry leaks the wrapped action's
`INPUT_*` vars into the caller job's `GITHUB_ENV`.

Both composites are the highest-leverage call sites: `setup-build` is pulled by
~every Java job, so wrapping it once covers most `setup-java` invocations
transitively.

### Caveat handled: setup-java carries its own `${{ }}` defaults

Blanking the `*_context` inputs is only safe when the wrapped action has no
`${{ }}` expressions of its own. That holds for `google-github-actions/auth`
(all literal defaults) but **not** for `actions/setup-java`, whose `action.yml`
defaults `token` from the `github` context. Blanking `github_context` would drop
the default `github.token` and risk github.com rate-limiting on JDK manifest
fetches, so the wrap passes `token` explicitly. `job-status` is a post-step-only
workaround "not intended for manual setting", so defaulting it empty is fine.

### Renovate

Wrapping moves the pinned digest from a `uses:` key (seen by the github-actions
manager) into wretry's `action:` input (invisible to it). The repo already has a
custom regex manager for this plus a `_js_action` versioning rule; both are
extended — the two files are added to the `_js_action` rule, and the wrapped
`auth` comment uses full semver (`# v3.0.0`) so the custom manager's `vX.Y.Z`
regex tracks it.

## Scope

Fixes the two composites the incident hit. **Not** included (separate follow-ups):

- ~20 standalone workflow-level `setup-java`/`auth` calls (mostly release /
  scheduled / c8run paths).
- `identity-regression-test.yml` pinning `actions/setup-java@v5` (floating tag,
  not a SHA) — a pinning-hygiene bug.
- INC-7431 / INC-7444–7446 (Harbor push + Jib image-build stalls) — a different
  code path with its own internal retry loop, not a missing-retry gap.

Owner: `@camunda/engineering-operations` (both actions' `# owner:` header).

