### PR TITLE
fix: return 415 instead of 500 for unsupported Content-Type in Tasklist v1 API

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/ApiErrorController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/ApiErrorController.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -62,6 +63,20 @@ public abstract class ApiErrorController {
   @ExceptionHandler(NotFoundException.class)
   public ResponseEntity<Error> handleNotFound(NotFoundException exception) {
     return handleNotFound(new NotFoundApiException(exception.getMessage(), exception));
+  }
+
+  @Hidden
+  @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+  @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+  public ResponseEntity<Error> handleException(HttpMediaTypeNotSupportedException exception) {
+    logger.warn(exception.getMessage(), exception);
+    final Error error =
+        new Error()
+            .setStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value())
+            .setMessage(exception.getMessage());
+    return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(error);
   }
 
   @Hidden

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
@@ -1079,6 +1079,22 @@ class TaskControllerTest {
     }
 
     @Test
+    void completeTaskWithUnsupportedContentType() throws Exception {
+      // Given
+      final var taskId = "55555555";
+
+      // When
+      mockMvc
+          .perform(
+              patch(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/complete"), taskId)
+                  .characterEncoding(StandardCharsets.UTF_8.name())
+                  .content("{}")
+                  .contentType(MediaType.TEXT_PLAIN))
+          // Then
+          .andExpect(status().isUnsupportedMediaType());
+    }
+
+    @Test
     void completeTaskWithoutTenantAccess() throws Exception {
       final var taskId = "55555555";
       final var variables = List.of(new VariableInputDTO().setName("var_a").setValue("val_a"));

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
@@ -37,6 +37,7 @@ import io.camunda.tasklist.webapp.dto.VariableInputDTO;
 import io.camunda.tasklist.webapp.group.UserGroupService;
 import io.camunda.tasklist.webapp.mapper.TaskMapper;
 import io.camunda.tasklist.webapp.permission.TasklistPermissionServices;
+import io.camunda.tasklist.webapp.rest.exception.Error;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.tasklist.webapp.service.TaskService;
@@ -58,6 +59,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -1079,19 +1081,28 @@ class TaskControllerTest {
     }
 
     @Test
-    void completeTaskWithUnsupportedContentType() throws Exception {
+    void shouldReturn415WhenCompletingTaskWithUnsupportedContentType() throws Exception {
       // Given
       final var taskId = "55555555";
 
       // When
-      mockMvc
-          .perform(
-              patch(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/complete"), taskId)
-                  .characterEncoding(StandardCharsets.UTF_8.name())
-                  .content("{}")
-                  .contentType(MediaType.TEXT_PLAIN))
-          // Then
-          .andExpect(status().isUnsupportedMediaType());
+      final var responseAsString =
+          mockMvc
+              .perform(
+                  patch(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/complete"), taskId)
+                      .characterEncoding(StandardCharsets.UTF_8.name())
+                      .content("{}")
+                      .contentType(MediaType.TEXT_PLAIN))
+              // Then
+              .andExpect(status().isUnsupportedMediaType())
+              .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      final var result = CommonUtils.OBJECT_MAPPER.readValue(responseAsString, Error.class);
+      assertThat(result.getStatus()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value());
+      assertThat(result.getMessage()).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
## Summary

`TaskController` (Tasklist v1 REST API, `stable/8.9`) extends `ApiErrorController`, whose only
handler matching a client-sent unsupported `Content-Type` (e.g. `text/plain` instead of
`application/json`) was the catch-all `@ExceptionHandler(Exception.class)`. That handler is meant
for genuinely unexpected server errors: it logs at **ERROR** severity ("Unexpected exception
happened: %s") and returns **HTTP 500** ("Unexpected server error occurred."), even though the
request never reached application logic and the mistake is entirely on the client side. This
misclassifies a routine client error as a server failure and floods error-level logging/alerting
(243/310 observed production log entries in the linked issue).

Adds a specific `@ExceptionHandler(HttpMediaTypeNotSupportedException.class)` to
`ApiErrorController`, returning **415** with the exception's own descriptive message — following
the exact pattern already used for `HttpMessageNotReadableException` in the same class. Spring
resolves the most specific matching `@ExceptionHandler` automatically, so this takes precedence
over the generic fallback without changing it.

`ApiErrorController` is also extended by `PublicProcessController`, `FormController`,
`VariablesController`, `ProcessExternalController`, and `ProcessInternalController` — this fix
benefits all of them, not just `TaskController`.

Closes #61026

## Scope

The bug reproduces identically on `stable/8.6`, `8.7`, and `8.8` (same `TaskController` /
`ApiErrorController` pair). This PR is scoped to `stable/8.9` (the reported version) only —
`8.6`–`8.8` are an explicit follow-up, not silently left broken.

The Tasklist v1 API (and this whole code path) no longer exists on `main`/`stable/8.10`, removed by
#50702 — there is nothing to fix there.

## Validation

- Added `completeTaskWithUnsupportedContentType` to `TaskControllerTest`, sending
  `PATCH {taskId}/complete` with `Content-Type: text/plain`.
- Ran the full `TaskControllerTest` class (47 tests) — all green. The new test's log output
  confirms the exception is `HttpMediaTypeNotSupportedException`, now logged at **WARN** by the new
  handler (previously ERROR by the catch-all), with a real **415** response.
- Ran the full `tasklist/webapp` module unit test suite (230 tests) — all green — to check for
  regressions across every controller extending `ApiErrorController`, not just `TaskController`.

Local build note: this environment has no credentials for Camunda's internal Artifactory, which
`stable/8.9`'s `camunda-service` needs for `org.camunda.bpm:camunda-license-check:2.10.0`. I used a
local-only Maven stand-in (the already-public `2.11.2` jar re-installed under the `2.10.0`
coordinates in my local `~/.m2`) purely to unblock running the tests above in this sandbox — nothing
related to this is committed or pushed.

## Confidence

High — root cause confirmed against real branch content and log-message match; fix follows an
established in-file pattern; validated by actually running the reproducing test plus the full
module suite, both green.

🤖 Generated by an AI agent (`bug-investigation` skill) re-investigating after a maintainer
correction on the linked issue — see the issue for the full investigation history. Not a substitute
for maintainer review.
