### PR TITLE
test: follow Spring Security hop in Optimize OIDC startup check

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/optimize/optimize-startup.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/optimize/optimize-startup.spec.ts
@@ -37,10 +37,25 @@ test.describe('Optimize startup and accessibility', () => {
         .toBe(302);
     });
 
-    await test.step('redirect targets the Optimize OIDC login', () => {
-      expect(redirectLocation).toContain('/protocol/openid-connect/auth');
-      expect(redirectLocation).toContain('client_id=optimize');
-      expect(redirectLocation).toContain('audience=optimize-api');
+    // Optimize delegates unauthenticated access to Spring Security's OAuth2
+    // client, so `/` first redirects to the local login-initiation endpoint,
+    // which then builds the authorization request and redirects to the OIDC
+    // provider. Follow that one hop to reach the real authorization URL.
+    await test.step('redirect enters the Spring Security OIDC login flow', () => {
+      expect(redirectLocation).toContain('/oauth2/authorization/oidc');
+    });
+
+    await test.step('login initiation redirects to the Optimize OIDC provider', async () => {
+      const response = await request.get(redirectLocation, {
+        maxRedirects: 0,
+        timeout: 5000,
+      });
+      expect(response.status()).toBe(302);
+
+      const authorizationLocation = response.headers()['location'] ?? '';
+      expect(authorizationLocation).toContain('/protocol/openid-connect/auth');
+      expect(authorizationLocation).toContain('client_id=optimize');
+      expect(authorizationLocation).toContain('/api/authentication/callback');
     });
   });
 });


### PR DESCRIPTION
## Description

The nightly e2e check `optimize-startup.spec.ts › should start and redirect unauthenticated users to the OIDC login` fails deterministically on `main`, turning the nightly red.

### Root cause

The test asserted that `GET /` `302`-redirects straight to Keycloak's `/protocol/openid-connect/auth`. After the recent Optimize OIDC rework onto the CSL / Spring Security OAuth2 stack, unauthenticated access is delegated to Spring Security's OAuth2 client: `/` now `302`-redirects to the local login-initiation endpoint `/oauth2/authorization/oidc`, which builds the authorization request and issues a **second** `302` to the OIDC provider. Because the test used `maxRedirects: 0`, it only captured the intermediate hop and failed:

```
Expected substring: "/protocol/openid-connect/auth"
Received string:    "http://localhost:8083/oauth2/authorization/oidc"
```

The redirect behavior itself — unauthenticated users are sent to the OIDC login — is unchanged and correct; only the redirect shape gained an intermediate Spring Security hop. This is a **test-side correction**, not a product regression, so it is not masked with a weakened assertion.

### Fix

The test now follows that one hop:

1. Confirms `/` enters the Spring Security login flow (`/oauth2/authorization/oidc`).
2. Requests `/oauth2/authorization/oidc` (still `maxRedirects: 0`) and asserts the resulting authorization URL carries `/protocol/openid-connect/auth`, `client_id=optimize`, and the `/api/authentication/callback` `redirect_uri`.

The obsolete `audience=optimize-api` assertion is dropped: that parameter was legacy Optimize/Auth0 behavior that the CSL stack never appends to the authorization URL and Keycloak ignores.

### Notes

- Prettier, eslint and `tsc --noEmit` are clean.
- No backport needed — the affected test only exists on `main`.
- Supersedes the auto-closed bot PR #60958 (closed by the `close-stale-fix-prs` workflow before it could merge).

### Links

- Failing nightly E2E run: https://github.com/camunda/camunda/actions/runs/32800429341
