### PR TITLE
fix: properly register recovering partition health monitor

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -127,6 +127,6 @@ public interface PartitionManager {
         brokerStartupContext.getGatewayBrokerTransport(),
         brokerStartupContext.getExportedPositionSupplier(physicalTenantId),
         topologyManager,
-        brokerStartupContext.getHealthCheckService().componentName());
+        brokerStartupContext.getHealthCheckService());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveringPartitionHealth.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveringPartitionHealth.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning;
+
+import com.google.common.collect.ImmutableMap;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
+import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.health.HealthStatus;
+import java.time.Instant;
+
+/**
+ * Stands in for a partition's {@link ZeebePartition} in the broker's {@link HealthMonitor} while
+ * the partition group is in recovery mode, so that the broker reports healthy during a recovery
+ * that is going well and surfaces a partition whose recovery failed. Reuses the {@link
+ * ZeebePartition#componentName(PartitionId)} so the partition occupies the same slot in the health
+ * component tree across mode transitions, overwriting any stale placeholder the processing-mode
+ * bootstrap registration may have left behind.
+ *
+ * <p>The reported status is fixed at construction: a recovery partition either started (healthy for
+ * the duration of recovery mode) or failed to start with nothing left running to bring it back
+ * (dead). Failure listeners are therefore never invoked.
+ */
+final class RecoveringPartitionHealth implements HealthMonitorable {
+
+  private final String componentName;
+  private final HealthReport healthReport;
+
+  private RecoveringPartitionHealth(final String componentName, final HealthReport healthReport) {
+    this.componentName = componentName;
+    this.healthReport = healthReport;
+  }
+
+  static RecoveringPartitionHealth recovered(final PartitionId partitionId) {
+    final var componentName = ZeebePartition.componentName(partitionId);
+    return new RecoveringPartitionHealth(
+        componentName,
+        new HealthReport(componentName, HealthStatus.HEALTHY, null, ImmutableMap.of()));
+  }
+
+  static RecoveringPartitionHealth failed(final PartitionId partitionId) {
+    final var componentName = ZeebePartition.componentName(partitionId);
+    return new RecoveringPartitionHealth(
+        componentName,
+        new HealthReport(componentName, HealthStatus.DEAD, null, ImmutableMap.of())
+            .withMessage(
+                "Partition %s failed to recover and will stay dead until the restore is retried"
+                    .formatted(partitionId),
+                Instant.now()));
+  }
+
+  @Override
+  public String componentName() {
+    return componentName;
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return healthReport;
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener failureListener) {
+    // the status never changes, so there is nothing to notify
+  }
+
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    // no listeners are ever stored
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveringPartitionHealth.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveringPartitionHealth.java
@@ -25,9 +25,15 @@ import java.time.Instant;
  * component tree across mode transitions, overwriting any stale placeholder the processing-mode
  * bootstrap registration may have left behind.
  *
- * <p>The reported status is fixed at construction: a recovery partition either started (healthy for
- * the duration of recovery mode) or failed to start (unhealthy). Failure listeners are therefore
- * never invoked.
+ * <p>One is registered for every local partition as soon as recovery mode starts, before the
+ * partitions have begun recovering, and replaced by {@link #failed(PartitionId)} only for the ones
+ * that fail. The health monitor derives the broker's status from the components it holds, so a
+ * partition with no component at all leaves the broker unhealthy - registering only after recovery
+ * settled would report the broker unhealthy for the whole recovery it is supposed to survive.
+ *
+ * <p>The reported status is fixed at construction: an instance is either recovering (healthy for
+ * the duration of recovery mode) or failed to start (unhealthy), and the manager swaps the instance
+ * rather than mutating it. Failure listeners are therefore never invoked.
  *
  * <p>A failed recovery is reported {@link HealthStatus#UNHEALTHY} rather than {@link
  * HealthStatus#DEAD}: the steps that can fail here start metrics, the backup service and the backup
@@ -46,7 +52,7 @@ final class RecoveringPartitionHealth implements HealthMonitorable {
     this.healthReport = healthReport;
   }
 
-  static RecoveringPartitionHealth recovered(final PartitionId partitionId) {
+  static RecoveringPartitionHealth recovering(final PartitionId partitionId) {
     final var componentName = ZeebePartition.componentName(partitionId);
     return new RecoveringPartitionHealth(
         componentName,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveringPartitionHealth.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveringPartitionHealth.java
@@ -26,8 +26,15 @@ import java.time.Instant;
  * bootstrap registration may have left behind.
  *
  * <p>The reported status is fixed at construction: a recovery partition either started (healthy for
- * the duration of recovery mode) or failed to start with nothing left running to bring it back
- * (dead). Failure listeners are therefore never invoked.
+ * the duration of recovery mode) or failed to start (unhealthy). Failure listeners are therefore
+ * never invoked.
+ *
+ * <p>A failed recovery is reported {@link HealthStatus#UNHEALTHY} rather than {@link
+ * HealthStatus#DEAD}: the steps that can fail here start metrics, the backup service and the backup
+ * API request handler, so a failure is a transient infrastructure problem (an actor that could not
+ * be scheduled, a transport subscription that was rejected) rather than the kind of unrecoverable
+ * damage - a corrupted journal, say - that DEAD is meant for. Retrying the restore, or restarting
+ * the broker, is expected to clear it.
  */
 final class RecoveringPartitionHealth implements HealthMonitorable {
 
@@ -50,9 +57,9 @@ final class RecoveringPartitionHealth implements HealthMonitorable {
     final var componentName = ZeebePartition.componentName(partitionId);
     return new RecoveringPartitionHealth(
         componentName,
-        new HealthReport(componentName, HealthStatus.DEAD, null, ImmutableMap.of())
+        new HealthReport(componentName, HealthStatus.UNHEALTHY, null, ImmutableMap.of())
             .withMessage(
-                "Partition %s failed to recover and will stay dead until the restore is retried"
+                "Partition %s failed to recover and stays unhealthy until the restore is retried"
                     .formatted(partitionId),
                 Instant.now()));
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
@@ -47,6 +48,7 @@ import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.concurrency.FuturesUtil;
+import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
@@ -114,7 +116,8 @@ public final class RecoveryPartitionManager
   private final BrokerInfo brokerInfo;
   private final AtomixServerTransport gatewayBrokerTransport;
   private final @Nullable IntFunction<Long> exportedPositionSupplier;
-  private final String brokerComponentName;
+  private final BrokerHealthCheckService healthCheckService;
+  private final List<HealthMonitorable> registeredHealthComponents = new ArrayList<>();
   private @Nullable BackupStore backupStore;
   private @Nullable ExecutorService restoreExecutor;
 
@@ -130,8 +133,8 @@ public final class RecoveryPartitionManager
       final AtomixServerTransport gatewayBrokerTransport,
       final @Nullable IntFunction<Long> exportedPositionSupplier,
       final TopologyManagerImpl topologyManager,
-      final String brokerComponentName) {
-    this.brokerComponentName = brokerComponentName;
+      final BrokerHealthCheckService healthCheckService) {
+    this.healthCheckService = healthCheckService;
     this.partitionGroup = partitionGroup;
     this.concurrencyControl = concurrencyControl;
     actorSchedulingService = schedulingService;
@@ -190,6 +193,12 @@ public final class RecoveryPartitionManager
     restoreExecutor =
         Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("zeebe-restore-", 0).factory());
     final var localPartitions = localPartitions();
+    // A broker in recovery mode is ready by design: it must accept management traffic (restore
+    // requests) and must not be restarted by the readiness-based liveness probe while a restore is
+    // in progress. Register upfront - including with no local partitions, so an expected physical
+    // tenant is never mistaken for one that failed to start (see registerBootstrapPartitions).
+    healthCheckService.registerRecoveringPartitions(
+        partitionGroup, localPartitions.stream().map(PartitionMetadata::id).toList());
     if (localPartitions.isEmpty()) {
       LOG.info("No local partitions to recover for partition group {}", partitionGroup);
       result.complete(null);
@@ -246,9 +255,17 @@ public final class RecoveryPartitionManager
                       topologyManager.onHealthChanged(
                           p.partitionId().number(), HealthStatus.HEALTHY);
                       p.healthMetrics().setRecovering();
+                      registerHealthComponent(
+                          p.partitionId().number(),
+                          RecoveringPartitionHealth.recovered(p.partitionId()));
                     });
                 failedPartitionIds.forEach(
-                    id -> topologyManager.onHealthChanged(id, HealthStatus.DEAD));
+                    id -> {
+                      topologyManager.onHealthChanged(id, HealthStatus.DEAD);
+                      registerHealthComponent(
+                          id,
+                          RecoveringPartitionHealth.failed(new PartitionId(partitionGroup, id)));
+                    });
                 if (recoveryPartitions.isEmpty()) {
                   if (deactivateError != null) {
                     LOG.error(
@@ -286,10 +303,22 @@ public final class RecoveryPartitionManager
         brokerInfo,
         gatewayBrokerTransport,
         backupStore,
-        brokerComponentName);
+        healthCheckService.componentName());
+  }
+
+  private void registerHealthComponent(
+      final int partitionId, final RecoveringPartitionHealth healthComponent) {
+    registeredHealthComponents.add(healthComponent);
+    healthCheckService.registerMonitoredPartition(partitionId, healthComponent);
   }
 
   private void stopInternal(final ActorFuture<Void> result) {
+    // Unregister the readiness and health state this manager contributed, so the next manager's
+    // registration starts from a clean slate: after exiting recovery, readiness must be gated on
+    // the partitions genuinely rejoining Raft rather than on the recovery-mode "installed" marks.
+    registeredHealthComponents.forEach(healthCheckService::removeMonitoredPartition);
+    registeredHealthComponents.clear();
+    healthCheckService.unregisterPhysicalTenant(partitionGroup);
     final var stopFutures =
         recoveryPartitions.stream()
             .map(RecoveryPartition::stop)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -261,7 +261,7 @@ public final class RecoveryPartitionManager
                     });
                 failedPartitionIds.forEach(
                     id -> {
-                      topologyManager.onHealthChanged(id, HealthStatus.DEAD);
+                      topologyManager.onHealthChanged(id, HealthStatus.UNHEALTHY);
                       registerHealthComponent(
                           id,
                           RecoveringPartitionHealth.failed(new PartitionId(partitionGroup, id)));

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -62,6 +62,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -117,7 +118,7 @@ public final class RecoveryPartitionManager
   private final AtomixServerTransport gatewayBrokerTransport;
   private final @Nullable IntFunction<Long> exportedPositionSupplier;
   private final BrokerHealthCheckService healthCheckService;
-  private final List<HealthMonitorable> registeredHealthComponents = new ArrayList<>();
+  private final Map<Integer, HealthMonitorable> registeredHealthComponents = new LinkedHashMap<>();
   private @Nullable BackupStore backupStore;
   private @Nullable ExecutorService restoreExecutor;
 
@@ -199,6 +200,10 @@ public final class RecoveryPartitionManager
     // tenant is never mistaken for one that failed to start (see registerBootstrapPartitions).
     healthCheckService.registerRecoveringPartitions(
         partitionGroup, localPartitions.stream().map(PartitionMetadata::id).toList());
+    localPartitions.forEach(
+        metadata ->
+            registerHealthComponent(
+                metadata.id().number(), RecoveringPartitionHealth.recovering(metadata.id())));
     if (localPartitions.isEmpty()) {
       LOG.info("No local partitions to recover for partition group {}", partitionGroup);
       result.complete(null);
@@ -210,6 +215,10 @@ public final class RecoveryPartitionManager
       backupStore = BackupCfg.BackupStoreFactory.createStore(backupCfg);
     } catch (final Exception e) {
       LOG.error("Failed to create backup store for partition group {}", partitionGroup, e);
+      localPartitions.forEach(
+          metadata ->
+              registerHealthComponent(
+                  metadata.id().number(), RecoveringPartitionHealth.failed(metadata.id())));
       result.completeExceptionally(e);
       return;
     }
@@ -255,10 +264,9 @@ public final class RecoveryPartitionManager
                       topologyManager.onHealthChanged(
                           p.partitionId().number(), HealthStatus.HEALTHY);
                       p.healthMetrics().setRecovering();
-                      registerHealthComponent(
-                          p.partitionId().number(),
-                          RecoveringPartitionHealth.recovered(p.partitionId()));
                     });
+                // Only the failures need a new component; the rest keep the recovering one
+                // registered before the partitions started.
                 failedPartitionIds.forEach(
                     id -> {
                       topologyManager.onHealthChanged(id, HealthStatus.UNHEALTHY);
@@ -306,9 +314,16 @@ public final class RecoveryPartitionManager
         healthCheckService.componentName());
   }
 
+  /**
+   * Registers {@code healthComponent} as the partition's node in the broker health tree, replacing
+   * whatever this manager registered for the same partition before. Both instances share the {@link
+   * ZeebePartition#componentName(PartitionId)}, so the health monitor overwrites the slot by name;
+   * keying the bookkeeping by partition keeps {@link #stopInternal} from holding a superseded
+   * instance whose removal would take the live one's slot with it.
+   */
   private void registerHealthComponent(
       final int partitionId, final RecoveringPartitionHealth healthComponent) {
-    registeredHealthComponents.add(healthComponent);
+    registeredHealthComponents.put(partitionId, healthComponent);
     healthCheckService.registerMonitoredPartition(partitionId, healthComponent);
   }
 
@@ -316,7 +331,7 @@ public final class RecoveryPartitionManager
     // Unregister the readiness and health state this manager contributed, so the next manager's
     // registration starts from a clean slate: after exiting recovery, readiness must be gated on
     // the partitions genuinely rejoining Raft rather than on the recovery-mode "installed" marks.
-    registeredHealthComponents.forEach(healthCheckService::removeMonitoredPartition);
+    registeredHealthComponents.values().forEach(healthCheckService::removeMonitoredPartition);
     registeredHealthComponents.clear();
     healthCheckService.unregisterPhysicalTenant(partitionGroup);
     final var stopFutures =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -119,6 +119,7 @@ public final class RecoveryPartitionManager
   private final @Nullable IntFunction<Long> exportedPositionSupplier;
   private final BrokerHealthCheckService healthCheckService;
   private final Map<Integer, HealthMonitorable> registeredHealthComponents = new LinkedHashMap<>();
+  private boolean stopped = false;
   private @Nullable BackupStore backupStore;
   private @Nullable ExecutorService restoreExecutor;
 
@@ -191,6 +192,7 @@ public final class RecoveryPartitionManager
   }
 
   private void startInternal(final ActorFuture<Void> result) {
+    stopped = false;
     restoreExecutor =
         Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("zeebe-restore-", 0).factory());
     final var localPartitions = localPartitions();
@@ -257,23 +259,7 @@ public final class RecoveryPartitionManager
           concurrencyControl.runOnCompletion(
               deactivateFutures,
               (ignoredDeactivate, deactivateError) -> {
-                // reported once the partition is registered as INACTIVE above, since
-                // onHealthChanged is a no-op for a partition the topology doesn't know about yet
-                recoveryPartitions.forEach(
-                    p -> {
-                      topologyManager.onHealthChanged(
-                          p.partitionId().number(), HealthStatus.HEALTHY);
-                      p.healthMetrics().setRecovering();
-                    });
-                // Only the failures need a new component; the rest keep the recovering one
-                // registered before the partitions started.
-                failedPartitionIds.forEach(
-                    id -> {
-                      topologyManager.onHealthChanged(id, HealthStatus.UNHEALTHY);
-                      registerHealthComponent(
-                          id,
-                          RecoveringPartitionHealth.failed(new PartitionId(partitionGroup, id)));
-                    });
+                reportRecoveryOutcome();
                 if (recoveryPartitions.isEmpty()) {
                   if (deactivateError != null) {
                     LOG.error(
@@ -314,6 +300,28 @@ public final class RecoveryPartitionManager
         healthCheckService.componentName());
   }
 
+  private void reportRecoveryOutcome() {
+    if (stopped) {
+      LOG.debug(
+          "Not reporting the recovery outcome for partition group {}, this manager has stopped",
+          partitionGroup);
+      return;
+    }
+    recoveryPartitions.forEach(
+        p -> {
+          topologyManager.onHealthChanged(p.partitionId().number(), HealthStatus.HEALTHY);
+          p.healthMetrics().setRecovering();
+        });
+    // Only the failures need a new component; the rest keep the recovering one registered before
+    // the partitions started.
+    failedPartitionIds.forEach(
+        id -> {
+          topologyManager.onHealthChanged(id, HealthStatus.UNHEALTHY);
+          registerHealthComponent(
+              id, RecoveringPartitionHealth.failed(new PartitionId(partitionGroup, id)));
+        });
+  }
+
   /**
    * Registers {@code healthComponent} as the partition's node in the broker health tree, replacing
    * whatever this manager registered for the same partition before. Both instances share the {@link
@@ -328,6 +336,7 @@ public final class RecoveryPartitionManager
   }
 
   private void stopInternal(final ActorFuture<Void> result) {
+    stopped = true;
     // Unregister the readiness and health state this manager contributed, so the next manager's
     // registration starts from a clean slate: after exiting recovery, readiness must be gated on
     // the partitions genuinely rejoining Raft rather than on the recovery-mode "installed" marks.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -143,6 +143,42 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     actor.run(this::logBrokerReadyOnce);
   }
 
+  /**
+   * Registers the partitions of a physical tenant that is in recovery mode. Recovery partitions
+   * never join Raft, so the {@link PartitionRaftListener} callbacks that normally mark a bootstrap
+   * partition as installed never fire for them. A broker in recovery mode is ready by design - it
+   * must accept management traffic (e.g. restore requests) - so its partitions count as installed
+   * immediately. Unhealthy recovery outcomes are surfaced through the health monitor instead, via
+   * {@link #registerMonitoredPartition(int, HealthMonitorable)}.
+   */
+  public void registerRecoveringPartitions(
+      final String physicalTenantId, final Collection<PartitionId> partitions) {
+    registeredPhysicalTenants.add(physicalTenantId);
+    if (partitionInstallStatus == null) {
+      partitionInstallStatus = new ConcurrentHashMap<>();
+    }
+    // put, not putIfAbsent: entering recovery from processing mode must override a partition that
+    // was still installing, since readiness in recovery does not depend on Raft roles
+    partitions.forEach(partitionId -> partitionInstallStatus.put(partitionId, true));
+    actor.run(this::logBrokerReadyOnce);
+  }
+
+  /**
+   * Unregisters a physical tenant and all of its partitions' install status. Called when the
+   * tenant's partition manager stops as part of a mode transition, so that the next manager's
+   * registration starts from a clean slate: without this, the "installed" marks left behind by
+   * recovery mode would make {@link #isBrokerReady()} claim readiness after exiting recovery,
+   * before the partitions have actually rejoined Raft ({@link #registerBootstrapPartitions} only
+   * uses putIfAbsent).
+   */
+  public void unregisterPhysicalTenant(final String physicalTenantId) {
+    registeredPhysicalTenants.remove(physicalTenantId);
+    final var status = partitionInstallStatus;
+    if (status != null) {
+      status.keySet().removeIf(partitionId -> partitionId.group().equals(physicalTenantId));
+    }
+  }
+
   public boolean isBrokerReady() {
     // Ready once every expected physical tenant has registered and every one of their partitions
     // has been installed. Both conditions are evaluated live: requiring all tenants prevents a

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -157,8 +157,11 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     if (partitionInstallStatus == null) {
       partitionInstallStatus = new ConcurrentHashMap<>();
     }
-    // put, not putIfAbsent: entering recovery from processing mode must override a partition that
-    // was still installing, since readiness in recovery does not depend on Raft roles
+    // Clear this tenant's previous entries first: its partition manager may have stopped for the
+    // mode transition without unregistering (e.g. a processing-mode manager never does), leaving
+    // a still-installing ("false") or now-stale partition behind. Left in place, that entry would
+    // permanently block isBrokerReady() even though recovery does not depend on Raft roles.
+    partitionInstallStatus.keySet().removeIf(id -> id.group().equals(physicalTenantId));
     partitions.forEach(partitionId -> partitionInstallStatus.put(partitionId, true));
     actor.run(this::logBrokerReadyOnce);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -104,9 +104,11 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   private final Set<String> registeredPhysicalTenants = ConcurrentHashMap.newKeySet();
   /* Tracks the install status of every bootstrap partition the broker is responsible for, keyed by
   its full PartitionId (partition group + id). Each physical tenant registers its own partitions, so
-  this map accumulates across all tenants. Stays null until the first registration so that an
-  install status update before any partition is known fails fast. */
-  private volatile Map<PartitionId, Boolean> partitionInstallStatus;
+  this map accumulates across all tenants. Concurrent by construction: physical tenants register
+  from their own threads (each tenant's partition manager starts on its own topology-manager actor,
+  a recovering tenant registers from the broker actor), and lazily creating the map instead would
+  let two such registrations race and drop one tenant's partitions. */
+  private final Map<PartitionId, Boolean> partitionInstallStatus = new ConcurrentHashMap<>();
   /* Guards against logging "broker is ready" more than once. Only touched on the actor thread. */
   private boolean readyLogged = false;
   private volatile boolean brokerStarted = false;
@@ -130,9 +132,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     // never started". Accumulate rather than replace so a later tenant's call does not drop the
     // partitions registered by previous tenants.
     registeredPhysicalTenants.add(physicalTenantId);
-    if (partitionInstallStatus == null) {
-      partitionInstallStatus = new ConcurrentHashMap<>();
-    }
     partitions.forEach(
         metadata -> {
           partitionInstallStatus.putIfAbsent(metadata.id(), false);
@@ -154,9 +153,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   public void registerRecoveringPartitions(
       final String physicalTenantId, final Collection<PartitionId> partitions) {
     registeredPhysicalTenants.add(physicalTenantId);
-    if (partitionInstallStatus == null) {
-      partitionInstallStatus = new ConcurrentHashMap<>();
-    }
     // Clear this tenant's previous entries first: its partition manager may have stopped for the
     // mode transition without unregistering (e.g. a processing-mode manager never does), leaving
     // a still-installing ("false") or now-stale partition behind. Left in place, that entry would
@@ -176,10 +172,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
    */
   public void unregisterPhysicalTenant(final String physicalTenantId) {
     registeredPhysicalTenants.remove(physicalTenantId);
-    final var status = partitionInstallStatus;
-    if (status != null) {
-      status.keySet().removeIf(partitionId -> partitionId.group().equals(physicalTenantId));
-    }
+    partitionInstallStatus.keySet().removeIf(id -> id.group().equals(physicalTenantId));
   }
 
   public boolean isBrokerReady() {
@@ -187,11 +180,9 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     // has been installed. Both conditions are evaluated live: requiring all tenants prevents a
     // missing tenant from being silently ignored, and reading the map directly lets partitions
     // registered by a later tenant still gate readiness even if an earlier tenant already finished.
-    final var status = partitionInstallStatus;
     return brokerStarted
         && registeredPhysicalTenants.containsAll(expectedPhysicalTenants)
-        && status != null
-        && !status.containsValue(false);
+        && !partitionInstallStatus.containsValue(false);
   }
 
   public String componentName() {
@@ -212,8 +203,10 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   }
 
   private void checkState() {
-    if (partitionInstallStatus == null) {
-      throw new IllegalStateException("PartitionInstallStatus must not be null.");
+    if (registeredPhysicalTenants.isEmpty()) {
+      throw new IllegalStateException(
+          "No physical tenant has registered its partitions yet, so no install status can be"
+              + " updated.");
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -163,16 +163,27 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   }
 
   /**
-   * Unregisters a physical tenant and all of its partitions' install status. Called when the
-   * tenant's partition manager stops as part of a mode transition, so that the next manager's
-   * registration starts from a clean slate: without this, the "installed" marks left behind by
-   * recovery mode would make {@link #isBrokerReady()} claim readiness after exiting recovery,
-   * before the partitions have actually rejoined Raft ({@link #registerBootstrapPartitions} only
-   * uses putIfAbsent).
+   * Unregisters a physical tenant, dropping both its partitions' install status and their nodes in
+   * the health tree. Called when the tenant's partition manager stops as part of a mode transition,
+   * so that the next manager's registration starts from a clean slate: without this, the
+   * "installed" marks left behind by recovery mode would make {@link #isBrokerReady()} claim
+   * readiness after exiting recovery, before the partitions have actually rejoined Raft ({@link
+   * #registerBootstrapPartitions} only uses putIfAbsent).
    */
   public void unregisterPhysicalTenant(final String physicalTenantId) {
     registeredPhysicalTenants.remove(physicalTenantId);
-    partitionInstallStatus.keySet().removeIf(id -> id.group().equals(physicalTenantId));
+    final var tenantPartitions =
+        partitionInstallStatus.keySet().stream()
+            .filter(partitionId -> partitionId.group().equals(physicalTenantId))
+            .toList();
+    tenantPartitions.forEach(partitionInstallStatus::remove);
+    // Take the health tree nodes with it, mirroring registerBootstrapPartitions. Its
+    // monitorComponent placeholders are the only entries nothing else removes - a partition that
+    // registers a real component has it removed when the component shuts down - and a placeholder
+    // left behind counts as unknown, which reads UNHEALTHY, so it would keep the broker unhealthy
+    // for the rest of its life.
+    tenantPartitions.forEach(
+        partitionId -> healthMonitor.removeComponent(ZeebePartition.componentName(partitionId)));
   }
 
   public boolean isBrokerReady() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitModeChangeApplier;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
@@ -88,6 +90,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
   private MemberId localMemberId;
   private TopologyManagerImpl topologyManager;
   private PartitionModeHandler handler;
+  private BrokerHealthCheckService healthCheckService;
 
   @BeforeEach
   void setUp() {
@@ -144,6 +147,12 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
     when(clusterServices.getMembershipService()).thenReturn(membershipService);
     when(brokerStartupContext.getClusterServices()).thenReturn(clusterServices);
 
+    healthCheckService =
+        new BrokerHealthCheckService(
+            MemberId.from("0"), new HealthTreeMetrics(new SimpleMeterRegistry()), Set.of(GROUP));
+    actorScheduler.submitActor(healthCheckService).join();
+    healthCheckService.setBrokerStarted();
+
     // recovery manager: real, driven by the real actor scheduler, with partition 2's recovery
     // steps rigged to fail so only partition 1 actually recovers
     final var recoveryManager =
@@ -159,7 +168,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
             transport,
             (ignored) -> 0L,
             topologyManager,
-            "Broker-0");
+            healthCheckService);
 
     // exit manager: a lightweight fake standing in for a real Raft-based PartitionManagerImpl -
     // it just marks both local partitions LEADER on start, matching what PartitionModeHandlerTest
@@ -177,6 +186,9 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
 
   @AfterEach
   void tearDown() {
+    if (healthCheckService != null) {
+      healthCheckService.closeAsync().join();
+    }
     if (controlActor != null) {
       controlActor.closeAsync().join();
     }
@@ -229,6 +241,16 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
                       });
             });
 
+    // and - the broker reports ready to the probes while recovering, so Kubernetes keeps the pod
+    // alive for the whole restore, but not healthy, since partition 2's recovery failure must
+    // surface through the health status
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(healthCheckService.isBrokerReady()).isTrue();
+              assertThat(healthCheckService.isBrokerHealthy()).isFalse();
+            });
+
     // and - confirming and writing recovery state excludes the dead partition but still completes
     final var recoveringConfirmed = handler.awaitModeApplied(Mode.RECOVERING);
     assertThat(recoveringConfirmed).succeedsWithin(AWAIT_TIMEOUT);
@@ -249,6 +271,11 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
     // brand-new partition manager
     final var exitResult = handler.exitRecovery();
     assertThat(exitResult).succeedsWithin(AWAIT_TIMEOUT);
+
+    // and - stopping the recovery manager unregistered the tenant, so readiness is now gated on
+    // the next manager genuinely installing its partitions (the fake exit manager never registers
+    // bootstrap partitions, so the broker must not claim readiness from recovery leftovers)
+    await().untilAsserted(() -> assertThat(healthCheckService.isBrokerReady()).isFalse());
 
     // and - the new manager brings both partitions to a processing role, including the one that
     // was DEAD during recovery

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
@@ -63,8 +63,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Proves the full round trip through recovery mode with a partial failure: one partition fails to
- * recover (reported {@code DEAD}) while its sibling recovers cleanly, the group still confirms and
- * writes {@code RECOVERING} only for the healthy partition, and - crucially - exiting recovery
+ * recover (reported {@code UNHEALTHY}) while its sibling recovers cleanly, the group still confirms
+ * and writes {@code RECOVERING} only for the healthy partition, and - crucially - exiting recovery
  * afterward is not blocked or corrupted by that earlier partial failure. The exit path
  * (`PartitionModeHandler#exitRecovery`/`awaitModeApplied(PROCESSING)`) gates purely on Raft role,
  * not health, and starts a brand-new partition manager from scratch, so the group must converge
@@ -224,7 +224,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
     assertThat(enterResult).succeedsWithin(AWAIT_TIMEOUT);
 
     // and - partition 1 recovers healthily, partition 2 reaches INACTIVE but never recovers so
-    // it is reported DEAD
+    // it is reported UNHEALTHY
     await()
         .untilAsserted(
             () -> {
@@ -237,7 +237,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
                             .containsEntry(PARTITION_ID_2, PartitionRole.INACTIVE);
                         assertThat(info.getPartitionHealthStatuses())
                             .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
-                            .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD);
+                            .containsEntry(PARTITION_ID_2, PartitionHealthStatus.UNHEALTHY);
                       });
             });
 
@@ -278,7 +278,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
     await().untilAsserted(() -> assertThat(healthCheckService.isBrokerReady()).isFalse());
 
     // and - the new manager brings both partitions to a processing role, including the one that
-    // was DEAD during recovery
+    // was UNHEALTHY during recovery
     await()
         .untilAsserted(
             () -> {
@@ -291,7 +291,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
                               .containsEntry(PARTITION_ID_2, PartitionRole.LEADER));
             });
 
-    // and - confirming exit is role-only: partition 2's earlier DEAD health status must not matter
+    // and - confirming exit is role-only: partition 2's earlier unhealthy status must not matter
     final var processingConfirmed = handler.awaitModeApplied(Mode.PROCESSING);
     assertThat(processingConfirmed).succeedsWithin(AWAIT_TIMEOUT);
     assertThat(processingConfirmed.join()).containsExactlyInAnyOrder(PARTITION_ID, PARTITION_ID_2);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -25,6 +25,8 @@ import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
@@ -71,6 +73,7 @@ final class RecoveryPartitionManagerTest {
   private BrokerInfo brokerInfo;
   private AtomixServerTransport transport;
   private SimpleMeterRegistry meterRegistry;
+  private BrokerHealthCheckService healthCheckService;
 
   @BeforeEach
   void setUp() {
@@ -107,6 +110,15 @@ final class RecoveryPartitionManagerTest {
     when(transport.unsubscribe(any(), any())).thenReturn(CompletableActorFuture.completed(null));
 
     meterRegistry = new SimpleMeterRegistry();
+
+    // real health check service, named Broker-0 to match BROKER_COMPONENT_NAME, so the tests can
+    // observe the readiness and health the recovery manager reports to the broker probes
+    healthCheckService =
+        new BrokerHealthCheckService(
+            MemberId.from("0"), new HealthTreeMetrics(new SimpleMeterRegistry()), Set.of(GROUP));
+    actorScheduler.submitActor(healthCheckService).join();
+    healthCheckService.setBrokerStarted();
+
     partitionManager = buildManager(new BrokerCfg(), actorScheduler);
   }
 
@@ -124,7 +136,7 @@ final class RecoveryPartitionManagerTest {
         transport,
         null,
         topologyManager,
-        BROKER_COMPONENT_NAME);
+        healthCheckService);
   }
 
   private PartitionMetadata localPartitionMetadata(final int partitionId) {
@@ -140,6 +152,9 @@ final class RecoveryPartitionManagerTest {
   void tearDown() {
     if (partitionManager != null) {
       partitionManager.stop().join();
+    }
+    if (healthCheckService != null) {
+      healthCheckService.closeAsync().join();
     }
     if (controlActor != null) {
       controlActor.closeAsync().join();
@@ -339,6 +354,62 @@ final class RecoveryPartitionManagerTest {
         .tags("physicalTenant", GROUP, "partition", String.valueOf(partitionId))
         .gauge()
         .value();
+  }
+
+  @Test
+  void shouldReportBrokerReadyAndHealthyWhileRecovering() {
+    // when
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - a broker in recovery mode is ready and healthy by design: it must keep accepting
+    // management traffic (restore requests) and must not be restarted by the Kubernetes probes,
+    // even though its partitions never join Raft
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(healthCheckService.isBrokerReady()).isTrue();
+              assertThat(healthCheckService.isBrokerHealthy()).isTrue();
+            });
+  }
+
+  @Test
+  void shouldReportBrokerUnhealthyWhenAPartitionFailsToRecover() {
+    // given: partition 2's recovery steps fail to schedule, so only partition 1 recovers
+    partitionManager =
+        buildManager(
+            new BrokerCfg(), new FailingActorSchedulingService(actorScheduler, PARTITION_ID_2));
+
+    // when
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - the broker stays ready so the restore can be retried through the management API,
+    // but the dead partition must surface through the health status
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(healthCheckService.isBrokerReady()).isTrue();
+              assertThat(healthCheckService.isBrokerHealthy()).isFalse();
+            });
+  }
+
+  @Test
+  void shouldResetReadinessAndHealthOnStop() {
+    // given - the broker reports ready and healthy while recovering
+    assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
+    await().untilAsserted(() -> assertThat(healthCheckService.isBrokerReady()).isTrue());
+
+    // when
+    assertThat(partitionManager.stop()).succeedsWithin(Duration.ofSeconds(10));
+
+    // then - the tenant and its recovery health components are unregistered, so readiness and
+    // health are gated on the next partition manager (e.g. processing mode after exiting
+    // recovery) genuinely installing its partitions rather than on recovery leftovers
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(healthCheckService.isBrokerReady()).isFalse();
+              assertThat(healthCheckService.isBrokerHealthy()).isFalse();
+            });
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -115,7 +115,7 @@ final class RecoveryPartitionManagerTest {
     // observe the readiness and health the recovery manager reports to the broker probes
     healthCheckService =
         new BrokerHealthCheckService(
-            MemberId.from("0"), new HealthTreeMetrics(new SimpleMeterRegistry()), Set.of(GROUP));
+            MemberId.from("0"), new HealthTreeMetrics(meterRegistry), Set.of(GROUP));
     actorScheduler.submitActor(healthCheckService).join();
     healthCheckService.setBrokerStarted();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -330,8 +330,12 @@ final class RecoveryPartitionManagerTest {
         .isNull();
   }
 
+  private static String partitionComponentName(final int partitionId) {
+    return "Partition-%s-%d".formatted(GROUP, partitionId);
+  }
+
   private double healthTreeGaugeValue(final int partitionId) {
-    final var componentName = "Partition-%s-%d".formatted(GROUP, partitionId);
+    final var componentName = partitionComponentName(partitionId);
     return meterRegistry
         .get("zeebe.broker.health.nodes")
         .tags(
@@ -438,6 +442,39 @@ final class RecoveryPartitionManagerTest {
   }
 
   @Test
+  void shouldNotRegisterHealthComponentsAfterStop() {
+    // given - partition 2's recovery is held up, so the callback that reports the recovery
+    // outcome is still outstanding
+    final var gate = new CompletableActorFuture<Void>();
+    partitionManager =
+        buildManager(
+            new BrokerCfg(), new GatedActorSchedulingService(actorScheduler, gate, PARTITION_ID_2));
+    final var startResult = partitionManager.start();
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(healthCheckService.getHealthReport().children())
+                    .containsOnlyKeys(
+                        partitionComponentName(PARTITION_ID),
+                        partitionComponentName(PARTITION_ID_2)));
+
+    // when - the mode transition stops this manager, and only then does partition 2's recovery
+    // fail. stop() does not wait for start(): a transition completes as soon as the next
+    // manager's start is initiated, so both run on the same actor with no ordering between them
+    assertThat(partitionManager.stop()).succeedsWithin(Duration.ofSeconds(10));
+    gate.completeExceptionally(new RuntimeException("Injected failure for partition 2"));
+    assertThat(startResult).failsWithin(Duration.ofSeconds(10));
+
+    // then - the outcome this manager reports afterwards never reaches the health tree. Such a
+    // component would take the slot the next manager's ZeebePartition needs and sit there frozen,
+    // so the broker would report a dead recovery's health for as long as it runs
+    await()
+        .during(Duration.ofSeconds(1))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(healthCheckService.getHealthReport().children()).isEmpty());
+  }
+
+  @Test
   void shouldResetReadinessAndHealthOnStop() {
     // given - the broker reports ready and healthy while recovering
     assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
@@ -497,6 +534,39 @@ final class RecoveryPartitionManagerTest {
                               .containsEntry(PARTITION_ID, PartitionHealthStatus.UNHEALTHY)
                               .containsEntry(PARTITION_ID_2, PartitionHealthStatus.UNHEALTHY));
             });
+  }
+
+  /**
+   * Hands out {@code gate} as the submitted actor's future, so the gated partition's recovery only
+   * settles once the test completes it.
+   */
+  private static final class GatedActorSchedulingService implements ActorSchedulingService {
+    private final ActorSchedulingService delegate;
+    private final ActorFuture<Void> gate;
+    private final Set<Integer> gatedPartitionIds;
+
+    private GatedActorSchedulingService(
+        final ActorSchedulingService delegate,
+        final ActorFuture<Void> gate,
+        final Integer... gatedPartitionIds) {
+      this.delegate = delegate;
+      this.gate = gate;
+      this.gatedPartitionIds = Set.of(gatedPartitionIds);
+    }
+
+    @Override
+    public ActorFuture<Void> submitActor(final Actor actor) {
+      return shouldGate(actor) ? gate : delegate.submitActor(actor);
+    }
+
+    @Override
+    public ActorFuture<Void> submitActor(final Actor actor, final SchedulingHints schedulingHints) {
+      return shouldGate(actor) ? gate : delegate.submitActor(actor, schedulingHints);
+    }
+
+    private boolean shouldGate(final Actor actor) {
+      return gatedPartitionIds.stream().anyMatch(id -> actor.getName().endsWith("-" + id));
+    }
   }
 
   /**

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -232,9 +232,8 @@ final class RecoveryPartitionManagerTest {
                               .containsEntry(PARTITION_ID_2, PartitionRole.INACTIVE));
             });
 
-    // and: only the partition that failed to start is reported as DEAD, since it never
-    // recovered and nothing is left running to ever bring it back; the one that succeeded is
-    // reported HEALTHY
+    // and: only the partition that failed to start is reported as UNHEALTHY, since it never
+    // recovered and needs the restore to be retried; the one that succeeded is reported HEALTHY
     await()
         .untilAsserted(
             () -> {
@@ -244,7 +243,7 @@ final class RecoveryPartitionManagerTest {
                       info ->
                           assertThat(info.getPartitionHealthStatuses())
                               .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
-                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD));
+                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.UNHEALTHY));
             });
   }
 
@@ -383,7 +382,7 @@ final class RecoveryPartitionManagerTest {
     assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
 
     // then - the broker stays ready so the restore can be retried through the management API,
-    // but the dead partition must surface through the health status
+    // but the failed partition must surface through the health status
     await()
         .untilAsserted(
             () -> {
@@ -438,9 +437,9 @@ final class RecoveryPartitionManagerTest {
                               .containsEntry(PARTITION_ID_2, PartitionRole.INACTIVE));
             });
 
-    // and: both partitions are reported as DEAD, since neither recovered and nothing is left
-    // running to ever bring them back - this is the signal that the mode-change bookkeeping
-    // (which only checks the INACTIVE role above) otherwise misses
+    // and: both partitions are reported as UNHEALTHY, since neither recovered - this is the
+    // signal that the mode-change bookkeeping (which only checks the INACTIVE role above)
+    // otherwise misses
     await()
         .untilAsserted(
             () -> {
@@ -449,8 +448,8 @@ final class RecoveryPartitionManagerTest {
                   .anySatisfy(
                       info ->
                           assertThat(info.getPartitionHealthStatuses())
-                              .containsEntry(PARTITION_ID, PartitionHealthStatus.DEAD)
-                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD));
+                              .containsEntry(PARTITION_ID, PartitionHealthStatus.UNHEALTHY)
+                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.UNHEALTHY));
             });
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -392,6 +392,52 @@ final class RecoveryPartitionManagerTest {
   }
 
   @Test
+  void shouldReportBrokerHealthyWhilePartitionsAreStillRecovering() {
+    // given - partition 2 never finishes starting, so the start future stays pending and the
+    // callback that reports the recovery outcome never runs
+    partitionManager =
+        buildManager(
+            new BrokerCfg(), new HangingActorSchedulingService(actorScheduler, PARTITION_ID_2));
+
+    // when
+    final var startResult = partitionManager.start();
+
+    // then - the broker is ready and healthy for the whole of the recovery, not only once it
+    // settles: the health monitor derives the broker's status from the components it holds, so a
+    // partition with no component at all would report the broker unhealthy exactly while it is
+    // recovering
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(healthCheckService.isBrokerReady()).isTrue();
+              assertThat(healthCheckService.isBrokerHealthy()).isTrue();
+            });
+    // and - the recovery really is still in flight, so the assertions above cover the window
+    // between entering recovery mode and the partitions having recovered
+    assertThat(startResult.isDone()).isFalse();
+  }
+
+  @Test
+  void shouldReportBrokerUnhealthyWhenTheBackupStoreCannotBeCreated() {
+    // given - a filesystem backup store with no base path configured cannot be created
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().getBackup().setStore(BackupStoreType.FILESYSTEM);
+    partitionManager = buildManager(brokerCfg, actorScheduler);
+
+    // when
+    assertThat(partitionManager.start()).failsWithin(Duration.ofSeconds(10));
+
+    // then - the broker stays ready so the configuration can be fixed and the restore retried,
+    // but without a backup store no partition can recover, so it must not claim to be healthy
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(healthCheckService.isBrokerReady()).isTrue();
+              assertThat(healthCheckService.isBrokerHealthy()).isFalse();
+            });
+  }
+
+  @Test
   void shouldResetReadinessAndHealthOnStop() {
     // given - the broker reports ready and healthy while recovering
     assertThat(partitionManager.start()).succeedsWithin(Duration.ofSeconds(10));
@@ -451,6 +497,36 @@ final class RecoveryPartitionManagerTest {
                               .containsEntry(PARTITION_ID, PartitionHealthStatus.UNHEALTHY)
                               .containsEntry(PARTITION_ID_2, PartitionHealthStatus.UNHEALTHY));
             });
+  }
+
+  /**
+   * Leaves the submitted actor's future pending forever, so the partition never finishes starting.
+   */
+  private static final class HangingActorSchedulingService implements ActorSchedulingService {
+    private final ActorSchedulingService delegate;
+    private final Set<Integer> hangingPartitionIds;
+
+    private HangingActorSchedulingService(
+        final ActorSchedulingService delegate, final Integer... hangingPartitionIds) {
+      this.delegate = delegate;
+      this.hangingPartitionIds = Set.of(hangingPartitionIds);
+    }
+
+    @Override
+    public ActorFuture<Void> submitActor(final Actor actor) {
+      return shouldHang(actor) ? new CompletableActorFuture<>() : delegate.submitActor(actor);
+    }
+
+    @Override
+    public ActorFuture<Void> submitActor(final Actor actor, final SchedulingHints schedulingHints) {
+      return shouldHang(actor)
+          ? new CompletableActorFuture<>()
+          : delegate.submitActor(actor, schedulingHints);
+    }
+
+    private boolean shouldHang(final Actor actor) {
+      return hangingPartitionIds.stream().anyMatch(id -> actor.getName().endsWith("-" + id));
+    }
   }
 
   private static final class FailingActorSchedulingService implements ActorSchedulingService {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -247,6 +247,28 @@ public class BrokerHealthCheckServiceTest {
   }
 
   @Test
+  public void shouldBeReadyWhenRecoveringTenantOverridesAStillInstallingBootstrapPartition() {
+    // given a tenant that was still installing a bootstrap partition (e.g. processing mode was
+    // stopped for a mode transition before the partition joined Raft, and its manager never
+    // unregisters its own tenant on stop)
+    final var healthCheckService = newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID);
+    healthCheckService.registerBootstrapPartitions(
+        DEFAULT_PHYSICAL_TENANT_ID, List.of(partition(DEFAULT_PHYSICAL_TENANT_ID, 1)));
+    scheduler.workUntilDone();
+
+    // when the tenant enters recovery mode with no local partitions to recover this time (e.g.
+    // partition distribution changed), leaving the earlier still-installing partition unaccounted
+    // for in the new registration
+    healthCheckService.registerRecoveringPartitions(DEFAULT_PHYSICAL_TENANT_ID, List.of());
+    scheduler.workUntilDone();
+
+    // then the broker is ready: the stale still-installing entry must not survive the mode
+    // transition and block readiness, contradicting recovery's "ready even with nothing to
+    // recover" contract
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  @Test
   public void shouldBeReadyWhenRecoveringTenantHasNoLocalPartitions() {
     // given a broker whose only physical tenant recovers with no partitions on this node
     final var healthCheckService = newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -230,6 +230,93 @@ public class BrokerHealthCheckServiceTest {
     }
   }
 
+  @Test
+  public void shouldBeReadyWhenRecoveringPartitionsAreRegistered() {
+    // given a broker whose only physical tenant starts in recovery mode. Recovery partitions never
+    // join Raft, so readiness cannot come from onBecameRaftLeader/Follower; registering them as
+    // recovering is the only installation signal.
+    final var healthCheckService = newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when the recovery partition manager registers its local partitions
+    healthCheckService.registerRecoveringPartitions(
+        DEFAULT_PHYSICAL_TENANT_ID, List.of(new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 1)));
+    scheduler.workUntilDone();
+
+    // then the broker is ready without any Raft role events
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  @Test
+  public void shouldBeReadyWhenRecoveringTenantHasNoLocalPartitions() {
+    // given a broker whose only physical tenant recovers with no partitions on this node
+    final var healthCheckService = newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when the recovery partition manager registers an empty partition set
+    healthCheckService.registerRecoveringPartitions(DEFAULT_PHYSICAL_TENANT_ID, List.of());
+    scheduler.workUntilDone();
+
+    // then the broker is ready: the tenant started and simply had nothing to recover
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  @Test
+  public void shouldNotBeReadyUntilRecoveringTenantRegisters() {
+    // given a broker with two physical tenants: the default tenant runs in processing mode and
+    // fully installs its partition, while the second tenant is in recovery mode
+    final var healthCheckService =
+        newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID, SECOND_PHYSICAL_TENANT);
+    healthCheckService.registerBootstrapPartitions(
+        DEFAULT_PHYSICAL_TENANT_ID, List.of(partition(DEFAULT_PHYSICAL_TENANT_ID, 1)));
+    healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker is not ready while the recovering tenant is unaccounted for
+    assertThat(healthCheckService.isBrokerReady()).isFalse();
+
+    // when the recovering tenant registers its partitions
+    healthCheckService.registerRecoveringPartitions(
+        SECOND_PHYSICAL_TENANT, List.of(new PartitionId(SECOND_PHYSICAL_TENANT, 1)));
+    scheduler.workUntilDone();
+
+    // then the broker is ready: processing and recovering tenants both accounted for
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  @Test
+  public void shouldRequireReinstallationAfterPhysicalTenantIsUnregistered() {
+    // given a broker whose only tenant was ready in recovery mode and then exits recovery: the
+    // recovery manager unregisters the tenant on stop, so the stale "installed" marks from
+    // recovery must not carry over into processing mode
+    final var healthCheckService = newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID);
+    healthCheckService.registerRecoveringPartitions(
+        DEFAULT_PHYSICAL_TENANT_ID, List.of(new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 1)));
+    scheduler.workUntilDone();
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+
+    // when the recovery manager stops and unregisters the tenant
+    healthCheckService.unregisterPhysicalTenant(DEFAULT_PHYSICAL_TENANT_ID);
+    scheduler.workUntilDone();
+
+    // then the broker is no longer ready
+    assertThat(healthCheckService.isBrokerReady()).isFalse();
+
+    // when the processing partition manager re-registers the same partition as a bootstrap
+    // partition
+    healthCheckService.registerBootstrapPartitions(
+        DEFAULT_PHYSICAL_TENANT_ID, List.of(partition(DEFAULT_PHYSICAL_TENANT_ID, 1)));
+    scheduler.workUntilDone();
+
+    // then readiness waits for the partition to actually rejoin Raft
+    assertThat(healthCheckService.isBrokerReady()).isFalse();
+
+    // when the partition rejoins Raft
+    healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker is ready again
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
   private BrokerHealthCheckService newHealthCheckService(final String... expectedPhysicalTenants) {
     return new BrokerHealthCheckService(
         member, new HealthTreeMetrics(new SimpleMeterRegistry()), Set.of(expectedPhysicalTenants));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -14,8 +14,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.test.util.logging.RecordingAppender;
+import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.health.HealthStatus;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
@@ -231,6 +236,35 @@ public class BrokerHealthCheckServiceTest {
   }
 
   @Test
+  public void shouldRemovePartitionsFromTheHealthTreeWhenTheTenantUnregisters() {
+    // given a tenant with two bootstrap partitions, one of which registers a real health
+    // component while the other is left as the monitorComponent placeholder - counted as unknown,
+    // which reads unhealthy, and so drags the whole tree down
+    final var healthCheckService = newStartedHealthCheckService(DEFAULT_PHYSICAL_TENANT_ID);
+    final var registered = new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 1);
+    final var placeholder = new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 2);
+    healthCheckService.registerBootstrapPartitions(
+        DEFAULT_PHYSICAL_TENANT_ID,
+        List.of(
+            partition(DEFAULT_PHYSICAL_TENANT_ID, 1), partition(DEFAULT_PHYSICAL_TENANT_ID, 2)));
+    healthCheckService.registerMonitoredPartition(
+        registered.number(), healthyComponent(ZeebePartition.componentName(registered)));
+    scheduler.workUntilDone();
+    assertThat(healthCheckService.getHealthReport().children())
+        .containsOnlyKeys(
+            ZeebePartition.componentName(registered), ZeebePartition.componentName(placeholder));
+    assertThat(healthCheckService.getHealthReport().getStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+
+    // when the tenant's partition manager stops as part of a mode transition
+    healthCheckService.unregisterPhysicalTenant(DEFAULT_PHYSICAL_TENANT_ID);
+    scheduler.workUntilDone();
+
+    // then both nodes go with it. The placeholder is the one entry nothing else ever removes, so
+    // without this it would keep the broker unhealthy for the rest of its life
+    assertThat(healthCheckService.getHealthReport().children()).isEmpty();
+  }
+
+  @Test
   public void shouldBeReadyWhenRecoveringPartitionsAreRegistered() {
     // given a broker whose only physical tenant starts in recovery mode. Recovery partitions never
     // join Raft, so readiness cannot come from onBecameRaftLeader/Follower; registering them as
@@ -351,6 +385,26 @@ public class BrokerHealthCheckServiceTest {
     healthCheckService.setBrokerStarted();
     scheduler.workUntilDone();
     return healthCheckService;
+  }
+
+  private static HealthMonitorable healthyComponent(final String componentName) {
+    return new HealthMonitorable() {
+      @Override
+      public String componentName() {
+        return componentName;
+      }
+
+      @Override
+      public HealthReport getHealthReport() {
+        return HealthReport.healthy(this);
+      }
+
+      @Override
+      public void addFailureListener(final FailureListener failureListener) {}
+
+      @Override
+      public void removeFailureListener(final FailureListener failureListener) {}
+    };
   }
 
   private static PartitionMetadata partition(final String partitionGroup, final int partitionId) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -97,19 +97,32 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
 
   @Override
   public void removeComponent(final HealthMonitorable component) {
-    actor.run(
-        () -> {
-          final var componentName = component.componentName();
-          final var monitoredComponent = monitoredComponents.remove(componentName);
-          if (monitoredComponent != null) {
-            componentHealth.remove(componentName);
-            monitoredComponent.component.removeFailureListener(monitoredComponent);
-            graphListener.unregisterRelationship(componentName, name);
-            graphListener.unregisterNode(monitoredComponent.component);
-            log.trace("Unregistered edge {}:{}", name, componentName);
-            calculateHealth();
-          }
-        });
+    actor.run(() -> removeComponentByName(component.componentName()));
+  }
+
+  @Override
+  public void removeComponent(final String componentName) {
+    actor.run(() -> removeComponentByName(componentName));
+  }
+
+  /**
+   * Removes whatever is held under {@code componentName}. A component added by {@link
+   * #monitorComponent(String)} has only a health entry and no graph node or failure listener to
+   * undo, so both kinds are removed here and the graph teardown is conditional on there being a
+   * registered component.
+   */
+  private void removeComponentByName(final String componentName) {
+    final var monitoredComponent = monitoredComponents.remove(componentName);
+    final var hadHealthEntry = componentHealth.remove(componentName) != null;
+    if (monitoredComponent != null) {
+      monitoredComponent.component.removeFailureListener(monitoredComponent);
+      graphListener.unregisterRelationship(componentName, name);
+      graphListener.unregisterNode(monitoredComponent.component);
+      log.trace("Unregistered edge {}:{}", name, componentName);
+    }
+    if (monitoredComponent != null || hadHealthEntry) {
+      calculateHealth();
+    }
   }
 
   @Override

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -179,6 +179,27 @@ public class CriticalComponentsHealthMonitorTest {
   }
 
   @Test
+  public void shouldRemoveComponentMonitoredByNameOnly() {
+    // given - a monitored name that nothing ever registers under, next to a healthy component:
+    // the placeholder counts as unknown and so drags the whole monitor down
+    final ControllableComponent component = new ControllableComponent("registered");
+    monitor.monitorComponent("placeholder");
+    monitor.registerComponent(component);
+    waitUntilAllDone();
+    assertThat(monitor.getHealthReport().children()).containsOnlyKeys("placeholder", "registered");
+    assertThat(monitor.getHealthReport().getStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+
+    // when
+    monitor.removeComponent("placeholder");
+    waitUntilAllDone();
+
+    // then - removing by name is the only way to undo monitorComponent; without it nothing could
+    // ever clear the placeholder and the monitor would stay unhealthy for good
+    assertThat(monitor.getHealthReport().children()).containsOnlyKeys("registered");
+    assertThat(monitor.getHealthReport().getStatus()).isEqualTo(HealthStatus.HEALTHY);
+  }
+
+  @Test
   public void shouldMonitorComponentDeath() {
     // given
     final ControllableComponent component1 = new ControllableComponent("comp1");

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
@@ -47,4 +47,14 @@ public interface HealthMonitor extends HealthMonitorable {
    * @param component to be removed
    */
   void removeComponent(final HealthMonitorable component);
+
+  /**
+   * Stop monitoring the component with this name, whether it was added by {@link
+   * #monitorComponent(String)} or {@link #registerComponent(HealthMonitorable)}. This is the only
+   * way to undo a {@link #monitorComponent(String)} call, whose placeholder counts as not healthy
+   * and so keeps the monitor unhealthy until something removes it.
+   *
+   * @param componentName name of the component to be removed
+   */
+  void removeComponent(final String componentName);
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

A broker in recovery mode reports ready and healthy — that is the intended semantics, since a recovering broker must keep accepting management traffic (restore requests) and must not be restarted by Kubernetes probes. Previously the recovery mode was invisible to BrokerHealthCheckService, which broke each transition path differently:

- Cold start into recovery: the recovery manager never registered its tenant/partitions, so the broker was never ready — and since the liveness group includes brokerReady, Kubernetes restart-looped the pod for the whole restore.
- Runtime enter recovery: readiness stayed up only through stale install marks, while the health status went blank-DOWN because the stopped partitions left the health monitor with no components.
- Exit recovery: stale install marks made the broker claim readiness before its partitions rejoined Raft.

This PR makes the recovery manager register with the health check service:

- `registerRecoveringPartitions` marks the tenant's partitions installed immediately on recovery start (recovery partitions never fire Raft callbacks, the normal install signal).
- A new RecoveringPartitionHealth component fills the partition's slot in the broker health tree: HEALTHY while recovering, DEAD with a message for a partition whose recovery failed — so a broken restore still surfaces via `/actuator/health/status` while the broker stays ready for a retry.
- `unregisterPhysicalTenant` on recovery-manager stop purges the tenant's install marks, so readiness after exiting recovery is gated on the partitions genuinely rejoining Raft.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56005 
