### PR TITLE
test: align Identity E2E page objects with the new design system

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
@@ -76,17 +76,12 @@ export class IdentityGlobalTaskListenersPage {
         name: 'Listener type',
       });
     this.createGlobalTaskListenerEventTypeToggle =
-      this.createGlobalTaskListenerModal.locator(
-        '#event-type-multiselect button',
-      );
-    this.createGlobalTaskListenerEventTypeMenu =
-      this.createGlobalTaskListenerModal.locator(
-        '#event-type-multiselect .cds--list-box__menu',
-      );
+      this.createGlobalTaskListenerModal.locator('[data-slot="multi-select"]');
+    // The design-system MultiSelect renders its list in a portal outside the
+    // dialog, so this cannot be scoped to the modal.
+    this.createGlobalTaskListenerEventTypeMenu = page.getByRole('listbox');
     this.createGlobalTaskListenerInlineError =
-      this.createGlobalTaskListenerModal.locator(
-        '.cds--inline-notification--error',
-      );
+      this.createGlobalTaskListenerModal.getByRole('alert');
     this.createGlobalTaskListenerModalCancelButton =
       this.createGlobalTaskListenerModal.getByRole('button', {name: 'Cancel'});
     this.createGlobalTaskListenerModalCreateButton =
@@ -158,12 +153,10 @@ export class IdentityGlobalTaskListenersPage {
     if (newEventTypeLabel) {
       await this.editGlobalTaskListenerTypeField.blur();
       const editEventTypeToggle = this.editGlobalTaskListenerModal.locator(
-        '#event-type-multiselect-edit button',
+        '[data-slot="multi-select"]',
       );
       await editEventTypeToggle.click();
-      const editEventTypeMenu = this.editGlobalTaskListenerModal.locator(
-        '#event-type-multiselect-edit .cds--list-box__menu',
-      );
+      const editEventTypeMenu = this.page.getByRole('listbox');
       await expect(editEventTypeMenu).toBeVisible();
       await this.page
         .locator('[role="option"]', {hasText: newEventTypeLabel})

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGlobalTaskListenersPage.ts
@@ -60,7 +60,7 @@ export class IdentityGlobalTaskListenersPage {
     this.deleteGlobalTaskListenerButton = (rowName) =>
       this.globalTaskListenersList
         .getByRole('row', {name: rowName})
-        .getByLabel('Delete');
+        .getByRole('button', {name: 'Delete', exact: true});
 
     this.createGlobalTaskListenerModal = page.getByRole('dialog', {
       name: 'Create user task listener',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityHeader.ts
@@ -10,7 +10,7 @@ import {Page, Locator, expect} from '@playwright/test';
 
 export class IdentityHeader {
   readonly page: Page;
-  readonly openSettingsButton: Locator;
+  readonly userMenuButton: Locator;
   readonly logoutButton: Locator;
   readonly rolesTab: Locator;
   readonly tenantsTab: Locator;
@@ -21,10 +21,8 @@ export class IdentityHeader {
 
   constructor(page: Page) {
     this.page = page;
-    this.openSettingsButton = page.getByRole('button', {
-      name: 'Open Settings',
-    });
-    this.logoutButton = page.getByRole('button', {name: 'Log out'});
+    this.userMenuButton = page.getByRole('button', {name: /^User menu/});
+    this.logoutButton = page.getByRole('menuitem', {name: /log out/i});
     this.rolesTab = page.locator('nav a').filter({hasText: /^Roles$/});
     this.tenantsTab = page.locator('nav a').filter({hasText: /^Tenants$/});
     this.authorizationsTab = page
@@ -41,7 +39,7 @@ export class IdentityHeader {
   }
 
   async logout() {
-    await this.openSettingsButton.click();
+    await this.userMenuButton.click();
     await this.logoutButton.click();
     await expect(this.page.getByText('logged out...')).toBeVisible({
       timeout: 15000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMappingRulesPage.ts
@@ -61,7 +61,7 @@ export class IdentityMappingRulesPage {
     this.deleteMappingRuleButton = (rowName) =>
       this.mappingRulesList
         .getByRole('row', {name: rowName})
-        .getByLabel('Delete');
+        .getByRole('button', {name: 'Delete', exact: true});
 
     this.createMappingRuleModal = page.getByRole('dialog', {
       name: 'Create new mapping rule',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityUsersPage.ts
@@ -56,7 +56,7 @@ export class IdentityUsersPage {
     this.deleteUserButton = (rowName) =>
       this.usersList
         .getByRole('row', {name: rowName})
-        .getByLabel('Delete', {exact: true});
+        .getByRole('button', {name: 'Delete', exact: true});
 
     this.createUserModal = page.getByRole('dialog', {
       name: 'Create user',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/global-task-listeners.spec.ts
@@ -69,7 +69,7 @@ test.describe.serial('global task listeners CRUD', () => {
       );
       await expect(
         identityGlobalTaskListenersPage.createGlobalTaskListenerTypeField,
-      ).toHaveAttribute('data-invalid', 'true');
+      ).toHaveAttribute('aria-invalid', 'true');
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mapping-rules.spec.ts
@@ -60,7 +60,7 @@ test.describe.serial('mapping rules CRUD', () => {
     );
     await expect(
       identityMappingRulesPage.createMappingRuleIdField,
-    ).toHaveAttribute('data-invalid', 'true');
+    ).toHaveAttribute('aria-invalid', 'true');
   });
 
   test('creates a mapping rule', async ({page, identityMappingRulesPage}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/users.spec.ts
@@ -64,7 +64,7 @@ test.describe.serial('users CRUD', () => {
       'Please enter a valid username',
     );
     await expect(identityUsersPage.createUsernameField).toHaveAttribute(
-      'data-invalid',
+      'aria-invalid',
       'true',
     );
   });


### PR DESCRIPTION
## Description

The Identity Admin UI switched from Carbon to `@camunda/design-system` for Self-Managed in
[`12fcc8845`](https://github.com/camunda/camunda/commit/12fcc8845) ("feat: enable new redesign in
Admin", #61006), which flipped `IS_NEW_DESIGN_SYSTEM_ENABLED` from `false` to
`isSaaS ? false : true`. The orchestration-cluster E2E suite tests Self-Managed, so from that merge
onward the Identity page objects were driving DOM that no longer exists.

Run [33055406008](https://github.com/camunda/camunda/actions/runs/33055406008) went from 1 failure
the previous day (Optimize, being fixed separately) to 10, with both matrix cells failing on the
identical set of 9 Identity tests — deterministic, not flaky.

Four distinct breakages, one commit each:

1. **Header user menu** (6 failures) — `AppHeaderV2` renders a design-system `UserMenu`, so the C3
   "Open Settings" button is gone and logout timed out. Mirrors the change already made to
   `OperateHomePage` in [`52b09d0f6`](https://github.com/camunda/camunda/commit/52b09d0f6) when
   Operate adopted the same header.
2. **`aria-invalid`** (2 failures) — design-system inputs no longer emit `data-invalid`.
3. **Row delete action** (1 failure) — in `entityListV2` an `isDangerous` row action renders its
   label as visible text with no `aria-label`, while non-dangerous actions stay icon-only *with*
   one. That asymmetry is why `getByLabel('Edit user')` kept working and `getByLabel('Delete')`
   did not.
4. **Global task listener modal** — Carbon `MultiSelect` internals
   (`#event-type-multiselect button`, `.cds--list-box__menu`) and
   `.cds--inline-notification--error` were replaced by a `div[role=combobox]` carrying
   `data-slot="multi-select"`, a `role="listbox"` portaled out of the dialog, and a design-system
   `Alert` exposing `role="alert"`.

Breakages 2–4 were partly masked: each failing assertion is the first test in a
`test.describe.serial` block, so 11 siblings were reported as "did not run" instead of failing.
Fixing only the reported failures would have converted those into the next red run, so the masked
tests are covered here as well — breakage 4 was found this way and is not in the original failure
list. `mapping-rules.spec.ts` is included for a related reason: it was green in that run only
because the job tests the published `camunda/camunda:SNAPSHOT` image, which at the time predated
[`ac80933ab`](https://github.com/camunda/camunda/commit/ac80933ab); run 33066501890 already fails
it on a newer image.

Pages still rendering Carbon (`groups`, `roles`, `tenants`, `authorizations`) are deliberately
untouched — their equivalent assertions and delete actions pass today, and changing them now would
break them.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.
   - [x]  Successful (all admin related tests pass!) run [here](https://github.com/camunda/camunda/actions/runs/33075956783/job/98530585557)

## Related issues

Detected by triage of nightly run
[33055406008](https://github.com/camunda/camunda/actions/runs/33055406008).
