### PR TITLE
fix: align actor future nullability bounds

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -335,7 +335,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(final Supplier<ActorFuture<U>> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
+      final Supplier<ActorFuture<U>> next, final Executor executor) {
     return andThen(
         ignored -> {
           try {
@@ -366,7 +367,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> andThen(
+  public <U extends @Nullable Object> ActorFuture<U> andThen(
       final BiFunction<V, @Nullable Throwable, ActorFuture<U>> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
@@ -383,7 +384,8 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> thenApply(final Function<V, U> next, final Executor executor) {
+  public <U extends @Nullable Object> ActorFuture<U> thenApply(
+      final Function<V, U> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
         (value, error) -> {
@@ -403,7 +405,7 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
   }
 
   @Override
-  public <U> ActorFuture<U> thenApply(final Function<V, U> next) {
+  public <U extends @Nullable Object> ActorFuture<U> thenApply(final Function<V, U> next) {
     if (ActorThread.isCalledFromActorThread()) {
       final ActorControl actorControl = ActorControl.current();
       return thenApply(next, actorControl);


### PR DESCRIPTION
## Description

Aligns four generic upper bounds in `CompletableActorFuture` with the nullable bounds already declared by `ActorFuture`.

These explicit type-use bounds do not change erased signatures or runtime behavior. They allow the compatibility fix to land directly on `main`, independently of the NullAway 0.14 dependency update in #60956.

This supersedes the dependency-coupled approach in #61272.

## Verification

The branch is one commit ahead of the exact current `main` SHA (`c2a0bfad35edd52a63348a39b6fb547a336f5990`) and changes only:

- `zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java`

It does not modify `parent/pom.xml` or the NullAway version.

The same source patch was previously verified with:

- `./mvnw verify -pl zeebe/scheduler -DskipTests=false -DskipITs -Dquickly -T1C -ntp`
- the same command with `-Dversion.nullaway=0.13.8`
- the full Maven install across all 150 modules

This draft requests repository CI against current `main` before review.

## Checklist

- [ ] Enable backports when necessary.
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant on-demand tests have been run.