### PR TITLE
fix: repair DelayReplicationIT to be more stable

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/DelayReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/DelayReplicationIT.java
@@ -21,11 +21,9 @@ import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Objects;
-import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -45,7 +43,6 @@ import org.junit.jupiter.api.TestMethodOrder;
  * <p>Tagged {@code async-repl} so it runs in the path-scoped async-replication CI job once
  * re-enabled, rather than nightly-only.
  */
-@Disabled("shouldNotAcknowledgeBeforeDelayExpires currently failing - INC-6678")
 @Tag("async-repl")
 @TestInstance(Lifecycle.PER_CLASS)
 @TestMethodOrder(OrderAnnotation.class)
@@ -156,7 +153,7 @@ public class DelayReplicationIT {
         .untilAsserted(
             () ->
                 assertThat(getCurrentExporterPosition())
-                    .isCloseTo(getCurrentAcknowledgedExporterPosition(), Offset.offset(5L)));
+                    .isEqualTo(getCurrentAcknowledgedExporterPosition()));
   }
 
   private long getCurrentExporterPosition() {


### PR DESCRIPTION
## Description

Repairs a flaky test in `DelayReplicationIT` by making an assertion more stable.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58758
