### PR TITLE
fix: clear stale job streams before re-registering with a broker

### DIFF
--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -56,8 +56,13 @@ final class ClientStreamManager<M extends BufferWriter> {
   void onServerJoined(final MemberId serverId, final String physicalTenantId) {
     final var servers =
         serversByPhysicalTenantId.computeIfAbsent(physicalTenantId, id -> new HashSet<>());
-    servers.add(serverId);
+    final var added = servers.add(serverId);
     metricsFactory.apply(physicalTenantId).serverCount(servers.size());
+
+    if (!added) {
+      return;
+    }
+    requestManager.onServerJoined(serverId, physicalTenantId);
 
     registry.list().stream()
         .filter(c -> physicalTenantId.equals(c.physicalTenantId()))

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -11,6 +11,7 @@ import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.cluster.messaging.MessagingException.ProtocolException;
 import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import java.time.Duration;
 import java.util.Collection;
@@ -70,6 +72,8 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   // maps the registration state,  for each known host, of each stream
   private final Map<MemberId, Map<UUID, ClientStreamRegistration<M>>> registrations =
       new HashMap<>();
+  private final Map<ServerKey, ServerCleanup> serverCleanups = new HashMap<>();
+
   private final StreamResponseDecoder responseDecoder = new StreamResponseDecoder();
 
   private final ClusterCommunicationService communicationService;
@@ -79,6 +83,14 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       final ClusterCommunicationService communicationService, final ConcurrencyControl executor) {
     this.communicationService = communicationService;
     this.executor = executor;
+  }
+
+  /**
+   * Removes any streams left over from a previous incarnation of this client. Registrations for
+   * this server are held back until that removal is acknowledged.
+   */
+  void onServerJoined(final MemberId serverId, final String physicalTenantId) {
+    ensureStaleStreamsRemoved(new ServerKey(serverId, physicalTenantId));
   }
 
   /**
@@ -162,6 +174,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
         .flatMap(m -> m.values().stream())
         .forEach(ClientStreamRegistration::transitionToClosed);
     registrations.clear();
+    serverCleanups.clear();
 
     serversByPhysicalTenantId.forEach(
         (physicalTenantId, servers) ->
@@ -200,12 +213,6 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       return;
     }
 
-    final var request =
-        new AddStreamRequest()
-            .streamId(registration.streamId())
-            .streamType(registration.logicalId().streamType())
-            .metadata(registration.logicalId().metadata());
-
     final var pendingRequest = registration.pendingRequest();
     if (pendingRequest != null) {
       // error - should not have a pending request if we're registering!
@@ -214,6 +221,20 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
               .formatted(registration.streamId(), registration.serverId()));
     }
 
+    if (!ensureStaleStreamsRemoved(
+        new ServerKey(registration.serverId(), registration.physicalTenantId()))) {
+      return;
+    }
+
+    sendAddRequestAndLegacy(registration);
+  }
+
+  private void sendAddRequestAndLegacy(final ClientStreamRegistration<M> registration) {
+    final var request =
+        new AddStreamRequest()
+            .streamId(registration.streamId())
+            .streamType(registration.logicalId().streamType())
+            .metadata(registration.logicalId().metadata());
     final var payload = BufferUtil.bufferAsArray(request);
     final var added = new CompletableFuture<Void>();
     sendAddRequest(registration, payload, added);
@@ -298,6 +319,12 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
    * serve untouched.
    */
   void onServerRemoved(final MemberId serverId, final String physicalTenantId) {
+    final var cleanup = serverCleanups.get(new ServerKey(serverId, physicalTenantId));
+    if (cleanup != null) {
+      cleanup.serverActive = false;
+      cleanup.cleaned = false;
+    }
+
     final var perHost = registrations.get(serverId);
     if (perHost == null) {
       return;
@@ -578,6 +605,101 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     }
   }
 
+  private boolean ensureStaleStreamsRemoved(final ServerKey server) {
+    final var cleanup = serverCleanups.computeIfAbsent(server, ignored -> new ServerCleanup());
+    cleanup.serverActive = true;
+    if (cleanup.cleaned) {
+      return true;
+    }
+
+    if (!cleanup.inFlight) {
+      removeStaleStreams(server, cleanup);
+    }
+
+    return false;
+  }
+
+  private void removeStaleStreams(final ServerKey server, final ServerCleanup cleanup) {
+    final var topic =
+        DEFAULT_PHYSICAL_TENANT_ID.equals(server.physicalTenantId())
+            ? StreamTopics.REMOVE_ALL.legacyTopic()
+            : StreamTopics.REMOVE_ALL.topic(server.physicalTenantId());
+
+    cleanup.inFlight = true;
+    communicationService
+        .send(
+            topic,
+            REMOVE_ALL_REQUEST,
+            Function.identity(),
+            Function.identity(),
+            server.serverId(),
+            REQUEST_TIMEOUT)
+        .whenCompleteAsync(
+            (ok, error) -> {
+              if (error == null) {
+                cleanup.inFlight = false;
+                cleanup.cleaned = true;
+                sendPendingRegistrations(server);
+              } else {
+                handleCleanupFailure(server, cleanup, error);
+              }
+            },
+            executor::run);
+  }
+
+  private void sendPendingRegistrations(final ServerKey server) {
+    final var perHost = registrations.get(server.serverId());
+    if (perHost == null) {
+      return;
+    }
+
+    perHost.values().stream()
+        .filter(registration -> server.physicalTenantId().equals(registration.physicalTenantId()))
+        .filter(registration -> registration.state() == State.ADDING)
+        .filter(
+            registration ->
+                registration.pendingRequest() == null
+                    && registration.legacyPendingRequest() == null)
+        .toList()
+        .forEach(this::sendAddRequestAndLegacy);
+  }
+
+  private void handleCleanupFailure(
+      final ServerKey server, final ServerCleanup cleanup, final Throwable error) {
+    final var failure = FuturesUtil.unwrapCompletionException(error);
+
+    if (failure instanceof NoRemoteHandler || failure instanceof NoSuchMemberException) {
+      cleanup.inFlight = false;
+      if (!cleanup.serverActive) {
+        return;
+      }
+
+      LOGGER.debug(
+          "Cannot yet clear streams from a previous incarnation on server {}"
+              + " and physical tenant {}; retrying in {}",
+          server.serverId(),
+          server.physicalTenantId(),
+          RETRY_DELAY,
+          failure);
+      executor.schedule(RETRY_DELAY, () -> retryCleanup(server));
+      return;
+    }
+
+    LOGGER.warn(
+        "Failed to clear streams from a previous incarnation on server {} and physical tenant {};"
+            + " new streams remain disconnected until this client is restarted",
+        server.serverId(),
+        server.physicalTenantId(),
+        failure);
+  }
+
+  private void retryCleanup(final ServerKey server) {
+    final var cleanup = serverCleanups.get(server);
+    if (cleanup != null && cleanup.serverActive && !cleanup.cleaned && !cleanup.inFlight) {
+      removeStaleStreams(server, cleanup);
+    }
+  }
+
   private void doRemoveAll(final MemberId brokerId, final String physicalTenantId) {
     communicationService.unicast(
         StreamTopics.REMOVE_ALL.topic(physicalTenantId),
@@ -599,5 +721,13 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       return;
     }
     communicationService.unicast(topic.legacyTopic(), payload, Function.identity(), serverId, true);
+  }
+
+  private record ServerKey(MemberId serverId, String physicalTenantId) {}
+
+  private static final class ServerCleanup {
+    private boolean serverActive;
+    private boolean cleaned;
+    private boolean inFlight;
   }
 }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
@@ -196,6 +198,21 @@ class ClientStreamManagerTest {
 
     // then
     assertThat(serverStream.isConnected(server)).isTrue();
+  }
+
+  @Test
+  void shouldCleanupStaleStreamsOnlyOnFirstJoin() {
+    // given
+    final MemberId server = MemberId.from("3");
+    clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(server), any());
   }
 
   @Test

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.MessagingException;
+import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.cluster.messaging.MessagingException.ProtocolException;
 import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
@@ -40,6 +41,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -153,6 +156,9 @@ final class ClientStreamRequestManagerTest {
     final var serverId = MemberId.anonymous();
     when(mockTransport.<byte[], byte[]>send(any(), any(), any(), any(), any(), any()))
         .thenReturn(pendingRequest);
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
     requestManager.add(clientStream, serverId);
 
     // when
@@ -809,6 +815,451 @@ final class ClientStreamRequestManagerTest {
 
     // then
     assertThat(clientStream.isConnected(serverId)).isTrue();
+  }
+
+  @Test
+  void shouldWaitForPreviousIncarnationCleanupBeforeAdding() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var cleanup = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(cleanup);
+
+    // when
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+
+    cleanup.complete(new byte[0]);
+
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldUseOnlyLegacyCleanupTopicForDefaultTenant() {
+    // given
+    final var serverId = MemberId.anonymous();
+
+    // when
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    verify(mockTransport)
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.REMOVE_ALL.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldUseTenantScopedCleanupTopicForNonDefaultTenant() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var physicalTenantId = "tenant-" + UUID.randomUUID();
+
+    // when
+    requestManager.onServerJoined(serverId, physicalTenantId);
+
+    // then
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.REMOVE_ALL.topic(physicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport, never())
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+  }
+
+  @Test
+  void shouldCleanupOnlyOnceWhileServerStaysJoined() {
+    // given
+    final var serverId = MemberId.anonymous();
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+  }
+
+  @Test
+  void shouldCleanupAgainWhenServerRejoins() {
+    // given
+    final var serverId = MemberId.anonymous();
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+  }
+
+  @Test
+  void shouldNotAddWhenPreviousIncarnationCleanupFails() {
+    // given
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("expected")));
+
+    // when
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldKeepBlockingAddsAfterCleanupFailed() {
+    // given
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("expected")));
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // when
+    final var otherStream =
+        new AggregatedClientStream<>(
+            UUID.randomUUID(),
+            new LogicalId<>(new UnsafeBuffer(BufferUtil.wrapString("bar")), new TestMetadata()),
+            DEFAULT_PHYSICAL_TENANT_ID);
+    otherStream.open(requestManager, Collections.emptySet());
+    requestManager.add(otherStream, serverId);
+
+    // then
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+  }
+
+  @Test
+  void shouldCleanupBeforeAddingWhenServerNeverJoined() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var cleanup = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(cleanup);
+
+    // when
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport)
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldRetryCleanupWhenServerHasNoHandlerYet() {
+    // given
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new CompletionException(
+                    new NoRemoteHandler(StreamTopics.REMOVE_ALL.legacyTopic()))))
+        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
+
+    // when
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldRetryCleanupWhenMemberIsNotKnownYet() {
+    // given
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.failedFuture(new NoSuchMemberException("not known yet")))
+        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
+
+    // when
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldNotRetryCleanupWhenItMayStillExecute() {
+    // given
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.failedFuture(new CompletionException(new TimeoutException())))
+        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
+
+    // when
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldNotBypassCleanupThatMayStillExecuteWhenServerRejoins() {
+    // given
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.failedFuture(new CompletionException(new TimeoutException())))
+        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldWaitForOutstandingCleanupOnRejoinInsteadOfIssuingAnother() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var cleanup = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(cleanup);
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // when
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+
+    // when
+    cleanup.complete(new byte[0]);
+
+    // then
+    verify(mockTransport, times(1))
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldNotRetryCleanupAfterServerLeft() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var cleanup = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(cleanup);
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // when
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    cleanup.completeExceptionally(new NoSuchMemberException("gone"));
+
+    // then
+    verify(mockTransport, times(1))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(concurrencyControl, never()).schedule(any(), any());
+  }
+
+  @Test
+  void shouldCleanupOnRejoinAfterRemovalProvablyNeverExecuted() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var cleanup = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(cleanup)
+        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    cleanup.completeExceptionally(new NoSuchMemberException("gone"));
+
+    // when
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // then
+    verify(mockTransport, times(2))
+        .send(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldNotAddStreamsOfRemovedServerWhenItsCleanupCompletes() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var cleanup = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(cleanup);
+    requestManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    requestManager.add(clientStream, serverId);
+
+    // when
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    cleanup.complete(new byte[0]);
+
+    // then
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+  }
+
+  @Test
+  void shouldNotBlockOtherPhysicalTenantWhenCleanupFails() {
+    // given
+    final var serverId = MemberId.anonymous();
+    final var otherTenantId = "tenant-" + UUID.randomUUID();
+    final var otherStream =
+        new AggregatedClientStream<>(
+            UUID.randomUUID(),
+            new LogicalId<>(new UnsafeBuffer(BufferUtil.wrapString("bar")), new TestMetadata()),
+            otherTenantId);
+    otherStream.open(requestManager, Collections.emptySet());
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(new CompletionException(new TimeoutException())));
+
+    // when
+    requestManager.add(clientStream, serverId);
+    requestManager.add(otherStream, serverId);
+
+    // then
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport)
+        .send(eq(StreamTopics.ADD.topic(otherTenantId)), any(), any(), any(), eq(serverId), any());
   }
 
   @Test

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -9,6 +9,10 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterMembershipEvent;
@@ -17,6 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -46,10 +51,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -63,6 +71,7 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
 
 /** Tests end-to-end stream management from client to server */
 final class StreamIntegrationTest {
@@ -426,6 +435,70 @@ final class StreamIntegrationTest {
     }
 
     @Test
+    void shouldAddStreamOnceServerStartsHandlingCleanup() {
+      // given
+      final var streamType = BufferUtil.wrapString("foo");
+      final var streamId =
+          clientStreamer
+              .add(
+                  streamType,
+                  new TestSerializableData(),
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+              .join();
+      awaitStreamAdded(streamType, streamId, server1, server2);
+      server1.close();
+      client.streamService.onServerRemoved(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+
+      // when
+      try (final var restartedServer =
+          new TestServer(createClusterNode(clusterNodes.getFirst(), clusterNodes))) {
+        restartedServer.startCluster();
+        client.streamService.onServerJoined(restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+        Awaitility.await().until(() -> client.cleanupAttempts(restartedServer.memberId()) >= 2);
+        restartedServer.startStreamService();
+
+        // then
+        awaitStreamAdded(streamType, streamId, restartedServer, server2);
+      }
+    }
+
+    @Test
+    void shouldRemoveStreamsOfPreviousIncarnationWhenRejoining() {
+      // given
+      final var staleStreamType = BufferUtil.wrapString("stale");
+      final var staleStreamId =
+          clientStreamer
+              .add(
+                  staleStreamType,
+                  new TestSerializableData(),
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+              .join();
+      awaitStreamAdded(staleStreamType, staleStreamId, server1, server2);
+      client.streamService.onServerRemoved(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+      clientStreamer.remove(staleStreamId).join();
+
+      final var streamType = BufferUtil.wrapString("current");
+      final var streamId =
+          clientStreamer
+              .add(
+                  streamType,
+                  new TestSerializableData(),
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+              .join();
+      awaitStreamAdded(streamType, streamId, server2);
+
+      // when
+      client.streamService.onServerJoined(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+
+      // then
+      awaitStreamAdded(streamType, streamId, server1, server2);
+      assertThat(server1.streamer.streamFor(staleStreamType)).isEmpty();
+    }
+
+    @Test
     void shouldAddStreamAgainOnLegacyRestartRequest() {
       // given
       final var streamType = BufferUtil.wrapString("foo");
@@ -500,8 +573,16 @@ final class StreamIntegrationTest {
     }
 
     private void start() {
+      startCluster();
+      startStreamService();
+    }
+
+    private void startCluster() {
       cluster.start().join();
       actorScheduler.submitActor(this).join();
+    }
+
+    private void startStreamService() {
       streamer = actor.call(() -> streamService.start(actorScheduler, this)).join().join();
     }
 
@@ -525,6 +606,7 @@ final class StreamIntegrationTest {
   private final class TestClient implements AutoCloseable {
     private final AtomixCluster cluster;
     private final ClientStreamService<TestSerializableData> streamService;
+    private final Map<MemberId, AtomicInteger> cleanupAttempts = new ConcurrentHashMap<>();
 
     public TestClient(final AtomixCluster cluster) {
       this.cluster = cluster;
@@ -532,7 +614,35 @@ final class StreamIntegrationTest {
       final var factory = new TransportFactory(actorScheduler);
       streamService =
           factory.createRemoteStreamClient(
-              cluster.getCommunicationService(), physicalTenantId -> ClientStreamMetrics.noop());
+              countingCleanupAttempts(cluster.getCommunicationService()),
+              physicalTenantId -> ClientStreamMetrics.noop());
+    }
+
+    private int cleanupAttempts(final MemberId serverId) {
+      return cleanupAttempts.getOrDefault(serverId, new AtomicInteger()).get();
+    }
+
+    private ClusterCommunicationService countingCleanupAttempts(
+        final ClusterCommunicationService delegate) {
+      final var answer = AdditionalAnswers.delegatesTo(delegate);
+      final var counting = mock(ClusterCommunicationService.class, answer);
+      doAnswer(
+              invocation -> {
+                cleanupAttempts
+                    .computeIfAbsent(invocation.getArgument(4), id -> new AtomicInteger())
+                    .incrementAndGet();
+                return answer.answer(invocation);
+              })
+          .when(counting)
+          .send(
+              eq(StreamTopics.REMOVE_ALL.legacyTopic()),
+              any(),
+              any(),
+              any(),
+              any(MemberId.class),
+              any());
+
+      return counting;
     }
 
     private void start() {


### PR DESCRIPTION
If a gateway restarts with the same member ID and faster than SWIM failure detection can process its removal, it can leave stale job streams registered with the broker. Mostly, this should be fairly low impact (job activations pushed to those streams will fail and yield back to retry), but it opens the window to more disruptive failures in scenarios where the yield can't be written back (e.g. during a change in partition leadership). In such cases, the job's failure to properly activate can go unresolved until the overall job activation timeout passes.

We now instruct the broker to remove all prior streams for this gateway before registering any new ones.

For the default physical tenant the removal deliberately uses only the legacy topic - during rolling upgrades we need to send it to the legacy topic, and we don't know if some brokers were already updated to 8.10 so we can't send it to both or we'd risk breaking the happens-before relationship between remove-existing and add-new.

Closes #28374.