### PR TITLE
Add Java client support for agent-definition get & search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -149,6 +149,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.request.AgentDefinitionSearchRequest;
 import io.camunda.client.api.search.request.AgentInstanceHistorySearchRequest;
 import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
 import io.camunda.client.api.search.request.AuditLogSearchRequest;
@@ -3721,6 +3722,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for fetching an agent definition
    */
   AgentDefinitionGetRequest newAgentDefinitionGetRequest(long agentDefinitionKey);
+
+  /**
+   * Creates a request to search for agent definitions.
+   *
+   * <p>Agent definitions can be searched with filtering and sorting capabilities:
+   *
+   * <pre>
+   *   camundaClient
+   *       .newAgentDefinitionSearchRequest()
+   *       .filter(f -> f.agentType(AgentDefinitionType.AI_AGENT_SUB_PROCESS))
+   *       .sort(s -> s.processDefinitionKey().desc())
+   *       .send();
+   * </pre>
+   *
+   * @return a builder for searching agent definitions
+   */
+  AgentDefinitionSearchRequest newAgentDefinitionSearchRequest();
 
   /**
    * Creates a request to fetch an agent instance by its key.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -113,6 +113,7 @@ import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.AgentDefinitionGetRequest;
 import io.camunda.client.api.fetch.AgentInstanceGetRequest;
 import io.camunda.client.api.fetch.AuditLogGetRequest;
 import io.camunda.client.api.fetch.AuthorizationGetRequest;
@@ -3706,6 +3707,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for searching global task listeners
    */
   GlobalTaskListenerSearchRequest newGlobalTaskListenerSearchRequest();
+
+  /**
+   * Creates a request to fetch an agent definition by its key.
+   *
+   * <pre>
+   *   camundaClient
+   *       .newAgentDefinitionGetRequest(agentDefinitionKey)
+   *       .send();
+   * </pre>
+   *
+   * @param agentDefinitionKey the key of the agent definition to retrieve
+   * @return a builder for fetching an agent definition
+   */
+  AgentDefinitionGetRequest newAgentDefinitionGetRequest(long agentDefinitionKey);
 
   /**
    * Creates a request to fetch an agent instance by its key.

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/AgentDefinitionGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/AgentDefinitionGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.AgentDefinition;
+
+public interface AgentDefinitionGetRequest extends FinalCommandStep<AgentDefinition> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentDefinitionType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/AgentDefinitionType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum AgentDefinitionType {
+  AI_AGENT_SUB_PROCESS,
+  AI_AGENT_TASK,
+  EXTERNAL_AGENT,
+  UNKNOWN_ENUM_VALUE
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentDefinitionFilter.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.filter.builder.AgentDefinitionTypeProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+public interface AgentDefinitionFilter extends SearchRequestFilter {
+
+  /**
+   * Filter agent definitions by their unique key.
+   *
+   * @param value the agent definition key
+   * @return the updated filter
+   */
+  AgentDefinitionFilter agentDefinitionKey(long value);
+
+  /**
+   * Filter agent definitions by their unique key using a {@link BasicLongProperty} consumer.
+   *
+   * @param fn the key filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter agentDefinitionKey(Consumer<BasicLongProperty> fn);
+
+  /**
+   * Filter agent definitions by the kind of agent they describe.
+   *
+   * @param value the agent type to match
+   * @return the updated filter
+   */
+  AgentDefinitionFilter agentType(AgentDefinitionType value);
+
+  /**
+   * Filter agent definitions by the kind of agent they describe using an {@link
+   * AgentDefinitionTypeProperty} consumer.
+   *
+   * @param fn the agent type filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter agentType(Consumer<AgentDefinitionTypeProperty> fn);
+
+  /**
+   * Filter agent definitions by the human-readable name of the process element that owns them.
+   *
+   * @param value the name to match
+   * @return the updated filter
+   */
+  AgentDefinitionFilter name(String value);
+
+  /**
+   * Filter agent definitions by the human-readable name of the process element that owns them using
+   * a {@link StringProperty} consumer.
+   *
+   * @param fn the name filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter name(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent definitions by the BPMN element ID of the process element that owns them.
+   *
+   * @param value the BPMN element ID
+   * @return the updated filter
+   */
+  AgentDefinitionFilter elementId(String value);
+
+  /**
+   * Filter agent definitions by the BPMN element ID using a {@link StringProperty} consumer.
+   *
+   * @param fn the element ID filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter elementId(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent definitions by the BPMN process ID of the process definition that owns them.
+   *
+   * @param value the BPMN process ID
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionId(String value);
+
+  /**
+   * Filter agent definitions by the BPMN process ID using a {@link StringProperty} consumer.
+   *
+   * @param fn the process definition ID filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionId(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent definitions by the key of the process definition that owns them.
+   *
+   * @param value the process definition key
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionKey(long value);
+
+  /**
+   * Filter agent definitions by the process definition key using a {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the process definition key filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionKey(Consumer<BasicLongProperty> fn);
+
+  /**
+   * Filter agent definitions by the version of the process definition that owns them.
+   *
+   * @param value the version number
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionVersion(int value);
+
+  /**
+   * Filter agent definitions by the process definition version using an {@link IntegerProperty}
+   * consumer.
+   *
+   * @param fn the version filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionVersion(Consumer<IntegerProperty> fn);
+
+  /**
+   * Filter agent definitions by the version tag of the process definition that owns them.
+   *
+   * @param value the version tag string
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionVersionTag(String value);
+
+  /**
+   * Filter agent definitions by the process definition version tag using a {@link StringProperty}
+   * consumer.
+   *
+   * @param fn the version tag filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter processDefinitionVersionTag(Consumer<StringProperty> fn);
+
+  /**
+   * Filter agent definitions by their tenant ID.
+   *
+   * @param value the tenant ID
+   * @return the updated filter
+   */
+  AgentDefinitionFilter tenantId(String value);
+
+  /**
+   * Filter agent definitions by their tenant ID using a {@link StringProperty} consumer.
+   *
+   * @param fn the tenant ID filter consumer
+   * @return the updated filter
+   */
+  AgentDefinitionFilter tenantId(Consumer<StringProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentDefinitionTypeProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/AgentDefinitionTypeProperty.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import java.util.Collection;
+
+public interface AgentDefinitionTypeProperty
+    extends LikeProperty<AgentDefinitionType, String, AgentDefinitionTypeProperty> {
+
+  AgentDefinitionTypeProperty notIn(AgentDefinitionType... values);
+
+  AgentDefinitionTypeProperty notIn(Collection<AgentDefinitionType> values);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/AgentDefinitionSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/AgentDefinitionSearchRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.AgentDefinitionFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.client.api.search.sort.AgentDefinitionSort;
+
+public interface AgentDefinitionSearchRequest
+    extends TypedSearchRequest<
+            AgentDefinitionFilter, AgentDefinitionSort, AnyPage, AgentDefinitionSearchRequest>,
+        TypedPageableRequest<AnyPage, AgentDefinitionSearchRequest>,
+        FinalSearchRequestStep<AgentDefinition> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.request;
 
+import io.camunda.client.api.search.filter.AgentDefinitionFilter;
 import io.camunda.client.api.search.filter.AgentInstanceFilter;
 import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.client.api.search.filter.AuditLogFilter;
@@ -49,6 +50,7 @@ import io.camunda.client.api.search.page.CursorBackwardPage;
 import io.camunda.client.api.search.page.CursorForwardPage;
 import io.camunda.client.api.search.page.LimitPage;
 import io.camunda.client.api.search.page.OffsetPage;
+import io.camunda.client.api.search.sort.AgentDefinitionSort;
 import io.camunda.client.api.search.sort.AgentInstanceHistorySort;
 import io.camunda.client.api.search.sort.AgentInstanceSort;
 import io.camunda.client.api.search.sort.AuditLogSort;
@@ -85,6 +87,7 @@ import io.camunda.client.api.search.sort.VariableSort;
 import io.camunda.client.api.statistics.filter.JobErrorStatisticsFilter;
 import io.camunda.client.api.statistics.filter.JobTypeStatisticsFilter;
 import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.client.impl.search.filter.AgentDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.AgentInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.AgentInstanceHistoryFilterImpl;
 import io.camunda.client.impl.search.filter.AuthorizationFilterImpl;
@@ -119,6 +122,7 @@ import io.camunda.client.impl.search.page.CursorForwardPageImpl;
 import io.camunda.client.impl.search.page.LimitPageImpl;
 import io.camunda.client.impl.search.page.OffsetPageImpl;
 import io.camunda.client.impl.search.request.SearchRequestPageImpl;
+import io.camunda.client.impl.search.sort.AgentDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.AgentInstanceHistorySortImpl;
 import io.camunda.client.impl.search.sort.AgentInstanceSortImpl;
 import io.camunda.client.impl.search.sort.AuditLogSortImpl;
@@ -588,6 +592,19 @@ public final class SearchRequestBuilders {
   public static GlobalTaskListenerSort globalTaskListenerSort(
       final Consumer<GlobalTaskListenerSort> fn) {
     final GlobalTaskListenerSort sort = new GlobalTaskListenerSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static AgentDefinitionFilter agentDefinitionFilter(
+      final Consumer<AgentDefinitionFilter> fn) {
+    final AgentDefinitionFilter filter = new AgentDefinitionFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static AgentDefinitionSort agentDefinitionSort(final Consumer<AgentDefinitionSort> fn) {
+    final AgentDefinitionSort sort = new AgentDefinitionSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentDefinition.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentDefinition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+
+/** Represents an agent definition returned from the Camunda REST API. */
+public interface AgentDefinition {
+
+  /** Returns the unique key identifying this agent definition. */
+  long getAgentDefinitionKey();
+
+  /** Returns the kind of agent this agent definition describes. */
+  AgentDefinitionType getAgentType();
+
+  /**
+   * Returns the human-readable name of the process element that owns the agent definition. Falls
+   * back to the element ID when the element has no BPMN name configured.
+   */
+  String getName();
+
+  /** Returns the BPMN element ID of the process element that owns the agent definition. */
+  String getElementId();
+
+  /** Returns the BPMN process ID of the process definition that owns the agent definition. */
+  String getProcessDefinitionId();
+
+  /** Returns the key of the process definition that owns the agent definition. */
+  long getProcessDefinitionKey();
+
+  /** Returns the version of the process definition that owns the agent definition. */
+  int getProcessDefinitionVersion();
+
+  /**
+   * Returns the version tag of the process definition that owns the agent definition, or {@code
+   * null} if none was configured.
+   */
+  String getProcessDefinitionVersionTag();
+
+  /** Returns the tenant ID of this agent definition. */
+  String getTenantId();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentDefinitionSort.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+
+public interface AgentDefinitionSort extends SearchRequestSort<AgentDefinitionSort> {
+
+  AgentDefinitionSort agentDefinitionKey();
+
+  AgentDefinitionSort agentType();
+
+  AgentDefinitionSort name();
+
+  AgentDefinitionSort elementId();
+
+  AgentDefinitionSort processDefinitionId();
+
+  AgentDefinitionSort processDefinitionKey();
+
+  AgentDefinitionSort processDefinitionVersion();
+
+  AgentDefinitionSort processDefinitionVersionTag();
+
+  AgentDefinitionSort tenantId();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -124,6 +124,7 @@ import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.AgentDefinitionGetRequest;
 import io.camunda.client.api.fetch.AgentInstanceGetRequest;
 import io.camunda.client.api.fetch.AuditLogGetRequest;
 import io.camunda.client.api.fetch.AuthorizationGetRequest;
@@ -317,6 +318,7 @@ import io.camunda.client.impl.command.UpdateRoleCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
 import io.camunda.client.impl.command.UpdateUserCommandImpl;
 import io.camunda.client.impl.command.UpdateUserTaskCommandImpl;
+import io.camunda.client.impl.fetch.AgentDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.AgentInstanceGetRequestImpl;
 import io.camunda.client.impl.fetch.AuditLogGetRequestImpl;
 import io.camunda.client.impl.fetch.AuthorizationGetRequestImpl;
@@ -1844,6 +1846,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public GlobalTaskListenerSearchRequest newGlobalTaskListenerSearchRequest() {
     return new GlobalTaskListenerSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public AgentDefinitionGetRequest newAgentDefinitionGetRequest(final long agentDefinitionKey) {
+    return new AgentDefinitionGetRequestImpl(httpClient, agentDefinitionKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -160,6 +160,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.request.AgentDefinitionSearchRequest;
 import io.camunda.client.api.search.request.AgentInstanceHistorySearchRequest;
 import io.camunda.client.api.search.request.AgentInstanceSearchRequest;
 import io.camunda.client.api.search.request.AuditLogSearchRequest;
@@ -353,6 +354,7 @@ import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
 import io.camunda.client.impl.fetch.VariableGetRequestImpl;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.http.HttpClientFactory;
+import io.camunda.client.impl.search.request.AgentDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.AgentInstanceHistorySearchRequestImpl;
 import io.camunda.client.impl.search.request.AgentInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.AuditLogSearchRequestImpl;
@@ -1851,6 +1853,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public AgentDefinitionGetRequest newAgentDefinitionGetRequest(final long agentDefinitionKey) {
     return new AgentDefinitionGetRequestImpl(httpClient, agentDefinitionKey);
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest newAgentDefinitionSearchRequest() {
+    return new AgentDefinitionSearchRequestImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/AgentDefinitionGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/AgentDefinitionGetRequestImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.AgentDefinitionGetRequest;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.AgentDefinitionImpl;
+import io.camunda.client.protocol.rest.AgentDefinitionResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AgentDefinitionGetRequestImpl implements AgentDefinitionGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long agentDefinitionKey;
+
+  public AgentDefinitionGetRequestImpl(final HttpClient httpClient, final long agentDefinitionKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    ArgumentUtil.ensureGreaterThan("agentDefinitionKey", agentDefinitionKey, 0);
+    this.agentDefinitionKey = agentDefinitionKey;
+  }
+
+  @Override
+  public FinalCommandStep<AgentDefinition> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<AgentDefinition> send() {
+    final HttpCamundaFuture<AgentDefinition> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        "/agent-definitions/" + agentDefinitionKey,
+        httpRequestConfig.build(),
+        AgentDefinitionResult.class,
+        AgentDefinitionImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentDefinitionFilterImpl.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.filter.AgentDefinitionFilter;
+import io.camunda.client.api.search.filter.builder.AgentDefinitionTypeProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.AgentDefinitionTypePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import java.util.function.Consumer;
+
+public class AgentDefinitionFilterImpl
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.AgentDefinitionFilter>
+    implements AgentDefinitionFilter {
+
+  private final io.camunda.client.protocol.rest.AgentDefinitionFilter filter;
+
+  public AgentDefinitionFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.AgentDefinitionFilter();
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.AgentDefinitionFilter getSearchRequestProperty() {
+    return filter;
+  }
+
+  @Override
+  public AgentDefinitionFilter agentDefinitionKey(final long value) {
+    return agentDefinitionKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter agentDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setAgentDefinitionKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter agentType(final AgentDefinitionType value) {
+    return agentType(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter agentType(final Consumer<AgentDefinitionTypeProperty> fn) {
+    final AgentDefinitionTypeProperty property = new AgentDefinitionTypePropertyImpl();
+    fn.accept(property);
+    filter.setAgentType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter name(final String value) {
+    return name(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter elementId(final String value) {
+    return elementId(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter elementId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setElementId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionId(final String value) {
+    return processDefinitionId(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionId(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionKey(final long value) {
+    return processDefinitionKey(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionKey(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionVersion(final int value) {
+    return processDefinitionVersion(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionVersion(final Consumer<IntegerProperty> fn) {
+    final IntegerProperty property = new IntegerPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionVersion(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionVersionTag(final String value) {
+    return processDefinitionVersionTag(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter processDefinitionVersionTag(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionVersionTag(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionFilter tenantId(final String value) {
+    return tenantId(f -> f.eq(value));
+  }
+
+  @Override
+  public AgentDefinitionFilter tenantId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setTenantId(provideSearchRequestProperty(property));
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentDefinitionTypePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/AgentDefinitionTypePropertyImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.filter.builder.AgentDefinitionTypeProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentDefinitionTypeEnum;
+import io.camunda.client.protocol.rest.AgentDefinitionTypeFilterProperty;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AgentDefinitionTypePropertyImpl
+    extends TypedSearchRequestPropertyProvider<AgentDefinitionTypeFilterProperty>
+    implements AgentDefinitionTypeProperty {
+
+  private final AgentDefinitionTypeFilterProperty filterProperty =
+      new AgentDefinitionTypeFilterProperty();
+
+  @Override
+  public AgentDefinitionTypeProperty eq(final AgentDefinitionType value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, AgentDefinitionTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty neq(final AgentDefinitionType value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, AgentDefinitionTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty in(final List<AgentDefinitionType> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(value -> EnumUtil.convert(value, AgentDefinitionTypeEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty in(final AgentDefinitionType... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty notIn(final AgentDefinitionType... values) {
+    return notIn(CollectionUtil.toList(values));
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty notIn(final Collection<AgentDefinitionType> values) {
+    filterProperty.set$NotIn(
+        values.stream()
+            .map(value -> EnumUtil.convert(value, AgentDefinitionTypeEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  protected AgentDefinitionTypeFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public AgentDefinitionTypeProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/AgentDefinitionSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/AgentDefinitionSearchRequestImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.agentDefinitionFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.agentDefinitionSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.anyPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.AgentDefinitionFilter;
+import io.camunda.client.api.search.page.AnyPage;
+import io.camunda.client.api.search.request.AgentDefinitionSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.AgentDefinitionSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.AgentDefinitionSearchQuery;
+import io.camunda.client.protocol.rest.AgentDefinitionSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AgentDefinitionSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<AgentDefinitionSearchQuery>
+    implements AgentDefinitionSearchRequest {
+
+  private final AgentDefinitionSearchQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public AgentDefinitionSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AgentDefinitionSearchQuery();
+  }
+
+  @Override
+  public FinalSearchRequestStep<AgentDefinition> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<AgentDefinition>> send() {
+    final HttpCamundaFuture<SearchResponse<AgentDefinition>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/agent-definitions/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        AgentDefinitionSearchQueryResult.class,
+        SearchResponseMapper::toAgentDefinitionSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest filter(final AgentDefinitionFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest filter(final Consumer<AgentDefinitionFilter> fn) {
+    return filter(agentDefinitionFilter(fn));
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest page(final AnyPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest page(final Consumer<AnyPage> fn) {
+    return page(anyPage(fn));
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest sort(final AgentDefinitionSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toAgentDefinitionSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionSearchRequest sort(final Consumer<AgentDefinitionSort> fn) {
+    return sort(agentDefinitionSort(fn));
+  }
+
+  @Override
+  protected AgentDefinitionSearchQuery getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -667,6 +667,21 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<AgentDefinitionSearchQuerySortRequest> toAgentDefinitionSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final AgentDefinitionSearchQuerySortRequest request =
+                  new AgentDefinitionSearchQuerySortRequest();
+              request.setField(
+                  AgentDefinitionSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<AgentInstanceSearchQuerySortRequest> toAgentInstanceSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentDefinitionImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AgentDefinitionResult;
+
+public class AgentDefinitionImpl implements AgentDefinition {
+
+  private final long agentDefinitionKey;
+  private final AgentDefinitionType agentType;
+  private final String name;
+  private final String elementId;
+  private final String processDefinitionId;
+  private final long processDefinitionKey;
+  private final int processDefinitionVersion;
+  private final String processDefinitionVersionTag;
+  private final String tenantId;
+
+  public AgentDefinitionImpl(final AgentDefinitionResult result) {
+    agentDefinitionKey = Long.parseLong(result.getAgentDefinitionKey());
+    agentType = EnumUtil.convert(result.getAgentType(), AgentDefinitionType.class);
+    name = result.getName();
+    elementId = result.getElementId();
+    processDefinitionId = result.getProcessDefinitionId();
+    processDefinitionKey = Long.parseLong(result.getProcessDefinitionKey());
+    processDefinitionVersion = result.getProcessDefinitionVersion();
+    processDefinitionVersionTag = result.getProcessDefinitionVersionTag();
+    tenantId = result.getTenantId();
+  }
+
+  @Override
+  public long getAgentDefinitionKey() {
+    return agentDefinitionKey;
+  }
+
+  @Override
+  public AgentDefinitionType getAgentType() {
+    return agentType;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+
+  @Override
+  public String getProcessDefinitionVersionTag() {
+    return processDefinitionVersionTag;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.response.Resource;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.api.search.response.AgentDefinition;
 import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.client.api.search.response.AuditLogResult;
@@ -72,6 +73,10 @@ import java.util.stream.Collectors;
 public final class SearchResponseMapper {
 
   private SearchResponseMapper() {}
+
+  public static AgentDefinition toAgentDefinitionGetResponse(final AgentDefinitionResult result) {
+    return new AgentDefinitionImpl(result);
+  }
 
   public static AgentInstance toAgentInstanceGetResponse(final AgentInstanceResult result) {
     return new AgentInstanceImpl(result);

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -78,6 +78,14 @@ public final class SearchResponseMapper {
     return new AgentDefinitionImpl(result);
   }
 
+  public static SearchResponse<AgentDefinition> toAgentDefinitionSearchResponse(
+      final AgentDefinitionSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<AgentDefinition> instances =
+        toSearchResponseInstances(response.getItems(), AgentDefinitionImpl::new);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
   public static AgentInstance toAgentInstanceGetResponse(final AgentInstanceResult result) {
     return new AgentInstanceImpl(result);
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentDefinitionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentDefinitionSortImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.AgentDefinitionSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class AgentDefinitionSortImpl extends SearchRequestSortBase<AgentDefinitionSort>
+    implements AgentDefinitionSort {
+
+  @Override
+  protected AgentDefinitionSort self() {
+    return this;
+  }
+
+  @Override
+  public AgentDefinitionSort agentDefinitionKey() {
+    return field("agentDefinitionKey");
+  }
+
+  @Override
+  public AgentDefinitionSort agentType() {
+    return field("agentType");
+  }
+
+  @Override
+  public AgentDefinitionSort name() {
+    return field("name");
+  }
+
+  @Override
+  public AgentDefinitionSort elementId() {
+    return field("elementId");
+  }
+
+  @Override
+  public AgentDefinitionSort processDefinitionId() {
+    return field("processDefinitionId");
+  }
+
+  @Override
+  public AgentDefinitionSort processDefinitionKey() {
+    return field("processDefinitionKey");
+  }
+
+  @Override
+  public AgentDefinitionSort processDefinitionVersion() {
+    return field("processDefinitionVersion");
+  }
+
+  @Override
+  public AgentDefinitionSort processDefinitionVersionTag() {
+    return field("processDefinitionVersionTag");
+  }
+
+  @Override
+  public AgentDefinitionSort tenantId() {
+    return field("tenantId");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentdefinition/GetAgentDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentdefinition/GetAgentDefinitionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentdefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.client.protocol.rest.AgentDefinitionResult;
+import io.camunda.client.protocol.rest.AgentDefinitionTypeEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+class GetAgentDefinitionTest extends ClientRestTest {
+
+  @Test
+  void shouldGetAgentDefinitionByKey() {
+    // given
+    final long agentDefinitionKey = 1234L;
+
+    gatewayService.onAgentDefinitionGetRequest(
+        agentDefinitionKey,
+        Instancio.create(AgentDefinitionResult.class)
+            .agentDefinitionKey(String.valueOf(agentDefinitionKey))
+            .agentType(AgentDefinitionTypeEnum.AI_AGENT_SUB_PROCESS)
+            .name("My Agent")
+            .elementId("agentElement")
+            .processDefinitionId("testProcess")
+            .processDefinitionKey("5000")
+            .processDefinitionVersion(2)
+            .processDefinitionVersionTag("v2")
+            .tenantId("<default>"));
+
+    // when
+    final AgentDefinition result =
+        client.newAgentDefinitionGetRequest(agentDefinitionKey).send().join();
+
+    // then it sends the correct request
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).as("HTTP method").isEqualTo(RequestMethod.GET);
+    assertThat(request.getUrl())
+        .as("request URL should target the agent definition by key")
+        .isEqualTo("/v2/agent-definitions/1234");
+    assertThat(request.getBodyAsString()).as("GET request should have no body").isEmpty();
+
+    // and maps the response correctly
+    assertSoftly(
+        softly -> {
+          softly
+              .assertThat(result.getAgentDefinitionKey())
+              .as("agentDefinitionKey")
+              .isEqualTo(agentDefinitionKey);
+          softly
+              .assertThat(result.getAgentType())
+              .as("agentType")
+              .isEqualTo(AgentDefinitionType.AI_AGENT_SUB_PROCESS);
+          softly.assertThat(result.getName()).as("name").isEqualTo("My Agent");
+          softly.assertThat(result.getElementId()).as("elementId").isEqualTo("agentElement");
+          softly
+              .assertThat(result.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo("testProcess");
+          softly
+              .assertThat(result.getProcessDefinitionKey())
+              .as("processDefinitionKey")
+              .isEqualTo(5000L);
+          softly
+              .assertThat(result.getProcessDefinitionVersion())
+              .as("processDefinitionVersion")
+              .isEqualTo(2);
+          softly
+              .assertThat(result.getProcessDefinitionVersionTag())
+              .as("processDefinitionVersionTag")
+              .isEqualTo("v2");
+          softly.assertThat(result.getTenantId()).as("tenantId").isEqualTo("<default>");
+        });
+  }
+
+  @Test
+  void shouldThrowOnInvalidAgentDefinitionKey() {
+    assertThatThrownBy(() -> client.newAgentDefinitionGetRequest(0).send().join())
+        .as("a key of 0 is not a valid agent definition key")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("agentDefinitionKey must be greater than 0");
+
+    assertThatThrownBy(() -> client.newAgentDefinitionGetRequest(-1).send().join())
+        .as("a negative key is not a valid agent definition key")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("agentDefinitionKey must be greater than 0");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/agentdefinition/SearchAgentDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentdefinition/SearchAgentDefinitionTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.agentdefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.client.protocol.rest.AgentDefinitionResult;
+import io.camunda.client.protocol.rest.AgentDefinitionSearchQuery;
+import io.camunda.client.protocol.rest.AgentDefinitionSearchQueryResult;
+import io.camunda.client.protocol.rest.AgentDefinitionSearchQuerySortRequest;
+import io.camunda.client.protocol.rest.AgentDefinitionTypeEnum;
+import io.camunda.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.client.protocol.rest.SortOrderEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.util.Collections;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+
+class SearchAgentDefinitionTest extends ClientRestTest {
+
+  @Test
+  void shouldSearchAgentDefinitions() {
+    // when
+    client.newAgentDefinitionSearchRequest().send().join();
+
+    // then
+    final LoggedRequest restRequest = RestGatewayService.getLastRequest();
+    assertThat(restRequest.getMethod()).as("HTTP method").isEqualTo(RequestMethod.POST);
+    assertThat(restRequest.getUrl())
+        .as("request URL should target the agent definition search endpoint")
+        .isEqualTo("/v2/agent-definitions/search");
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter()).as("no filter should be sent when none is specified").isNull();
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithAgentDefinitionKeyFilter() {
+    // when
+    client.newAgentDefinitionSearchRequest().filter(f -> f.agentDefinitionKey(1234L)).send().join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter().getAgentDefinitionKey().get$Eq())
+        .as("agentDefinitionKey filter should be sent as its string-encoded $eq value")
+        .isEqualTo("1234");
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithAgentTypeFilter() {
+    // when
+    client
+        .newAgentDefinitionSearchRequest()
+        .filter(f -> f.agentType(AgentDefinitionType.AI_AGENT_TASK))
+        .send()
+        .join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter().getAgentType().get$Eq())
+        .as("agentType filter should be sent as its $eq value")
+        .isEqualTo(AgentDefinitionTypeEnum.AI_AGENT_TASK);
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithAgentTypeNotInFilter() {
+    // when
+    client
+        .newAgentDefinitionSearchRequest()
+        .filter(
+            f ->
+                f.agentType(
+                    b ->
+                        b.notIn(
+                            AgentDefinitionType.AI_AGENT_TASK, AgentDefinitionType.EXTERNAL_AGENT)))
+        .send()
+        .join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter().getAgentType().get$NotIn())
+        .as("agentType $notIn filter should carry both excluded values, in order")
+        .containsExactly(
+            AgentDefinitionTypeEnum.AI_AGENT_TASK, AgentDefinitionTypeEnum.EXTERNAL_AGENT);
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithNameAndElementIdFilters() {
+    // when
+    client
+        .newAgentDefinitionSearchRequest()
+        .filter(f -> f.name("My Agent").elementId("agentElement"))
+        .send()
+        .join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter().getName().get$Eq())
+        .as("name filter should be sent as its $eq value")
+        .isEqualTo("My Agent");
+    assertThat(request.getFilter().getElementId().get$Eq())
+        .as("elementId filter should be sent as its $eq value")
+        .isEqualTo("agentElement");
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithProcessDefinitionFilters() {
+    // when
+    client
+        .newAgentDefinitionSearchRequest()
+        .filter(
+            f ->
+                f.processDefinitionId("testProcess")
+                    .processDefinitionKey(5000L)
+                    .processDefinitionVersion(2)
+                    .processDefinitionVersionTag("v2"))
+        .send()
+        .join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionId().get$Eq())
+        .as("processDefinitionId filter should be sent as its $eq value")
+        .isEqualTo("testProcess");
+    assertThat(request.getFilter().getProcessDefinitionKey().get$Eq())
+        .as("processDefinitionKey filter should be sent as its string-encoded $eq value")
+        .isEqualTo("5000");
+    assertThat(request.getFilter().getProcessDefinitionVersion().get$Eq())
+        .as("processDefinitionVersion filter should be sent as its $eq value")
+        .isEqualTo(2);
+    assertThat(request.getFilter().getProcessDefinitionVersionTag().get$Eq())
+        .as("processDefinitionVersionTag filter should be sent as its $eq value")
+        .isEqualTo("v2");
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithTenantIdFilter() {
+    // when
+    client.newAgentDefinitionSearchRequest().filter(f -> f.tenantId("<default>")).send().join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getFilter().getTenantId().get$Eq())
+        .as("tenantId filter should be sent as its $eq value")
+        .isEqualTo("<default>");
+  }
+
+  @Test
+  void shouldSearchAgentDefinitionsWithFullSorting() {
+    // when
+    client
+        .newAgentDefinitionSearchRequest()
+        .sort(
+            s ->
+                s.agentDefinitionKey()
+                    .asc()
+                    .agentType()
+                    .asc()
+                    .name()
+                    .asc()
+                    .elementId()
+                    .asc()
+                    .processDefinitionId()
+                    .asc()
+                    .processDefinitionKey()
+                    .asc()
+                    .processDefinitionVersion()
+                    .asc()
+                    .processDefinitionVersionTag()
+                    .asc()
+                    .tenantId()
+                    .desc())
+        .send()
+        .join();
+
+    // then
+    final AgentDefinitionSearchQuery request =
+        gatewayService.getLastRequest(AgentDefinitionSearchQuery.class);
+    assertThat(request.getSort())
+        .as("sort fields and orders")
+        .extracting(
+            AgentDefinitionSearchQuerySortRequest::getField,
+            AgentDefinitionSearchQuerySortRequest::getOrder)
+        .containsExactly(
+            tuple(
+                AgentDefinitionSearchQuerySortRequest.FieldEnum.AGENT_DEFINITION_KEY,
+                SortOrderEnum.ASC),
+            tuple(AgentDefinitionSearchQuerySortRequest.FieldEnum.AGENT_TYPE, SortOrderEnum.ASC),
+            tuple(AgentDefinitionSearchQuerySortRequest.FieldEnum.NAME, SortOrderEnum.ASC),
+            tuple(AgentDefinitionSearchQuerySortRequest.FieldEnum.ELEMENT_ID, SortOrderEnum.ASC),
+            tuple(
+                AgentDefinitionSearchQuerySortRequest.FieldEnum.PROCESS_DEFINITION_ID,
+                SortOrderEnum.ASC),
+            tuple(
+                AgentDefinitionSearchQuerySortRequest.FieldEnum.PROCESS_DEFINITION_KEY,
+                SortOrderEnum.ASC),
+            tuple(
+                AgentDefinitionSearchQuerySortRequest.FieldEnum.PROCESS_DEFINITION_VERSION,
+                SortOrderEnum.ASC),
+            tuple(
+                AgentDefinitionSearchQuerySortRequest.FieldEnum.PROCESS_DEFINITION_VERSION_TAG,
+                SortOrderEnum.ASC),
+            tuple(AgentDefinitionSearchQuerySortRequest.FieldEnum.TENANT_ID, SortOrderEnum.DESC));
+  }
+
+  @Test
+  void shouldMapSearchAgentDefinitionsResponse() {
+    // given
+    final AgentDefinitionResult provided =
+        Instancio.create(AgentDefinitionResult.class)
+            .agentDefinitionKey("84")
+            .agentType(AgentDefinitionTypeEnum.EXTERNAL_AGENT)
+            .name("My Agent")
+            .elementId("agentElement")
+            .processDefinitionId("testProcess")
+            .processDefinitionKey("100")
+            .processDefinitionVersion(1)
+            .processDefinitionVersionTag("v1")
+            .tenantId("<default>");
+
+    gatewayService.onAgentDefinitionSearchRequest(
+        Instancio.create(AgentDefinitionSearchQueryResult.class)
+            .page(
+                Instancio.create(SearchQueryPageResponse.class)
+                    .totalItems(1L)
+                    .hasMoreTotalItems(false))
+            .items(Collections.singletonList(provided)));
+
+    // when
+    final io.camunda.client.api.search.response.SearchResponse<AgentDefinition> result =
+        client.newAgentDefinitionSearchRequest().send().join();
+
+    // then
+    assertSoftly(
+        softly -> {
+          softly.assertThat(result.page().totalItems()).as("page.totalItems").isEqualTo(1);
+          softly.assertThat(result.items()).as("items").hasSize(1);
+
+          final AgentDefinition item = result.items().get(0);
+          softly.assertThat(item.getAgentDefinitionKey()).as("agentDefinitionKey").isEqualTo(84L);
+          softly
+              .assertThat(item.getAgentType())
+              .as("agentType")
+              .isEqualTo(AgentDefinitionType.EXTERNAL_AGENT);
+          softly.assertThat(item.getName()).as("name").isEqualTo("My Agent");
+          softly.assertThat(item.getElementId()).as("elementId").isEqualTo("agentElement");
+          softly
+              .assertThat(item.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo("testProcess");
+          softly
+              .assertThat(item.getProcessDefinitionKey())
+              .as("processDefinitionKey")
+              .isEqualTo(100L);
+          softly
+              .assertThat(item.getProcessDefinitionVersion())
+              .as("processDefinitionVersion")
+              .isEqualTo(1);
+          softly
+              .assertThat(item.getProcessDefinitionVersionTag())
+              .as("processDefinitionVersionTag")
+              .isEqualTo("v1");
+          softly.assertThat(item.getTenantId()).as("tenantId").isEqualTo("<default>");
+        });
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -22,6 +22,9 @@ public class RestGatewayPaths {
 
   private static final String URL_AUTHORIZATION = REST_API_PATH + "/authorizations/%s";
   private static final String URL_AUTHORIZATIONS = REST_API_PATH + "/authorizations";
+  private static final String URL_AGENT_DEFINITION = REST_API_PATH + "/agent-definitions/%s";
+  private static final String URL_AGENT_DEFINITIONS_SEARCH =
+      REST_API_PATH + "/agent-definitions/search";
   private static final String URL_AGENT_INSTANCES = REST_API_PATH + "/agent-instances";
   private static final String URL_AGENT_INSTANCE = REST_API_PATH + "/agent-instances/%s";
   private static final String URL_AGENT_HISTORY_SEARCH =
@@ -549,6 +552,14 @@ public class RestGatewayPaths {
 
   public static String getJobErrorStatisticsUrl() {
     return URL_JOB_ERROR_STATISTICS;
+  }
+
+  public static String getAgentDefinitionUrl(final long agentDefinitionKey) {
+    return String.format(URL_AGENT_DEFINITION, agentDefinitionKey);
+  }
+
+  public static String getAgentDefinitionsSearchUrl() {
+    return URL_AGENT_DEFINITIONS_SEARCH;
   }
 
   public static String getAgentInstancesUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -21,6 +21,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.protocol.rest.AgentDefinitionResult;
+import io.camunda.client.protocol.rest.AgentDefinitionSearchQueryResult;
 import io.camunda.client.protocol.rest.AgentInstanceCreationResult;
 import io.camunda.client.protocol.rest.AgentInstanceHistorySearchQueryResult;
 import io.camunda.client.protocol.rest.AgentInstanceResult;
@@ -402,6 +404,15 @@ public class RestGatewayService {
   public void onBatchOperationRequest(
       final String batchOperationKey, final BatchOperationResponse response) {
     registerGet(RestGatewayPaths.getBatchOperationUrl(batchOperationKey), response);
+  }
+
+  public void onAgentDefinitionGetRequest(
+      final long agentDefinitionKey, final AgentDefinitionResult response) {
+    registerGet(RestGatewayPaths.getAgentDefinitionUrl(agentDefinitionKey), response);
+  }
+
+  public void onAgentDefinitionSearchRequest(final AgentDefinitionSearchQueryResult response) {
+    registerPost(RestGatewayPaths.getAgentDefinitionsSearchUrl(), response);
   }
 
   public void onCreateAgentInstanceRequest(final AgentInstanceCreationResult response) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentDefinitionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentDefinitionAuthorizationIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentDefinitionsToBeIndexed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class AgentDefinitionAuthorizationIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentDefinitionAuthElement";
+  private static final String PROCESS_ID_1 = "agentDefinitionAuthProcess1";
+  private static final String PROCESS_ID_2 = "agentDefinitionAuthProcess2";
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*"))));
+
+  // user1 may read agent definitions of PROCESS_ID_1 only
+  @UserDefinition
+  private static final TestUser USER1_USER =
+      new TestUser(
+          USER1,
+          "password",
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of(PROCESS_ID_1))));
+
+  // user2 may read agent definitions of PROCESS_ID_2 only
+  @UserDefinition
+  private static final TestUser USER2_USER =
+      new TestUser(
+          USER2,
+          "password",
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of(PROCESS_ID_2))));
+
+  private static long agentDefinitionKey1;
+  private static long agentDefinitionKey2;
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    final var processDefinitionKey1 = deployAgentProcess(adminClient, PROCESS_ID_1);
+    final var processDefinitionKey2 = deployAgentProcess(adminClient, PROCESS_ID_2);
+
+    waitForAgentDefinitionsToBeIndexed(
+        adminClient, f -> f.processDefinitionKey(processDefinitionKey1), 1);
+    waitForAgentDefinitionsToBeIndexed(
+        adminClient, f -> f.processDefinitionKey(processDefinitionKey2), 1);
+
+    agentDefinitionKey1 = fetchAgentDefinitionKey(adminClient, processDefinitionKey1);
+    agentDefinitionKey2 = fetchAgentDefinitionKey(adminClient, processDefinitionKey2);
+  }
+
+  // ── search ────────────────────────────────────────────────────────────────
+
+  @Test
+  void searchShouldReturnOnlyAuthorizedAgentDefinitions(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionSearchRequest().execute();
+
+    // then
+    assertThat(result.items())
+        .as("user1 is only authorized to read PROCESS_ID_1, so search must not leak PROCESS_ID_2")
+        .singleElement()
+        .satisfies(
+            definition ->
+                assertThat(definition.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey1));
+  }
+
+  @Test
+  void searchShouldNotReturnUnauthorizedAgentDefinitions(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when — user1 filters explicitly on the process they cannot read
+    final var result =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionId(PROCESS_ID_2))
+            .execute();
+
+    // then
+    assertThat(result.items())
+        .as("filtering on an unauthorized process should yield no results, not an error")
+        .isEmpty();
+  }
+
+  @Test
+  void searchShouldReturnAllAgentDefinitionsForAdmin(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionSearchRequest().execute();
+
+    // then — admin sees both agent definitions
+    assertThat(result.items())
+        .as("admin has read access to every process, so both agent definitions should be visible")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .containsExactlyInAnyOrder(agentDefinitionKey1, agentDefinitionKey2);
+  }
+
+  // ── getByKey ──────────────────────────────────────────────────────────────
+
+  @Test
+  void getByKeyShouldReturnAuthorizedAgentDefinition(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionGetRequest(agentDefinitionKey2).execute();
+
+    // then
+    assertThat(result).as("user2 should be able to fetch a definition of PROCESS_ID_2").isNotNull();
+    assertThat(result.getAgentDefinitionKey())
+        .as("the fetched agent definition should be the requested one")
+        .isEqualTo(agentDefinitionKey2);
+    assertThat(result.getProcessDefinitionId())
+        .as("the fetched agent definition should belong to PROCESS_ID_2")
+        .isEqualTo(PROCESS_ID_2);
+  }
+
+  @Test
+  void getByKeyShouldReturn403ForUnauthorizedAgentDefinition(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final ThrowingCallable executeGet =
+        () -> camundaClient.newAgentDefinitionGetRequest(agentDefinitionKey2).execute();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(executeGet).actual();
+    assertThat(problemException.code())
+        .as(
+            "user1 lacks READ_PROCESS_DEFINITION on PROCESS_ID_2, so the request should be forbidden")
+        .isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .as("problem detail should name the missing permission and resource type")
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_PROCESS_DEFINITION' on resource"
+                + " 'PROCESS_DEFINITION'");
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static long deployAgentProcess(final CamundaClient adminClient, final String processId) {
+    final var processModel =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType("agent-definition-auth-job-" + processId)
+            .zeebeAiAgentSubProcessDefinition()
+            .endEvent()
+            .done();
+
+    return deployProcessAndWaitForIt(adminClient, processModel, processId + ".bpmn")
+        .getProcessDefinitionKey();
+  }
+
+  private static long fetchAgentDefinitionKey(
+      final CamundaClient client, final long processDefinitionKey) {
+    return client
+        .newAgentDefinitionSearchRequest()
+        .filter(f -> f.processDefinitionKey(processDefinitionKey))
+        .execute()
+        .items()
+        .getFirst()
+        .getAgentDefinitionKey();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentDefinitionFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentDefinitionFetchIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentDefinitionsToBeIndexed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.ProblemDetail;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class AgentDefinitionFetchIT {
+
+  private static final String SUB_PROCESS_ELEMENT_ID = "explicitNameAgent";
+  private static final String TASK_ELEMENT_ID = "fallbackNameAgent";
+  private static final String EXPLICIT_NAME = "Explicit Agent Name";
+
+  private static CamundaClient camundaClient;
+
+  private static long processDefinitionKey;
+  private static String bpmnProcessId;
+
+  // agentDefinition1: AI_AGENT_SUB_PROCESS with an explicit BPMN name
+  private static long agentDefinitionKey1;
+
+  // agentDefinition2: AI_AGENT_TASK with no explicit name (falls back to elementId)
+  private static long agentDefinitionKey2;
+
+  @BeforeAll
+  static void setup() {
+    final var processModel =
+        Bpmn.createExecutableProcess("AgentDefinitionFetchProcess")
+            .startEvent()
+            .adHocSubProcess(
+                SUB_PROCESS_ELEMENT_ID,
+                ahsp ->
+                    ahsp.name(EXPLICIT_NAME)
+                        .zeebeJobType("agent-fetch-sub-process-job")
+                        .zeebeAiAgentSubProcessDefinition()
+                        .task("inner"))
+            .serviceTask(
+                TASK_ELEMENT_ID,
+                t -> t.zeebeJobType("agent-fetch-task-job").zeebeAiAgentTaskDefinition())
+            .endEvent()
+            .done();
+
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "agent-definition-fetch.bpmn");
+    processDefinitionKey = process.getProcessDefinitionKey();
+    bpmnProcessId = process.getBpmnProcessId();
+
+    waitForAgentDefinitionsToBeIndexed(
+        camundaClient, f -> f.processDefinitionKey(processDefinitionKey), 2);
+
+    agentDefinitionKey1 = fetchAgentDefinitionKey(SUB_PROCESS_ELEMENT_ID);
+    agentDefinitionKey2 = fetchAgentDefinitionKey(TASK_ELEMENT_ID);
+  }
+
+  private static long fetchAgentDefinitionKey(final String elementId) {
+    return camundaClient
+        .newAgentDefinitionSearchRequest()
+        .filter(f -> f.processDefinitionKey(processDefinitionKey).elementId(elementId))
+        .execute()
+        .items()
+        .getFirst()
+        .getAgentDefinitionKey();
+  }
+
+  @Test
+  void shouldGetAgentDefinitionWithExplicitName() {
+    // when
+    final var response = camundaClient.newAgentDefinitionGetRequest(agentDefinitionKey1).execute();
+
+    // then
+    assertSoftly(
+        softly -> {
+          softly
+              .assertThat(response.getAgentDefinitionKey())
+              .as("agentDefinitionKey")
+              .isEqualTo(agentDefinitionKey1);
+          softly
+              .assertThat(response.getAgentType())
+              .as("agentType")
+              .isEqualTo(AgentDefinitionType.AI_AGENT_SUB_PROCESS);
+          softly.assertThat(response.getName()).as("name").isEqualTo(EXPLICIT_NAME);
+          softly
+              .assertThat(response.getElementId())
+              .as("elementId")
+              .isEqualTo(SUB_PROCESS_ELEMENT_ID);
+          softly
+              .assertThat(response.getProcessDefinitionId())
+              .as("processDefinitionId")
+              .isEqualTo(bpmnProcessId);
+          softly
+              .assertThat(response.getProcessDefinitionKey())
+              .as("processDefinitionKey")
+              .isEqualTo(processDefinitionKey);
+          softly
+              .assertThat(response.getProcessDefinitionVersion())
+              .as("processDefinitionVersion")
+              .isGreaterThan(0);
+          softly
+              .assertThat(response.getProcessDefinitionVersionTag())
+              .as("processDefinitionVersionTag")
+              .isNull();
+          softly.assertThat(response.getTenantId()).as("tenantId").isNotNull();
+        });
+  }
+
+  @Test
+  void shouldGetAgentDefinitionWithNameFallenBackToElementId() {
+    // when
+    final var response = camundaClient.newAgentDefinitionGetRequest(agentDefinitionKey2).execute();
+
+    // then
+    assertSoftly(
+        softly -> {
+          softly
+              .assertThat(response.getAgentDefinitionKey())
+              .as("agentDefinitionKey")
+              .isEqualTo(agentDefinitionKey2);
+          softly
+              .assertThat(response.getAgentType())
+              .as("agentType")
+              .isEqualTo(AgentDefinitionType.AI_AGENT_TASK);
+          softly.assertThat(response.getName()).as("name").isEqualTo(TASK_ELEMENT_ID);
+          softly.assertThat(response.getElementId()).as("elementId").isEqualTo(TASK_ELEMENT_ID);
+        });
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnknownKey() {
+    // when
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newAgentDefinitionGetRequest(Long.MAX_VALUE).execute())
+            .actual();
+
+    // then
+    assertThat(problemException.code()).as("HTTP status code").isEqualTo(404);
+    final ProblemDetail details = problemException.details();
+    assertThat(details.getDetail())
+        .as("problem detail should name the missing agent definition key")
+        .contains("Agent Definition with key '%d' not found".formatted(Long.MAX_VALUE));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentDefinitionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentDefinitionSearchIT.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentDefinitionsToBeIndexed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.AgentDefinitionType;
+import io.camunda.client.api.search.response.AgentDefinition;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+@CompatibilityTest
+public class AgentDefinitionSearchIT {
+
+  private static final String SUB_PROCESS_ELEMENT_ID = "searchSubProcessAgent";
+  private static final String TASK_ELEMENT_ID = "searchTaskAgent";
+  private static final String EXTERNAL_ELEMENT_ID = "searchExternalAgent";
+  private static final String SUB_PROCESS_NAME = "Search Agent";
+
+  private static CamundaClient camundaClient;
+
+  // agentDefinition1v1 / agentDefinition1v2: same process id + elementId, two versions
+  private static long processDefinitionKey1v1;
+  private static long processDefinitionKey1v2;
+  private static String processDefinitionId1;
+  private static long agentDefinitionKey1v1;
+  private static long agentDefinitionKey1v2;
+
+  // agentDefinition2: AI_AGENT_TASK, no explicit name
+  private static long processDefinitionKey2;
+  private static String processDefinitionId2;
+  private static long agentDefinitionKey2;
+
+  // agentDefinition3: EXTERNAL_AGENT
+  private static long processDefinitionKey3;
+  private static long agentDefinitionKey3;
+
+  @BeforeAll
+  static void setup() {
+    // process1 v1 — AI_AGENT_SUB_PROCESS, versionTag "v1"
+    final var process1v1 =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            subProcessAgentModel(
+                "AgentDefinitionSearchProcess1", "search-sub-process-job-v1", "v1"),
+            "agent-definition-search-1-v1.bpmn");
+    processDefinitionKey1v1 = process1v1.getProcessDefinitionKey();
+    processDefinitionId1 = process1v1.getBpmnProcessId();
+
+    // process1 v2 — same process id + elementId, new version, versionTag "v2"
+    final var process1v2 =
+        deployProcessAndWaitForIt(
+            camundaClient,
+            subProcessAgentModel(processDefinitionId1, "search-sub-process-job-v2", "v2"),
+            "agent-definition-search-1-v2.bpmn");
+    processDefinitionKey1v2 = process1v2.getProcessDefinitionKey();
+
+    // process2 — AI_AGENT_TASK, no explicit name
+    final var process2Model =
+        Bpmn.createExecutableProcess("AgentDefinitionSearchProcess2")
+            .startEvent()
+            .serviceTask(
+                TASK_ELEMENT_ID,
+                t -> t.zeebeJobType("search-task-job").zeebeAiAgentTaskDefinition())
+            .endEvent()
+            .done();
+    final var process2 =
+        deployProcessAndWaitForIt(camundaClient, process2Model, "agent-definition-search-2.bpmn");
+    processDefinitionKey2 = process2.getProcessDefinitionKey();
+    processDefinitionId2 = process2.getBpmnProcessId();
+
+    // process3 — EXTERNAL_AGENT
+    final var process3Model =
+        Bpmn.createExecutableProcess("AgentDefinitionSearchProcess3")
+            .startEvent()
+            .serviceTask(
+                EXTERNAL_ELEMENT_ID,
+                t -> t.zeebeJobType("search-external-job").zeebeExternalAgentDefinition())
+            .endEvent()
+            .done();
+    final var process3 =
+        deployProcessAndWaitForIt(camundaClient, process3Model, "agent-definition-search-3.bpmn");
+    processDefinitionKey3 = process3.getProcessDefinitionKey();
+
+    waitForAgentDefinitionsToBeIndexed(
+        camundaClient, f -> f.processDefinitionId(processDefinitionId1), 2);
+    waitForAgentDefinitionsToBeIndexed(
+        camundaClient, f -> f.processDefinitionKey(processDefinitionKey2), 1);
+    waitForAgentDefinitionsToBeIndexed(
+        camundaClient, f -> f.processDefinitionKey(processDefinitionKey3), 1);
+
+    agentDefinitionKey1v1 = fetchAgentDefinitionKey(processDefinitionKey1v1);
+    agentDefinitionKey1v2 = fetchAgentDefinitionKey(processDefinitionKey1v2);
+    agentDefinitionKey2 = fetchAgentDefinitionKey(processDefinitionKey2);
+    agentDefinitionKey3 = fetchAgentDefinitionKey(processDefinitionKey3);
+  }
+
+  private static io.camunda.zeebe.model.bpmn.BpmnModelInstance subProcessAgentModel(
+      final String processId, final String jobType, final String versionTag) {
+    return Bpmn.createExecutableProcess(processId)
+        .versionTag(versionTag)
+        .startEvent()
+        .adHocSubProcess(
+            SUB_PROCESS_ELEMENT_ID,
+            ahsp ->
+                ahsp.name(SUB_PROCESS_NAME)
+                    .zeebeJobType(jobType)
+                    .zeebeAiAgentSubProcessDefinition()
+                    .task("inner"))
+        .endEvent()
+        .done();
+  }
+
+  private static long fetchAgentDefinitionKey(final long processDefinitionKey) {
+    return camundaClient
+        .newAgentDefinitionSearchRequest()
+        .filter(f -> f.processDefinitionKey(processDefinitionKey))
+        .execute()
+        .items()
+        .getFirst()
+        .getAgentDefinitionKey();
+  }
+
+  @Test
+  void shouldSearchReturnAgentDefinitions() {
+    // when
+    final var response = camundaClient.newAgentDefinitionSearchRequest().execute();
+
+    // then
+    assertThat(response.items())
+        .as("search with no filter should return every deployed agent definition")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .contains(
+            agentDefinitionKey1v1, agentDefinitionKey1v2, agentDefinitionKey2, agentDefinitionKey3);
+  }
+
+  @Test
+  void shouldFilterByAgentDefinitionKey() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.agentDefinitionKey(agentDefinitionKey2))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("agentDefinitionKey filter should return only the matching definition")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey2));
+  }
+
+  @Test
+  void shouldFilterByAgentType() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.agentType(AgentDefinitionType.EXTERNAL_AGENT))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("agentType filter should return only the EXTERNAL_AGENT definition")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey3));
+  }
+
+  @Test
+  void shouldFilterByAgentTypeWithAdvancedOperators() {
+    // when — notIn excludes AI_AGENT_SUB_PROCESS and AI_AGENT_TASK, leaving only the external agent
+    final var notInResponse =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(
+                f ->
+                    f.agentType(
+                        b ->
+                            b.notIn(
+                                AgentDefinitionType.AI_AGENT_SUB_PROCESS,
+                                AgentDefinitionType.AI_AGENT_TASK)))
+            .execute();
+
+    // then
+    assertThat(notInResponse.items())
+        .as("agentType $notIn should exclude sub-process and task types, leaving the external one")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .containsExactly(agentDefinitionKey3);
+  }
+
+  @Test
+  void shouldFilterByName() {
+    // when — both versions of process1 share the same explicit BPMN name
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.name(SUB_PROCESS_NAME))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("name filter should match both process versions sharing the same BPMN name")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .containsExactlyInAnyOrder(agentDefinitionKey1v1, agentDefinitionKey1v2);
+  }
+
+  @Test
+  void shouldFilterByElementId() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.elementId(TASK_ELEMENT_ID))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("elementId filter should return only the matching definition")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey2));
+  }
+
+  @Test
+  void shouldFilterByProcessDefinitionId() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId2))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("processDefinitionId filter should return only definitions owned by that process")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey2));
+  }
+
+  @Test
+  void shouldListAcrossProcessDefinitionVersions() {
+    // when — filtering by processDefinitionId + elementId, omitting processDefinitionKey, is how
+    // the same agent element is listed across all of its process definition's versions
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(
+                f -> f.processDefinitionId(processDefinitionId1).elementId(SUB_PROCESS_ELEMENT_ID))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as(
+            "filtering by processDefinitionId + elementId should list the same agent element"
+                + " across all of its process definition's versions")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .containsExactlyInAnyOrder(agentDefinitionKey1v1, agentDefinitionKey1v2);
+    assertThat(response.items())
+        .as("the listed definitions should span both deployed process definition versions")
+        .extracting(AgentDefinition::getProcessDefinitionVersion)
+        .containsExactlyInAnyOrder(1, 2);
+  }
+
+  @Test
+  void shouldFilterByProcessDefinitionKey() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey1v2))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("processDefinitionKey filter should return only that exact version's definition")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey1v2));
+  }
+
+  @Test
+  void shouldFilterByProcessDefinitionVersion() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId1).processDefinitionVersion(2))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("processDefinitionVersion filter should return only the matching version")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey1v2));
+  }
+
+  @Test
+  void shouldFilterByProcessDefinitionVersionTag() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionVersionTag("v1"))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("processDefinitionVersionTag filter should return only the matching version")
+        .singleElement()
+        .satisfies(ad -> assertThat(ad.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey1v1));
+  }
+
+  @Test
+  void shouldFilterByTenantId() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.tenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("tenantId filter should return every agent definition owned by the default tenant")
+        .extracting(AgentDefinition::getAgentDefinitionKey, AgentDefinition::getTenantId)
+        .contains(
+            tuple(agentDefinitionKey1v1, TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            tuple(agentDefinitionKey1v2, TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            tuple(agentDefinitionKey2, TenantOwned.DEFAULT_TENANT_IDENTIFIER),
+            tuple(agentDefinitionKey3, TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  }
+
+  @Test
+  void shouldReturnEmptyForUnknownTenant() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.tenantId("unknown-tenant"))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("an unknown tenant should match no agent definitions")
+        .isEmpty();
+  }
+
+  @Test
+  void shouldSortByAgentDefinitionKeyAscending() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .sort(s -> s.agentDefinitionKey().asc())
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("results should be ordered by ascending agentDefinitionKey")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .isSorted();
+  }
+
+  @Test
+  void shouldSortByProcessDefinitionVersionAscending() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId1))
+            .sort(s -> s.processDefinitionVersion().asc())
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .as("results should be ordered by ascending processDefinitionVersion, v1 before v2")
+        .extracting(AgentDefinition::getAgentDefinitionKey)
+        .containsExactly(agentDefinitionKey1v1, agentDefinitionKey1v2);
+  }
+
+  @Test
+  void shouldPaginateResults() {
+    // when — process1 has 2 agent definition versions; request them one at a time
+    final var page1 =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId1))
+            .sort(s -> s.processDefinitionVersion().asc())
+            .page(p -> p.limit(1))
+            .execute();
+
+    assertThat(page1.items()).as("first page should return exactly the requested limit").hasSize(1);
+
+    final var page2 =
+        camundaClient
+            .newAgentDefinitionSearchRequest()
+            .filter(f -> f.processDefinitionId(processDefinitionId1))
+            .sort(s -> s.processDefinitionVersion().asc())
+            .page(p -> p.limit(1).from(1))
+            .execute();
+
+    // then — page1 + page2 cover both versions without overlap
+    assertThat(page2.items())
+        .as("second page should return exactly the requested limit")
+        .hasSize(1);
+    final var page1Keys =
+        page1.items().stream().map(AgentDefinition::getAgentDefinitionKey).toList();
+    final var page2Keys =
+        page2.items().stream().map(AgentDefinition::getAgentDefinitionKey).toList();
+    assertThat(page1Keys)
+        .as("paginated pages should not overlap")
+        .doesNotContainAnyElementsOf(page2Keys);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentDefinitionTenancyIT.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tenancy;
+
+import static io.camunda.it.util.TestHelper.deployProcessForTenantAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForAgentDefinitionsToBeIndexed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class AgentDefinitionTenancyIT {
+
+  private static final String AGENT_ELEMENT_ID = "agentDefinitionTenancyElement";
+  private static final String PROCESS_ID = "agentDefinitionTenancyProcess";
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess();
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
+
+  /** user1 is assigned to TENANT_A only. */
+  @UserDefinition
+  private static final TestUser USER1_USER = new TestUser(USER1, "password", List.of());
+
+  /** user2 is not assigned to any tenant. */
+  @UserDefinition
+  private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
+
+  private static long agentDefinitionKeyA;
+  private static long agentDefinitionKeyB;
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    createTenant(adminClient, TENANT_A);
+    createTenant(adminClient, TENANT_B);
+    assignUserToTenant(adminClient, ADMIN, TENANT_A);
+    assignUserToTenant(adminClient, ADMIN, TENANT_B);
+    assignUserToTenant(adminClient, USER1, TENANT_A);
+
+    final BpmnModelInstance processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
+            .zeebeJobType("agent-definition-tenancy-job")
+            .zeebeAiAgentSubProcessDefinition()
+            .endEvent()
+            .done();
+
+    // Deploy the same process in both tenants; agent definitions are created at deploy time.
+    deployProcessForTenant(adminClient, processModel, TENANT_A);
+    deployProcessForTenant(adminClient, processModel, TENANT_B);
+
+    waitForAgentDefinitionsToBeIndexed(adminClient, f -> f.tenantId(TENANT_A), 1);
+    waitForAgentDefinitionsToBeIndexed(adminClient, f -> f.tenantId(TENANT_B), 1);
+
+    agentDefinitionKeyA = fetchAgentDefinitionKey(adminClient, TENANT_A);
+    agentDefinitionKeyB = fetchAgentDefinitionKey(adminClient, TENANT_B);
+  }
+
+  // ── search ────────────────────────────────────────────────────────────────
+
+  @Test
+  void searchShouldReturnAllAgentDefinitionsForAdminWithBothTenants(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionSearchRequest().execute();
+
+    // then
+    assertThat(result.items())
+        .as("admin can see agent definitions from every tenant they're assigned to")
+        .hasSize(2);
+    assertThat(result.items().stream().map(ad -> ad.getTenantId()).toList())
+        .as("the two returned agent definitions should each belong to a different tenant")
+        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+  }
+
+  @Test
+  void searchShouldReturnOnlyTenantAAgentDefinitionsForUser1(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionSearchRequest().execute();
+
+    // then
+    assertThat(result.items())
+        .as("user1 is only assigned to TENANT_A, so search must not leak TENANT_B's definition")
+        .hasSize(1);
+    assertThat(result.items().getFirst().getTenantId())
+        .as("the single visible agent definition should belong to TENANT_A")
+        .isEqualTo(TENANT_A);
+    assertThat(result.items().getFirst().getAgentDefinitionKey())
+        .as("the single visible agent definition should be TENANT_A's own")
+        .isEqualTo(agentDefinitionKeyA);
+  }
+
+  @Test
+  void searchShouldReturnNoAgentDefinitionsForUserWithNoTenantAccess(
+      @Authenticated(USER2) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionSearchRequest().execute();
+
+    // then
+    assertThat(result.items())
+        .as("user2 has no tenant assignment, so search must return nothing")
+        .isEmpty();
+  }
+
+  // ── getByKey ──────────────────────────────────────────────────────────────
+
+  @Test
+  void getByKeyShouldReturnAgentDefinitionWithinAccessibleTenant(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when
+    final var result = camundaClient.newAgentDefinitionGetRequest(agentDefinitionKeyA).execute();
+
+    // then
+    assertThat(result).as("user1 should be able to fetch a definition within TENANT_A").isNotNull();
+    assertThat(result.getAgentDefinitionKey())
+        .as("the fetched agent definition should be the requested one")
+        .isEqualTo(agentDefinitionKeyA);
+    assertThat(result.getTenantId())
+        .as("the fetched agent definition should belong to TENANT_A")
+        .isEqualTo(TENANT_A);
+  }
+
+  @Test
+  void getByKeyShouldReturn404ForAgentDefinitionOutsideAccessibleTenant(
+      @Authenticated(USER1) final CamundaClient camundaClient) {
+    // when — user1 has no access to TENANT_B
+    final var exception =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () -> camundaClient.newAgentDefinitionGetRequest(agentDefinitionKeyB).execute())
+            .actual();
+
+    // then — tenant boundary surfaced as 404, not 403
+    assertThat(exception.getMessage())
+        .as("a definition outside the caller's tenant should surface as 404, not 403")
+        .startsWith("Failed with code 404");
+    assertThat(exception.details()).as("problem detail should be present").isNotNull();
+    assertThat(exception.details().getTitle()).as("problem title").isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).as("problem status").isEqualTo(404);
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private static long fetchAgentDefinitionKey(final CamundaClient client, final String tenantId) {
+    return client
+        .newAgentDefinitionSearchRequest()
+        .filter(f -> f.tenantId(tenantId))
+        .execute()
+        .items()
+        .getFirst()
+        .getAgentDefinitionKey();
+  }
+
+  private static void createTenant(final CamundaClient client, final String tenantId) {
+    client.newCreateTenantCommand().tenantId(tenantId).name(tenantId).send().join();
+  }
+
+  private static void assignUserToTenant(
+      final CamundaClient client, final String username, final String tenantId) {
+    client.newAssignUserToTenantCommand().username(username).tenantId(tenantId).send().join();
+  }
+
+  private static void deployProcessForTenant(
+      final CamundaClient client, final BpmnModelInstance model, final String tenantId) {
+    final String filename = PROCESS_ID + "-" + tenantId + ".bpmn";
+    deployProcessForTenantAndWaitForIt(client, model, filename, tenantId);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -28,6 +28,7 @@ import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.AgentDefinitionFilter;
 import io.camunda.client.api.search.filter.AuditLogFilter;
 import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
@@ -2129,6 +2130,25 @@ public final class TestHelper {
                       .execute();
               assertThat(result.items()).hasSize(listenerIds.size());
             });
+  }
+
+  /**
+   * Waits for agent definitions matching the given filter to be indexed in secondary storage after
+   * deployment.
+   *
+   * @param camundaClient CamundaClient
+   * @param filter the agent definition filter to match
+   * @param expectedAgentDefinitions the expected number of matching agent definitions
+   */
+  public static void waitForAgentDefinitionsToBeIndexed(
+      final CamundaClient camundaClient,
+      final Consumer<AgentDefinitionFilter> filter,
+      final int expectedAgentDefinitions) {
+    waitForItemsPaginated(
+        "should index agent definitions after deployment",
+        expectedAgentDefinitions,
+        page ->
+            camundaClient.newAgentDefinitionSearchRequest().filter(filter).page(page).execute());
   }
 
   /**


### PR DESCRIPTION
## Description

Adds Java client (`clients/java`) support for the `AgentDefinition` search and get-by-key resource, matching the REST/OpenAPI contract already defined in `agent-definitions.yaml`. The backend (search-domain, service layer, REST controller) is already merged; this closes the gap for programmatic/SDK consumers of the queryable agent registry (part of the "Real-Time Agent Visibility" epic).

**What's added:**
- `CamundaClient.newAgentDefinitionGetRequest(long)` / `newAgentDefinitionSearchRequest()`
- All 9 `AgentDefinitionFilter` fields + sort, including the `agentType` `$notIn` filter
- Client-facing `AgentDefinition` response type and `AgentDefinitionType` enum
- Unit tests (WireMock) and integration tests (`@MultiDbTest`) covering fetch, search, sorting, pagination, cross-version listing (the same agent element across process definition versions via `processDefinitionId` + `elementId`), tenancy isolation, and authorization (`READ_PROCESS_DEFINITION`)

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59086