### PR TITLE
deps: upgrade micrometer to 1.16.7 to remediate CVE-2026-59296 (stable/8.7)

### DIFF
--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -38,7 +38,15 @@
   <dependencyManagement>
     <dependencies>
       <!-- Re-import these BOMs (first-import-wins) ahead of spring-boot-dependencies so its
-      vulnerable netty/jackson/log4j/plexus-utils pins don't leak into the flattened clients. -->
+      vulnerable netty/jackson/log4j/plexus-utils/micrometer pins don't leak into the flattened
+      clients. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,7 +83,7 @@
     <version.opensearch-java>2.9.1</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>4.32.0</version.protobuf>
+    <version.protobuf>4.33.6</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
     <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,9 +83,9 @@
     <version.opensearch-java>2.9.1</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>4.31.1</version.protobuf>
+    <version.protobuf>4.32.0</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.15.12</version.micrometer>
+    <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
## What

Bumps `io.micrometer` from **1.15.12 → 1.16.7** and `com.google.protobuf:protobuf-java` from **4.31.1 → 4.33.6** on `stable/8.7` to remediate **CVE-2026-59296**.

## Why

CVE-2026-59296 (CWE-93, CVSS 8.2): `micrometer-core` does not sanitize line terminators (`\n`, `\r`) in metric names, tag keys, or tag values, enabling metric/log line-injection via the StatsD (Datadog/Etsy) registry or `LoggingMeterRegistry`.

- **Exploitability here: Not Affected.** The vulnerable sinks are unused — `micrometer-registry-statsd` is not a dependency, and `LoggingMeterRegistry` is never configured. Only Prometheus and OTLP registries are used. This PR is **scanner hygiene**, not an active-exposure fix.
- **Version choice (micrometer):** the 1.15.x line's OSS support window ended 2026-06 (before this CVE was published 2026-08-23) and no `1.15.13` artifact exists on Maven Central. The lowest public OSS fix is **1.16.7**.

## Supersedes #60916

That earlier attempt at the same bump broke application startup:

```
Failed to instantiate [io.micrometer.registry.otlp.OtlpMeterRegistry]:
Factory method 'otlpMeterRegistry' threw exception
```

This was **misdiagnosed at the time** as a Spring Boot 3.5 / micrometer OTLP-registry API-shape incompatibility requiring a Spring Boot uplift. Root-caused this time to something much narrower: **a protobuf gencode/runtime version mismatch.**

`micrometer-registry-otlp:1.16.7` pulls a newer transitive `io.opentelemetry.proto` artifact whose generated classes were compiled (gencode) against a newer `protobuf-java`. This branch pinned `protobuf-java:4.31.1`. `protobuf-java` 4.x enforces at class-init time that the runtime version must be `>=` the gencode version baked into generated message classes, so `OtlpMeterRegistry`'s static initializer throws `ExceptionInInitializerError` — Spring Boot's exception handling only surfaces the generic wrapper ("Factory method threw exception ... null"), which is why the real cause wasn't visible in the original PR's CI logs.

Full chain (trimmed):
```
Caused by: java.lang.ExceptionInInitializerError
    at io.micrometer.registry.otlp.OtlpMeterRegistry.<init>(OtlpMeterRegistry.java:129)
Caused by: com.google.protobuf.RuntimeVersion$ProtobufRuntimeVersionException:
    Detected incompatible Protobuf Gencode/Runtime versions when loading io.opentelemetry.proto.resource.v1.Resource:
    gencode 4.32.0, runtime 4.31.1. Runtime version cannot be older than the linked gencode version.
```

Bumping `version.protobuf` alongside micrometer resolves it — **no Spring Boot / grpc version change needed** (grpc stays at `1.76.3`).

**Version choice (protobuf):** the bare minimum needed to fix the crash is `4.32.0`, but protobuf's own support policy ends support for a minor version the instant the next one ships — `4.32.0` was already superseded when `4.33.0` released, so picking it would hand this branch another already-EOL dependency, the same trap this PR is meant to get away from on the micrometer side. `4.33.6` is used instead: it's already running in production on `stable/8.9` with no known issues, and its changelog vs `4.32.0` has no Java-relevant breaking changes (checked every release note between them — mostly additive/bugfix-only; grpc-java `1.76.3`, unchanged here, is itself built against protobuf `3.25.8`, well below either candidate floor, so the choice between `4.32.0` and `4.33.6` has no bearing on grpc compatibility).

## #59640 check

Also checked whether this newly exposes `stable/8.7` to #59640 (`camunda-spring-boot-3-starter` pulling an incompatible Micrometer version on Spring Boot 3.5.x due to a `MeterRegistry.counter(String, Tags)` call baked into the compiled starter jar). **It does not**: on this branch, `clients/camunda-spring-boot-3-starter` is a relocation alias for `spring-boot-starter-camunda-sdk`, and that module's `MicrometerMetricsRecorder`/`clients/java`'s worker-metrics builder pass `List<Tag>`/`Iterable<Tag>`-typed arguments to `MeterRegistry.counter()`/`timer()`, which bind to the overload present in both micrometer 1.15.x and 1.16.x — unlike the `Tags`-typed call on `main` that #59640 is filed against.

## Related

- Companion PR: #61198 (stable/8.8, same fix)
- Tracking issue: #61174 (broader micrometer-1.15.x-EOL remediation decision for stable/8.7 and stable/8.8)
- Related issue: #59640 (checked not applicable to this branch, see above)
- CVE-2026-59296 — https://nvd.nist.gov/vuln/detail/CVE-2026-59296

Closes: https://github.com/camunda/camunda/issues/61174