### PR TITLE
deps: upgrade micrometer to 1.16.7 to remediate CVE-2026-59296 (stable/8.8)

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>micrometer-commons</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -38,7 +38,15 @@
   <dependencyManagement>
     <dependencies>
       <!-- Re-import these BOMs (first-import-wins) ahead of spring-boot-dependencies so its
-      vulnerable netty/jackson/log4j/plexus-utils pins don't leak into the flattened clients. -->
+      vulnerable netty/jackson/log4j/plexus-utils/micrometer pins don't leak into the flattened
+      clients. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,9 +83,9 @@
     <version.opensearch-java>2.19.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>4.31.1</version.protobuf>
+    <version.protobuf>4.33.6</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.15.12</version.micrometer>
+    <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>10.2.1</version.rocksdbjni>
     <version.sbe>1.35.6</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
## What

Bumps `io.micrometer` from **1.15.12 → 1.16.7** and `com.google.protobuf:protobuf-java` from **4.31.1 → 4.33.6** on `stable/8.8` to remediate **CVE-2026-59296**.

## Why

CVE-2026-59296 (CWE-93, CVSS 8.2): `micrometer-core` does not sanitize line terminators (`\n`, `\r`) in metric names, tag keys, or tag values, enabling metric/log line-injection via the StatsD (Datadog/Etsy) registry or `LoggingMeterRegistry`.

- **Exploitability here: Not Affected.** The vulnerable sinks are unused — `micrometer-registry-statsd` is not a dependency, and `LoggingMeterRegistry` is never configured. Only Prometheus and OTLP registries are used. This PR is **scanner hygiene**, not an active-exposure fix.
- **Version choice:** the 1.15.x line's OSS support window ended 2026-06 (before this CVE was published 2026-08-23) and no `1.15.13` artifact exists on Maven Central. The lowest public OSS fix is **1.16.7**.

## Supersedes #60914 — companion to #61194 (stable/8.7)

That earlier attempt at the same bump broke application startup:

```
Failed to instantiate [io.micrometer.registry.otlp.OtlpMeterRegistry]:
Factory method 'otlpMeterRegistry' threw exception
```

This was **misdiagnosed at the time** as a Spring Boot 3.5 / micrometer OTLP-registry API-shape incompatibility requiring a Spring Boot uplift. Root-caused (on the identical `stable/8.7` case, see #61194) to something much narrower: **a protobuf gencode/runtime version mismatch.**

`micrometer-registry-otlp:1.16.7` pulls a newer transitive `io.opentelemetry.proto` artifact whose generated classes were compiled (gencode) against a newer `protobuf-java`. This branch pinned `protobuf-java:4.31.1`. `protobuf-java` 4.x enforces at class-init time that the runtime version must be `>=` the gencode version baked into generated message classes, so `OtlpMeterRegistry`'s static initializer throws `ExceptionInInitializerError` — Spring Boot's exception handling only surfaces the generic wrapper ("Factory method threw exception ... null"), which is why the real cause wasn't visible in the original PR's CI logs.

Bumping `version.protobuf` resolves it — **no Spring Boot / grpc version change needed** (grpc stays at `1.76.3`).

**Version choice for protobuf:** the bare minimum needed is `4.32.0`, but protobuf's own support policy ends support for a minor version the instant the next one ships — `4.32.0` was already superseded when `4.33.0` released, so picking it would hand this branch another already-EOL dependency. `4.33.6` is used instead: it's already running in production on `stable/8.9`, and its changelog vs `4.32.0` has no Java-relevant breaking changes (checked every release note between them).

## #59640 check

Also checked whether this newly exposes this branch to #59640 (camunda-spring-boot-3-starter pulling an incompatible Micrometer version on Spring Boot 3.5.x due to a `MeterRegistry.counter(String, Tags)` call baked into the compiled starter jar). **It does not**: `stable/8.8`'s `camunda-spring-boot-starter` and `clients/java` metrics code pass `List<Tag>`/`Iterable<Tag>`-typed arguments to `MeterRegistry.counter()`/`timer()`, which bind to the overload present in both micrometer 1.15.x and 1.16.x — unlike the `Tags`-typed call on `main` that #59640 is filed against.

## Verification

- `./mvnw install -pl parent,zeebe/qa/integration-tests -am -Dquickly -T1C` — green.
- `./mvnw verify -pl zeebe/qa/integration-tests -Dit.test=MetricsConfigurationIT -DskipTests=false -DskipUTs -Dquickly` — **`OtlpIT.shouldExportViaOtlp`** and **`PrometheusIT`** both pass (real IT run: embedded Tomcat + OTLP collector via testcontainers, not just a compile check).
- `./mvnw install -Dquickly -T1C` (full-repo baseline) — green, no enforcer/`dependencyConvergence` failures.

## ⚠️ CI must still validate the broader surface

Local verification covered `zeebe/qa/integration-tests` only. Please confirm this is fully green across CI before merging, especially:

- [ ] All CI green, including `[Spring-Boot-Compatibility] 3.5.x` and any Operate/Tasklist/Identity/Optimize startup or backup-restore integration tests that exercise the actuator/metrics stack — this is exactly what caught the original break in #60914.

## Related

- Companion PR: #61194 (stable/8.7, same fix, already confirmed green in CI)
- Tracking issue: #61174 (broader micrometer-1.15.x-EOL remediation decision for stable/8.7 and stable/8.8)
- Related issue: #59640 (same 1.15.x/1.16.x incompatibility class on `main`, opposite direction — checked not applicable here, see above)
- CVE-2026-59296 — https://nvd.nist.gov/vuln/detail/CVE-2026-59296

Closes: Closes: https://github.com/camunda/camunda/issues/61174