### PR TITLE
fix: prevent streaming job worker from permanently stopping polling when activated jobs are rejected at maxJobsActive

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerMetrics.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerMetrics.java
@@ -40,6 +40,19 @@ public interface JobWorkerMetrics {
   default void jobHandled(final int count) {}
 
   /**
+   * Called every time one or more jobs are refused by the executor that runs the job handler,
+   * before the handler had a chance to run.
+   *
+   * <p>A refused job is neither worked on nor kept: one the worker polled for is handed straight
+   * back to the broker, and one the broker pushed to it is left to time out. Such a job is reported
+   * to {@link #jobActivated(int)} but never to {@link #jobHandled(int)}, so subtracting this count
+   * as well is what gives the number of jobs the worker is actually working on.
+   *
+   * @param count the amount of jobs that were refused
+   */
+  default void jobRefused(final int count) {}
+
+  /**
    * Called every time the streaming job worker recreates its stream because the configured stream
    * inactivity timeout elapsed without any activity. Useful to monitor whether the inactivity
    * watchdog is firing in a given deployment (e.g. due to an upstream proxy idle close), without

--- a/clients/java/src/main/java/io/camunda/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
@@ -82,6 +82,14 @@ public interface MicrometerJobWorkerMetricsBuilder {
       }
     },
 
+    /** Counter name backing the {@link JobWorkerMetrics#jobRefused(int)} count. */
+    JOB_REFUSED {
+      @Override
+      public String asString() {
+        return "camunda.client.worker.job.refused";
+      }
+    },
+
     /**
      * Counter name backing {@link JobWorkerMetrics#streamInactivityRecreated()}. Incremented every
      * time the streaming worker recreates its stream because the configured inactivity timeout

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/BlockingExecutor.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/BlockingExecutor.java
@@ -20,7 +20,20 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * An executor that only takes a command when it has capacity to run it, waiting up to a fixed time
+ * for capacity to become available.
+ *
+ * <p>A command is either handed to the wrapped executor or refused with a {@link
+ * RejectedExecutionException}; it is never dropped without notice.
+ *
+ * <p>A refusal does not always mean the command did not run. The wrapped executor may run the
+ * command on the calling thread and let it fail there, which reaches the caller as a refusal too.
+ * What callers can rely on is the capacity: every command takes one slot and gives it back exactly
+ * once, whether it ran or was refused.
+ */
 final class BlockingExecutor implements Executor {
   private static final TimeUnit TIMEOUT_UNIT = TimeUnit.MILLISECONDS;
 
@@ -37,23 +50,46 @@ final class BlockingExecutor implements Executor {
 
   @Override
   public void execute(final Runnable command) throws RejectedExecutionException {
-    try {
-      if (!semaphore.tryAcquire(timeoutMillis, TIMEOUT_UNIT)) {
-        throw new RejectedExecutionException(
-            String.format(
-                "Not able to acquire lease in %d%s", timeoutMillis, TIMEOUT_UNIT.toString()));
-      }
+    acquireCapacity();
 
+    // The wrapped executor may run the command on the calling thread. A command that fails then
+    // looks exactly like a command the executor refused, so both paths below can be taken for the
+    // same command. The flag makes sure its capacity is given back only once, as giving it back
+    // twice would let the executor run more commands at a time than it is allowed to.
+    final AtomicBoolean capacityHeld = new AtomicBoolean(true);
+    try {
       wrappedExecutor.execute(
           () -> {
             try {
               command.run();
             } finally {
-              semaphore.release();
+              releaseCapacity(capacityHeld);
             }
           });
+    } catch (final RuntimeException | Error e) {
+      // nothing else will give the capacity back, unless the command ran on the calling thread and
+      // its finalizer already did, which is what the flag above is there to catch
+      releaseCapacity(capacityHeld);
+      throw e;
+    }
+  }
+
+  private void releaseCapacity(final AtomicBoolean capacityHeld) {
+    if (capacityHeld.compareAndSet(true, false)) {
+      semaphore.release();
+    }
+  }
+
+  private void acquireCapacity() {
+    try {
+      if (!semaphore.tryAcquire(timeoutMillis, TIMEOUT_UNIT)) {
+        throw new RejectedExecutionException(
+            String.format("Not able to acquire lease in %d%s", timeoutMillis, TIMEOUT_UNIT));
+      }
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
+      throw new RejectedExecutionException(
+          "Interrupted while waiting to acquire a lease to run the command", e);
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -282,6 +282,7 @@ public final class JobWorkerBuilderImpl
             maxJobsActive,
             scheduledExecutor,
             pollInterval,
+            jobClient,
             jobRunnableFactory,
             jobPoller,
             jobStreamer,

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -225,7 +225,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     if (jobStreamer.isOpen() && activatedJobs == 0) {
       // to keep polling requests to a minimum, if streaming is enabled, and the response is empty,
       // we back off on poll success responses.
-      backoff(jobPoller, streamNoJobsBackoffSupplier);
+      backOffPolling(streamNoJobsBackoffSupplier);
       LOG.trace("No jobs to activate via polling, will backoff and poll in {}", pollInterval);
     } else if (activatedJobs > 0 && refusedJobs == activatedJobs && actualRemainingJobs <= 0) {
       // The executor took none of the jobs in this response and the worker has nothing left
@@ -233,8 +233,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       // repeat as fast as the broker can answer. Both halves of the condition are needed: a worker
       // that is keeping up can finish a whole response before this runs, which leaves no remaining
       // jobs either, and it is the refusals that tell the two apart.
-      getPollInterval(backoffSupplier);
-      schedulePoll();
+      backOffPolling(backoffSupplier);
       LOG.debug(
           "The job handler executor took none of the {} jobs activated, will backoff and poll in {}",
           activatedJobs,
@@ -260,6 +259,17 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
         pollInterval);
   }
 
+  /**
+   * Slows the next poll down and schedules it. Does not touch the job poller, so it is safe for a
+   * caller that has already released it: releasing a poller twice can publish one that another
+   * thread has since claimed and is polling with.
+   */
+  private void backOffPolling(final BackoffSupplier backoffSupplier) {
+    getPollInterval(backoffSupplier);
+    schedulePoll();
+  }
+
+  /** Same, for a caller that is still holding the job poller. */
   private void backoff(final JobPoller jobPoller, final BackoffSupplier backoffSupplier) {
     getPollInterval(backoffSupplier);
     releaseJobPoller(jobPoller);

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -362,6 +362,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
         return false;
       }
 
+      metrics.jobRefused(1);
       onRefused.accept(job, e);
       return false;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
  * will poll for new jobs. To determine what is considered enough jobs it compares its number of
  * {@code remainingJobs} with the {@code activationThreshold}. If the executor refuses a job, the
  * worker frees up that job's capacity immediately, so that a refused job never takes up capacity
- * for good.
+ * for good. Each job's capacity is freed up exactly once, whether the job ran or was refused.
  *
  * <p>If a poll fails with an error response, a retry is scheduled with a delay using the {@code
  * retryDelaySupplier} to ask for a new {@code pollInterval}. By default, this retry delay supplier
@@ -255,8 +255,13 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     // the executor does not take the job. Taking capacity for the whole response at once would
     // also count the jobs that were rejected, and that capacity would never be given back.
     remainingJobs.incrementAndGet();
-    if (!handleActivatedJob(job, this::handleJobFinished)) {
-      releaseCapacity();
+    // The executor may run the job on the calling thread and still report it as refused, in which
+    // case the job both ran and was refused and the two paths below are taken for the same job.
+    // The flag makes sure the slot taken above is given back only once, as giving it back twice
+    // would let the worker ask the broker for more jobs than it is allowed to run at a time.
+    final AtomicBoolean capacityHeld = new AtomicBoolean(true);
+    if (!handleActivatedJob(job, () -> handleJobFinished(capacityHeld))) {
+      releaseCapacity(capacityHeld);
     }
   }
 
@@ -291,13 +296,19 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     }
   }
 
-  private void handleJobFinished() {
-    releaseCapacity();
+  private void handleJobFinished(final AtomicBoolean capacityHeld) {
+    releaseCapacity(capacityHeld);
     metrics.jobHandled(1);
   }
 
-  /** Gives back the capacity slot taken for a job, and polls again if there is room for more. */
-  private void releaseCapacity() {
+  /**
+   * Gives back the capacity slot taken for a job, and polls again if there is room for more. Does
+   * nothing if the slot was already given back.
+   */
+  private void releaseCapacity(final AtomicBoolean capacityHeld) {
+    if (!capacityHeld.compareAndSet(true, false)) {
+      return;
+    }
     final int actualRemainingJobs = remainingJobs.decrementAndGet();
     if (!isPollScheduled.get() && shouldPoll(actualRemainingJobs)) {
       tryPoll();

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.worker;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.BackoffSupplier;
+import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.client.api.worker.JobWorkerMetrics;
 import io.camunda.client.impl.Loggers;
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 /**
@@ -56,11 +58,13 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
 
   public static final String ERROR_MSG =
       "Expected to handle received job with key {}, but the worker reached maximum capacity (maxJobsActive). "
-          + "The job activation timed out (controllable by timeout parameter). It will get reactivated shortly. "
-          + "If this issue persist, make sure to either scale your workers, threads, increase maxJobsActive or reduce the load you want to work on. ";
+          + "The job is made available again right away, so that it can be picked up by another worker. "
+          + "If this issue persists, make sure to either scale your workers, threads, increase maxJobsActive or reduce the load you want to work on. ";
   private static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       JobWorkerBuilderImpl.DEFAULT_BACKOFF_SUPPLIER;
   private static final Logger LOG = Loggers.JOB_WORKER_LOGGER;
+  private static final String RETURN_JOB_ERROR_MSG =
+      "The worker had no capacity to handle this job, so it was returned to the broker.";
   private static final String SUPPLY_RETRY_DELAY_FAILURE_MESSAGE =
       "Expected to supply retry delay, but an exception was thrown. Falling back to default backoff supplier";
   // job queue state
@@ -70,6 +74,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
 
   // job execution facilities
   private final Executor executor;
+  private final JobClient jobClient;
   private final JobRunnableFactory jobHandlerFactory;
   private final long initialPollInterval;
   private final JobStreamer jobStreamer;
@@ -89,6 +94,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       final int maxJobsActive,
       final ScheduledExecutorService executor,
       final Duration pollInterval,
+      final JobClient jobClient,
       final JobRunnableFactory jobHandlerFactory,
       final JobPoller jobPoller,
       final JobStreamer jobStreamer,
@@ -101,6 +107,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     remainingJobs = new AtomicInteger(0);
 
     this.executor = jobExecutor;
+    this.jobClient = jobClient;
     scheduledExecutorService = executor;
     this.jobHandlerFactory = jobHandlerFactory;
     this.jobStreamer = jobStreamer;
@@ -260,22 +267,25 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     // The flag makes sure the slot taken above is given back only once, as giving it back twice
     // would let the worker ask the broker for more jobs than it is allowed to run at a time.
     final AtomicBoolean capacityHeld = new AtomicBoolean(true);
-    if (!handleActivatedJob(job, () -> handleJobFinished(capacityHeld))) {
+    if (!handleActivatedJob(job, () -> handleJobFinished(capacityHeld), this::returnJobToBroker)) {
       releaseCapacity(capacityHeld);
     }
   }
 
   private void handleStreamedJob(final ActivatedJob job) {
-    handleActivatedJob(job, this::handleStreamJobFinished);
+    handleActivatedJob(job, this::handleStreamJobFinished, this::leaveStreamedJobToBroker);
   }
 
   /**
    * Hands the job over to the executor that runs the job handler.
    *
+   * @param onRefused what to do with a job the executor would not take, which differs between a job
+   *     the worker asked for and one the broker pushed to it
    * @return true if the executor took the job, in which case the given finalizer is guaranteed to
    *     run once the handler is done
    */
-  private boolean handleActivatedJob(final ActivatedJob job, final Runnable finalizer) {
+  private boolean handleActivatedJob(
+      final ActivatedJob job, final Runnable finalizer, final Consumer<ActivatedJob> onRefused) {
     metrics.jobActivated(1);
     try {
       executor.execute(jobHandlerFactory.create(job, finalizer));
@@ -292,8 +302,56 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       }
 
       LOG.warn(ERROR_MSG, job.getKey(), e);
+      onRefused.accept(job);
       return false;
     }
+  }
+
+  /**
+   * Fails the job without using up a retry, so that the broker offers it again right away instead
+   * of holding it back until its timeout expires.
+   *
+   * <p>Never throws: a job that could not be handed back simply stays out of reach until its
+   * timeout expires, which is where it would have been anyway. Letting a failure out of here would
+   * stop the worker from handling the rest of the jobs it just activated.
+   */
+  private void returnJobToBroker(final ActivatedJob job) {
+    try {
+      jobClient
+          .newFailCommand(job)
+          .retries(job.getRetries())
+          .errorMessage(RETURN_JOB_ERROR_MSG)
+          .send()
+          .exceptionally(
+              error -> {
+                logFailedReturn(job, error);
+                return null;
+              });
+    } catch (final RuntimeException e) {
+      // sending can also fail on the spot, for example once the client starts shutting down
+      logFailedReturn(job, e);
+    }
+  }
+
+  /**
+   * Leaves a refused streamed job to the broker. The broker yields a job whose push to a stream
+   * fails, which makes it activatable again just as quickly as a fail command from here would.
+   * Sending one anyway would only race that yield, and the broker's version is the sounder of the
+   * two: it cannot be made stale by the job being activated again in the meantime.
+   */
+  private void leaveStreamedJobToBroker(final ActivatedJob job) {
+    LOG.debug(
+        "Job with key {} was refused. Leaving it to the broker, which offers it again once the "
+            + "push to this worker fails.",
+        job.getKey());
+  }
+
+  private void logFailedReturn(final ActivatedJob job, final Throwable error) {
+    LOG.debug(
+        "Failed to return job with key {} to the broker. It stays out of reach until its "
+            + "timeout expires.",
+        job.getKey(),
+        error);
   }
 
   private void handleJobFinished(final AtomicBoolean capacityHeld) {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -43,7 +43,9 @@ import org.slf4j.Logger;
  * <p>If a poll successfully provides jobs, the worker submits each job to the job handler. Every
  * time a job is completed, the worker checks if it still has enough jobs to work on. If not, it
  * will poll for new jobs. To determine what is considered enough jobs it compares its number of
- * {@code remainingJobs} with the {@code activationThreshold}.
+ * {@code remainingJobs} with the {@code activationThreshold}. If the executor refuses a job, the
+ * worker frees up that job's capacity immediately, so that a refused job never takes up capacity
+ * for good.
  *
  * <p>If a poll fails with an error response, a retry is scheduled with a delay using the {@code
  * retryDelaySupplier} to ask for a new {@code pollInterval}. By default, this retry delay supplier
@@ -204,7 +206,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   private void onPollSuccess(final JobPoller jobPoller, final int activatedJobs) {
     // first release, then lookup remaining jobs, to allow handleJobFinished() to poll
     releaseJobPoller(jobPoller);
-    final int actualRemainingJobs = remainingJobs.addAndGet(activatedJobs);
+    final int actualRemainingJobs = remainingJobs.get();
 
     if (jobStreamer.isOpen() && activatedJobs == 0) {
       // to keep polling requests to a minimum, if streaming is enabled, and the response is empty,
@@ -245,38 +247,57 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   }
 
   private void handleJob(final ActivatedJob job) {
-    handleActivatedJob(job, this::handleJobFinished);
+    // Take a capacity slot for this job before handing it over, and give it back right away if
+    // the executor does not take the job. Taking capacity for the whole response at once would
+    // also count the jobs that were rejected, and that capacity would never be given back.
+    remainingJobs.incrementAndGet();
+    if (!handleActivatedJob(job, this::handleJobFinished)) {
+      releaseCapacity();
+    }
   }
 
   private void handleStreamedJob(final ActivatedJob job) {
     handleActivatedJob(job, this::handleStreamJobFinished);
   }
 
-  private void handleActivatedJob(final ActivatedJob job, final Runnable finalizer) {
+  /**
+   * Hands the job over to the executor that runs the job handler.
+   *
+   * @return true if the executor took the job, in which case the given finalizer is guaranteed to
+   *     run once the handler is done
+   */
+  private boolean handleActivatedJob(final ActivatedJob job, final Runnable finalizer) {
     metrics.jobActivated(1);
     try {
       executor.execute(jobHandlerFactory.create(job, finalizer));
+      return true;
     } catch (final RejectedExecutionException e) {
       if (isClosed()) {
-        return;
+        return false;
       }
 
       if (scheduledExecutorService.isShutdown() || scheduledExecutorService.isTerminated()) {
         LOG.warn("Underlying executor was closed before the worker. Closing the worker now.", e);
         close();
-        return;
+        return false;
       }
 
       LOG.warn(ERROR_MSG, job.getKey(), e);
+      return false;
     }
   }
 
   private void handleJobFinished() {
+    releaseCapacity();
+    metrics.jobHandled(1);
+  }
+
+  /** Gives back the capacity slot taken for a job, and polls again if there is room for more. */
+  private void releaseCapacity() {
     final int actualRemainingJobs = remainingJobs.decrementAndGet();
     if (!isPollScheduled.get() && shouldPoll(actualRemainingJobs)) {
       tryPoll();
     }
-    metrics.jobHandled(1);
   }
 
   private void handleStreamJobFinished() {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -282,13 +282,24 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
    * @param onRefused what to do with a job the executor would not take, which differs between a job
    *     the worker asked for and one the broker pushed to it
    * @return true if the executor took the job, in which case the given finalizer is guaranteed to
-   *     run once the handler is done
+   *     run once the handler is done. A false answer does not mean the handler never ran: an
+   *     executor may run the job on the calling thread and report it as refused all the same, so
+   *     anything the caller does with a refused job has to cope with the job having run.
    */
   private boolean handleActivatedJob(
       final ActivatedJob job, final Runnable finalizer, final Consumer<ActivatedJob> onRefused) {
     metrics.jobActivated(1);
+    // The executor may run the job on the calling thread and still report it as refused. Once the
+    // handler has started, only it knows what became of the job, so the flag below keeps the
+    // worker from stepping in afterwards.
+    final AtomicBoolean handlerStarted = new AtomicBoolean(false);
     try {
-      executor.execute(jobHandlerFactory.create(job, finalizer));
+      final Runnable jobRunnable = jobHandlerFactory.create(job, finalizer);
+      executor.execute(
+          () -> {
+            handlerStarted.set(true);
+            jobRunnable.run();
+          });
       return true;
     } catch (final RejectedExecutionException e) {
       if (isClosed()) {
@@ -298,6 +309,15 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       if (scheduledExecutorService.isShutdown() || scheduledExecutorService.isTerminated()) {
         LOG.warn("Underlying executor was closed before the worker. Closing the worker now.", e);
         close();
+        return false;
+      }
+
+      if (handlerStarted.get()) {
+        LOG.debug(
+            "Job with key {} ran on the calling thread even though the executor reported it as "
+                + "refused. Leaving the job to the handler that ran it.",
+            job.getKey(),
+            e);
         return false;
       }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -215,10 +215,14 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       LOG.trace("No jobs to activate via polling, will backoff and poll in {}", pollInterval);
     } else {
       pollInterval = initialPollInterval;
-      if (actualRemainingJobs <= 0) {
+      // Normally the jobs just activated go on to free their own capacity as they finish, and each
+      // one that does asks for another poll. A job the executor refused gives its capacity back
+      // while this poll is still running, though, so the poll it asks for finds the poller still
+      // taken and is dropped. Asking again here, now that the poller is free, is what keeps a
+      // worker going that would otherwise sit still until the jobs it did take are done.
+      if (shouldPoll(actualRemainingJobs)) {
         schedulePoll();
       }
-      // if jobs were activated, then successive polling happens due to handleJobFinished
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -52,7 +52,9 @@ import org.slf4j.Logger;
  * <p>If a poll fails with an error response, a retry is scheduled with a delay using the {@code
  * retryDelaySupplier} to ask for a new {@code pollInterval}. By default, this retry delay supplier
  * is the {@link ExponentialBackoff}. This default is also used as a fallback for the user provided
- * backoff. On the next success, the {@code pollInterval} is reset to its original value.
+ * backoff. On the next success, the {@code pollInterval} is reset to its original value. A poll
+ * whose jobs the executor refused in full is treated the same way, since a worker that takes no job
+ * at all has nothing to wait for and would otherwise poll as fast as the broker can answer.
  */
 public final class JobWorkerImpl implements JobWorker, Closeable {
 
@@ -71,6 +73,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   private final int maxJobsActive;
   private final int activationThreshold;
   private final AtomicInteger remainingJobs;
+  private final AtomicInteger refusedJobsInPoll = new AtomicInteger(0);
 
   // job execution facilities
   private final Executor executor;
@@ -202,6 +205,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       return;
     }
     final int maxJobsToActivate = maxJobsActive - actualRemainingJobs;
+    refusedJobsInPoll.set(0);
     jobPoller.poll(
         maxJobsToActivate,
         this::handleJob,
@@ -211,6 +215,9 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   }
 
   private void onPollSuccess(final JobPoller jobPoller, final int activatedJobs) {
+    // Read the refusals before releasing the poller: once it is free, a job that finishes can start
+    // the next poll, and that poll resets the count.
+    final int refusedJobs = refusedJobsInPoll.get();
     // first release, then lookup remaining jobs, to allow handleJobFinished() to poll
     releaseJobPoller(jobPoller);
     final int actualRemainingJobs = remainingJobs.get();
@@ -220,6 +227,18 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       // we back off on poll success responses.
       backoff(jobPoller, streamNoJobsBackoffSupplier);
       LOG.trace("No jobs to activate via polling, will backoff and poll in {}", pollInterval);
+    } else if (activatedJobs > 0 && refusedJobs == activatedJobs && actualRemainingJobs <= 0) {
+      // The executor took none of the jobs in this response and the worker has nothing left
+      // running. Polling again right away would activate another batch, hand it straight back, and
+      // repeat as fast as the broker can answer. Both halves of the condition are needed: a worker
+      // that is keeping up can finish a whole response before this runs, which leaves no remaining
+      // jobs either, and it is the refusals that tell the two apart.
+      getPollInterval(backoffSupplier);
+      schedulePoll();
+      LOG.debug(
+          "The job handler executor took none of the {} jobs activated, will backoff and poll in {}",
+          activatedJobs,
+          pollInterval);
     } else {
       pollInterval = initialPollInterval;
       // Normally the jobs just activated go on to free their own capacity as they finish, and each
@@ -268,7 +287,12 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     // would let the worker ask the broker for more jobs than it is allowed to run at a time.
     final AtomicBoolean capacityHeld = new AtomicBoolean(true);
     if (!handleActivatedJob(job, () -> handleJobFinished(capacityHeld), this::returnJobToBroker)) {
-      releaseCapacity(capacityHeld);
+      if (releaseCapacity(capacityHeld)) {
+        // Only a job whose slot was still held never ran, and only those say anything about
+        // whether the executor is taking work. Counting them lets the poll that activated them
+        // tell a response nobody took from one that is being worked through.
+        refusedJobsInPoll.incrementAndGet();
+      }
     }
   }
 
@@ -382,15 +406,18 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   /**
    * Gives back the capacity slot taken for a job, and polls again if there is room for more. Does
    * nothing if the slot was already given back.
+   *
+   * @return true if this call was the one that gave the slot back
    */
-  private void releaseCapacity(final AtomicBoolean capacityHeld) {
+  private boolean releaseCapacity(final AtomicBoolean capacityHeld) {
     if (!capacityHeld.compareAndSet(true, false)) {
-      return;
+      return false;
     }
     final int actualRemainingJobs = remainingJobs.decrementAndGet();
     if (!isPollScheduled.get() && shouldPoll(actualRemainingJobs)) {
       tryPoll();
     }
+    return true;
   }
 
   private void handleStreamJobFinished() {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.slf4j.Logger;
 
 /**
@@ -61,6 +61,10 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   public static final String ERROR_MSG =
       "Expected to handle received job with key {}, but the worker reached maximum capacity (maxJobsActive). "
           + "The job is made available again right away, so that it can be picked up by another worker. "
+          + "If this issue persists, make sure to either scale your workers, threads, increase maxJobsActive or reduce the load you want to work on. ";
+  private static final String STREAMED_ERROR_MSG =
+      "Expected to handle received job with key {}, but the worker reached maximum capacity (maxJobsActive). "
+          + "The job stays with this worker until its timeout expires, and only then is it offered to another worker. "
           + "If this issue persists, make sure to either scale your workers, threads, increase maxJobsActive or reduce the load you want to work on. ";
   private static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       JobWorkerBuilderImpl.DEFAULT_BACKOFF_SUPPLIER;
@@ -314,14 +318,17 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
    * Hands the job over to the executor that runs the job handler.
    *
    * @param onRefused what to do with a job the executor would not take, which differs between a job
-   *     the worker asked for and one the broker pushed to it
+   *     the worker asked for and one the broker pushed to it. It is also what tells the user about
+   *     the refusal, since the two paths leave the job in very different places.
    * @return true if the executor took the job, in which case the given finalizer is guaranteed to
    *     run once the handler is done. A false answer does not mean the handler never ran: an
    *     executor may run the job on the calling thread and report it as refused all the same, so
    *     anything the caller does with a refused job has to cope with the job having run.
    */
   private boolean handleActivatedJob(
-      final ActivatedJob job, final Runnable finalizer, final Consumer<ActivatedJob> onRefused) {
+      final ActivatedJob job,
+      final Runnable finalizer,
+      final BiConsumer<ActivatedJob, RejectedExecutionException> onRefused) {
     metrics.jobActivated(1);
     // The executor may run the job on the calling thread and still report it as refused. Once the
     // handler has started, only it knows what became of the job, so the flag below keeps the
@@ -355,8 +362,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
         return false;
       }
 
-      LOG.warn(ERROR_MSG, job.getKey(), e);
-      onRefused.accept(job);
+      onRefused.accept(job, e);
       return false;
     }
   }
@@ -369,7 +375,8 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
    * timeout expires, which is where it would have been anyway. Letting a failure out of here would
    * stop the worker from handling the rest of the jobs it just activated.
    */
-  private void returnJobToBroker(final ActivatedJob job) {
+  private void returnJobToBroker(final ActivatedJob job, final RejectedExecutionException cause) {
+    LOG.warn(ERROR_MSG, job.getKey(), cause);
     try {
       jobClient
           .newFailCommand(job)
@@ -388,16 +395,16 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   }
 
   /**
-   * Leaves a refused streamed job to the broker. The broker yields a job whose push to a stream
-   * fails, which makes it activatable again just as quickly as a fail command from here would.
-   * Sending one anyway would only race that yield, and the broker's version is the sounder of the
-   * two: it cannot be made stale by the job being activated again in the meantime.
+   * Leaves a refused streamed job to the broker, which holds on to it until its timeout expires.
+   *
+   * <p>The broker takes a streamed job back by itself when the push to the worker fails, which is
+   * how the streaming path recovers without the worker having to say anything. That does not cover
+   * this case: the push had already succeeded and the job was only refused afterwards, so nothing
+   * tells the broker that this worker will never run it.
    */
-  private void leaveStreamedJobToBroker(final ActivatedJob job) {
-    LOG.debug(
-        "Job with key {} was refused. Leaving it to the broker, which offers it again once the "
-            + "push to this worker fails.",
-        job.getKey());
+  private void leaveStreamedJobToBroker(
+      final ActivatedJob job, final RejectedExecutionException cause) {
+    LOG.warn(STREAMED_ERROR_MSG, job.getKey(), cause);
   }
 
   private void logFailedReturn(final ActivatedJob job, final Throwable error) {

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/metrics/MicrometerJobWorkerMetrics.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/metrics/MicrometerJobWorkerMetrics.java
@@ -23,16 +23,20 @@ public final class MicrometerJobWorkerMetrics implements JobWorkerMetrics {
 
   private final Counter jobActivatedCounter;
   private final Counter jobHandledCounter;
+  private final Counter jobRefusedCounter;
   private final Counter streamInactivityRecreatedCounter;
 
   public MicrometerJobWorkerMetrics(
       final Counter jobActivatedCounter,
       final Counter jobHandledCounter,
+      final Counter jobRefusedCounter,
       final Counter streamInactivityRecreatedCounter) {
     this.jobActivatedCounter =
         Objects.requireNonNull(jobActivatedCounter, "must specify a job activated counter");
     this.jobHandledCounter =
         Objects.requireNonNull(jobHandledCounter, "must specify a job handled counter");
+    this.jobRefusedCounter =
+        Objects.requireNonNull(jobRefusedCounter, "must specify a job refused counter");
     this.streamInactivityRecreatedCounter =
         Objects.requireNonNull(
             streamInactivityRecreatedCounter, "must specify a stream inactivity recreated counter");
@@ -46,6 +50,11 @@ public final class MicrometerJobWorkerMetrics implements JobWorkerMetrics {
   @Override
   public void jobHandled(final int count) {
     jobHandledCounter.increment(count);
+  }
+
+  @Override
+  public void jobRefused(final int count) {
+    jobRefusedCounter.increment(count);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/metrics/MicrometerJobWorkerMetricsBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/metrics/MicrometerJobWorkerMetricsBuilderImpl.java
@@ -44,9 +44,13 @@ public final class MicrometerJobWorkerMetricsBuilderImpl
   public JobWorkerMetrics build() {
     final Counter jobActivatedCounter = meterRegistry.counter(Names.JOB_ACTIVATED.asString(), tags);
     final Counter jobHandledCounter = meterRegistry.counter(Names.JOB_HANDLED.asString(), tags);
+    final Counter jobRefusedCounter = meterRegistry.counter(Names.JOB_REFUSED.asString(), tags);
     final Counter streamInactivityRecreatedCounter =
         meterRegistry.counter(Names.STREAM_INACTIVITY_RECREATED.asString(), tags);
     return new MicrometerJobWorkerMetrics(
-        jobActivatedCounter, jobHandledCounter, streamInactivityRecreatedCounter);
+        jobActivatedCounter,
+        jobHandledCounter,
+        jobRefusedCounter,
+        streamInactivityRecreatedCounter);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/util/EnvironmentExtension.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/EnvironmentExtension.java
@@ -19,34 +19,19 @@ import java.util.Map;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.rules.ExternalResource;
 
-/**
- * we still need to support JUnit 4 for {@link io.camunda.client.impl.worker.JobWorkerImplTest} that
- * uses {@link io.grpc.testing.GrpcCleanupRule}
- */
-public final class EnvironmentExtension extends ExternalResource
-    implements BeforeEachCallback, AfterEachCallback {
+/** Restores the environment a test found, so that changes made by one test do not reach another. */
+public final class EnvironmentExtension implements BeforeEachCallback, AfterEachCallback {
 
   private Map<String, String> previousEnvironment;
 
   @Override
-  protected void before() {
+  public void beforeEach(final ExtensionContext context) {
     previousEnvironment = Environment.system().copy();
   }
 
   @Override
-  protected void after() {
-    Environment.system().overwrite(previousEnvironment);
-  }
-
-  @Override
-  public void beforeEach(final ExtensionContext context) {
-    before();
-  }
-
-  @Override
   public void afterEach(final ExtensionContext context) {
-    after();
+    Environment.system().overwrite(previousEnvironment);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/BlockingExecutorTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/BlockingExecutorTest.java
@@ -83,6 +83,31 @@ public class BlockingExecutorTest {
   }
 
   @Test
+  public void shouldKeepCapacityLimitWhenCommandFailsOnTheCallingThread() {
+    // given an executor whose wrapped executor runs commands on the calling thread
+    final AtomicReference<Executor> wrappedExecutor = new AtomicReference<>(Runnable::run);
+    final BlockingExecutor executor =
+        new BlockingExecutor(
+            command -> wrappedExecutor.get().execute(command), 1, Duration.ofMillis(10));
+
+    // when a command fails, so that the failure reaches the caller the same way a refusal would
+    assertThatThrownBy(
+            () ->
+                executor.execute(
+                    () -> {
+                      throw new IllegalStateException("Command failed");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+
+    // then the one capacity slot the command took is free again, but only once: an executor that
+    // holds on to a command holds on to its capacity too, leaving nothing for a second command
+    wrappedExecutor.set(command -> {});
+    executor.execute(() -> {});
+    assertThatThrownBy(() -> executor.execute(() -> {}))
+        .isInstanceOf(RejectedExecutionException.class);
+  }
+
+  @Test
   public void shouldRejectCommandWhenInterruptedWhileWaitingForCapacity() {
     // given an executor whose only capacity is taken
     final Executor dropsCommands = command -> {};

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/BlockingExecutorTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/BlockingExecutorTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,65 @@ public class BlockingExecutorTest {
     executor.execute(() -> {});
     assertThatThrownBy(() -> executor.execute(() -> {}))
         .isInstanceOf(RejectedExecutionException.class);
+  }
+
+  @Test
+  public void shouldReleaseCapacityWhenWrappedExecutorRejectsCommand() {
+    // given a wrapped executor that refuses the first command and runs every later one
+    final AtomicBoolean refuseNextCommand = new AtomicBoolean(true);
+    final Executor wrappedExecutor =
+        command -> {
+          if (refuseNextCommand.compareAndSet(true, false)) {
+            throw new RejectedExecutionException("Wrapped executor is saturated");
+          }
+          command.run();
+        };
+    final BlockingExecutor executor =
+        new BlockingExecutor(wrappedExecutor, 1, Duration.ofMillis(10));
+
+    // when the wrapped executor refuses the command
+    assertThatThrownBy(() -> executor.execute(() -> {}))
+        .isInstanceOf(RejectedExecutionException.class);
+
+    // then the capacity taken for that command is free again
+    final AtomicBoolean executed = new AtomicBoolean(false);
+    executor.execute(() -> executed.set(true));
+    assertThat(executed).isTrue();
+  }
+
+  @Test
+  public void shouldRejectCommandWhenInterruptedWhileWaitingForCapacity() {
+    // given an executor whose only capacity is taken
+    final Executor dropsCommands = command -> {};
+    final BlockingExecutor executor = new BlockingExecutor(dropsCommands, 1, Duration.ofMinutes(1));
+    executor.execute(() -> {});
+
+    final AtomicBoolean executed = new AtomicBoolean(false);
+    final AtomicBoolean interruptFlagRestored = new AtomicBoolean(false);
+    final AtomicReference<Throwable> failure = new AtomicReference<>();
+    final Thread caller =
+        new Thread(
+            () -> {
+              try {
+                executor.execute(() -> executed.set(true));
+              } catch (final Throwable t) {
+                failure.set(t);
+              } finally {
+                interruptFlagRestored.set(Thread.currentThread().isInterrupted());
+              }
+            });
+    caller.start();
+    Awaitility.await("Caller should be waiting for capacity")
+        .until(caller::getState, Matchers.equalTo(Thread.State.TIMED_WAITING));
+
+    // when the caller is interrupted before capacity becomes available
+    caller.interrupt();
+    Awaitility.await("Caller should stop waiting once interrupted").until(() -> !caller.isAlive());
+
+    // then the command is refused instead of being dropped without notice
+    assertThat(failure.get()).isInstanceOf(RejectedExecutionException.class);
+    assertThat(executed).isFalse();
+    assertThat(interruptFlagRestored).isTrue();
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -312,6 +312,57 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldKeepPollingWhileALongRunningJobHoldsPartOfTheCapacity() {
+    // given a worker whose handler executor can run a single job and rejects the rest
+    final int maxJobsActive = 4;
+    final AtomicInteger rejectedJobs = new AtomicInteger();
+    final CountDownLatch releaseHandler = new CountDownLatch(1);
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor =
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            (rejected, executor) -> {
+              rejectedJobs.incrementAndGet();
+              throw new RejectedExecutionException("Job handling executor is saturated");
+            });
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler((c, job) -> Uninterruptibles.awaitUninterruptibly(releaseHandler))
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .open()) {
+      try {
+        // when one job occupies the handler and the rest of the batch is rejected
+        Awaitility.await("Executor should reject the jobs it cannot run")
+            .untilAtomic(rejectedJobs, Matchers.greaterThanOrEqualTo(maxJobsActive - 1));
+
+        // then the worker keeps asking for jobs to fill the capacity the rejected jobs gave back,
+        // rather than waiting for the one running job to finish
+        gateway.startMeasuring();
+        Awaitility.await("Worker should keep activating jobs while one job is still running")
+            .atMost(Duration.ofSeconds(10))
+            .until(() -> gateway.getCountedPolls() > 1);
+      } finally {
+        releaseHandler.countDown();
+      }
+    }
+  }
+
+  @Test
   void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -33,6 +33,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
@@ -400,6 +402,95 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldFailRejectedJobsBackToTheBroker() {
+    // given a worker whose handler executor refuses every job
+    final int maxJobsActive = 4;
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = Executors.newSingleThreadExecutor();
+    jobHandlingExecutor.shutdown();
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(NOOP_JOB_HANDLER)
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .open()) {
+
+      // when the executor refuses the activated jobs
+      // then they are handed back so another worker can pick them up right away
+      Awaitility.await("Refused jobs should be failed back without using up a retry")
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(
+              () -> {
+                final List<FailJobRequest> failedJobs = gateway.getFailedJobs();
+                assertThat(failedJobs)
+                    .extracting(FailJobRequest::getJobKey)
+                    .contains(0L, 1L, 2L, 3L);
+                assertThat(failedJobs)
+                    .allSatisfy(
+                        request -> {
+                          assertThat(request.getRetries()).isEqualTo(TestData.JOB_RETRIES);
+                          assertThat(request.getRetryBackOff()).isZero();
+                        });
+              });
+    }
+  }
+
+  @Test
+  void shouldLeaveARefusedStreamedJobToTheBroker() {
+    // given a worker that streams jobs and whose handler executor refuses every job
+    final int maxJobsActive = 4;
+    final long streamedJobKey = 777L;
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = Executors.newSingleThreadExecutor();
+    jobHandlingExecutor.shutdown();
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(NOOP_JOB_HANDLER)
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .streamEnabled(true)
+                .open()) {
+      Awaitility.await("Stream should be open").until(() -> !gateway.openStreams.isEmpty());
+
+      // when a streamed job is refused by the handler executor. The push runs the worker's handling
+      // inline, so the job has been refused by the time this returns.
+      gateway.pushJob(TestData.job(streamedJobKey));
+
+      // then the worker keeps handing polled jobs back, so the fail path is demonstrably live
+      Awaitility.await("Refused polled jobs should still be handed back")
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(
+              () -> assertThat(gateway.getFailedJobs()).hasSizeGreaterThanOrEqualTo(maxJobsActive));
+
+      // and the streamed job is left alone, because the broker yields a job whose push fails and a
+      // fail command from here would race that yield
+      assertThat(gateway.getFailedJobs())
+          .extracting(FailJobRequest::getJobKey)
+          .doesNotContain(streamedJobKey);
+    }
+  }
+
+  @Test
   void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();
@@ -536,6 +627,9 @@ final class JobWorkerImplTest {
     private final Object requestedJobCountsLock = new Object();
     private final List<Integer> requestedJobCounts = new ArrayList<>();
 
+    private final Object failedJobsLock = new Object();
+    private final List<FailJobRequest> failedJobs = new ArrayList<>();
+
     private final Object metricsLock = new Object();
     private boolean isMeasuring = false;
     private long countedPolls = 0;
@@ -636,6 +730,22 @@ final class JobWorkerImplTest {
     public List<Integer> getRequestedJobCounts() {
       synchronized (requestedJobCountsLock) {
         return new ArrayList<>(requestedJobCounts);
+      }
+    }
+
+    @Override
+    public void failJob(
+        final FailJobRequest request, final StreamObserver<FailJobResponse> responseObserver) {
+      synchronized (failedJobsLock) {
+        failedJobs.add(request);
+      }
+      responseObserver.onNext(FailJobResponse.newBuilder().build());
+      responseObserver.onCompleted();
+    }
+
+    public List<FailJobRequest> getFailedJobs() {
+      synchronized (failedJobsLock) {
+        return new ArrayList<>(failedJobs);
       }
     }
   }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -52,7 +52,12 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -244,6 +249,65 @@ final class JobWorkerImplTest {
         // then
         Awaitility.await("Handler should see both").until(() -> jobs, Matchers.hasSize(2));
       }
+    }
+  }
+
+  @Test
+  void shouldKeepPollingAfterHandlerExecutorRejectsJobs() {
+    // given a worker whose handler executor can run a single job and rejects the rest, so that
+    // most of an activated batch never reaches a handler
+    final int maxJobsActive = 4;
+    final AtomicInteger rejectedJobs = new AtomicInteger();
+    final AtomicInteger handledJobs = new AtomicInteger();
+    final CountDownLatch releaseHandler = new CountDownLatch(1);
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor =
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            (rejected, executor) -> {
+              rejectedJobs.incrementAndGet();
+              throw new RejectedExecutionException("Job handling executor is saturated");
+            });
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(
+                    (c, job) -> {
+                      if (handledJobs.incrementAndGet() == 1) {
+                        Uninterruptibles.awaitUninterruptibly(releaseHandler);
+                      }
+                    })
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .open()) {
+
+      try {
+        // when the executor rejects the rest of the activated batch
+        Awaitility.await("Executor should reject the jobs it cannot run")
+            .untilAtomic(rejectedJobs, Matchers.greaterThanOrEqualTo(maxJobsActive - 1));
+      } finally {
+        // and the handler capacity is free again, also when the check above failed: a handler left
+        // waiting keeps its thread alive and holds up closing the client for 15 seconds
+        releaseHandler.countDown();
+      }
+
+      // then the worker keeps activating jobs
+      Awaitility.await("Worker should activate jobs again once capacity is free")
+          .atMost(Duration.ofSeconds(10))
+          .untilAtomic(handledJobs, Matchers.greaterThan(maxJobsActive));
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -540,6 +540,41 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldNotHandBackAJobWhoseHandlerAlreadyRan() {
+    // given a worker whose handler executor runs a job and then reports it as refused
+    final int maxJobsActive = 3;
+    final AtomicInteger handledJobs = new AtomicInteger();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = new RunsThenRefusesExecutor();
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler((c, job) -> handledJobs.incrementAndGet())
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .open()) {
+
+      // when the handler has run several rounds of jobs
+      Awaitility.await("Handler should run the activated jobs")
+          .atMost(Duration.ofSeconds(10))
+          .untilAtomic(handledJobs, Matchers.greaterThan(maxJobsActive * 2));
+
+      // then those jobs are left to the handler that ran them. Handing them back would have the
+      // broker offer them again, so a job the handler already completed could be run a second time
+      assertThat(gateway.getFailedJobs()).isEmpty();
+    }
+  }
+
+  @Test
   void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -20,11 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
+import io.camunda.client.api.worker.JobWorkerMetrics;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.CamundaClientImpl;
+import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.impl.response.ActivatedJobImpl;
 import io.camunda.client.impl.util.Environment;
 import io.camunda.client.impl.util.EnvironmentExtension;
 import io.camunda.client.impl.util.JobWorkerExecutors;
@@ -53,6 +58,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -62,8 +68,13 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
+import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -491,6 +502,44 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldKeepPollingWhenHandingARefusedJobBackFails() {
+    // given a job client that cannot send commands any more, as it would be while shutting down
+    final JobClient brokenJobClient = Mockito.mock(JobClient.class);
+    Mockito.when(
+            brokenJobClient.newFailCommand(
+                Mockito.any(io.camunda.client.api.response.ActivatedJob.class)))
+        .thenThrow(new IllegalStateException("Client is shutting down"));
+
+    // and a worker whose handler executor refuses every job
+    final DeterministicScheduler scheduler = new AlwaysRunningDeterministicScheduler();
+    final RecordingJobPoller poller = new RecordingJobPoller();
+    try (final JobWorkerImpl ignored =
+        new JobWorkerImpl(
+            4,
+            scheduler,
+            Duration.ofMillis(50),
+            brokenJobClient,
+            (job, doneCallback) -> doneCallback,
+            poller,
+            JobStreamer.noop(),
+            delay -> delay,
+            delay -> delay,
+            JobWorkerMetrics.noop(),
+            command -> {
+              throw new RejectedExecutionException("The executor has no capacity");
+            })) {
+
+      // when the poller hands over two jobs and handing the first one back to the broker fails
+      scheduler.tick(50, TimeUnit.MILLISECONDS);
+      poller.handOverJobs(TestData.jobs(2));
+
+      // then the worker still finished the poll, so it asks for jobs again
+      scheduler.tick(50, TimeUnit.MILLISECONDS);
+      assertThat(poller.getPollCount()).isEqualTo(2);
+    }
+  }
+
+  @Test
   void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();
@@ -602,6 +651,63 @@ final class JobWorkerImplTest {
     public void execute(final Runnable command) {
       command.run();
       throw new RejectedExecutionException("Command ran here, but the executor is out of capacity");
+    }
+  }
+
+  /**
+   * A scheduler that runs tasks only when the test tells it to. {@link DeterministicScheduler}
+   * refuses to answer whether it was shut down, while the worker asks that question whenever the
+   * handler executor refuses a job, so the answer is supplied here.
+   */
+  private static final class AlwaysRunningDeterministicScheduler extends DeterministicScheduler {
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+  }
+
+  /**
+   * Hands the jobs over the way the real poller does: from a callback of the request future rather
+   * than from the call to {@link #poll}. Anything thrown while handing a job over therefore ends up
+   * in that future, where nobody looks at it, instead of reaching the worker.
+   */
+  private static final class RecordingJobPoller implements JobPoller {
+    private final JsonMapper jsonMapper = new CamundaObjectMapper();
+    private final AtomicInteger pollCount = new AtomicInteger();
+    private final AtomicReference<Consumer<io.camunda.client.api.response.ActivatedJob>>
+        jobConsumer = new AtomicReference<>();
+    private final AtomicReference<IntConsumer> doneCallback = new AtomicReference<>();
+
+    @Override
+    public void poll(
+        final int maxJobsToActivate,
+        final Consumer<io.camunda.client.api.response.ActivatedJob> jobConsumer,
+        final IntConsumer doneCallback,
+        final Consumer<Throwable> errorCallback,
+        final BooleanSupplier openSupplier) {
+      pollCount.incrementAndGet();
+      this.jobConsumer.set(jobConsumer);
+      this.doneCallback.set(doneCallback);
+    }
+
+    private int getPollCount() {
+      return pollCount.get();
+    }
+
+    private void handOverJobs(final List<ActivatedJob> jobs) {
+      CompletableFuture.completedFuture(jobs)
+          .thenApply(
+              activatedJobs -> {
+                activatedJobs.forEach(
+                    job -> jobConsumer.get().accept(new ActivatedJobImpl(jsonMapper, job)));
+                doneCallback.get().accept(activatedJobs.size());
+                return null;
+              });
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -55,30 +55,29 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.migrationsupport.rules.ExternalResourceSupport;
 import org.mockito.Mockito;
 
 @SuppressWarnings("resource")
-@RunWith(JUnit4.class)
-public final class JobWorkerImplTest {
+@ExtendWith({ExternalResourceSupport.class, EnvironmentExtension.class})
+final class JobWorkerImplTest {
 
   private static final JobHandler NOOP_JOB_HANDLER = (client, job) -> {};
   private static final long SLOW_POLL_DELAY_IN_MS = 1_000L;
   private static final Duration SLOW_POLL_THRESHOLD = Duration.ofMillis(SLOW_POLL_DELAY_IN_MS / 2);
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-  @Rule public final EnvironmentExtension environmentRule = new EnvironmentExtension();
 
   private MockedGateway gateway;
   private CamundaClient client;
   private ManagedChannel channel;
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeEach
+  void setup() throws IOException {
     gateway = new MockedGateway();
 
     // ensure all gRPC resources are registered for cleanup. Since clients identify the in-process
@@ -102,7 +101,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void shouldBackoffWhenGatewayRespondsWithResourceExhausted() {
+  void shouldBackoffWhenGatewayRespondsWithResourceExhausted() {
     // given a gateway that responds with some jobs
     gateway.respondWith(TestData.jobs(10));
 
@@ -139,7 +138,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void shouldBackoffWhenStreamEnabledOnPollSuccessAndResponseIsEmpty() {
+  void shouldBackoffWhenStreamEnabledOnPollSuccessAndResponseIsEmpty() {
     // given a gateway that responds with some jobs
     gateway.respondWith(TestData.jobs(0));
 
@@ -168,7 +167,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void shouldOpenStreamIfOptedIn() {
+  void shouldOpenStreamIfOptedIn() {
     // given
     final JobWorkerBuilderStep3 builder =
         client.newWorker().jobType("test").handler(NOOP_JOB_HANDLER).streamEnabled(true);
@@ -184,7 +183,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void workerBuilderShouldOverrideEnvVariables() {
+  void workerBuilderShouldOverrideEnvVariables() {
     // given
     Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "false");
 
@@ -207,7 +206,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void shouldHandleOnlyCapacity() {
+  void shouldHandleOnlyCapacity() {
     // given
     final ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
     final ArrayList<io.camunda.client.api.response.ActivatedJob> jobs = new ArrayList<>();
@@ -249,7 +248,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void shouldCloseIfExecutorIsClosed() {
+  void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();
 
@@ -283,7 +282,7 @@ public final class JobWorkerImplTest {
   }
 
   @Test
-  public void shouldUseJobHandlingExecutorForJobs() {
+  void shouldUseJobHandlingExecutorForJobs() {
     // given
     final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     final ExecutorService jobHandlingExecutor =

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -575,6 +575,44 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldBackOffWhenTheHandlerExecutorTakesNoJobAtAll() {
+    // given a worker whose handler executor takes no job at all, so that nothing the worker
+    // activates ever runs and nothing is left running to prompt the next poll
+    final int maxJobsActive = 4;
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = Executors.newSingleThreadExecutor();
+    jobHandlingExecutor.shutdown();
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(NOOP_JOB_HANDLER)
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .backoffSupplier(prev -> SLOW_POLL_DELAY_IN_MS)
+                .open()) {
+
+      // when the worker keeps activating jobs the executor takes none of
+      // then it slows down, rather than activating and handing back jobs as fast as it can
+      gateway.startMeasuring();
+      Awaitility.await("Worker should slow down its polling")
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(
+              () ->
+                  assertThat(gateway.getTimeBetweenLatestPolls())
+                      .isGreaterThan(SLOW_POLL_THRESHOLD));
+    }
+  }
+
+  @Test
   void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -46,9 +46,11 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -363,6 +365,41 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldNotAskForMoreJobsThanItCanRunWhenAJobRunsAndIsRefusedAtTheSameTime() {
+    // given a worker whose handler executor runs a job and then reports it as refused
+    final int maxJobsActive = 3;
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = new RunsThenRefusesExecutor();
+    gateway.respondWith(TestData.jobs(maxJobsActive));
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(NOOP_JOB_HANDLER)
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .open()) {
+
+      // when the worker has been through several rounds of activating those jobs
+      Awaitility.await("Worker should activate jobs repeatedly")
+          .atMost(Duration.ofSeconds(10))
+          .until(() -> gateway.getRequestedJobCounts().size() >= 3);
+
+      // then it never asks for more jobs than it is allowed to run at a time, which it would do if
+      // it counted a job that both ran and was refused as two free slots instead of one
+      assertThat(gateway.getRequestedJobCounts())
+          .allSatisfy(requested -> assertThat(requested).isLessThanOrEqualTo(maxJobsActive));
+    }
+  }
+
+  @Test
   void shouldCloseIfExecutorIsClosed() {
     // given
     final ScheduledExecutorService closedExecutor = Executors.newSingleThreadScheduledExecutor();
@@ -441,6 +478,43 @@ final class JobWorkerImplTest {
   }
 
   /**
+   * An executor that runs the command and then reports it as refused. A saturated {@link
+   * java.util.concurrent.ThreadPoolExecutor} using {@link
+   * java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy} behaves this way when it is shut down
+   * while the caller is running the command.
+   */
+  private static final class RunsThenRefusesExecutor extends AbstractExecutorService {
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+      return true;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      command.run();
+      throw new RejectedExecutionException("Command ran here, but the executor is out of capacity");
+    }
+  }
+
+  /**
    * This mocked gateway is able to record metrics on polling for new jobs and easily switch how it
    * responds to polling.
    *
@@ -459,6 +533,9 @@ final class JobWorkerImplTest {
     private ActivateJobsResponse pollSuccessResponse = ActivateJobsResponse.newBuilder().build();
     private StatusRuntimeException pollErrorResponse = new StatusRuntimeException(Status.UNKNOWN);
 
+    private final Object requestedJobCountsLock = new Object();
+    private final List<Integer> requestedJobCounts = new ArrayList<>();
+
     private final Object metricsLock = new Object();
     private boolean isMeasuring = false;
     private long countedPolls = 0;
@@ -469,6 +546,9 @@ final class JobWorkerImplTest {
     public void activateJobs(
         final ActivateJobsRequest request,
         final StreamObserver<ActivateJobsResponse> responseObserver) {
+      synchronized (requestedJobCountsLock) {
+        requestedJobCounts.add(request.getMaxJobsToActivate());
+      }
       synchronized (metricsLock) {
         if (isMeasuring) {
           final Instant now = Instant.now();
@@ -550,6 +630,12 @@ final class JobWorkerImplTest {
     public long getCountedPolls() {
       synchronized (metricsLock) {
         return countedPolls;
+      }
+    }
+
+    public List<Integer> getRequestedJobCounts() {
+      synchronized (requestedJobCountsLock) {
+        return new ArrayList<>(requestedJobCounts);
       }
     }
   }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
@@ -25,6 +25,8 @@ import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.response.ActivatedJobImpl;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -39,7 +41,11 @@ import org.mockito.Mockito;
 final class JobWorkerMetricsTest {
 
   private static final int AUTO_COMPLETE_ALL_JOBS = 0;
-  private final DeterministicScheduler executor = new DeterministicScheduler();
+  private static final Executor REFUSING_EXECUTOR =
+      command -> {
+        throw new RejectedExecutionException("The executor has no capacity");
+      };
+  private final DeterministicScheduler executor = new AlwaysRunningDeterministicScheduler();
 
   private JobWorkerImpl createWorker(
       final int autoCompleteCount,
@@ -58,6 +64,15 @@ final class JobWorkerMetricsTest {
       final JobPoller poller,
       final JobStreamer streamer,
       final JobWorkerMetrics metrics) {
+    return createWorker(autoCompleteCount, poller, streamer, metrics, executor);
+  }
+
+  private JobWorkerImpl createWorker(
+      final int autoCompleteCount,
+      final JobPoller poller,
+      final JobStreamer streamer,
+      final JobWorkerMetrics metrics,
+      final Executor jobExecutor) {
     return new JobWorkerImpl(
         32,
         executor,
@@ -69,16 +84,33 @@ final class JobWorkerMetricsTest {
         delay -> delay,
         delay -> delay,
         metrics,
-        executor);
+        jobExecutor);
   }
 
   private JobPoller createNoopJobPoller() {
     return (maxJobsToActivate, jobConsumer, doneCallback, errorCallback, openSupplier) -> {};
   }
 
+  /**
+   * The worker asks the scheduler whether it is still running when the executor refuses a job.
+   * {@link DeterministicScheduler} answers both questions by throwing.
+   */
+  private static final class AlwaysRunningDeterministicScheduler extends DeterministicScheduler {
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+  }
+
   private static final class TestJobWorkerMetrics implements JobWorkerMetrics {
     private final AtomicInteger jobsActivated = new AtomicInteger();
     private final AtomicInteger jobsHandled = new AtomicInteger();
+    private final AtomicInteger jobsRefused = new AtomicInteger();
 
     @Override
     public void jobActivated(final int count) {
@@ -88,6 +120,11 @@ final class JobWorkerMetricsTest {
     @Override
     public void jobHandled(final int count) {
       jobsHandled.addAndGet(count);
+    }
+
+    @Override
+    public void jobRefused(final int count) {
+      jobsRefused.addAndGet(count);
     }
   }
 
@@ -192,6 +229,32 @@ final class JobWorkerMetricsTest {
         assertThat(metrics.jobsHandled).hasValue(2);
       }
     }
+
+    @Test
+    void shouldCountARefusedJobAsRefused() {
+      // given a worker whose handler executor takes no job at all
+      final TestJobStreamer streamer = new TestJobStreamer();
+      final TestJobWorkerMetrics metrics = new TestJobWorkerMetrics();
+
+      try (final JobWorkerImpl ignored =
+          createWorker(
+              AUTO_COMPLETE_ALL_JOBS,
+              createNoopJobPoller(),
+              streamer,
+              metrics,
+              REFUSING_EXECUTOR)) {
+        // when the broker pushes two jobs to it
+        streamer.streamJob();
+        streamer.streamJob();
+
+        // then the jobs are reported as refused rather than as still being worked on, so that
+        // activated minus handled minus refused reads as the nothing the worker is really doing
+        executor.runUntilIdle();
+        assertThat(metrics.jobsActivated).hasValue(2);
+        assertThat(metrics.jobsHandled).hasValue(0);
+        assertThat(metrics.jobsRefused).hasValue(2);
+      }
+    }
   }
 
   @Nested
@@ -231,6 +294,29 @@ final class JobWorkerMetricsTest {
         // then
         executor.runUntilIdle();
         assertThat(metrics.jobsHandled).hasValue(3);
+      }
+    }
+
+    @Test
+    void shouldCountARefusedJobAsRefused() {
+      // given a worker whose handler executor takes no job at all
+      final TestJobPoller poller = new TestJobPoller();
+      final TestJobWorkerMetrics metrics = new TestJobWorkerMetrics();
+
+      try (final JobWorkerImpl ignored =
+          createWorker(
+              AUTO_COMPLETE_ALL_JOBS, poller, JobStreamer.noop(), metrics, REFUSING_EXECUTOR)) {
+        // when the poller hands over two jobs
+        executor.tick(1, TimeUnit.MINUTES);
+        poller.produceJob();
+        poller.produceJob();
+
+        // then the jobs are reported as refused rather than as still being worked on, so that
+        // activated minus handled minus refused reads as the nothing the worker is really doing
+        executor.runUntilIdle();
+        assertThat(metrics.jobsActivated).hasValue(2);
+        assertThat(metrics.jobsHandled).hasValue(0);
+        assertThat(metrics.jobsRefused).hasValue(2);
       }
     }
   }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerMetrics;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.response.ActivatedJobImpl;
@@ -33,6 +34,7 @@ import java.util.function.IntConsumer;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 final class JobWorkerMetricsTest {
 
@@ -60,6 +62,7 @@ final class JobWorkerMetricsTest {
         32,
         executor,
         Duration.ofSeconds(30),
+        Mockito.mock(JobClient.class),
         new TestJobRunnableFactory(autoCompleteCount),
         poller,
         streamer,

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/TestData.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/TestData.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 final class TestData {
+  static final int JOB_RETRIES = 34;
+
   static ActivatedJob job() {
     return job(12);
   }
@@ -37,7 +39,7 @@ final class TestData {
         .setElementInstanceKey(23213)
         .setCustomHeaders("{\"version\": \"1\"}")
         .setWorker("worker1")
-        .setRetries(34)
+        .setRetries(JOB_RETRIES)
         .setDeadline(1231)
         .setVariables("{\"key\": \"val\"}")
         .build();

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/metrics/MicrometerJobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/metrics/MicrometerJobWorkerMetricsTest.java
@@ -59,6 +59,17 @@ final class MicrometerJobWorkerMetricsTest {
   }
 
   @Test
+  void shouldCountRefusedJobs() {
+    // when
+    metrics.jobRefused(4);
+
+    // then
+    Assertions.assertThat(meterRegistry).has(hasCounter(Names.JOB_REFUSED, tags));
+    Assertions.assertThat(meterRegistry.counter(Names.JOB_REFUSED.asString(), tags))
+        .has(hasCount(4));
+  }
+
+  @Test
   void shouldCountStreamInactivityRecreations() {
     // when
     metrics.streamInactivityRecreated();


### PR DESCRIPTION
## Description

Fixes a bug where a streaming job worker permanently stops polling after all jobs in a poll batch are rejected by the executor (e.g. when `maxJobsActive` is reached via `BlockingExecutor` timeout).

### Root Cause

`remainingJobs` was incremented for every job in a poll response upfront, before knowing whether the executor would actually accept them. When the executor threw `RejectedExecutionException`, the job's `Runnable` — and the cleanup logic inside it — never ran, so `remainingJobs` was never decremented. The counter kept growing until it permanently exceeded `activationThreshold`, causing `shouldPoll()` to return `false` indefinitely with no way to recover.

### Changes

**`JobWorkerImpl`**
- Capacity is now reserved per-job at the point of handing it off to the executor, rather than for the entire response at once.
- If the executor rejects a job, its reserved capacity is released immediately. An `AtomicBoolean` guard prevents the slot from being released twice in cases where a job both runs on the calling thread and gets rejected.
- Rejected polled jobs are actively returned to the broker (with their retry count preserved) via `returnJobToBroker()`, making them available for activation again right away rather than waiting for the full timeout. Rejected streamed jobs are left to the broker, which already handles failed pushes.
- When every job in a response is rejected and nothing is still running, the worker waits before attempting another poll instead of immediately hammering the broker.

**`BlockingExecutor`**
- Fixed a capacity leak where a `RejectedExecutionException` from the wrapped executor left a semaphore permit unreleased.
- An `AtomicBoolean` guard prevents a permit from being released twice when a command runs on the calling thread and then throws.
- If a thread is interrupted while waiting for capacity, the method now throws `RejectedExecutionException` (with the interrupt flag restored) instead of silently swallowing the interrupt.

**Tests**
- Migrated `JobWorkerImplTest` from JUnit 4 to JUnit 5.
- Added regression tests covering: rejected jobs resume polling, backoff when all jobs are rejected, refused jobs returned to the broker streamed jobs left to the broker, no double-counting when a job is simultaneously run and rejected, and interrupted capacity waits.

### Related Issues

Closes #59633