### PR TITLE
ci: retry HTTP/2 stream errors when waiting for SaaS E2E run

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -858,7 +858,7 @@ jobs:
                 return 0
               fi
 
-              if echo "$out" | grep -Eq 'HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF|tls: failed to verify certificate|x509: certificate'; then
+              if echo "$out" | grep -Eq 'HTTP 500|HTTP 502|HTTP 503|HTTP 504|TLS handshake timeout|timeout|temporarily unavailable|connection reset by peer|EOF|tls: failed to verify certificate|x509: certificate|stream error|GOAWAY|broken pipe|no such host|connection refused'; then
                 if (( attempt >= max_attempts )); then
                   echo "gh api failed after ${attempt}/${max_attempts} attempts for $endpoint" >&2
                   echo "$out" >&2
@@ -872,9 +872,11 @@ jobs:
                 continue
               fi
 
+              # Exit code 2 marks a permanent error (bad token, renamed workflow
+              # file) so the caller fails fast instead of polling to the timeout.
               echo "Non-retryable gh/api error for $endpoint:" >&2
               echo "$out" >&2
-              return 1
+              return 2
             done
           }
 
@@ -882,15 +884,28 @@ jobs:
 
           for _ in {1..80}; do
             if [[ -z "$RUN_ID" ]]; then
+              # A retry-exhausted poll must not end the wait: this loop is the
+              # timeout mechanism, so fall through to the next tick. Only a
+              # permanent error (exit 2) aborts.
+              RUNS_JSON="" RC=0
+              RUNS_JSON="$(gh_api_with_retry "/repos/$TARGET_REPO/actions/workflows/$WORKFLOW_FILE/runs?event=repository_dispatch&per_page=50")" || RC=$?
+              if (( RC == 2 )); then
+                echo "downstream_conclusion=dispatch-error" >> "$GITHUB_OUTPUT"
+                exit 1
+              elif (( RC != 0 )); then
+                echo "Could not list downstream runs on this poll; retrying on the next tick." >&2
+                sleep 30
+                continue
+              fi
+
               RUN_ID=$(
-                gh_api_with_retry "/repos/$TARGET_REPO/actions/workflows/$WORKFLOW_FILE/runs?event=repository_dispatch&per_page=50" \
-                | jq -r --arg c "$CORRELATION_ID" '
+                jq -r --arg c "$CORRELATION_ID" '
                     .workflow_runs
                     | map(select(.display_title != null and (.display_title | contains($c))))
                     | sort_by(.created_at)
                     | last
                     | .id // empty
-                  '
+                  ' <<<"$RUNS_JSON"
               )
 
               if [[ -z "$RUN_ID" ]]; then
@@ -903,7 +918,17 @@ jobs:
               echo "downstream_run_url=https://github.com/$TARGET_REPO/actions/runs/$RUN_ID" >> "$GITHUB_OUTPUT"
             fi
 
-            RUN_JSON="$(gh_api_with_retry "/repos/$TARGET_REPO/actions/runs/$RUN_ID")"
+            RUN_JSON="" RC=0
+            RUN_JSON="$(gh_api_with_retry "/repos/$TARGET_REPO/actions/runs/$RUN_ID")" || RC=$?
+            if (( RC == 2 )); then
+              echo "downstream_conclusion=dispatch-error" >> "$GITHUB_OUTPUT"
+              exit 1
+            elif (( RC != 0 )); then
+              echo "Could not read downstream run $RUN_ID on this poll; retrying on the next tick." >&2
+              sleep 30
+              continue
+            fi
+
             STATUS="$(jq -r .status <<<"$RUN_JSON")"
             CONCLUSION="$(jq -r .conclusion <<<"$RUN_JSON")"
             echo "Workflow run $RUN_ID status: $STATUS ($CONCLUSION)"


### PR DESCRIPTION
## Description

The `Trigger SaaS E2E tests` job failed on `main` in
[run 33061531883](https://github.com/camunda/camunda/actions/runs/33061531883/job/98483305310)
**while the downstream SaaS E2E run it was waiting on was dispatched successfully and still
running.** No test failed; the wait step gave up on a transient GitHub API error.

### Root cause

`Wait for downstream workflow to finish` polls the GitHub API for the downstream run. Its
`gh_api_with_retry` helper matched transient errors against a fixed pattern list. The observed
sequence was:

```
10:14:43  Transient gh/api error (attempt 1/6) … gh: Server Error (HTTP 502)     -> retried
10:14:56  Non-retryable gh/api error … stream error: stream ID 1; CANCEL; received from peer
10:14:56  ##[error]Process completed with exit code 1.
```

`stream error: stream ID 1; CANCEL; received from peer` is an HTTP/2 transport error — the same
transient class as the 502 one attempt earlier — but it matched none of the patterns, so it took
the non-retryable branch and returned 1. Under `set -euo pipefail` that killed the step **22
seconds into an 80-iteration / ~40-minute wait**.

The downstream run was fine: `c8-cross-component-e2e-tests` run
[33062175412](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/33062175412)
was created at `10:14:34`, two seconds after the dispatch, and was still `in_progress` long after
the upstream job had already gone red. The AlwaysGreen feedback then reported *"SaaS E2E dispatch
or wait failed before a downstream run could be resolved"*, which was not accurate — the run
existed and was resolvable.

### Changes

Two changes, so a transient API blip is no longer reported as an E2E failure:

1. **Broaden the transient pattern** to cover HTTP/2 stream errors, `GOAWAY`, `broken pipe`,
   `no such host`, `connection refused` and `HTTP 500`, alongside the existing patterns.
2. **A retry-exhausted poll no longer ends the wait.** The 80-iteration loop is already the
   timeout mechanism, so one failed poll now falls through to the next tick instead of
   short-circuiting the step. Permanent errors (bad token, renamed workflow file) return `2` and
   still fail fast rather than polling to the timeout.

### Nothing is masked

No `continue-on-error`, no weakened check, no lowered timeout. Verified by replaying the exact
observed error sequence against a stubbed `gh`:

| Scenario | Exit | Output |
|---|---|---|
| 502 → HTTP/2 stream error → OK (this run's sequence) | **0** | `downstream_conclusion=success` |
| Real downstream failure | **1** | `downstream_conclusion=failure` |
| Sustained API outage for the whole window | **1** | `downstream_conclusion=timeout` |
| Permanent 404 | **1** (after 1 call, no retry storm) | `downstream_conclusion=dispatch-error` |

The same replay against the current `main` script exits **1** on row 1, reproducing the failure.

`downstream_conclusion` feeds only the job-summary and Slack evidence strings; the category
resolution step re-queries the API itself and is gated on `downstream_run_url`, so the new
`dispatch-error` value breaks no consumer.

### Validation

- `actionlint` (with `shellcheck` present, so `run:` blocks were linted too): **no new findings**
  vs. the `main` baseline — the single pre-existing `gcp-perf-core-8-default` runner-label warning
  at line 411 is unrelated and untouched.
- YAML parses; extracted step passes `bash -n`.
- No Java, markdown or `pom.xml` touched, so `spotless`/`license:format` and a module build do not
  apply to this change.

## Checklist

- [x] Enable backports when necessary — `stable/8.7`, `stable/8.8`, `stable/8.9` and `stable/8.10`
      all carry the byte-identical helper and are exposed to the same failure mode; labels added.

## Related issues

Failing run: https://github.com/camunda/camunda/actions/runs/33061531883/job/98483305310
