### PR TITLE
fix: show camunda-gateway metrics in Core Features Overview dashboard

### DIFF
--- a/monitor/grafana/dashboards/core-features/overview.json
+++ b/monitor/grafana/dashboards/core-features/overview.json
@@ -7444,7 +7444,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "topk(20,\r\n  avg (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{\r\n    container=~\"zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*\",\r\n    camunda_geo_area=~\"$geo_area\",\r\n    camunda_provider=~\"$cloud_provider\",\r\n    namespace=~\"$namespace\",\r\n    cluster=~\"$cluster\"\r\n  }\r\n  * on(namespace)\r\n  group_left(\r\n    label_cloud_camunda_io_generation,\r\n    label_cloud_camunda_io_sales_plan_type\r\n  )\r\n  max(\r\n    kube_namespace_labels{\r\n      namespace=~\"$namespace\",\r\n      label_cloud_camunda_io_generation=~\"$generation\",\r\n      label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n  }\r\n  ) by (\r\n    namespace\r\n  )\r\n  ) by (container, namespace)\r\n  /\r\n  avg (kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"$namespace\", cluster=~\"$cluster\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"}\r\n    * on(namespace)\r\n    group_left(\r\n      label_cloud_camunda_io_generation,\r\n      label_cloud_camunda_io_sales_plan_type\r\n    )\r\n    max(\r\n      kube_namespace_labels{\r\n        namespace=~\"$namespace\",\r\n        label_cloud_camunda_io_generation=~\"$generation\",\r\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n      }\r\n    ) by (\r\n      namespace\r\n    )\r\n  ) by (container, namespace)\r\n)",
+              "expr": "topk(20,\r\n  avg (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{\r\n    container=~\"zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*|camunda-gateway.*\",\r\n    camunda_geo_area=~\"$geo_area\",\r\n    camunda_provider=~\"$cloud_provider\",\r\n    namespace=~\"$namespace\",\r\n    cluster=~\"$cluster\"\r\n  }\r\n  * on(namespace)\r\n  group_left(\r\n    label_cloud_camunda_io_generation,\r\n    label_cloud_camunda_io_sales_plan_type\r\n  )\r\n  max(\r\n    kube_namespace_labels{\r\n      namespace=~\"$namespace\",\r\n      label_cloud_camunda_io_generation=~\"$generation\",\r\n      label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n  }\r\n  ) by (\r\n    namespace\r\n  )\r\n  ) by (container, namespace)\r\n  /\r\n  avg (kube_pod_container_resource_limits{resource=\"cpu\", namespace=~\"$namespace\", cluster=~\"$cluster\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"}\r\n    * on(namespace)\r\n    group_left(\r\n      label_cloud_camunda_io_generation,\r\n      label_cloud_camunda_io_sales_plan_type\r\n    )\r\n    max(\r\n      kube_namespace_labels{\r\n        namespace=~\"$namespace\",\r\n        label_cloud_camunda_io_generation=~\"$generation\",\r\n        label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n      }\r\n    ) by (\r\n      namespace\r\n    )\r\n  ) by (container, namespace)\r\n)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{namespace}} {{container}}",
@@ -7551,7 +7551,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "topk(20,\r\navg (node_namespace_pod_container:container_memory_working_set_bytes{container=~\"zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*\",\r\n    cluster=~\"$cluster\",\r\n    namespace=~\"$namespace\",\r\n    camunda_geo_area=~\"$geo_area\",\r\n    camunda_provider=~\"$cloud_provider\"}\r\n    * on(namespace)\r\n  group_left(\r\n    label_cloud_camunda_io_generation,\r\n    label_cloud_camunda_io_sales_plan_type\r\n  )\r\n  max(\r\n    kube_namespace_labels{\r\n      namespace=~\"$namespace\",\r\n      label_cloud_camunda_io_generation=~\"$generation\",\r\n      label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n    }\r\n  ) by (\r\n    namespace\r\n  )\r\n  ) by (container, namespace)\r\n    /\r\navg (kube_pod_container_resource_limits{resource=\"memory\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"}\r\n* on(namespace)\r\n  group_left(\r\n    label_cloud_camunda_io_generation,\r\n    label_cloud_camunda_io_sales_plan_type\r\n  )\r\n  max(\r\n    kube_namespace_labels{\r\n      namespace=~\"$namespace\",\r\n      label_cloud_camunda_io_generation=~\"$generation\",\r\n      label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n    }\r\n  ) by (\r\n    namespace\r\n  )\r\n  ) by (container, namespace)\r\n)",
+              "expr": "topk(20,\r\navg (node_namespace_pod_container:container_memory_working_set_bytes{container=~\"zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*|camunda-gateway.*\",\r\n    cluster=~\"$cluster\",\r\n    namespace=~\"$namespace\",\r\n    camunda_geo_area=~\"$geo_area\",\r\n    camunda_provider=~\"$cloud_provider\"}\r\n    * on(namespace)\r\n  group_left(\r\n    label_cloud_camunda_io_generation,\r\n    label_cloud_camunda_io_sales_plan_type\r\n  )\r\n  max(\r\n    kube_namespace_labels{\r\n      namespace=~\"$namespace\",\r\n      label_cloud_camunda_io_generation=~\"$generation\",\r\n      label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n    }\r\n  ) by (\r\n    namespace\r\n  )\r\n  ) by (container, namespace)\r\n    /\r\navg (kube_pod_container_resource_limits{resource=\"memory\", cluster=~\"$cluster\", namespace=~\"$namespace\", camunda_geo_area=~\"$geo_area\", camunda_provider=~\"$cloud_provider\"}\r\n* on(namespace)\r\n  group_left(\r\n    label_cloud_camunda_io_generation,\r\n    label_cloud_camunda_io_sales_plan_type\r\n  )\r\n  max(\r\n    kube_namespace_labels{\r\n      namespace=~\"$namespace\",\r\n      label_cloud_camunda_io_generation=~\"$generation\",\r\n      label_cloud_camunda_io_sales_plan_type=~\"$sales_plan_type\"\r\n    }\r\n  ) by (\r\n    namespace\r\n  )\r\n  ) by (container, namespace)\r\n)",
               "legendFormat": "{{namespace}} {{container}}",
               "range": true,
               "refId": "A"
@@ -8100,7 +8100,7 @@
         "type": "query"
       },
       {
-        "allValue": "zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*",
+        "allValue": "zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*|camunda-gateway.*",
         "allowCustomValue": true,
         "current": {
           "text": "All",
@@ -8123,7 +8123,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*",
+        "regex": "zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*|camunda-gateway.*",
         "sort": 1,
         "type": "query"
       },


### PR DESCRIPTION
## Summary

The "Core Features Overview" Grafana dashboard's `container` template variable, and its two "Top
20" CPU/memory panels, filter container names through a hardcoded allowlist
(`zeebe.*|operate.*|tasklist.*|optimize.*|elasticsearch.*`) that predates SaaS 8.9's change to
deploy the gateway separately as its own `camunda-gateway` pod. As a result, gateway metrics (e.g.
REST search query counts) never show up in any panel filtered by `$container` — including with
"All" selected, since Grafana's `allValue` field governs that case too.

The issue's original diagnosis pointed at the variable's source metric (`atomix_role`, a Raft-only
metric the gateway never emits) — but that had already been replaced by
`container_cpu_usage_seconds_total` (a universal cAdvisor metric every container reports) in a
prior commit. The symptom persisted because of a separate, still-live allowlist gap, not the
originally-suspected metric source.

Adds `camunda-gateway.*` to the same allowlist in all four locations (the variable's `allValue` and
`regex`, plus the two panel queries), rather than opening the filter to an unrestricted wildcard —
`container_cpu_usage_seconds_total` is cluster-wide and not namespace-scoped, so removing the
allowlist entirely would surface unrelated Kubernetes system/sidecar containers (`istio-proxy`,
pause containers, etc.) in the dropdown and dilute the "Top 20" ranking panels.

Closes #50134

## Validation

Validated end-to-end against a real Grafana instance rather than reasoning about the JSON in
isolation:
- Local Prometheus (Homebrew, no Docker) scraping a stub exporter serving synthetic
  `container_cpu_usage_seconds_total` samples for `camunda-gateway`, `zeebe-broker`, `operate`
  (real components) and `istio-proxy`/`POD` (noise, to prove the filter doesn't overcorrect).
- Imported the dashboard JSON as it existed **before** this fix and confirmed, via the actual
  rendered `$container` dropdown: options are `All, operate, zeebe-broker` — `camunda-gateway`
  genuinely absent, reproducing the reported bug through Grafana's real regex-filtering engine.
- Imported the dashboard JSON **after** this fix and confirmed the dropdown now shows
  `All, camunda-gateway, operate, zeebe-broker` — gateway is selectable, and `istio-proxy`/`POD`
  remain excluded in both cases.

## Confidence

High — root cause is precise (4 exact locations, confirmed against every sibling variable's
convention in the same file), and the fix is validated by observing the real, corrected behavior in
a live Grafana instance, not just by proving the regex logic in isolation.

🤖 Generated by an AI agent (`bug-investigation` skill).
