### PR TITLE
feat: configure Admin redesign through client config

### DIFF
--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -25,6 +25,10 @@ export const isTenantsApiEnabled = getClientConfigBoolean(
   "isTenantsApiEnabled",
   false,
 );
+export const isNewDesignSystemEnabled = getClientConfigBoolean(
+  "isNewDesignSystemEnabled",
+  false,
+);
 
 export const docsUrl = "https://docs.camunda.io/docs/next";
 

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -6,9 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { isSaaS } from "./configuration";
+import { isNewDesignSystemEnabled } from "./configuration";
 
 export const featureFlags = [];
 
-export const IS_NEW_DESIGN_SYSTEM_ENABLED = isSaaS ? false : true;
+export const IS_NEW_DESIGN_SYSTEM_ENABLED = isNewDesignSystemEnabled;
 export const IS_NAV_V2_ENABLED = IS_NEW_DESIGN_SYSTEM_ENABLED;

--- a/identity/client/src/types/global.d.ts
+++ b/identity/client/src/types/global.d.ts
@@ -11,6 +11,7 @@ export declare global {
     isOidc?: string;
     isCamundaGroupsEnabled?: string;
     isTenantsApiEnabled?: string;
+    isNewDesignSystemEnabled?: string;
     organizationId?: string;
     clusterId?: string;
     idPattern?: string;


### PR DESCRIPTION
## Description

Use Admin's backend-provided `isNewDesignSystemEnabled` client config instead
of inferring the redesign state from SaaS markers in the frontend.

This makes the backend's Self-Managed/SaaS defaults and explicit override the
single source of truth for both the redesign and navigation flags.

Follow-up to #61189. Relates to #61006.

## Testing

- `npm test`
- `npm run build`
- `./mvnw install -Dquickly -T1C`
