### PR TITLE
refactor: add JSpecify annotations to zeebe-msgpack-core

### DIFF
--- a/zeebe/msgpack-core/pom.xml
+++ b/zeebe/msgpack-core/pom.xml
@@ -22,6 +22,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>msgpack-core</artifactId>
       <scope>test</scope>

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackWriter.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackWriter.java
@@ -49,7 +49,9 @@ import org.agrona.MutableDirectBuffer;
  * instead of 2^33 - 1, etc.
  */
 public final class MsgPackWriter {
+  @SuppressWarnings("NullAway.Init")
   private MutableDirectBuffer buffer;
+
   private int offset;
 
   public MsgPackWriter wrap(final MutableDirectBuffer buffer, final int offset) {

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/package-info.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.msgpack.spec;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
 Adds the jspecify dependency and marks the module's single package, io.camunda.zeebe.msgpack.spec, as @NullMarked.

MsgPackWriter.buffer is set via wrap() rather than the constructor, so it is suppressed with NullAway.Init instead of being marked @Nullable.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53255 
