### PR TITLE
fix: prevent invalid JSON in daily load test metrics artifact upload

### DIFF
--- a/.github/workflows/stress-load-test.yml
+++ b/.github/workflows/stress-load-test.yml
@@ -208,8 +208,8 @@ jobs:
           jq -n \
             --arg namespace "${NAMESPACE}" \
             --argjson soakEndEpoch "${SOAK_END_EPOCH:-0}" \
-            --argjson results "${RESULTS_JSON:-{}}" \
-            '{namespace: $namespace, soakEndEpoch: $soakEndEpoch, results: $results}' \
+            --argjson results "${RESULTS_JSON:-null}" \
+            '{namespace: $namespace, soakEndEpoch: $soakEndEpoch, results: ($results // {})}' \
             > stress-result.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Description

Today's daily load test run failed the "Upload variant metrics artifact" step for all three variants (gRPC, REST, none): [run 33037565231](https://github.com/camunda/camunda/actions/runs/33037565231/job/98437263581). Reported in [Slack](https://camunda.slack.com/archives/C0ANMGS3D4Y/p1787814528416249).

Root cause: `${RESULTS_JSON:-{}}` in `stress-load-test.yml`'s manifest-writing step is a bash brace-matching trap. Bash closes the `${...}` expansion at the first unescaped `}`, so the "default" it actually applies is a lone `{`, and the second `}` in the source becomes a literal character appended right after the expansion.

- When `RESULTS_JSON` is unset, this coincidentally still produces `{}` (`{` default + literal `}`), so it looked fine.
- When `RESULTS_JSON` holds real metrics (the success case), the trailing `}` gets appended to valid JSON, corrupting it (e.g. `{"p50":123}` becomes `{"p50":123}}`), so `jq --argjson` rejected it with "invalid JSON text passed to --argjson".

This logic was extracted into `stress-load-test.yml` yesterday as part of the daily load test refactor, so it broke on its first real run today.

No backport needed: this is the daily main-branch stress test workflow, which isn't part of a versioned release.

## Examples

Reproducing the bug: the trailing `}` corrupts a real value, and only "accidentally" looks right when the variable is empty.

```
[27-08-2026 10:01:25 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ RESULTS_JSON={"abc":1}
[27-08-2026 10:01:42 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ echo "${RESULTS_JSON:-{}}"
{abc:1}}    <--- bug
[27-08-2026 10:01:51 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ RESULTS_JSON={"abc":1}
[27-08-2026 10:02:00 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ RESULTS_JSON="{"abc":1}"
[27-08-2026 10:02:05 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ echo "${RESULTS_JSON:-{}}"
{abc:1}}   <--- bug


[27-08-2026 10:03:15 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ RESULTS_JSON=
${RESULTS_JSON:-{}}
[27-08-2026 10:11:22 +02:00]: ~ k8s:camunda-benchmark-prod:c8-ck-one-pi 
$ echo "${RESULTS_JSON:-{}}"
{}    <-- default
```

Fixes we tried and ruled out:

- Assigning the default to a plain shell variable first (`results_json="${RESULTS_JSON:-}"`, then `[[ -z ... ]]` sets it to `'{}'`) — works, but adds 4 lines of workaround code for a one-line problem.
- Quoting or escaping the braces (`${RESULTS_JSON:-'{}'}`, `${RESULTS_JSON:-\{\}}`) — fixes the non-empty case but breaks the empty case the other way: the default then evaluates to the literal string `'{}'` (quotes included), which `jq` rejects as invalid JSON. Any `{`/`}` pair inside a bash `${VAR:-word}` default is landmine-prone, no matter how it's quoted/escaped.

The solution: default to `null` instead of `{}`, and let jq coalesce it back to an empty object:

```bash
jq -n \
  --arg namespace "${NAMESPACE}" \
  --argjson soakEndEpoch "${SOAK_END_EPOCH:-0}" \
  --argjson results "${RESULTS_JSON:-null}" \
  '{namespace: $namespace, soakEndEpoch: $soakEndEpoch, results: ($results // {})}' \
  > stress-result.json
```

`null` has no braces, so bash's `${VAR:-word}` parses it correctly, no matter whether `RESULTS_JSON` is set or empty — the ambiguity that broke `{}` never exists in the first place:

```
$ RESULTS_JSON='{"abc":1}'
$ echo "${RESULTS_JSON:-null}" | jq
{
  "abc": 1
}    <-- fix: real value passes through untouched, nothing to misparse

$ RESULTS_JSON=
$ echo "${RESULTS_JSON:-null}" | jq
null    <-- fix: empty case now yields valid JSON `null`, not a mangled `{}`
```

`$results // {}` (jq's alternative operator) then turns that `null` into `{}` inside jq itself, once we're safely past bash: it evaluates to the left side unless that's `false` or `null`, in which case it falls through to `{}`. So the output manifest is unchanged either way, only the mechanism producing it is no longer ambiguous.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

n/a