### PR TITLE
fix: enforce the Kryo registration allowlist for map entries on the cluster transport

### DIFF
--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
@@ -16,12 +16,10 @@
  */
 package io.atomix.utils.serializer;
 
-import com.esotericsoftware.kryo.serializers.JavaSerializer;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import io.atomix.utils.Version;
@@ -33,8 +31,10 @@ import io.atomix.utils.serializer.serializers.ByteBufferSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableListSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableMapSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableSetSerializer;
+import io.atomix.utils.serializer.serializers.SimpleImmutableEntrySerializer;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,7 +91,7 @@ public final class Namespaces {
           .register(HashMultiset.class)
           .register(Multisets.immutableEntry("", 0).getClass())
           .register(Sets.class)
-          .register(new JavaSerializer(), Maps.immutableEntry("a", "b").getClass())
+          .register(new SimpleImmutableEntrySerializer(), SimpleImmutableEntry.class)
           .register(new ArraysAsListSerializer(), Arrays.asList().getClass())
           .register(Collections.singletonList(1).getClass())
           .register(Duration.class)

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/SimpleImmutableEntrySerializer.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/serializer/serializers/SimpleImmutableEntrySerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.atomix.utils.serializer.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+/**
+ * Kryo Serializer for {@link SimpleImmutableEntry}.
+ *
+ * <p>Neither of the two obvious alternatives works here. Kryo's default {@code
+ * CompatibleFieldSerializer} cannot read the private final fields of a {@code java.util} class,
+ * because the JDK does not open that package for reflection. {@code JavaSerializer} does work, but
+ * it hands the key and the value to {@code ObjectInputStream}, which ignores Kryo's registration
+ * allowlist and so reconstructs whatever type the bytes name.
+ *
+ * <p>Writing key and value through {@link Kryo#writeClassAndObject} keeps both on the registered
+ * type path, so an entry can only carry types the namespace already allows.
+ */
+public final class SimpleImmutableEntrySerializer extends Serializer<SimpleImmutableEntry<?, ?>> {
+
+  /** Creates a {@link SimpleImmutableEntry} serializer instance. */
+  public SimpleImmutableEntrySerializer() {
+    // non-null, immutable
+    super(false, true);
+  }
+
+  @Override
+  public void write(final Kryo kryo, final Output output, final SimpleImmutableEntry<?, ?> object) {
+    kryo.writeClassAndObject(output, object.getKey());
+    kryo.writeClassAndObject(output, object.getValue());
+  }
+
+  @Override
+  public SimpleImmutableEntry<?, ?> read(
+      final Kryo kryo, final Input input, final Class<? extends SimpleImmutableEntry<?, ?>> type) {
+    final Object key = kryo.readClassAndObject(input);
+    final Object value = kryo.readClassAndObject(input);
+    return new SimpleImmutableEntry<>(key, value);
+  }
+}

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/NamespacesTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/NamespacesTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.esotericsoftware.kryo.KryoException;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.serializers.JavaSerializer;
+import io.atomix.utils.serializer.Namespace.RegistrationBlock;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class NamespacesTest {
+
+  /** Set from {@link Unregistered#readObject}, i.e. only if Java deserialization was reached. */
+  private static final AtomicBoolean JAVA_DESERIALIZATION_REACHED = new AtomicBoolean();
+
+  @BeforeEach
+  void resetSink() {
+    JAVA_DESERIALIZATION_REACHED.set(false);
+  }
+
+  @Test
+  void shouldRoundTripMapEntry() {
+    // given
+    final var entry = new SimpleImmutableEntry<>("key", new ArrayList<>(List.of(1, 2, 3)));
+
+    // when
+    final Object decoded = Namespaces.BASIC.deserialize(Namespaces.BASIC.serialize(entry));
+
+    // then
+    assertThat(decoded).isEqualTo(entry);
+  }
+
+  @Test
+  void shouldRejectUnregisteredTypeNestedInMapEntry() {
+    // given
+    final var entry = new SimpleImmutableEntry<>(new Unregistered(), "value");
+
+    // when - then
+    assertThatThrownBy(() -> Namespaces.BASIC.serialize(entry))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is not registered");
+  }
+
+  @Test
+  void shouldRejectUnregisteredTypeInIncomingMapEntry() {
+    // given - bytes an attacker could put on the cluster transport, produced here by the
+    // registration this namespace used before the fix
+    final byte[] bytes =
+        javaSerializingNamespace().serialize(new SimpleImmutableEntry<>(new Unregistered(), "v"));
+
+    // when - then
+    assertThatThrownBy(() -> Namespaces.BASIC.deserialize(bytes))
+        .isInstanceOf(KryoException.class)
+        .hasMessageContaining("unregistered");
+    assertThat(JAVA_DESERIALIZATION_REACHED)
+        .withFailMessage("Expected Java deserialization to never run for an unregistered type")
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotRegisterJavaSerializer() {
+    // given - when
+    final List<Serializer<?>> serializers =
+        Namespaces.BASIC.getRegisteredBlocks().stream()
+            .flatMap(block -> block.types().stream())
+            .map(Pair::getRight)
+            .filter(Objects::nonNull)
+            .toList();
+
+    // then - a JavaSerializer delegates to ObjectInputStream, which ignores the Kryo registration
+    // allowlist and so reconstructs any type nested in the value it deserializes
+    assertThat(serializers).doesNotHaveAnyElementsOfTypes(JavaSerializer.class);
+  }
+
+  /**
+   * {@link Namespaces#BASIC} with {@link SimpleImmutableEntry} registered through a {@link
+   * JavaSerializer} again, so that it produces the same bytes a pre-fix broker would. Copying the
+   * registration blocks keeps every class id identical, which is what makes the output readable by
+   * {@link Namespaces#BASIC}.
+   */
+  private static Namespace javaSerializingNamespace() {
+    final List<RegistrationBlock> blocks =
+        Namespaces.BASIC.getRegisteredBlocks().stream()
+            .map(
+                block ->
+                    new RegistrationBlock(
+                        block.begin(),
+                        block.types().stream()
+                            .map(NamespacesTest::withJavaSerializerForMapEntry)
+                            .toList()))
+            .toList();
+    return new Namespace(blocks, "JAVA_SERIALIZING");
+  }
+
+  private static Pair<Class<?>[], Serializer<?>> withJavaSerializerForMapEntry(
+      final Pair<Class<?>[], Serializer<?>> registration) {
+    if (List.of(registration.getLeft()).contains(SimpleImmutableEntry.class)) {
+      return Pair.of(registration.getLeft(), new JavaSerializer());
+    }
+    return registration;
+  }
+
+  /** Deliberately not registered with any namespace, and observably read if it ever is. */
+  private static final class Unregistered implements Serializable {
+    private final String tag = "unregistered";
+
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      JAVA_DESERIALIZATION_REACHED.set(true);
+    }
+  }
+}

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/NamespacesTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/serializer/NamespacesTest.java
@@ -68,18 +68,17 @@ final class NamespacesTest {
   }
 
   @Test
-  void shouldRejectUnregisteredTypeInIncomingMapEntry() {
+  void shouldNotJavaDeserializeIncomingMapEntry() {
     // given - bytes an attacker could put on the cluster transport, produced here by the
     // registration this namespace used before the fix
     final byte[] bytes =
         javaSerializingNamespace().serialize(new SimpleImmutableEntry<>(new Unregistered(), "v"));
 
-    // when - then
-    assertThatThrownBy(() -> Namespaces.BASIC.deserialize(bytes))
-        .isInstanceOf(KryoException.class)
-        .hasMessageContaining("unregistered");
+    // when - then the payload is now read as Kryo rather than handed to ObjectInputStream, so it
+    // fails to decode and, more importantly, never reaches Java deserialization
+    assertThatThrownBy(() -> Namespaces.BASIC.deserialize(bytes)).isInstanceOf(KryoException.class);
     assertThat(JAVA_DESERIALIZATION_REACHED)
-        .withFailMessage("Expected Java deserialization to never run for an unregistered type")
+        .withFailMessage("Expected Java deserialization to never run while decoding a map entry")
         .isFalse();
   }
 
@@ -101,8 +100,9 @@ final class NamespacesTest {
   /**
    * {@link Namespaces#BASIC} with {@link SimpleImmutableEntry} registered through a {@link
    * JavaSerializer} again, so that it produces the same bytes a pre-fix broker would. Copying the
-   * registration blocks keeps every class id identical, which is what makes the output readable by
-   * {@link Namespaces#BASIC}.
+   * registration blocks keeps every class id identical, so {@link Namespaces#BASIC} recognises the
+   * entry and attempts to decode it — the point of the test is what happens next, not that the
+   * decode succeeds.
    */
   private static Namespace javaSerializingNamespace() {
     final List<RegistrationBlock> blocks =


### PR DESCRIPTION
# Description 

`Namespaces.BASIC` registered Kryo's `JavaSerializer` for `SimpleImmutableEntry`. That
serializer hands the entry's key and value to `java.io.ObjectInputStream`, which ignores the
Kryo registration allowlist that `CompatibleKryoPool` establishes with
`setRegistrationRequired(true)` — so an unregistered type nested in an entry was reconstructed
anyway. `Namespaces.BASIC` is the base namespace for SWIM gossip, cluster events, the UDP
unicast service and Raft.

The registration came in with the Guava 33.4.8 → 33.5.0 upgrade (ab167037). Guava changed
`Maps.immutableEntry` to return `java.util.AbstractMap$SimpleImmutableEntry`, whose private
final fields Kryo's `CompatibleFieldSerializer` cannot reflect over because the JDK does not
open `java.util`. So dropping back to the default serializer is not an option — it throws
`InaccessibleObjectException` while the namespace is being built.

Instead, a small `SimpleImmutableEntrySerializer` writes key and value through
`Kryo#writeClassAndObject`, keeping both on the registered-type path, and rebuilds the entry
through its public constructor. The registration also names `SimpleImmutableEntry` directly
rather than deriving it from `Maps.immutableEntry(...)`, so it no longer tracks Guava's choice
of return type.

Registration ids were verified to remain the same (and thus backwards compatible).

Tests cover both directions — an unregistered `Serializable` can no longer be written into an
entry, nor read back out of bytes produced by the previous registration — plus a check that no
registration in the namespace resolves to a `JavaSerializer`.

Fixes camunda/security-testing-findings#223

### Notes

- 8.8 is unaffected: it predates the Guava upgrade. Backport labels set for 8.9 and 8.10
