### PR TITLE
refactor: move comparator for alpha + rc sorting of version numbers

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.it.schema;
 
-import static org.apache.commons.lang3.StringUtils.isNumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -37,11 +36,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.awaitility.Awaitility;
@@ -656,7 +653,7 @@ public class ExporterMigrationTestHelper {
       throw new NoSuchElementException("No images found for " + previousMinorVersion);
     }
 
-    allPreviousVersions.sort(ExporterMigrationTestHelper::compareSemanticVersions);
+    allPreviousVersions.sort(SemanticVersion.ALPHA_AND_RELEASE_CANDIDATE_COMPARATOR);
 
     final List<String> releaseVersions =
         allPreviousVersions.stream()
@@ -712,72 +709,5 @@ public class ExporterMigrationTestHelper {
     }
 
     return String.format("%s.%s", components[0], String.valueOf(minor - 1));
-  }
-
-  // need to slightly customize how we do version comparisons here
-  // in particular we want to ensure that we correctly sort alpha and rc versions, but also
-  // want to ensure that alpha rc versions are not considered "later" than the final alpha version
-  // e.g. 8.10.0-alpha4-rc1 < 8.10.0-alpha4 < 8.10.0-alpha11 < 8.10.0
-  private static int compareSemanticVersions(final SemanticVersion v1, final SemanticVersion v2) {
-    if (v1.major() != v2.major()) {
-      return Integer.compare(v1.major(), v2.major());
-    }
-    if (v1.minor() != v2.minor()) {
-      return Integer.compare(v1.minor(), v2.minor());
-    }
-    if (v1.patch() != v2.patch()) {
-      return Integer.compare(v1.patch(), v2.patch());
-    }
-    return comparePreRelease(v1, v2);
-  }
-
-  private static int comparePreRelease(final SemanticVersion v1, final SemanticVersion v2) {
-    if (v1.preRelease() == null && v2.preRelease() == null) {
-      return 0;
-    } else if (v1.preRelease() != null && v2.preRelease() == null) {
-      return -1;
-    } else if (v1.preRelease() == null && v2.preRelease() != null) {
-      return 1;
-    }
-
-    final var preReleaseParts = splitPreRelease(v1.preRelease());
-    final var otherPreReleaseParts = splitPreRelease(v2.preRelease());
-
-    // sort by comparing the numeric parts as actual numbers (human readable) and the non-numeric
-    // parts lexicographically (ASCII sort order)
-    // this means that things like alpha2 will come before alpha10
-    for (int i = 0; i < Math.min(preReleaseParts.size(), otherPreReleaseParts.size()); i++) {
-      final var thisPart = preReleaseParts.get(i);
-      final var otherPart = otherPreReleaseParts.get(i);
-
-      if (isNumeric(thisPart) && isNumeric(otherPart)) {
-        // Identifiers consisting of only digits are compared numerically.
-        final var thisNumericPart = Integer.parseInt(thisPart);
-        final var otherNumericPart = Integer.parseInt(otherPart);
-        if (thisNumericPart != otherNumericPart) {
-          return Integer.compare(thisNumericPart, otherNumericPart);
-        }
-      } else if (isNumeric(thisPart)) {
-        // Numeric identifiers always have higher precedence than non-numeric identifiers.
-        return 1;
-      } else if (isNumeric(otherPart)) {
-        return -1;
-      } else {
-        final var comparison = thisPart.compareTo(otherPart);
-        if (comparison != 0) {
-          return comparison;
-        }
-      }
-    }
-
-    // prefer the shorter version as that will indicate we have a non-RC version
-    // e.g. 8.9.1-alpha1 is a later version than 8.9.1-alpha1-rc1
-    return -Integer.compare(preReleaseParts.size(), otherPreReleaseParts.size());
-  }
-
-  private static List<String> splitPreRelease(final String preRelease) {
-    return Arrays.stream(Objects.requireNonNull(preRelease).splitWithDelimiters("\\d+", 0))
-        .filter(s -> !s.isEmpty())
-        .toList();
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/AlphaAndReleaseCandidateComparator.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/AlphaAndReleaseCandidateComparator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.apache.commons.lang3.StringUtils.isNumeric;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This provides a slightly different implementation of the {@link SemanticVersion} comparator than
+ * the default.
+ *
+ * <p>The main difference is how it handles pre-release comparison. The default will sort those by
+ * splitting the pre-release string on "." and then comparing each part. This implementation splits
+ * on numeric boundaries, so that "alpha1" will be considered less than "alpha10", and it treats
+ * extra qualifiers like "-rc1" as lower precedence than their base pre-release (e.g.
+ * "8.10.0-alpha4-rc1" < "8.10.0-alpha4" < "8.10.0-alpha11" < "8.10.0").
+ *
+ * <p>This should match how we actually sort our own versions in the wild.
+ *
+ * <p>This has been left optional so as not to affect any existing code that may be relying on the
+ * default comparator behavior.
+ */
+class AlphaAndReleaseCandidateComparator implements Comparator<SemanticVersion> {
+
+  @Override
+  public int compare(final SemanticVersion v1, final SemanticVersion v2) {
+    if (v1.major() != v2.major()) {
+      return Integer.compare(v1.major(), v2.major());
+    }
+    if (v1.minor() != v2.minor()) {
+      return Integer.compare(v1.minor(), v2.minor());
+    }
+    if (v1.patch() != v2.patch()) {
+      return Integer.compare(v1.patch(), v2.patch());
+    }
+    return comparePreRelease(v1, v2);
+  }
+
+  private static int comparePreRelease(final SemanticVersion v1, final SemanticVersion v2) {
+    if (v1.preRelease() == null && v2.preRelease() == null) {
+      return 0;
+    } else if (v1.preRelease() != null && v2.preRelease() == null) {
+      return -1;
+    } else if (v1.preRelease() == null && v2.preRelease() != null) {
+      return 1;
+    }
+
+    final var preReleaseParts = splitPreRelease(Objects.requireNonNull(v1.preRelease()));
+    final var otherPreReleaseParts = splitPreRelease(Objects.requireNonNull(v2.preRelease()));
+
+    // sort by comparing the numeric parts as actual numbers (human readable) and the non-numeric
+    // parts lexicographically (ASCII sort order)
+    // this means that things like alpha2 will come before alpha10
+    for (int i = 0; i < Math.min(preReleaseParts.size(), otherPreReleaseParts.size()); i++) {
+      final var thisPart = preReleaseParts.get(i);
+      final var otherPart = otherPreReleaseParts.get(i);
+
+      if (isNumeric(thisPart) && isNumeric(otherPart)) {
+        // Identifiers consisting of only digits are compared numerically.
+        final var thisNumericPart = Integer.parseInt(thisPart);
+        final var otherNumericPart = Integer.parseInt(otherPart);
+        if (thisNumericPart != otherNumericPart) {
+          return Integer.compare(thisNumericPart, otherNumericPart);
+        }
+      } else if (isNumeric(thisPart)) {
+        // Numeric identifiers always have higher precedence than non-numeric identifiers.
+        return 1;
+      } else if (isNumeric(otherPart)) {
+        return -1;
+      } else {
+        final var comparison = thisPart.compareTo(otherPart);
+        if (comparison != 0) {
+          return comparison;
+        }
+      }
+    }
+
+    // prefer the shorter version as that will indicate we have a non-RC version
+    // e.g. 8.9.1-alpha1 is a later version than 8.9.1-alpha1-rc1
+    return -Integer.compare(preReleaseParts.size(), otherPreReleaseParts.size());
+  }
+
+  private static List<String> splitPreRelease(final String preRelease) {
+    return Arrays.stream(Objects.requireNonNull(preRelease).splitWithDelimiters("\\d+", 0))
+        .filter(s -> !s.isEmpty())
+        .toList();
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.util;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNumeric;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -24,6 +25,18 @@ import org.jspecify.annotations.Nullable;
 public record SemanticVersion(
     int major, int minor, int patch, @Nullable String preRelease, @Nullable String buildMetadata)
     implements Comparable<SemanticVersion> {
+
+  /**
+   * Comparator for Camunda-style pre-release versions (e.g. {@code alpha1}, {@code alpha1-rc1},
+   * {@code rc3}, {@code SNAPSHOT}) which splits identifiers on numeric boundaries so that {@code
+   * alpha2 < alpha10}, and treats qualifiers like {@code -rcN} as lower precedence than the base
+   * pre-release.
+   *
+   * <p>Note: this comparator is not SemVer 2.0.0 compliant for all possible pre-release forms; use
+   * {@link #compareTo(SemanticVersion)} for strict SemVer ordering.
+   */
+  public static final Comparator<SemanticVersion> ALPHA_AND_RELEASE_CANDIDATE_COMPARATOR =
+      new AlphaAndReleaseCandidateComparator();
 
   private static final ConcurrentHashMap<String, SemanticVersion> CACHE =
       new ConcurrentHashMap<>(16);

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 final class SemanticVersionTest {
@@ -81,5 +84,48 @@ final class SemanticVersionTest {
   void shouldCompareVersionsWithBuildMetadata() {
     assertThat(new SemanticVersion(1, 0, 0, "alpha", "build.1"))
         .isEqualByComparingTo(new SemanticVersion(1, 0, 0, "alpha", "build.2"));
+  }
+
+  @Test
+  void shouldSortAlphaAndReleaseCandidateVersions() {
+    final var versions =
+        Stream.of(
+                "1.0.0",
+                "2.0.0",
+                "2.0.0-rc3",
+                "2.0.0-SNAPSHOT",
+                "2.1.0-alpha3",
+                "2.1.0",
+                "1.0.0-alpha1",
+                "1.0.0-alpha1-rc1",
+                "1.0.0-alpha1-rc10",
+                "1.0.0-alpha1-rc2",
+                "1.0.0-alpha2-rc1",
+                "1.0.1-alpha2-rc1")
+            .map(SemanticVersion::parse)
+            .map(Optional::orElseThrow)
+            .toList();
+
+    final var sorted =
+        versions.stream()
+            .sorted(SemanticVersion.ALPHA_AND_RELEASE_CANDIDATE_COMPARATOR)
+            .map(SemanticVersion::toString)
+            .toList();
+
+    assertThat(sorted)
+        .isEqualTo(
+            List.of(
+                "1.0.0-alpha1-rc1",
+                "1.0.0-alpha1-rc2",
+                "1.0.0-alpha1-rc10",
+                "1.0.0-alpha1",
+                "1.0.0-alpha2-rc1",
+                "1.0.0",
+                "1.0.1-alpha2-rc1",
+                "2.0.0-SNAPSHOT",
+                "2.0.0-rc3",
+                "2.0.0",
+                "2.1.0-alpha3",
+                "2.1.0"));
   }
 }


### PR DESCRIPTION
so it could be usuable for other things too (if needed).

also add an extra test to verify it sorts as expected.

This is a follow on from https://github.com/camunda/camunda/pull/60898

