### PR TITLE
fix: align actor future nullability bounds

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -335,7 +335,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(final Supplier<ActorFuture<U>> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
+      final Supplier<ActorFuture<U>> next, final Executor executor) {
     return andThen(
         ignored -> {
           try {
@@ -366,7 +367,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
       final BiFunction<V, @Nullable Throwable, ActorFuture<U>> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
@@ -383,7 +384,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> thenApply(final Function<V, U> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> thenApply(
+      final Function<V, U> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
         (value, error) -> {
@@ -403,7 +405,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> thenApply(final Function<V, U> next) {
+  public <U extends @Nullable Object> ActorFuture<U> thenApply(final Function<V, U> next) {
     if (ActorThread.isCalledFromActorThread()) {
       final ActorControl actorControl = ActorControl.current();
       return thenApply(next, actorControl);


### PR DESCRIPTION
## Description

Aligns four generic upper bounds in `CompletableActorFuture` with the nullable bounds already declared by `ActorFuture`.

These explicit type-use bounds do not change erased signatures or runtime behavior. They fix the override relationship exposed by the NullAway 0.14 update in #60956 while allowing the source change to land directly on `main`.

## Verification

- `./mvnw license:format spotless:apply -T1C` — passed without changing files
- `./mvnw verify -pl zeebe/scheduler -DskipTests=false -Dquickly -T1C -ntp` — 279 tests, 0 failures/errors, 1 skipped
- `./mvnw install -Dquickly -T1C -ntp` — all 150 reactor modules compiled and installed successfully
- The branch is one commit ahead of `main` and changes only `CompletableActorFuture.java`; it does not modify `parent/pom.xml` or the NullAway version.

## Related PR

Addresses the compatibility issue exposed by #60956.

## Checklist

- [ ] Enable backports when necessary.
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant on-demand tests have been run.
