### PR TITLE
ci: remove unintended job in 8.10-nighlty-es workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-es.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-es.yml
@@ -27,8 +27,3 @@ jobs:
       camunda_mode: all-in-one
     secrets: inherit
 
-  nightly-analytics-exporter-tests:
-    uses: ./.github/workflows/c8-orchestration-cluster-reusable-analytics-exporter-tests.yml
-    with:
-      branch: stable/8.10
-    secrets: inherit


### PR DESCRIPTION
## Description

The 8.10 nightly file got created by templating off main's nightly-api-es workflow, and the analytics-exporter job came along for the ride. This PR removes the analytics-exporter job from 8.10 es nightly

Successful C8 Orchestration Cluster Nightly 8.10 - API Tests (ES) [here](https://github.com/camunda/camunda/actions/runs/33074554694)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
