### PR TITLE
fix: remove permanent noise WARN for disabled Optimize object variable import

### DIFF
--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -113,13 +113,6 @@
       <artifactId>log4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.github.netmikey.logunit</groupId>
-      <artifactId>logunit-log4j2</artifactId>
-      <version>${logunit.version}</version>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Utilities -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationValidator.java
@@ -9,12 +9,9 @@ package io.camunda.optimize.service.util.configuration;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConfigurationValidator {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ConfigurationValidator.class);
   private static final Pattern INVALID_INDEX_PREFIX_CHARS = Pattern.compile("[\\\\/*?\"<>| _]");
 
   public void validate(final ConfigurationService configurationService) {
@@ -22,23 +19,6 @@ public class ConfigurationValidator {
 
     validateIndexPrefix(configurationService.getElasticSearchConfiguration().getIndexPrefix());
     validateIndexPrefix(configurationService.getOpenSearchConfiguration().getIndexPrefix());
-    warnIfObjectVariableValuesAreNotImported(configurationService);
-  }
-
-  private void warnIfObjectVariableValuesAreNotImported(
-      final ConfigurationService configurationService) {
-    final ZeebeConfiguration zeebeConfiguration = configurationService.getConfiguredZeebe();
-    final boolean isImportingZeebeVariables =
-        zeebeConfiguration.isEnabled() && zeebeConfiguration.isVariableImportEnabled();
-    if (isImportingZeebeVariables && !zeebeConfiguration.isIncludeObjectVariableValue()) {
-      LOG.warn(
-          "Optimize is not importing object variable values (zeebe.includeObjectVariableValue "
-              + "is false). As of Camunda 8.10, this is the default for Self-Managed. Object "
-              + "variables will not be flattened into report-usable fields and their raw value "
-              + "will not be stored. If you rely on this, set zeebe.includeObjectVariableValue "
-              + "to true (or the CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE environment "
-              + "variable) to opt in.");
-    }
   }
 
   private void validateIndexPrefix(final String indexPrefix) {

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationValidatorTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/util/configuration/ConfigurationValidatorTest.java
@@ -14,25 +14,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
-import io.github.netmikey.logunit.api.LogCapturer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.event.Level;
 
 public class ConfigurationValidatorTest {
-
-  @RegisterExtension
-  final LogCapturer logs =
-      LogCapturer.create().captureForType(ConfigurationValidator.class, Level.WARN);
 
   private ConfigurationService configurationService;
   private EmailAuthenticationConfiguration emailAuthConfig;
   private ElasticSearchConfiguration elasticSearchConfiguration;
   private OpenSearchConfiguration openSearchConfiguration;
-  private ZeebeConfiguration zeebeConfiguration;
 
   private ConfigurationValidator configurationValidator;
 
@@ -42,14 +34,9 @@ public class ConfigurationValidatorTest {
     emailAuthConfig = mock(EmailAuthenticationConfiguration.class);
     elasticSearchConfiguration = mock(ElasticSearchConfiguration.class);
     openSearchConfiguration = mock(OpenSearchConfiguration.class);
-    zeebeConfiguration = mock(ZeebeConfiguration.class);
     when(configurationService.getElasticSearchConfiguration())
         .thenReturn(elasticSearchConfiguration);
     when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
-    when(configurationService.getConfiguredZeebe()).thenReturn(zeebeConfiguration);
-    when(zeebeConfiguration.isEnabled()).thenReturn(true);
-    when(zeebeConfiguration.isVariableImportEnabled()).thenReturn(true);
-    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
 
     configurationValidator = new ConfigurationValidator();
   }
@@ -116,77 +103,5 @@ public class ConfigurationValidatorTest {
     assertThatCode(() -> configurationValidator.validate(configurationService))
         .hasMessageContaining("Optimize indexPrefix must not begin with invalid characters [. +].")
         .isInstanceOf(OptimizeConfigurationException.class);
-  }
-
-  @Test
-  public void validateShouldWarnWhenObjectVariableValuesAreNotImported() {
-    // given
-    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
-    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
-
-    // when
-    configurationValidator.validate(configurationService);
-
-    // then
-    logs.assertContains(
-        entry ->
-            entry.getLevel() == Level.WARN
-                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
-        "expected a WARN log about object variable values not being imported");
-  }
-
-  @Test
-  public void validateShouldNotWarnWhenObjectVariableValuesAreImported() {
-    // given
-    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
-    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(true);
-
-    // when
-    configurationValidator.validate(configurationService);
-
-    // then
-    logs.assertDoesNotContain(
-        entry ->
-            entry.getLevel() == Level.WARN
-                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
-        "expected no WARN log when object variable values are imported");
-  }
-
-  @Test
-  public void validateShouldNotWarnWhenZeebeImportIsDisabled() {
-    // given
-    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
-    when(zeebeConfiguration.isEnabled()).thenReturn(false);
-    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
-
-    // when
-    configurationValidator.validate(configurationService);
-
-    // then
-    logs.assertDoesNotContain(
-        entry ->
-            entry.getLevel() == Level.WARN
-                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
-        "expected no WARN log when Zeebe import is disabled, regardless of "
-            + "includeObjectVariableValue");
-  }
-
-  @Test
-  public void validateShouldNotWarnWhenZeebeVariableImportIsDisabled() {
-    // given
-    when(configurationService.getEmailAuthenticationConfiguration()).thenReturn(emailAuthConfig);
-    when(zeebeConfiguration.isVariableImportEnabled()).thenReturn(false);
-    when(zeebeConfiguration.isIncludeObjectVariableValue()).thenReturn(false);
-
-    // when
-    configurationValidator.validate(configurationService);
-
-    // then
-    logs.assertDoesNotContain(
-        entry ->
-            entry.getLevel() == Level.WARN
-                && entry.getMessage().contains("zeebe.includeObjectVariableValue"),
-        "expected no WARN log when Zeebe variable import is disabled, regardless of "
-            + "includeObjectVariableValue");
   }
 }


### PR DESCRIPTION
Removes the WARN ConfigurationValidator logged at Optimize startup whenever zeebe.includeObjectVariableValue resolved to false while Zeebe variable import was enabled. It was added right after the 8.10 default flip to flag the change, but that flip is now well-known, so the WARN was firing permanently on the majority of healthy, correctly configured Self-Managed installations.

Closes #60686