### PR TITLE
LibC single binding

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
@@ -7,11 +7,8 @@
  */
 package io.camunda.zeebe.journal.fs;
 
-import io.camunda.zeebe.util.Loggers;
 import io.camunda.zeebe.util.VisibleForTesting;
-import java.util.Map;
 import jnr.ffi.LibraryLoader;
-import jnr.ffi.LibraryOption;
 import jnr.ffi.annotations.In;
 import jnr.ffi.types.off_t;
 
@@ -49,14 +46,7 @@ public interface LibC {
 
   @VisibleForTesting
   static LibC ofNativeLibrary(final String libraryName) {
-    try {
-      return LibraryLoader.loadLibrary(
-          LibC.class, Map.of(LibraryOption.LoadNow, true), libraryName);
-    } catch (final UnsatisfiedLinkError e) {
-      Loggers.FILE_LOGGER.warn(
-          "Failed to load C library; any native calls will not be available", e);
-      return new InvalidLibC();
-    }
+    return LibCHolder.bind(libraryName);
   }
 
   /**

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Map;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.LibraryOption;
-import jnr.ffi.Platform;
 import jnr.ffi.annotations.In;
 import jnr.ffi.types.off_t;
 
@@ -35,7 +34,7 @@ public interface LibC {
    * <p>If it fails to bind to the C library, it will return a {@link InvalidLibC} instance which
    * throws {@link UnsupportedOperationException} on every call.
    *
-   * <p>Binding is done exactly once per JVM, on first use, via {@link Holder}'s class
+   * <p>Binding is done exactly once per JVM, on first use, via {@link LibCHolder}'s class
    * initialization (guaranteed thread-safe and only-once by the JVM). This matters because {@link
    * LibraryLoader#loadLibrary} is not safe to call concurrently from multiple threads for the same
    * library: every {@code SegmentAllocator.defaultAllocator()} call (i.e. every raft partition
@@ -45,7 +44,7 @@ public interface LibC {
    * @return the shared instance of this library
    */
   static LibC ofNativeLibrary() {
-    return Holder.INSTANCE;
+    return LibCHolder.INSTANCE;
   }
 
   @VisibleForTesting
@@ -71,13 +70,5 @@ public interface LibC {
     public int posix_fallocate(final int fd, final long offset, final long len) {
       throw new UnsupportedOperationException();
     }
-  }
-
-  /** Lazy-init holder; the JVM guarantees {@link Holder}'s static init runs at most once. */
-  final class Holder {
-    static final LibC INSTANCE =
-        ofNativeLibrary(Platform.getNativePlatform().getStandardCLibraryName());
-
-    private Holder() {}
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibC.java
@@ -29,15 +29,23 @@ public interface LibC {
   int posix_fallocate(final @In int fd, final @In @off_t long offset, final @In @off_t long len);
 
   /**
-   * Returns an instance of LibC bound to the system's C library (e.g. glibc, musl, etc.).
+   * Returns a process-wide, cached instance of LibC bound to the system's C library (e.g. glibc,
+   * musl, etc.).
    *
    * <p>If it fails to bind to the C library, it will return a {@link InvalidLibC} instance which
    * throws {@link UnsupportedOperationException} on every call.
    *
-   * @return an instance of this library
+   * <p>Binding is done exactly once per JVM, on first use, via {@link Holder}'s class
+   * initialization (guaranteed thread-safe and only-once by the JVM). This matters because {@link
+   * LibraryLoader#loadLibrary} is not safe to call concurrently from multiple threads for the same
+   * library: every {@code SegmentAllocator.defaultAllocator()} call (i.e. every raft partition
+   * bootstrap) used to trigger its own native bind, and doing that from several partitions' actor
+   * threads at once could livelock inside jnr-ffi's internal (non-thread-safe) library registry.
+   *
+   * @return the shared instance of this library
    */
   static LibC ofNativeLibrary() {
-    return ofNativeLibrary(Platform.getNativePlatform().getStandardCLibraryName());
+    return Holder.INSTANCE;
   }
 
   @VisibleForTesting
@@ -63,5 +71,13 @@ public interface LibC {
     public int posix_fallocate(final int fd, final long offset, final long len) {
       throw new UnsupportedOperationException();
     }
+  }
+
+  /** Lazy-init holder; the JVM guarantees {@link Holder}'s static init runs at most once. */
+  final class Holder {
+    static final LibC INSTANCE =
+        ofNativeLibrary(Platform.getNativePlatform().getStandardCLibraryName());
+
+    private Holder() {}
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibCHolder.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibCHolder.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.zeebe.journal.fs;
 
+import io.camunda.zeebe.journal.fs.LibC.InvalidLibC;
+import io.camunda.zeebe.util.Loggers;
+import java.util.Map;
+import jnr.ffi.LibraryLoader;
+import jnr.ffi.LibraryOption;
 import jnr.ffi.Platform;
 
 /**
@@ -19,8 +24,23 @@ import jnr.ffi.Platform;
  * public API.
  */
 final class LibCHolder {
-  static final LibC INSTANCE =
-      LibC.ofNativeLibrary(Platform.getNativePlatform().getStandardCLibraryName());
+  static final LibC INSTANCE = bind(Platform.getNativePlatform().getStandardCLibraryName());
 
   private LibCHolder() {}
+
+  /**
+   * Binds a fresh {@link LibC} instance to the given library, falling back to {@link InvalidLibC}
+   * if the library cannot be linked. Production code must use the shared {@link #INSTANCE} instead;
+   * see {@link LibC#ofNativeLibrary()}.
+   */
+  static LibC bind(final String libraryName) {
+    try {
+      return LibraryLoader.loadLibrary(
+          LibC.class, Map.of(LibraryOption.LoadNow, true), libraryName);
+    } catch (final UnsatisfiedLinkError e) {
+      Loggers.FILE_LOGGER.warn(
+          "Failed to load C library; any native calls will not be available", e);
+      return new InvalidLibC();
+    }
+  }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibCHolder.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/fs/LibCHolder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.fs;
+
+import jnr.ffi.Platform;
+
+/**
+ * Lazy-init holder for the shared {@link LibC} instance; the JVM guarantees this class's static
+ * initialization runs at most once, under the class-init lock. See {@link LibC#ofNativeLibrary()}
+ * for why the native bind must happen at most once per JVM.
+ *
+ * <p>Deliberately a package-private top-level class: a member type nested in the {@link LibC}
+ * interface would be implicitly {@code public} (JLS 9.5) and leak an initialization detail into the
+ * public API.
+ */
+final class LibCHolder {
+  static final LibC INSTANCE =
+      LibC.ofNativeLibrary(Platform.getNativePlatform().getStandardCLibraryName());
+
+  private LibCHolder() {}
+}

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/LibCTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/fs/LibCTest.java
@@ -11,7 +11,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.camunda.zeebe.journal.fs.LibC.InvalidLibC;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class LibCTest {
 
@@ -28,5 +37,67 @@ public class LibCTest {
     final var loaded = LibC.ofNativeLibrary(libraryName);
     // then
     assertThat(loaded).isInstanceOf(InvalidLibC.class);
+  }
+
+  /**
+   * Regression test: {@link LibC#ofNativeLibrary()} must return a single, JVM-wide instance.
+   *
+   * <p>Binding a fresh instance per call means a fresh {@code LibraryLoader.loadLibrary} call each
+   * time. Concurrent loads race on jnr-ffi's unsynchronized, JVM-global {@code
+   * NativeRuntime.loadedLibraries} {@link java.util.WeakHashMap} — its {@code synchronized} load
+   * methods lock the per-call {@code NativeLibrary} instance, so they provide no cross-thread
+   * exclusion. A concurrent resize can then corrupt a bucket chain into a cycle, after which any
+   * thread touching the poisoned bucket spins forever in {@code WeakHashMap.put} (RUNNABLE, no
+   * monitor held — invisible to deadlock detection). This wedged raft partition bootstrap and
+   * halted ScaleUpPartitionsTest, since each partition bootstrap used to trigger its own bind.
+   *
+   * <p>The livelock itself is probabilistic, so we assert the deterministic invariant that closes
+   * the race window instead: all calls, from any thread, observe the same instance, proving the
+   * native bind happens at most once per JVM.
+   */
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void shouldReturnSameInstanceWhenLoadedConcurrently() throws Exception {
+    // given
+    final var threadCount = 16;
+    final var callsPerThread = 32;
+    final var barrier = new CyclicBarrier(threadCount);
+
+    // when - all threads start binding at the same time, as concurrently as possible
+    final List<LibC> instances;
+    try (final var executor = Executors.newFixedThreadPool(threadCount)) {
+      final List<Callable<List<LibC>>> tasks =
+          IntStream.range(0, threadCount)
+              .<Callable<List<LibC>>>mapToObj(
+                  i ->
+                      () -> {
+                        barrier.await(10, TimeUnit.SECONDS);
+                        return IntStream.range(0, callsPerThread)
+                            .mapToObj(j -> LibC.ofNativeLibrary())
+                            .collect(Collectors.toList());
+                      })
+              .collect(Collectors.toList());
+
+      instances =
+          executor.invokeAll(tasks, 20, TimeUnit.SECONDS).stream()
+              .map(LibCTest::getUnchecked)
+              .flatMap(List::stream)
+              .collect(Collectors.toList());
+    }
+
+    // then - every call observed the exact same instance, i.e. the library was bound at most once
+    assertThat(instances).hasSize(threadCount * callsPerThread);
+    assertThat(instances).allSatisfy(libC -> assertThat(libC).isSameAs(instances.get(0)));
+  }
+
+  private static <T> T getUnchecked(final Future<T> future) {
+    try {
+      return future.get();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    } catch (final Exception e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbOptionsFormatter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbOptionsFormatter.java
@@ -20,9 +20,6 @@ import org.slf4j.LoggerFactory;
 /** Helper class to format RocksDB options. */
 final class RocksDbOptionsFormatter {
   private static final Logger LOG = LoggerFactory.getLogger(RocksDbOptionsFormatter.class);
-  private static LibC libC;
-  private static Runtime runtime;
-  private static boolean libCUnavailable = false;
 
   static String format(final boolean value) {
     return String.valueOf(value);
@@ -44,12 +41,12 @@ final class RocksDbOptionsFormatter {
    * @see <a href="https://github.com/facebook/rocksdb/issues/13841">facebook/rocksdb#13841</a>
    */
   static String format(final double value) {
-    if (ensureLibCIsAvailable()) {
+    if (Holder.LIB_C != null && Holder.RUNTIME != null) {
       try {
         // Allocate a buffer for the formatted string
         // 64 bytes should be more than enough for any reasonable double formatting
-        final var buffer = runtime.getMemoryManager().allocateDirect(64);
-        final var bytesWritten = libC.sprintf(buffer, "%f", value);
+        final var buffer = Holder.RUNTIME.getMemoryManager().allocateDirect(64);
+        final var bytesWritten = Holder.LIB_C.sprintf(buffer, "%f", value);
 
         if (bytesWritten >= 0) {
           // Convert the C string to Java String
@@ -70,28 +67,6 @@ final class RocksDbOptionsFormatter {
     return String.format("%f", value);
   }
 
-  private static boolean ensureLibCIsAvailable() {
-    if (libC != null && runtime != null) {
-      return true;
-    }
-    if (libCUnavailable) {
-      return false;
-    }
-    try {
-      if (Platform.getNativePlatform().getOS() == OS.WINDOWS) {
-        libC = LibraryLoader.create(LibC.class).load("msvcrt");
-      } else {
-        libC = LibraryLoader.create(LibC.class).load("c");
-      }
-      runtime = Runtime.getRuntime(libC);
-      return true;
-    } catch (final Throwable e) {
-      libCUnavailable = true;
-      LOG.warn("Failed to load libc for sprintf formatting, will fall back to String.format", e);
-      return false;
-    }
-  }
-
   /** Interface to access libc functions via JNR-FFI. */
   public interface LibC {
     /**
@@ -103,5 +78,41 @@ final class RocksDbOptionsFormatter {
      * @return number of characters written (excluding null terminator)
      */
     int sprintf(@Out Pointer str, @In String format, Object... args);
+  }
+
+  /**
+   * Lazy-init holder which binds libc at most once per JVM. The JVM guarantees the static
+   * initializer runs exactly once, under the class-init lock, which provides both mutual exclusion
+   * (jnr-ffi's {@link LibraryLoader} is not safe to call concurrently, see {@code
+   * io.camunda.zeebe.journal.fs.LibC#ofNativeLibrary()}) and safe publication of the fields.
+   *
+   * <p>A bind failure is caught inside the initializer and leaves both fields null, so callers
+   * permanently fall back to {@link String#format}; it must not escape, or any later access to this
+   * class would throw {@link NoClassDefFoundError}.
+   */
+  private static final class Holder {
+    private static final LibC LIB_C;
+    private static final Runtime RUNTIME;
+
+    static {
+      LibC libC = null;
+      Runtime runtime = null;
+      try {
+        if (Platform.getNativePlatform().getOS() == OS.WINDOWS) {
+          libC = LibraryLoader.create(LibC.class).load("msvcrt");
+        } else {
+          libC = LibraryLoader.create(LibC.class).load("c");
+        }
+        runtime = Runtime.getRuntime(libC);
+      } catch (final Throwable e) {
+        LOG.warn("Failed to load libc for sprintf formatting, will fall back to String.format", e);
+        libC = null;
+        runtime = null;
+      }
+      LIB_C = libC;
+      RUNTIME = runtime;
+    }
+
+    private Holder() {}
   }
 }


### PR DESCRIPTION
## Description

Fixes a JVM-wide livelock caused by concurrent, uncached jnr-ffi native library binds. The livelock wedges broker partition bootstrap and was identified as the root cause of the `[IT] Zeebe Cluster ScaleUp QA` hang on `stable/8.9` (run of 2026-08-26, `ScaleUpPartitionsTest` — surefire watchdog thread dump + 26 min of `NoRemoteHandler` spam before the forked JVM was killed).

### Symptom

`ScaleUpPartitionsTest` halted: partition 3 on Broker-1 never finished `RaftBootstrapStep`, the raft leader for partition 3 retried `ConfigureRequest` forever with `MessagingException$NoRemoteHandler` / `NoSuchMemberException`, cluster scale-up never converged, `TestCluster.shutdown()` hung, and surefire eventually dumped threads and killed the JVM.

The thread dump shows the wedged thread (and, in later test iterations, six more like it) permanently `RUNNABLE` at:

```
java.util.WeakHashMap.put(WeakHashMap.java:465)
jnr.ffi.provider.jffi.NativeLibrary.putLibraryIntoRuntime(NativeLibrary.java:173)
jnr.ffi.provider.jffi.NativeLibrary.loadNativeLibraries(NativeLibrary.java:115)
jnr.ffi.provider.jffi.NativeLibrary.getNativeLibraries(NativeLibrary.java:85)
jnr.ffi.provider.jffi.NativeLibrary.<init>(NativeLibrary.java:56)
io.camunda.zeebe.journal.fs.LibC.ofNativeLibrary(...)
...
io.camunda.zeebe.broker.partitioning.startup.steps.RaftBootstrapStep.startup(...)
```

All frame line numbers match jnr-ffi **2.2.19** (the version pinned on `stable/8.9`) exactly.

### Root cause mechanism

1. **Unsynchronized JVM-global state in jnr-ffi.** `NativeRuntime` (a JVM singleton) keeps bookkeeping for `Runtime#getLoadedLibraries()` in a plain, unsynchronized map (`NativeRuntime.java:57` in 2.2.19):

   ```java
   final WeakHashMap<NativeLibrary, NativeLibrary.LoadedLibraryData> loadedLibraries = new WeakHashMap<>();
   ```

   `NativeLibrary.loadNativeLibraries()` is `synchronized`, but on the *`NativeLibrary` instance* — and every `LibraryLoader.loadLibrary(...)` call constructs a **new** instance. Concurrent loads therefore hold different locks and race freely on the singleton map. (The `dlopen` itself is cached and safe in jffi; only this bookkeeping map races.)

2. **Zeebe triggered many concurrent loads.** Every raft partition bootstrap performed up to three independent `LibC.ofNativeLibrary()` binds (via `SegmentAllocator.defaultAllocator()` in `RaftStorageConfig`, `RaftStorage$Builder`, and `SegmentedJournalBuilder`). In the QA suite — 3 embedded brokers × 3 partitions in one JVM, restarted per test-template iteration — that is bursts of ~27 concurrent `WeakHashMap.put` calls from ≥9 actor threads, repeated on every cluster restart. Additionally, `RocksDbOptionsFormatter.ensureLibCIsAvailable()` performed its own unsynchronized `LibraryLoader` bind into the same map.

3. **WeakHashMap corruption → infinite spin.** `WeakHashMap` (unlike `HashMap` since JDK 8, [JDK-8023463](https://bugs.openjdk.org/browse/JDK-8023463)) still uses head-insertion in `transfer()` during resize:

   ```java
   e.next = dest[i];
   dest[i] = e;   // reverses chain order
   ```

   With the map's default threshold of 12 and ~27 entries added per burst, resizes are guaranteed to occur *during* the concurrent burst. Two threads interleaving `put`/`resize`/`expungeStaleEntries` can cross-link entries into a **cyclic bucket chain**. Any subsequent `put` that walks the poisoned bucket spins forever in

   ```java
   for (Entry<K,V> e = tab[i]; e != null; e = e.next) { ... }   // WeakHashMap.java:465
   ```

   The thread is `RUNNABLE` and holds no monitor — invisible to JVM deadlock detection. Because the map is a JVM singleton, every later bind from any broker in the same JVM wedges as well, which matches the seven stuck threads across test iterations in the dump.

4. **Kill chain.** The wedged `zb-actors` thread never completes `RaftBootstrapStep` → the raft server for that partition never registers its message handlers → the partition leader retries configure/vote with `NoRemoteHandler` forever → scale-up never converges → the test times out → `TestCluster.shutdown()` posts its stop job to the same wedged actor scheduler → shutdown never completes → surefire watchdog kills the JVM.

### Why it surfaced now

This is a latent race, not a fresh regression:

- The per-bootstrap binds were introduced with the posix_fallocate `SegmentAllocator` feature (Dec 2025, `66ac31fa257` / `08ef6e31eec`).
- The jnr-ffi `loadedLibraries` bookkeeping has existed since ≥2.2.16.
- The ScaleUp QA suite (many embedded brokers per JVM, cluster restarts and restore-from-backup per test iteration) provides by far the highest concurrent-bind density anywhere in CI — production runs one broker per JVM with a single 9-bind burst at startup. Hit probability scales with the number of concurrent binds landing inside a resize window, so the QA suite hit it first and repeatedly (flakiness instrumentation was already being added to this test in early August: `c10600816e9`, `1217115365d`).

### Solution

Bind libc **once per JVM** using the lazy holder idiom, eliminating concurrent `LibraryLoader` calls entirely:

- **`journal` — `LibC.ofNativeLibrary()`**: now returns `Holder.INSTANCE`, bound once under the class-init lock (thread-safe and at-most-once by JVM spec). The `@VisibleForTesting` `ofNativeLibrary(String)` overload is unchanged and still produces fresh binds for tests.
- **`zb-db` — `RocksDbOptionsFormatter`**: replaced the racy `libC`/`runtime`/`libCUnavailable` static fields and the check-then-act `ensureLibCIsAvailable()` with the same holder pattern. Bind failure is caught *inside* the static initializer (leaving the fields `null`, preserving the existing warn-once + permanent `String.format` fallback semantics) so it cannot escape as `ExceptionInInitializerError`/`NoClassDefFoundError`. This also fixes a pre-existing unsafe-publication bug: the old non-volatile statics allowed a thread to observe `libC` set while `runtime` was still `null`.

Both call sites remain lazy (first use triggers the bind), and behavior on bind failure is unchanged.

After this change the whole JVM performs at most two `LibraryLoader` calls (journal libc + formatter libc). Even if those two race, the bookkeeping map holds ≤3 entries — far below the resize threshold of 12 — so `transfer()` never runs and a cyclic chain cannot form; the worst case is a lost bookkeeping entry, which is benign.


## Checklist

- [x] Enable backports when necessary — **backport to `stable/8.9` (and other affected stable branches) required**: the analyzed failure occurred on `stable/8.9`; the fault window opened with the Dec 2025 posix `SegmentAllocator` feature, so all branches containing it are affected.

## Related issues

closes https://github.com/camunda/camunda/issues/59100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
