### PR TITLE
refactor: type safe incident updates

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/DocumentUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/DocumentUpdate.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import java.util.Map;
+
+interface DocumentUpdate {
+  String id();
+
+  String index();
+
+  default String routing() {
+    return null;
+  }
+
+  Map<String, Object> doc();
+
+  abstract class Builder<T extends DocumentUpdate, B extends Builder<T, B>> {
+    protected final String id;
+    protected String index;
+
+    Builder(final String id) {
+      this.id = id;
+    }
+
+    @SuppressWarnings("unchecked")
+    public B index(final String index) {
+      this.index = index;
+      return (B) this;
+    }
+
+    public abstract T build();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -250,7 +250,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   }
 
   private CompletableFuture<List<String>> bulkUpdate(
-      final Stream<? extends DocumentUpdate> docUpdatesStream, final Refresh refresh) {
+      final Stream<? extends IncidentTaskUpdate> docUpdatesStream, final Refresh refresh) {
     final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());
@@ -324,7 +324,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     return QueryBuilders.bool(b -> b.must(piKeyQ, typeQ, stateQ));
   }
 
-  private BulkOperation createUpdateOperation(final DocumentUpdate update) {
+  private BulkOperation createUpdateOperation(final IncidentTaskUpdate update) {
     return new UpdateOperation.Builder<>()
         .index(update.index())
         .id(update.id())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -250,7 +250,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   }
 
   private CompletableFuture<List<String>> bulkUpdate(
-      final Stream<DocumentUpdate> docUpdatesStream, final Refresh refresh) {
+      final Stream<? extends DocumentUpdate> docUpdatesStream, final Refresh refresh) {
     final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/FlowNodeInstanceUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/FlowNodeInstanceUpdate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
+import java.util.Map;
+
+public record FlowNodeInstanceUpdate(String id, String index, boolean hasIncident)
+    implements DocumentUpdate {
+
+  @Override
+  public Map<String, Object> doc() {
+    return Map.of(FlowNodeInstanceTemplate.INCIDENT, hasIncident);
+  }
+
+  public static Builder id(final String id) {
+    return new Builder(id);
+  }
+
+  public static final class Builder
+      extends DocumentUpdate.Builder<FlowNodeInstanceUpdate, Builder> {
+    private boolean hasIncident;
+
+    private Builder(final String id) {
+      super(id);
+    }
+
+    public Builder hasIncident(final boolean hasIncident) {
+      this.hasIncident = hasIncident;
+      return this;
+    }
+
+    @Override
+    public FlowNodeInstanceUpdate build() {
+      return new FlowNodeInstanceUpdate(id, index, hasIncident);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/FlowNodeInstanceUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/FlowNodeInstanceUpdate.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.incident;
 
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import java.util.Map;
+import java.util.Objects;
 
 public record FlowNodeInstanceUpdate(String id, String index, boolean hasIncident)
     implements DocumentUpdate {
@@ -24,7 +25,7 @@ public record FlowNodeInstanceUpdate(String id, String index, boolean hasInciden
 
   public static final class Builder
       extends DocumentUpdate.Builder<FlowNodeInstanceUpdate, Builder> {
-    private boolean hasIncident;
+    private Boolean hasIncident;
 
     private Builder(final String id) {
       super(id);
@@ -37,7 +38,7 @@ public record FlowNodeInstanceUpdate(String id, String index, boolean hasInciden
 
     @Override
     public FlowNodeInstanceUpdate build() {
-      return new FlowNodeInstanceUpdate(id, index, hasIncident);
+      return new FlowNodeInstanceUpdate(id, index, Objects.requireNonNull(hasIncident));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/FlowNodeInstanceUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/FlowNodeInstanceUpdate.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public record FlowNodeInstanceUpdate(String id, String index, boolean hasIncident)
-    implements DocumentUpdate {
+    implements IncidentTaskUpdate {
 
   @Override
   public Map<String, Object> doc() {
@@ -24,7 +24,7 @@ public record FlowNodeInstanceUpdate(String id, String index, boolean hasInciden
   }
 
   public static final class Builder
-      extends DocumentUpdate.Builder<FlowNodeInstanceUpdate, Builder> {
+      extends IncidentTaskUpdate.Builder<FlowNodeInstanceUpdate, Builder> {
     private Boolean hasIncident;
 
     private Builder(final String id) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentTaskUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentTaskUpdate.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.tasks.incident;
 
 import java.util.Map;
 
-interface DocumentUpdate {
+interface IncidentTaskUpdate {
   String id();
 
   String index();
@@ -20,7 +20,7 @@ interface DocumentUpdate {
 
   Map<String, Object> doc();
 
-  abstract class Builder<T extends DocumentUpdate, B extends Builder<T, B>> {
+  abstract class Builder<T extends IncidentTaskUpdate, B extends Builder<T, B>> {
     protected final String id;
     protected String index;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentTaskUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentTaskUpdate.java
@@ -9,7 +9,8 @@ package io.camunda.exporter.tasks.incident;
 
 import java.util.Map;
 
-interface IncidentTaskUpdate {
+sealed interface IncidentTaskUpdate
+    permits IncidentUpdate, ListViewInstanceUpdate, FlowNodeInstanceUpdate {
   String id();
 
   String index();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdate.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public record IncidentUpdate(String id, String index, IncidentState state, String treePath)
-    implements DocumentUpdate {
+    implements IncidentTaskUpdate {
 
   @Override
   public Map<String, Object> doc() {
@@ -29,7 +29,7 @@ public record IncidentUpdate(String id, String index, IncidentState state, Strin
     return new Builder(id);
   }
 
-  public static final class Builder extends DocumentUpdate.Builder<IncidentUpdate, Builder> {
+  public static final class Builder extends IncidentTaskUpdate.Builder<IncidentUpdate, Builder> {
     private IncidentState state;
     private String treePath;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdate.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.entities.incident.IncidentState;
+import java.util.HashMap;
+import java.util.Map;
+
+public record IncidentUpdate(String id, String index, IncidentState state, String treePath)
+    implements DocumentUpdate {
+
+  @Override
+  public Map<String, Object> doc() {
+    final Map<String, Object> fields = new HashMap<>();
+    fields.put(IncidentTemplate.STATE, state);
+    if (treePath != null) {
+      fields.put(IncidentTemplate.TREE_PATH, treePath);
+    }
+    return fields;
+  }
+
+  public static Builder id(final String id) {
+    return new Builder(id);
+  }
+
+  public static final class Builder extends DocumentUpdate.Builder<IncidentUpdate, Builder> {
+    private IncidentState state;
+    private String treePath;
+
+    private Builder(final String id) {
+      super(id);
+    }
+
+    public Builder state(final IncidentState state) {
+      this.state = state;
+      return this;
+    }
+
+    public Builder treePath(final String treePath) {
+      this.treePath = treePath;
+      return this;
+    }
+
+    @Override
+    public IncidentUpdate build() {
+      return new IncidentUpdate(id, index, state, treePath);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -158,13 +158,13 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * the store specific implementation
    */
   record NonIncidentBulkUpdate(
-      Collection<DocumentUpdate> listViewRequests,
-      Collection<DocumentUpdate> flowNodeInstanceRequests) {
+      Collection<ListViewInstanceUpdate> listViewRequests,
+      Collection<FlowNodeInstanceUpdate> flowNodeInstanceRequests) {
     public NonIncidentBulkUpdate() {
       this(new ConcurrentLinkedQueue<>(), new ConcurrentLinkedQueue<>());
     }
 
-    public Stream<DocumentUpdate> stream() {
+    Stream<? extends DocumentUpdate> stream() {
       return Stream.concat(listViewRequests.stream(), flowNodeInstanceRequests.stream()).distinct();
     }
   }
@@ -174,22 +174,15 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * all the update queries into one, and pass it down to the store specific implementation to
    * execute.
    */
-  record IncidentBulkUpdate(Collection<DocumentUpdate> incidentRequests) {
+  record IncidentBulkUpdate(Collection<IncidentUpdate> incidentRequests) {
     public IncidentBulkUpdate() {
       this(new ConcurrentLinkedQueue<>());
     }
 
-    public Stream<DocumentUpdate> stream() {
+    Stream<IncidentUpdate> stream() {
       return incidentRequests.stream().distinct();
     }
   }
-
-  /**
-   * Represents a specific document store agnostic update to execute.
-   *
-   * <p>All fields are expected to be non-null, except routing.
-   */
-  record DocumentUpdate(String id, String index, Map<String, Object> doc, String routing) {}
 
   /**
    * A batch of pending incident updates fetched from the post importer queue. The {@code

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -163,7 +163,7 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       this(new ConcurrentLinkedQueue<>(), new ConcurrentLinkedQueue<>());
     }
 
-    Stream<? extends DocumentUpdate> stream() {
+    Stream<? extends IncidentTaskUpdate> stream() {
       return Stream.concat(listViewRequests.stream(), flowNodeInstanceRequests.stream()).distinct();
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -91,8 +91,8 @@ public interface IncidentUpdateRepository extends AutoCloseable {
   CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys);
 
   /**
-   * Executes the given bulk update against the underlying document store, waiting until the
-   * affected indices are refreshed. This ensures you will later read your own writes.
+   * Executes the given incident bulk update against the underlying document store, waiting until
+   * the affected indices are refreshed. This ensures you will later read your own writes.
    *
    * @param update the bulk update to execute
    * @return the ids of the documents updated
@@ -100,8 +100,7 @@ public interface IncidentUpdateRepository extends AutoCloseable {
   CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update);
 
   /**
-   * Executes the given bulk update against the underlying document store, waiting until the
-   * affected indices are refreshed. This ensures you will later read your own writes.
+   * Executes the given non-incident bulk update against the underlying document store.
    *
    * @param update the bulk update to execute
    * @return the ids of the documents updated

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -672,7 +672,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
             .map(IncidentDocument::incident)
             .collect(Collectors.groupingBy(IncidentEntity::getId));
     final var incidentUpdatesById =
-        incidentUpdates.stream().collect(Collectors.groupingBy(DocumentUpdate::id));
+        incidentUpdates.stream().collect(Collectors.groupingBy(IncidentTaskUpdate::id));
     final var incidentsToNotify =
         updatedIds.stream()
             .filter(incidentUpdatesById::containsKey)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -11,14 +11,10 @@ import com.google.common.collect.ImmutableList;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
-import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NonIncidentBulkUpdate;
 import io.camunda.webapps.operate.TreePath;
-import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
-import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
-import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentState;
 import io.camunda.zeebe.exporter.api.ExporterException;
@@ -28,11 +24,9 @@ import io.camunda.zeebe.util.concurrency.FuturesUtil;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -572,12 +566,21 @@ public final class IncidentUpdateTask implements BackgroundTask {
           index ->
               updates
                   .flowNodeInstanceRequests()
-                  .add(newFlowNodeInstanceUpdate(fniId, index, hasIncident)));
+                  .add(
+                      FlowNodeInstanceUpdate.id(fniId)
+                          .index(index)
+                          .hasIncident(hasIncident)
+                          .build()));
       listViewIndices.forEach(
           index ->
               updates
                   .listViewRequests()
-                  .add(newListViewInstanceUpdate(fniId, index, hasIncident, routing)));
+                  .add(
+                      ListViewInstanceUpdate.id(fniId)
+                          .index(index)
+                          .hasIncident(hasIncident)
+                          .routing(routing)
+                          .build()));
     }
   }
 
@@ -648,14 +651,21 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
     if (changedState) {
       for (final var index : indexes) {
-        updates.listViewRequests().add(newListViewInstanceUpdate(piId, index, hasIncident, piId));
+        updates
+            .listViewRequests()
+            .add(
+                ListViewInstanceUpdate.id(piId)
+                    .index(index)
+                    .hasIncident(hasIncident)
+                    .routing(piId)
+                    .build());
       }
     }
   }
 
   private CompletableFuture<Integer> notifyIncidents(
       final List<String> updatedIds,
-      final Collection<DocumentUpdate> incidentUpdates,
+      final Collection<IncidentUpdate> incidentUpdates,
       final Collection<IncidentDocument> incidentDocuments) {
     final var incidentsById =
         incidentDocuments.stream()
@@ -677,34 +687,21 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return incidentNotifier.notifyAsync(incidentsToNotify).thenApply(ignored -> updatedIds.size());
   }
 
-  private boolean shouldNotifyAboutUpdate(final DocumentUpdate update) {
-    if (update.doc().containsKey(IncidentTemplate.STATE)) {
-      final var stateUpdate = update.doc().get(IncidentTemplate.STATE);
+  private boolean shouldNotifyAboutUpdate(final IncidentUpdate update) {
+    final var stateUpdate = update.state();
+    if (stateUpdate != null) {
       return IncidentState.RESOLVED != stateUpdate && IncidentState.MIGRATED != stateUpdate;
     }
     return false;
   }
 
-  private DocumentUpdate newIncidentUpdate(
+  private IncidentUpdate newIncidentUpdate(
       final IncidentDocument incident, final IncidentState state, final String treePath) {
-    final Map<String, Object> fields = new HashMap<>();
-    fields.put(IncidentTemplate.STATE, state);
+    var builder = IncidentUpdate.id(incident.id()).index(incident.index()).state(state);
     if (IncidentState.ACTIVE == state) {
-      fields.put(IncidentTemplate.TREE_PATH, treePath);
+      builder = builder.treePath(treePath);
     }
-
-    return new DocumentUpdate(incident.id(), incident.index(), fields, null);
-  }
-
-  private DocumentUpdate newListViewInstanceUpdate(
-      final String id, final String index, final boolean hasIncident, final String routing) {
-    return new DocumentUpdate(id, index, Map.of(ListViewTemplate.INCIDENT, hasIncident), routing);
-  }
-
-  private DocumentUpdate newFlowNodeInstanceUpdate(
-      final String id, final String index, final boolean hasIncident) {
-    return new DocumentUpdate(
-        id, index, Map.of(FlowNodeInstanceTemplate.INCIDENT, hasIncident), null);
+    return builder.build();
   }
 
   private CompletableFuture<Void> mapActiveIncidentsToAffectedInstances(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ListViewInstanceUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ListViewInstanceUpdate.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.incident;
 
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import java.util.Map;
+import java.util.Objects;
 
 public record ListViewInstanceUpdate(String id, String index, String routing, boolean hasIncident)
     implements DocumentUpdate {
@@ -25,7 +26,7 @@ public record ListViewInstanceUpdate(String id, String index, String routing, bo
   public static final class Builder
       extends DocumentUpdate.Builder<ListViewInstanceUpdate, Builder> {
     private String routing;
-    private boolean hasIncident;
+    private Boolean hasIncident;
 
     private Builder(final String id) {
       super(id);
@@ -43,7 +44,7 @@ public record ListViewInstanceUpdate(String id, String index, String routing, bo
 
     @Override
     public ListViewInstanceUpdate build() {
-      return new ListViewInstanceUpdate(id, index, routing, hasIncident);
+      return new ListViewInstanceUpdate(id, index, routing, Objects.requireNonNull(hasIncident));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ListViewInstanceUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ListViewInstanceUpdate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import java.util.Map;
+
+public record ListViewInstanceUpdate(String id, String index, String routing, boolean hasIncident)
+    implements DocumentUpdate {
+
+  @Override
+  public Map<String, Object> doc() {
+    return Map.of(ListViewTemplate.INCIDENT, hasIncident);
+  }
+
+  public static Builder id(final String id) {
+    return new Builder(id);
+  }
+
+  public static final class Builder
+      extends DocumentUpdate.Builder<ListViewInstanceUpdate, Builder> {
+    private String routing;
+    private boolean hasIncident;
+
+    private Builder(final String id) {
+      super(id);
+    }
+
+    public Builder routing(final String routing) {
+      this.routing = routing;
+      return this;
+    }
+
+    public Builder hasIncident(final boolean hasIncident) {
+      this.hasIncident = hasIncident;
+      return this;
+    }
+
+    @Override
+    public ListViewInstanceUpdate build() {
+      return new ListViewInstanceUpdate(id, index, routing, hasIncident);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ListViewInstanceUpdate.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ListViewInstanceUpdate.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public record ListViewInstanceUpdate(String id, String index, String routing, boolean hasIncident)
-    implements DocumentUpdate {
+    implements IncidentTaskUpdate {
 
   @Override
   public Map<String, Object> doc() {
@@ -24,7 +24,7 @@ public record ListViewInstanceUpdate(String id, String index, String routing, bo
   }
 
   public static final class Builder
-      extends DocumentUpdate.Builder<ListViewInstanceUpdate, Builder> {
+      extends IncidentTaskUpdate.Builder<ListViewInstanceUpdate, Builder> {
     private String routing;
     private Boolean hasIncident;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -270,7 +270,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   private CompletableFuture<List<String>> bulkUpdate(
-      final Stream<DocumentUpdate> docUpdatesStream, final Refresh refresh) {
+      final Stream<? extends DocumentUpdate> docUpdatesStream, final Refresh refresh) {
     final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -270,7 +270,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   private CompletableFuture<List<String>> bulkUpdate(
-      final Stream<? extends DocumentUpdate> docUpdatesStream, final Refresh refresh) {
+      final Stream<? extends IncidentTaskUpdate> docUpdatesStream, final Refresh refresh) {
     final var updates = docUpdatesStream.map(this::createUpdateOperation).toList();
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());
@@ -369,7 +369,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     return QueryBuilders.bool().must(piKeyQ, typeQ, stateQ).build().toQuery();
   }
 
-  private BulkOperation createUpdateOperation(final DocumentUpdate update) {
+  private BulkOperation createUpdateOperation(final IncidentTaskUpdate update) {
     return new UpdateOperation.Builder<>()
         .index(update.index())
         .id(update.id())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletionStage;
 
 class ErrorInjectingIncidentUpdateRepository implements IncidentUpdateRepository {
   private IncidentUpdateRepository realUpdateRepository;
-  private boolean failFlowNodeBulkUpdates;
+  private volatile boolean failFlowNodeBulkUpdates;
 
   void setRealUpdateRepository(final IncidentUpdateRepository realUpdateRepository) {
     this.realUpdateRepository = realUpdateRepository;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -24,7 +24,6 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
-import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NonIncidentBulkUpdate;
@@ -719,7 +718,8 @@ abstract class IncidentUpdateRepositoryIT {
       final var bulk = new IncidentBulkUpdate();
 
       // when
-      bulk.incidentRequests().add(new DocumentUpdate("2", "doesn't-exist", Map.of(), "3"));
+      bulk.incidentRequests()
+          .add(IncidentUpdate.id("2").index("doesn't-exist").state(IncidentState.ACTIVE).build());
       final var result = repository.bulkUpdate(bulk);
 
       // then
@@ -752,18 +752,16 @@ abstract class IncidentUpdateRepositoryIT {
       // when
       bulk.incidentRequests()
           .add(
-              new DocumentUpdate(
-                  "1",
-                  incidentTemplate.getFullQualifiedName(),
-                  Map.of(IncidentTemplate.STATE, IncidentState.ACTIVE),
-                  "1"));
+              IncidentUpdate.id("1")
+                  .index(incidentTemplate.getFullQualifiedName())
+                  .state(IncidentState.ACTIVE)
+                  .build());
       bulk.incidentRequests()
           .add(
-              new DocumentUpdate(
-                  "2",
-                  incidentTemplate.getFullQualifiedName(),
-                  Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED),
-                  "1"));
+              IncidentUpdate.id("2")
+                  .index(incidentTemplate.getFullQualifiedName())
+                  .state(IncidentState.RESOLVED)
+                  .build());
       final var result = repository.bulkUpdate(bulk);
 
       // then
@@ -800,18 +798,18 @@ abstract class IncidentUpdateRepositoryIT {
       // when
       bulk.listViewRequests()
           .add(
-              new DocumentUpdate(
-                  "1",
-                  listViewTemplate.getFullQualifiedName(),
-                  Map.of(ListViewTemplate.INCIDENT, true),
-                  "1"));
+              ListViewInstanceUpdate.id("1")
+                  .index(listViewTemplate.getFullQualifiedName())
+                  .routing("1")
+                  .hasIncident(true)
+                  .build());
       bulk.listViewRequests()
           .add(
-              new DocumentUpdate(
-                  "2",
-                  listViewTemplate.getFullQualifiedName(),
-                  Map.of(ListViewTemplate.INCIDENT, false),
-                  "2"));
+              ListViewInstanceUpdate.id("2")
+                  .index(listViewTemplate.getFullQualifiedName())
+                  .routing("2")
+                  .hasIncident(false)
+                  .build());
       final var result = repository.bulkUpdate(bulk);
 
       // then
@@ -852,18 +850,16 @@ abstract class IncidentUpdateRepositoryIT {
       // when
       bulk.flowNodeInstanceRequests()
           .add(
-              new DocumentUpdate(
-                  "1",
-                  flowNodeInstanceTemplate.getFullQualifiedName(),
-                  Map.of(FlowNodeInstanceTemplate.INCIDENT, true),
-                  "1"));
+              FlowNodeInstanceUpdate.id("1")
+                  .index(flowNodeInstanceTemplate.getFullQualifiedName())
+                  .hasIncident(true)
+                  .build());
       bulk.flowNodeInstanceRequests()
           .add(
-              new DocumentUpdate(
-                  "2",
-                  flowNodeInstanceTemplate.getFullQualifiedName(),
-                  Map.of(FlowNodeInstanceTemplate.INCIDENT, false),
-                  "2"));
+              FlowNodeInstanceUpdate.id("2")
+                  .index(flowNodeInstanceTemplate.getFullQualifiedName())
+                  .hasIncident(false)
+                  .build());
       final var result = repository.bulkUpdate(bulk);
 
       // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -786,10 +786,88 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           final var updatedActiveIncident =
               getFromIndex(incidentTemplate, client, activeIncidentEntity);
           assertThat(updatedActiveIncident.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedActiveIncident.getTreePath()).isNotNull();
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyNoInteractions(incidentNotifier);
 
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(1);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
+        });
+  }
+
+  @TestTemplate
+  void shouldResolveIncidentButNotChangeTreePath(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resources) -> {
+          final var listViewTemplate = resources.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final var processInstanceKey = ID_GENERATOR.getAndIncrement();
+          final var treePath = String.format("PI_%d", processInstanceKey);
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity()
+                  .setId(String.valueOf(processInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(processInstanceKey)
+                  .setProcessDefinitionKey(9999L)
+                  .setBpmnProcessId("process-1")
+                  .setTreePath(treePath);
+          store(listViewTemplate, client, processInstance);
+
+          client.refresh(listViewTemplate.getFullQualifiedName());
+
+          final var incidentTemplate = resources.getIndexTemplateDescriptor(IncidentTemplate.class);
+
+          final var incidentKey = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity =
+              new IncidentEntity()
+                  .setId(String.valueOf(incidentKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(incidentKey)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setFlowNodeInstanceKey(processInstanceKey)
+                  .setTreePath(treePath);
+
+          store(incidentTemplate, client, incidentEntity);
+          client.refresh(incidentTemplate.getFullQualifiedName());
+
+          final var postImporterTemplate =
+              resources.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+
+          final PostImporterQueueEntity queueEntity =
+              new PostImporterQueueEntity()
+                  .setId("queue-1")
+                  .setPartitionId(PARTITION_ID)
+                  .setActionType(PostImporterActionType.INCIDENT)
+                  .setIntent("RESOLVED")
+                  .setKey(incidentKey)
+                  .setPosition(1L);
+
+          store(postImporterTemplate, client, queueEntity);
+          client.refresh(postImporterTemplate.getFullQualifiedName());
+
+          // when
+          final var updated = job.execute();
+
+          // then
+          assertThat(updated).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(1);
+
+          client.refresh(testPrefix);
+
+          final var updatedProcessInstance =
+              getFromIndex(listViewTemplate, client, processInstance);
+          assertThat(updatedProcessInstance.isIncident()).isFalse();
+
+          final var updatedIncident = getFromIndex(incidentTemplate, client, incidentEntity);
+          assertThat(updatedIncident.getState()).isEqualTo(IncidentState.RESOLVED);
+          assertThat(updatedIncident.getTreePath())
+              .isEqualTo(treePath); // tree path is not changed by RESOLVED update
+
+          assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
           verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(1);
           verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -215,14 +215,14 @@ final class IncidentUpdateTaskTest {
               inv -> {
                 final IncidentBulkUpdate update = inv.getArgument(0);
                 return CompletableFuture.completedFuture(
-                    update.stream().map(DocumentUpdate::id).toList());
+                    update.stream().map(IncidentTaskUpdate::id).toList());
               });
       when(repository.bulkUpdate(any(NonIncidentBulkUpdate.class)))
           .then(
               inv -> {
                 final NonIncidentBulkUpdate update = inv.getArgument(0);
                 return CompletableFuture.completedFuture(
-                    update.stream().map(DocumentUpdate::id).toList());
+                    update.stream().map(IncidentTaskUpdate::id).toList());
               });
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -25,7 +25,6 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
-import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NonIncidentBulkUpdate;
@@ -33,9 +32,6 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncide
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ProcessInstanceDocument;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.operate.TreePath;
-import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
-import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
-import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentState;
 import io.camunda.zeebe.exporter.api.ExporterException;
@@ -358,28 +354,18 @@ final class IncidentUpdateTaskTest {
       assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "5",
-                  "incidents",
-                  Map.of(
-                      IncidentTemplate.STATE,
-                      IncidentState.ACTIVE,
-                      IncidentTemplate.TREE_PATH,
-                      "PI_3/FNI_4"),
-                  null));
+              new IncidentUpdate("5", "incidents", IncidentState.ACTIVE, "PI_3/FNI_4"));
 
       final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
       // only the PI and flow node referenced by the sparse path are touched (no parent ancestry)
       assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"),
-              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
+              new ListViewInstanceUpdate("3", "list-view", "3", true),
+              new ListViewInstanceUpdate("4", "list-view", "3", true));
       assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests())
           .hasSize(1)
-          .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
+          .containsExactlyInAnyOrder(new FlowNodeInstanceUpdate("4", "flow-nodes", true));
       assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(highestPosition);
       verify(metrics).recordIncidentUpdatesProcessed(1);
       verify(metrics).recordIncidentUpdatesDocumentsUpdated(4);
@@ -420,15 +406,8 @@ final class IncidentUpdateTaskTest {
       assertThat(update.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "5",
-                  "incidents",
-                  Map.of(
-                      IncidentTemplate.STATE,
-                      IncidentState.ACTIVE,
-                      IncidentTemplate.TREE_PATH,
-                      "PI_3/FNI_4"),
-                  null));
+              new IncidentUpdate("5", "incidents", IncidentState.ACTIVE, "PI_3/FNI_4"));
+
       assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(highestPosition);
     }
 
@@ -520,15 +499,8 @@ final class IncidentUpdateTaskTest {
       assertThat(update.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "5",
-                  "incidents",
-                  Map.of(
-                      IncidentTemplate.STATE,
-                      IncidentState.ACTIVE,
-                      IncidentTemplate.TREE_PATH,
-                      "PI_1/FNI_2/PI_3/FNI_4"),
-                  null));
+              new IncidentUpdate("5", "incidents", IncidentState.ACTIVE, "PI_1/FNI_2/PI_3/FNI_4"));
+
       final var incident =
           new IncidentEntity()
               .setKey(5L)
@@ -570,10 +542,10 @@ final class IncidentUpdateTaskTest {
       assertThat(update.listViewRequests())
           .hasSize(4)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"),
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"),
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"),
-              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
+              new ListViewInstanceUpdate("1", "list-view", "1", true),
+              new ListViewInstanceUpdate("2", "list-view", "1", true),
+              new ListViewInstanceUpdate("3", "list-view", "3", true),
+              new ListViewInstanceUpdate("4", "list-view", "3", true));
       final var incident =
           new IncidentEntity()
               .setKey(5L)
@@ -615,10 +587,8 @@ final class IncidentUpdateTaskTest {
       assertThat(update.flowNodeInstanceRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null),
-              new DocumentUpdate(
-                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
+              new FlowNodeInstanceUpdate("2", "flow-nodes", true),
+              new FlowNodeInstanceUpdate("4", "flow-nodes", true));
       final var incident =
           new IncidentEntity()
               .setKey(5L)
@@ -671,22 +641,13 @@ final class IncidentUpdateTaskTest {
       assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "5",
-                  "incidents",
-                  Map.of(
-                      IncidentTemplate.STATE,
-                      IncidentState.ACTIVE,
-                      IncidentTemplate.TREE_PATH,
-                      "PI_1/FNI_1"),
-                  null));
+              new IncidentUpdate("5", "incidents", IncidentState.ACTIVE, "PI_1/FNI_1"));
 
       final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
       assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests()).isEmpty();
       assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(1)
-          .containsExactlyInAnyOrder(
-              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"));
+          .containsExactlyInAnyOrder(new ListViewInstanceUpdate("1", "list-view", "1", true));
 
       final var incident =
           new IncidentEntity()
@@ -740,24 +701,21 @@ final class IncidentUpdateTaskTest {
       assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
+              new IncidentUpdate("5", "incidents", IncidentState.RESOLVED, null));
 
       final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
       assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null),
-              new DocumentUpdate(
-                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
+              new FlowNodeInstanceUpdate("2", "flow-nodes", false),
+              new FlowNodeInstanceUpdate("4", "flow-nodes", false));
       assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(4)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"),
-              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
+              new ListViewInstanceUpdate("1", "list-view", "1", false),
+              new ListViewInstanceUpdate("2", "list-view", "1", false),
+              new ListViewInstanceUpdate("3", "list-view", "3", false),
+              new ListViewInstanceUpdate("4", "list-view", "3", false));
 
       verify(incidentNotifier, times(0)).notifyAsync(any());
       verify(metrics).recordIncidentUpdatesProcessed(1);
@@ -807,23 +765,20 @@ final class IncidentUpdateTaskTest {
       assertThat(incidentBulkUpdate.incidentRequests())
           .hasSize(1)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
+              new IncidentUpdate("5", "incidents", IncidentState.RESOLVED, null));
 
       final var nonIncidentBulkUpdate = nonIncidentBulkUpdateCaptor.getValue();
       assertThat(nonIncidentBulkUpdate.flowNodeInstanceRequests())
           .hasSize(2)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate(
-                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null),
-              new DocumentUpdate(
-                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
+              new FlowNodeInstanceUpdate("2", "flow-nodes", false),
+              new FlowNodeInstanceUpdate("4", "flow-nodes", false));
       assertThat(nonIncidentBulkUpdate.listViewRequests())
           .hasSize(3)
           .containsExactlyInAnyOrder(
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"),
-              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
+              new ListViewInstanceUpdate("2", "list-view", "1", false),
+              new ListViewInstanceUpdate("3", "list-view", "3", false),
+              new ListViewInstanceUpdate("4", "list-view", "3", false));
       verify(metrics).recordIncidentUpdatesProcessed(1);
       verify(metrics).recordIncidentUpdatesDocumentsUpdated(6);
     }


### PR DESCRIPTION
## Description

This just creates separate `DocumentUpdate` implementations for the different updates we need to make in the incident update task.

This is done so it's a bit easier to keep track of what each kind of update is - rather than it just being a `Map<String, Object>` + some other metadata.

There should be no functional change, but hopefully it makes it a bit easier to understand and therefore debug the incident update task.

There's also a couple of minor tidy ups tacked on (Javadoc update + volatile for field in a test).

## Related issues

refs #59931
