### PR TITLE
ci: replace Minimus with WizOS as POC

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,12 +12,12 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:25-dev",
+  "org.opencontainers.image.ref.name": "registry.os.wiz.io/openjdk-jre:25",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",
   "org.opencontainers.image.url": "https://camunda.com/platform/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "25"
+  "io.wiz.image.repository-name": "openjdk-jre"
 }

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -195,7 +195,7 @@ runs:
         # Check if current workflow run is related to a fork PR
         if [[ "${{ steps.is-fork.outputs.is-fork }}" == "true" ]]; then
           echo "The current workflow run is related to a fork PR."
-          echo "As a result, private Minimus hardened base images will be replaced with public images."
+          echo "As a result, private hardened base images will be replaced with public images."
 
           {
             echo 'result<<EOF'

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -7,14 +7,14 @@ individual jobs don't repeat the same bootstrap. In one step it:
 
 - detects fork PRs (via [`is-fork`](../is-fork)) and disables all credential-dependent
   features when secrets aren't available;
-- imports CI secrets from Vault (Nexus, DockerHub, Minimus);
+- imports CI secrets from Vault (Nexus, DockerHub, Minimus, WizOS);
 - installs the JDK (`actions/setup-java`);
 - registers the Maven problem matcher and configures the Maven cache
   (via [`setup-maven-cache`](../setup-maven-cache));
 - merges Camunda Nexus + Google Central mirrors with any extra mirrors/servers and
   writes `settings.xml`;
 - optionally sets the build time zone;
-- optionally logs into DockerHub, Harbor, and Minimus.
+- optionally logs into DockerHub, Harbor, Minimus, and WizOS.
 
 All credential features are **automatically disabled for fork PRs**, since Vault
 secrets can't be retrieved there.
@@ -28,7 +28,7 @@ Vault/WIF hang (see that action's README).
 
 - The repository must be checked out first (e.g. `actions/checkout`), since this
   action and its nested actions are referenced by local path.
-- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus login),
+- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus/WizOS login),
   pass `vault-address` / `vault-role-id` / `vault-secret-id`.
 
 ## Usage
@@ -42,6 +42,7 @@ Vault/WIF hang (see that action's README).
 | dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits    | false    | `"false"` |
 | harbor                   | Log into Harbor with a Harbor robot account (disabled for fork PRs) | false    | `"false"` |
 | minimus                  | Log into Minimus with a CI account (disabled for fork PRs)          | false    | `"false"` |
+| wizos                    | Log into WizOS with a CI account (disabled for fork PRs)            | false    | `"false"` |
 | java-distribution        | Java distribution to install                                        | false    | `temurin` |
 | java-version             | JDK version to install                                              | false    | `"21"`    |
 | maven-cache-key-modifier | Modifier for the Maven cache key                                    | false    | `shared`  |

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -37,6 +37,12 @@ inputs:
       Minimus login is automatically disabled for fork PRs.
     required: false
     default: "false"
+  wizos:
+    description: |
+      If enabled, logs into WizOS with a CI account.
+      WizOS login is automatically disabled for fork PRs.
+    required: false
+    default: "false"
   java-distribution:
     description: Java distribution to use
     required: false
@@ -152,6 +158,8 @@ runs:
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_PSW${{ inputs.dockerhub-readonly == 'true' && '_READ_ONLY' || ''}} | dockerhub-token;
         ${{ steps.checks.outputs.dockerhub-vault-path }} REGISTRY_HUB_DOCKER_COM_USR | dockerhub-username;
         secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
+        secret/data/products/camunda/ci/github-actions REGISTRY_WIZ_USR | wizos-username;
+        secret/data/products/camunda/ci/github-actions REGISTRY_WIZ_PSW | wizos-token;
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
@@ -308,3 +316,20 @@ runs:
       command: |
         printf '%s' "${DOCKER_PASSWORD}" | docker login reg.mini.dev \
           --username minimus --password-stdin
+  - name: Logs on to WizOS
+    # WizOS login is disabled for fork PRs
+    if: >-
+      steps.is-fork.outputs.is-fork != 'true' &&
+      inputs.wizos == 'true'
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    env:
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.wizos-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.wizos-token }}
+    with:
+      max_attempts: 3
+      retry_wait_seconds: 10
+      timeout_seconds: 60
+      shell: bash
+      command: |
+        printf '%s' "${DOCKER_PASSWORD}" | docker login registry.os.wiz.io \
+          --username "${DOCKER_USERNAME}" --password-stdin

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,12 @@
       password: "{{ secrets.INFRA_MINIMUS_REGISTRY_TOKEN }}",
     },
     {
+      hostType: "docker",
+      matchHost: "https://registry.os.wiz.io",
+      username: "{{ secrets.INFRA_WIZOS_REGISTRY_USERNAME }}",
+      password: "{{ secrets.INFRA_WIZOS_REGISTRY_TOKEN }}",
+    },
+    {
       hostType: "maven",
       matchHost: "https://artifacts.camunda.com",
       username: "{{ secrets.ARTIFACTORY_USERNAME }}",
@@ -288,6 +294,7 @@
         "opensearchproject/opensearch",
         "eclipse-temurin",
         "reg.mini.dev/1212/openjre-base",
+        "registry.os.wiz.io/openjdk-jre",
       ],
       matchUpdateTypes: [
         "major",

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -387,6 +387,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         id: build-operate-fe

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -62,6 +62,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - id: image-tag
         name: Calculate image tag
         shell: bash

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -564,18 +564,19 @@ jobs:
           secrets: |
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/camunda/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
-            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+            secret/data/products/camunda/ci/github-actions REGISTRY_WIZ_USR | wizos-username;
+            secret/data/products/camunda/ci/github-actions REGISTRY_WIZ_PSW | wizos-token
       - name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
-      - name: Logs on to Minimus
+      - name: Logs on to WizOS
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          registry: reg.mini.dev
-          username: minimus
-          password: ${{ steps.secrets.outputs.minimus-token }}
+          registry: registry.os.wiz.io
+          username: ${{ steps.secrets.outputs.wizos-username }}
+          password: ${{ steps.secrets.outputs.wizos-token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -87,6 +87,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - uses: ./.github/actions/build-frontend
         name: Build Operate Frontend
         with:

--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -48,6 +48,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -105,6 +105,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - name: Build Maven
         run: |
           ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -425,6 +425,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       # Same class of check as camunda.Dockerfile gets in the docker-checks job
       # (.github/workflows/ci.yml), but here it's a metadata-only resolve since this job never
       # builds the image. The pinned digest is content-addressable, so we must resolve it by digest

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -498,6 +498,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - id: build-backend
         uses: ./.github/actions/build-zeebe
         with:

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -70,6 +70,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}
+          wizos: ${{ matrix.os != 'macos' && matrix.os != 'windows' }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -382,6 +383,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1578,6 +1578,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       # Timed out here directly (not via setup-build) so a Vault/WIF hang fails fast instead
       # of silently eating the whole job timeout-minutes budget -- see INC-6820.
       - name: Authenticate to GCS build-cache
@@ -1804,6 +1805,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       # Consume the shared distball instead of a ~15 min reactor build; GitHub-hosted,
       # so it stays on the GHA artifact API.
       - name: Download distball
@@ -2941,6 +2943,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       # Frontend bundles are built once in build-platform-frontend and downloaded here
       # instead of being rebuilt (issue #52693). build-zeebe runs with -PskipFrontendBuild below.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -3016,6 +3019,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       # Optimize frontend bundle is built once in build-platform-frontend and downloaded here
       # instead of being rebuilt (issue #52693). The Optimize assembly runs with -PskipFrontendBuild below.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -182,6 +182,7 @@ jobs:
         with:
           harbor: true
           minimus: true
+          wizos: true
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -68,6 +68,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: "true"
+          wizos: "true"
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -426,6 +426,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
 
       - name: Get Maven project version
         id: maven-version

--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -85,6 +85,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
 
       #########################################################################
       # Build Optimize frontend

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -132,6 +132,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
           maven-servers: |
             [{
                 "id": "central",

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -105,6 +105,7 @@ jobs:
         vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
         vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
         minimus: true
+        wizos: true
 
     - uses: ./.github/actions/build-zeebe
       id: build-camunda

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -102,6 +102,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - name: Import Snyk token from Vault
         id: snyk-secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -74,6 +74,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - id: image-tag
         name: Calculate image tag
         shell: bash

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -131,6 +131,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+          wizos: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.tar.gz
 dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.zip
 ```
 
-This distribution can be containerized with Docker (i.e. build a Docker image) with access to Minimus hardened base images](https://minimus.io/) by running:
+This distribution can be containerized with Docker (i.e. build a Docker image) with access to [WizOS hardened base images](https://www.wiz.io/solutions/wizos) by running:
 
 ```
 docker build \
@@ -178,7 +178,7 @@ docker build \
   .
 ```
 
-If you don't have access to [Minimus hardened base images](https://minimus.io/), you can use public base images instead at your own risk by running:
+If you don't have access to [WizOS hardened base images](https://www.wiz.io/solutions/wizos), you can use public base images instead at your own risk by running:
 
 ```
 docker build \

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -3,13 +3,13 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
-ARG BASE_DIGEST="sha256:feafa1cdd5fd39be1fbd53a71cb9e601b793bc075be4d52bff9e63418f2dcd89"
+ARG BASE_IMAGE="registry.os.wiz.io/openjdk-jre:25"
+ARG BASE_DIGEST="sha256:d4497b2ae98ef2826bd3fef1f9b3abdb8778e2bedb0552c4215ec4cd575e26f8"
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
 
-# If you don't have access to Minimus hardened base images, you can use public
+# If you don't have access to WizOS hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
 ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.4_7-jre-noble"
@@ -23,6 +23,20 @@ ARG DIST="distball"
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
 
+# The WizOS base ships no zone data, no glibc locale data, no bash, no terminfo database
+# and a headless JRE without a font manager. Do not drop these packages: without them
+# `sun.jnu.encoding` falls back to ASCII and the JVM silently mangles non-ASCII paths,
+# arguments and log output, TZ lookups resolve to the wrong zone, `bash` scripts fail,
+# `tput`/`clear` reject every $TERM so an interactive `docker exec` has no terminal
+# capabilities, and the first AWT font call throws UnsatisfiedLinkError. glibc-i18n is
+# removed in the same layer that adds it, since a delete in a later layer would not
+# reclaim the space.
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash ncurses-terminfo-base tzdata openjdk25-jre font-dejavu && \
+    apk add --no-cache --virtual .locale-deps glibc-i18n && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    apk del --no-network .locale-deps
+
 ### Base Public Application Image ###
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
@@ -31,8 +45,6 @@ FROM ${BASE_IMAGE_PUBLIC}@${BASE_DIGEST_PUBLIC} AS base-public
 # hadolint ignore=DL3006
 FROM base-${BASE} AS build
 
-# hadolint ignore=DL3002
-USER root
 WORKDIR /camunda
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
 COPY --link . ./
@@ -168,8 +180,6 @@ ENV ROCKSDB_MUSL_LIBC=false
 WORKDIR ${CAMUNDA_HOME}
 EXPOSE 8080 26500 26501 26502
 
-# Switch to root to allow setting up our own user
-USER root
 RUN addgroup --gid 1001 camunda && \
     adduser -S -G camunda -u 1001 -h ${CAMUNDA_HOME} camunda && \
     chmod g=u /etc/passwd && \

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -58,6 +58,8 @@ VAULT_SECRET_PATH="products/camunda/ci/github-actions"
 vault_field_for_secret() {
   case "$1" in
     INFRA_MINIMUS_REGISTRY_TOKEN) echo "REGISTRY_MINIMUS_PSW" ;;
+    INFRA_WIZOS_REGISTRY_USERNAME) echo "REGISTRY_WIZ_USR" ;;
+    INFRA_WIZOS_REGISTRY_TOKEN) echo "REGISTRY_WIZ_PSW" ;;
     *) echo "" ;;
   esac
 }

--- a/docs/monorepo-docs/ci-runbooks.md
+++ b/docs/monorepo-docs/ci-runbooks.md
@@ -19,7 +19,8 @@ incidents affecting the monorepo CI.
 - [GitHub status](https://www.githubstatus.com/) (Actions, PRs, API, Git, etc.)
 - [DockerHub status](https://www.dockerstatus.com/) (Docker image push/pull)
 - [Maven Central status](https://status.maven.org/) (Maven artifact up-/downloads)
-- [Minimus status](https://docs.minimus.io/status) (Minimus Docker registry)
+- [Minimus status](https://docs.minimus.io/status) (Minimus Docker registry, Optimize base image)
+- [WizOS status](https://status.wiz.io/) (WizOS Docker registry, Camunda base image)
 
 ### Temporarily Disable Tests To Lessen Impact
 


### PR DESCRIPTION
## Description

POC to test feasibility of migrating from Minimus to WizOS for `camunda.Dockerfile`,

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to https://github.com/camunda/team-eng-ops/issues/319
