### PR TITLE
test: cover call activity Business ID FEEL resolution and incidents in E2E suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_multiinstance.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_multiinstance.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_call_activity_business_id_multiinstance"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <!--
+    Parallel multi-instance call activity over a fixed collection ([10, 20, 30]) with loop
+    variable `item`. Each spawned child derives its own Business ID from a FEEL expression that
+    references `item`, so the three children get distinct Business IDs. The parent and child
+    process ids and the businessId expression are placeholders substituted per test case.
+  -->
+  <bpmn:process id="__MI_PARENT_ID__" isExecutable="true">
+    <bpmn:startEvent id="mi_start">
+      <bpmn:outgoing>mi_flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="mi_flow_1" sourceRef="mi_start" targetRef="mi_call" />
+    <bpmn:callActivity id="mi_call" name="MI Call Child">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="__MI_CHILD_ID__" businessId="__MI_BUSINESS_ID_EXPR__" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>mi_flow_1</bpmn:incoming>
+      <bpmn:outgoing>mi_flow_2</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="false">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[10, 20, 30]" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="mi_flow_2" sourceRef="mi_call" targetRef="mi_end" />
+    <bpmn:endEvent id="mi_end">
+      <bpmn:incoming>mi_flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="__MI_CHILD_ID__" isExecutable="true">
+    <bpmn:startEvent id="mi_child_start">
+      <bpmn:outgoing>mi_child_flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="mi_child_flow_1" sourceRef="mi_child_start" targetRef="mi_child_wait" />
+    <bpmn:userTask id="mi_child_wait" name="Wait">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>mi_child_flow_1</bpmn:incoming>
+      <bpmn:outgoing>mi_child_flow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="mi_child_flow_2" sourceRef="mi_child_wait" targetRef="mi_child_end" />
+    <bpmn:endEvent id="mi_child_end">
+      <bpmn:incoming>mi_child_flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_nested.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_nested.bpmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_call_activity_business_id_nested"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <!--
+    Nested call-activity chain for the grandchild propagation case: parent -> middle -> grandchild,
+    all three processes in one deployment. The parent's call activity OVERRIDES the child's
+    Business ID with a literal; the middle's call activity has NO businessId attribute, so the
+    grandchild INHERITS the middle's (overridden) Business ID rather than the parent's root value.
+    Process ids and the middle's literal Business ID are placeholders substituted per test case.
+  -->
+  <bpmn:process id="__NESTED_PARENT_ID__" isExecutable="true">
+    <bpmn:startEvent id="parent_start">
+      <bpmn:outgoing>p_flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="p_flow_1" sourceRef="parent_start" targetRef="parent_call" />
+    <bpmn:callActivity id="parent_call" name="Call Middle">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="__NESTED_MIDDLE_ID__" businessId="__NESTED_MIDDLE_BUSINESS_ID__" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>p_flow_1</bpmn:incoming>
+      <bpmn:outgoing>p_flow_2</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="p_flow_2" sourceRef="parent_call" targetRef="parent_end" />
+    <bpmn:endEvent id="parent_end">
+      <bpmn:incoming>p_flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="__NESTED_MIDDLE_ID__" isExecutable="true">
+    <bpmn:startEvent id="middle_start">
+      <bpmn:outgoing>m_flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="m_flow_1" sourceRef="middle_start" targetRef="middle_call" />
+    <bpmn:callActivity id="middle_call" name="Call Grandchild">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="__NESTED_GRANDCHILD_ID__" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>m_flow_1</bpmn:incoming>
+      <bpmn:outgoing>m_flow_2</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="m_flow_2" sourceRef="middle_call" targetRef="middle_end" />
+    <bpmn:endEvent id="middle_end">
+      <bpmn:incoming>m_flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="__NESTED_GRANDCHILD_ID__" isExecutable="true">
+    <bpmn:startEvent id="gc_start">
+      <bpmn:outgoing>gc_flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="gc_flow_1" sourceRef="gc_start" targetRef="gc_wait" />
+    <bpmn:userTask id="gc_wait" name="Wait">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>gc_flow_1</bpmn:incoming>
+      <bpmn:outgoing>gc_flow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="gc_flow_2" sourceRef="gc_wait" targetRef="gc_end" />
+    <bpmn:endEvent id="gc_end">
+      <bpmn:incoming>gc_flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_parent.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_parent.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_call_activity_business_id_parent"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <!--
+    Parametrized parent for the Call Activity Business ID specs. The process id, the
+    called child process id, and the businessId attribute value on zeebe:calledElement
+    are placeholders substituted per test case via deployWithSubstitutions so each case
+    runs in isolation. Do not remove the placeholders.
+  -->
+  <bpmn:process id="__PARENT_PROCESS_ID__" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow_to_call</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_call" sourceRef="start" targetRef="call_child" />
+    <bpmn:callActivity id="call_child" name="Call Child">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="__CHILD_PROCESS_ID__" businessId="__BUSINESS_ID_ATTR__" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_call</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="call_child" targetRef="end" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/child_business_id_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/child_business_id_process.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_child_business_id_process"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <!--
+    Parametrized child called by call_activity_business_id_parent.bpmn. The process id is a
+    placeholder substituted per test case. It waits on a native user task so the child stays
+    ACTIVE, keeping it reliably searchable and cancellable via its parent during cleanup.
+  -->
+  <bpmn:process id="__CHILD_PROCESS_ID__" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>flow_to_wait</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="flow_to_wait" sourceRef="start" targetRef="wait" />
+    <bpmn:userTask id="wait" name="Wait">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_to_wait</bpmn:incoming>
+      <bpmn:outgoing>flow_to_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="flow_to_end" sourceRef="wait" targetRef="end" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/call-activity-business-id-incidents-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/call-activity-business-id-incidents-api-tests.spec.ts
@@ -1,0 +1,533 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {readFileSync} from 'node:fs';
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  cancelProcessInstance,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+  uniqueBusinessId,
+} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import {deployInlineFilesRaw} from '../../../../utils/requestHelpers';
+
+// TestRail case ids: to be allocated on first nightly sync. The suite maps each case by its
+// `<spec path>.<describe › title>` automation id (see scripts/check-automation-id-length.ts),
+// so keep the titles below short and stable.
+
+const PROCESS_INSTANCE_ENDPOINT = '/process-instances';
+const PROCESS_INSTANCE_SEARCH_ENDPOINT = '/process-instances/search';
+const PROCESS_INSTANCE_GET_PATH = '/process-instances/{processInstanceKey}';
+const INCIDENT_SEARCH_ENDPOINT = '/incidents/search';
+
+const PARENT_RESOURCE = './resources/call_activity_business_id_parent.bpmn';
+const CHILD_RESOURCE = './resources/child_business_id_process.bpmn';
+const NESTED_RESOURCE = './resources/call_activity_business_id_nested.bpmn';
+const MI_RESOURCE = './resources/call_activity_business_id_multiinstance.bpmn';
+
+// Business-id uniqueness enforcement is on in this suite
+// (CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true), so every literal
+// Business ID a case relies on is made run-unique to avoid cross-run collisions.
+
+// Root process instances started during the run. Cleaned up guardedly in afterAll — cancelling
+// a root cancels its whole call-activity subtree, so children never leak. The array is
+// per-worker, which lines up with Playwright's per-worker afterAll under describe.parallel.
+const startedInstanceKeys: string[] = [];
+
+interface IncidentItem {
+  errorType: string;
+  errorMessage: string;
+  elementId: string;
+  processInstanceKey: string;
+}
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Mirrors deployWithSubstitutions' string replacement, but returns the rendered content instead
+// of deploying, so deploy-time rejection cases can post it and assert the raw HTTP 400.
+function renderResource(
+  filePath: string,
+  substitutions: Record<string, string>,
+): string {
+  let content = readFileSync(filePath, 'utf-8');
+  for (const [placeholder, replacement] of Object.entries(substitutions)) {
+    if (!content.includes(placeholder)) {
+      throw new Error(
+        `Placeholder '${placeholder}' not found in resource file '${filePath}'`,
+      );
+    }
+    content = content.split(placeholder).join(replacement);
+  }
+  return content;
+}
+
+// Deploys the parametrized child then parent with a per-case businessId attribute value and
+// isolated process ids. Returns the generated parent/child process ids.
+async function deployParentAndChild(
+  businessIdAttr: string,
+): Promise<{parentProcessId: string; childProcessId: string}> {
+  const suffix = generateUniqueId();
+  const parentProcessId = `ca-parent-${suffix}`;
+  const childProcessId = `ca-child-${suffix}`;
+  await deployWithSubstitutions(CHILD_RESOURCE, {
+    __CHILD_PROCESS_ID__: childProcessId,
+  });
+  await deployWithSubstitutions(PARENT_RESOURCE, {
+    __PARENT_PROCESS_ID__: parentProcessId,
+    __CHILD_PROCESS_ID__: childProcessId,
+    __BUSINESS_ID_ATTR__: escapeXmlAttr(businessIdAttr),
+  });
+  return {parentProcessId, childProcessId};
+}
+
+async function startProcessInstance(
+  request: APIRequestContext,
+  processDefinitionId: string,
+  businessId?: string,
+): Promise<Record<string, string>> {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: businessId
+      ? {processDefinitionId, businessId}
+      : {processDefinitionId},
+  });
+  await assertStatusCode(res, 200);
+  const json = await res.json();
+  startedInstanceKeys.push(json.processInstanceKey);
+  return json;
+}
+
+async function getProcessInstance(
+  request: APIRequestContext,
+  processInstanceKey: string,
+): Promise<Record<string, unknown>> {
+  const res = await request.get(
+    buildUrl(PROCESS_INSTANCE_GET_PATH, {processInstanceKey}),
+    {headers: jsonHeaders()},
+  );
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: PROCESS_INSTANCE_GET_PATH, method: 'GET', status: '200'},
+    res,
+  );
+  return res.json();
+}
+
+async function searchChildInstances(
+  request: APIRequestContext,
+  parentProcessInstanceKey: string,
+): Promise<{page: {totalItems: number}; items: Record<string, unknown>[]}> {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {filter: {parentProcessInstanceKey}},
+  });
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: PROCESS_INSTANCE_SEARCH_ENDPOINT, method: 'POST', status: '200'},
+    res,
+  );
+  return res.json();
+}
+
+async function searchIncidents(
+  request: APIRequestContext,
+  processInstanceKey: string,
+): Promise<{page: {totalItems: number}; items: IncidentItem[]}> {
+  const res = await request.post(buildUrl(INCIDENT_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {filter: {processInstanceKey}},
+  });
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: INCIDENT_SEARCH_ENDPOINT, method: 'POST', status: '200'},
+    res,
+  );
+  return res.json();
+}
+
+test.describe.parallel('Call Activity Business ID - FEEL & Incidents', () => {
+  test.afterAll(async () => {
+    await Promise.allSettled(
+      startedInstanceKeys.map(async (key) => {
+        try {
+          await cancelProcessInstance(key);
+        } catch {
+          // Guarded: a single failed cancellation (e.g. already-completed instance) must not
+          // prevent the remaining instances from being cleaned up.
+        }
+      }),
+    );
+  });
+
+  // Group 1 — FEEL happy path
+
+  test('FEEL businessId inherits parent Business ID via context variable', async ({
+    request,
+  }) => {
+    const parentBusinessId = uniqueBusinessId('feel-inherit');
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy parent whose child businessId reads the parent Business ID', async () => {
+      const {parentProcessId} = await deployParentAndChild(
+        '=camunda.processInstance.businessId',
+      );
+      localState['parentProcessId'] = parentProcessId;
+    });
+
+    await test.step('Start parent with a Business ID', async () => {
+      const json = await startProcessInstance(
+        request,
+        localState['parentProcessId'],
+        parentBusinessId,
+      );
+      expect(json.businessId).toBe(parentBusinessId);
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Child inherits the parent Business ID via FEEL', async () => {
+      await expect(async () => {
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(1);
+        expect(children.items[0].businessId).toBe(parentBusinessId);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  // Group 2 — Runtime incident matrix (parent stays ACTIVE with an incident, no child created)
+
+  test('FEEL resolving to a non-string raises an incident', async ({
+    request,
+  }) => {
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy parent whose child businessId resolves to a number', async () => {
+      const {parentProcessId} = await deployParentAndChild('=42 + 8');
+      localState['parentProcessId'] = parentProcessId;
+    });
+
+    await test.step('Start parent', async () => {
+      const json = await startProcessInstance(
+        request,
+        localState['parentProcessId'],
+      );
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Parent is ACTIVE with an EXTRACT_VALUE_ERROR incident and no child', async () => {
+      await expect(async () => {
+        const {items} = await searchIncidents(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        const incident = items.find(
+          (i) => i.errorType === 'EXTRACT_VALUE_ERROR',
+        );
+        expect(
+          incident,
+          `expected an EXTRACT_VALUE_ERROR incident, got ${JSON.stringify(items)}`,
+        ).toBeDefined();
+        expect(incident!.errorMessage).toMatch(/resolve to a string/i);
+
+        const parent = await getProcessInstance(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(parent.state).toBe('ACTIVE');
+        expect(parent.hasIncident).toBe(true);
+
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('FEEL referencing a missing variable raises an incident', async ({
+    request,
+  }) => {
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy parent whose child businessId references a missing variable', async () => {
+      const {parentProcessId} = await deployParentAndChild(
+        '=nonExistentVariable',
+      );
+      localState['parentProcessId'] = parentProcessId;
+    });
+
+    await test.step('Start parent', async () => {
+      const json = await startProcessInstance(
+        request,
+        localState['parentProcessId'],
+      );
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Parent has an EXTRACT_VALUE_ERROR incident about the coerced null and no child', async () => {
+      await expect(async () => {
+        const {items} = await searchIncidents(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        const incident = items.find(
+          (i) => i.errorType === 'EXTRACT_VALUE_ERROR',
+        );
+        expect(
+          incident,
+          `expected an EXTRACT_VALUE_ERROR incident, got ${JSON.stringify(items)}`,
+        ).toBeDefined();
+        expect(incident!.errorMessage).toMatch(/evaluated to null/i);
+        expect(incident!.errorMessage).toMatch(/NO_VARIABLE_FOUND/);
+
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('FEEL resolving beyond the max length raises an incident', async ({
+    request,
+  }) => {
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy parent whose child businessId resolves to 260 characters', async () => {
+      const {parentProcessId} = await deployParentAndChild(
+        '=string join(for i in 1..260 return "X", "")',
+      );
+      localState['parentProcessId'] = parentProcessId;
+    });
+
+    await test.step('Start parent', async () => {
+      const json = await startProcessInstance(
+        request,
+        localState['parentProcessId'],
+      );
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Parent has an EXTRACT_VALUE_ERROR incident about the length and no child', async () => {
+      await expect(async () => {
+        const {items} = await searchIncidents(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        const incident = items.find(
+          (i) => i.errorType === 'EXTRACT_VALUE_ERROR',
+        );
+        expect(
+          incident,
+          `expected an EXTRACT_VALUE_ERROR incident, got ${JSON.stringify(items)}`,
+        ).toBeDefined();
+        expect(incident!.errorMessage).toMatch(
+          /exceeds the max length of 256/i,
+        );
+
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  // Group 3 — Deploy-time rejection (no instance started)
+
+  test('Invalid FEEL syntax is rejected at deployment', async ({request}) => {
+    const suffix = generateUniqueId();
+    const parentContent = renderResource(PARENT_RESOURCE, {
+      __PARENT_PROCESS_ID__: `ca-parent-${suffix}`,
+      __CHILD_PROCESS_ID__: `ca-child-${suffix}`,
+      __BUSINESS_ID_ATTR__: escapeXmlAttr('=1 +'),
+    });
+
+    const res = await deployInlineFilesRaw(request, [
+      {fileName: `ca-parent-${suffix}.bpmn`, content: parentContent},
+    ]);
+
+    await assertStatusCode(res, 400);
+    const body = await res.json();
+    expect(body.detail).toMatch(/parse|expression/i);
+  });
+
+  test('Static literal over 256 characters is rejected at deployment', async ({
+    request,
+  }) => {
+    const suffix = generateUniqueId();
+    const parentContent = renderResource(PARENT_RESOURCE, {
+      __PARENT_PROCESS_ID__: `ca-parent-${suffix}`,
+      __CHILD_PROCESS_ID__: `ca-child-${suffix}`,
+      __BUSINESS_ID_ATTR__: escapeXmlAttr('a'.repeat(257)),
+    });
+
+    const res = await deployInlineFilesRaw(request, [
+      {fileName: `ca-parent-${suffix}.bpmn`, content: parentContent},
+    ]);
+
+    await assertStatusCode(res, 400);
+    const body = await res.json();
+    expect(body.detail).toMatch(/no longer than 256 characters/i);
+  });
+
+  // Group 4 — Intentional-null discard (child created, no incident)
+
+  test('Explicit FEEL null discards the child Business ID without an incident', async ({
+    request,
+  }) => {
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy parent whose child businessId is explicitly =null', async () => {
+      const {parentProcessId} = await deployParentAndChild('=null');
+      localState['parentProcessId'] = parentProcessId;
+    });
+
+    await test.step('Start parent', async () => {
+      const json = await startProcessInstance(
+        request,
+        localState['parentProcessId'],
+      );
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Child is created with a null Business ID', async () => {
+      await expect(async () => {
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(1);
+        expect(children.items[0]).toHaveProperty('businessId', null);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Parent has no incident', async () => {
+      const {page} = await searchIncidents(
+        request,
+        localState['parentProcessInstanceKey'],
+      );
+      expect(page.totalItems).toBe(0);
+    });
+  });
+
+  // Group 5 — Structural
+
+  test('Nested call activity: grandchild inherits the middle Business ID', async ({
+    request,
+  }) => {
+    const rootBusinessId = uniqueBusinessId('nested-root');
+    const middleBusinessId = uniqueBusinessId('nested-middle');
+    const suffix = generateUniqueId();
+    const parentProcessId = `nested-parent-${suffix}`;
+    const middleProcessId = `nested-middle-${suffix}`;
+    const grandchildProcessId = `nested-grandchild-${suffix}`;
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy the parent -> middle -> grandchild chain', async () => {
+      await deployWithSubstitutions(NESTED_RESOURCE, {
+        __NESTED_PARENT_ID__: parentProcessId,
+        __NESTED_MIDDLE_ID__: middleProcessId,
+        __NESTED_GRANDCHILD_ID__: grandchildProcessId,
+        __NESTED_MIDDLE_BUSINESS_ID__: escapeXmlAttr(middleBusinessId),
+      });
+    });
+
+    await test.step('Start parent with the root Business ID', async () => {
+      const json = await startProcessInstance(
+        request,
+        parentProcessId,
+        rootBusinessId,
+      );
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Middle inherits the overriding literal Business ID', async () => {
+      await expect(async () => {
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(1);
+        expect(children.items[0].businessId).toBe(middleBusinessId);
+        localState['middleProcessInstanceKey'] = children.items[0]
+          .processInstanceKey as string;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Grandchild inherits the middle Business ID, not the root', async () => {
+      await expect(async () => {
+        const grandchildren = await searchChildInstances(
+          request,
+          localState['middleProcessInstanceKey'],
+        );
+        expect(grandchildren.page.totalItems).toBe(1);
+        expect(grandchildren.items[0].businessId).toBe(middleBusinessId);
+        expect(grandchildren.items[0].businessId).not.toBe(rootBusinessId);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Multi-instance call activity derives a Business ID per element', async ({
+    request,
+  }) => {
+    const prefix = uniqueBusinessId('mi');
+    const suffix = generateUniqueId();
+    const parentProcessId = `mi-parent-${suffix}`;
+    const childProcessId = `mi-child-${suffix}`;
+    const expectedBusinessIds = [
+      `${prefix}-10`,
+      `${prefix}-20`,
+      `${prefix}-30`,
+    ];
+    const localState: Record<string, string> = {};
+
+    await test.step('Deploy the multi-instance parent and child', async () => {
+      await deployWithSubstitutions(MI_RESOURCE, {
+        __MI_PARENT_ID__: parentProcessId,
+        __MI_CHILD_ID__: childProcessId,
+        __MI_BUSINESS_ID_EXPR__: escapeXmlAttr(`="${prefix}-" + string(item)`),
+      });
+    });
+
+    await test.step('Start parent', async () => {
+      const json = await startProcessInstance(request, parentProcessId);
+      localState['parentProcessInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Three children get the distinct derived Business IDs', async () => {
+      await expect(async () => {
+        const children = await searchChildInstances(
+          request,
+          localState['parentProcessInstanceKey'],
+        );
+        expect(children.page.totalItems).toBe(3);
+        const businessIds = children.items
+          .map((item) => item.businessId as string)
+          .sort();
+        expect(businessIds).toEqual([...expectedBusinessIds].sort());
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a new Playwright API E2E spec to the C8 orchestration-cluster suite covering
**Call Activity Business ID FEEL resolution and the runtime incident matrix**, plus
nested and multi-instance propagation. This fills the gap left by the existing
Business ID call-activity coverage (literal override / inherit / explicit-clear),
which does not exercise FEEL expressions or any incident case.

New spec: `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/call-activity-business-id-incidents-api-tests.spec.ts`

### Cases

- **FEEL happy path** — child inherits the parent Business ID via
  `=camunda.processInstance.businessId`.
- **Runtime incident matrix** — non-string (`=42 + 8`), missing variable
  (`=nonExistentVariable`), and over-256 (`=string join(...)`) each raise a resolvable
  `EXTRACT_VALUE_ERROR`; parent stays `ACTIVE` with `hasIncident` and no child.
- **Deploy-time rejection** — invalid FEEL syntax (`=1 +`) and an over-256 static
  literal are rejected with HTTP 400; no instance is started.
- **Intentional-null discard** — `=null` creates the child with `businessId: null`
  and no incident (clean mirror of the accidental-null incident).
- **Structural** — nested grandchild inherits the middle's overridden `MIDDLE`
  (not the root), and a parallel multi-instance call activity derives 3 distinct
  Business IDs.

### New BPMN resources

The nested (3-process) and multi-instance cases need dedicated resources because the
parametrized parent cannot express a middle process or loop characteristics via string
substitution:

- `call_activity_business_id_parent.bpmn` / `child_business_id_process.bpmn`
- `call_activity_business_id_nested.bpmn` (parent → middle → grandchild)
- `call_activity_business_id_multiinstance.bpmn`

## Notes for reviewers

- Every started instance is cancelled guardedly in `afterAll`
  (`Promise.allSettled` + per-item try/catch); cancelling a root tears down its subtree.
- All Business IDs are run-unique to satisfy the suite's uniqueness enforcement
  (`CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true`).
- Incident cases poll with `toPass` (incidents / `hasIncident` are eventually consistent).
- Static checks pass locally: `tsc`, `eslint`, `prettier --check`, `check:testrail-ids`.
  The specs need a live cluster to execute — please run via the on-demand E2E workflow
  before merge.
- TestRail IDs are left as a placeholder comment (the suite maps cases by automation-id).
- A couple of deploy-rejection / incident message regexes may need tightening against
  real cluster output.

## Reference

- ADR `zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md`
- Engine test `CallActivityBusinessIdTest` for nested / multi-instance / FEEL semantics
