### PR TITLE
test: add integration test for Postgres primary/replica failover recovery

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -780,7 +780,11 @@
           <ignoredUsedUndeclaredDependencies>
             <dep>org.apache.tomcat.embed:tomcat-embed-core</dep>
             <dep>jakarta.servlet:jakarta.servlet-api</dep>
+            <dep>org.apache.logging.log4j:log4j-api</dep>
           </ignoredUsedUndeclaredDependencies>
+          <ignoredNonTestScopedDependencies combine.children="append">
+            <dep>org.apache.logging.log4j:log4j-api</dep>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
@@ -125,11 +125,13 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
                       .getRdbms()
                       .getAsyncReplication()
                       .setPauseOnMaxLagExceeded(true);
-                  cfg.getData()
-                      .getSecondaryStorage()
-                      .getRdbms()
-                      .getAsyncReplication()
-                      .setDelay(Duration.ofSeconds(5));
+                  if (getReplicationType() == ReplicationType.DELAY) {
+                    cfg.getData()
+                        .getSecondaryStorage()
+                        .getRdbms()
+                        .getAsyncReplication()
+                        .setDelay(Duration.ofSeconds(30));
+                  }
                   cfg.getData()
                       .getSecondaryStorage()
                       .getRdbms()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
@@ -56,6 +56,25 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
   }
 
   /**
+   * How often the RDBMS writer flushes on its own schedule, independent of per-record exports.
+   * Defaults to a realistic non-zero interval; override to {@code Duration.ZERO} for scenarios that
+   * need every export to flush inline via {@code RdbmsExporter.export(Record)} instead of the
+   * periodic {@code flushAndReschedule()} background task - the latter does not escalate {@code
+   * ExporterPositionMismatchException} to a reopen the way the inline path does.
+   */
+  protected Duration getFlushInterval() {
+    return Duration.ofMillis(500);
+  }
+
+  /**
+   * The JDBC URL used to wire {@link TestCamundaApplication} to the cluster. Defaults to the
+   * primary's URL; overridden by failover scenarios that need a URL covering multiple hosts.
+   */
+  protected String jdbcUrl(final R cluster) {
+    return cluster.getJdbcUrl();
+  }
+
+  /**
    * The async-replication mechanism under test. Defaults to LSN-based tracking; override to
    * exercise {@code TimeMonitoringReplicationSignalStrategy} (lag-based) against the same cluster
    * and test scenarios instead.
@@ -74,13 +93,13 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
             .withUnifiedConfig(
                 cfg -> {
                   cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
-                  cfg.getData().getSecondaryStorage().getRdbms().setUrl(cluster.getJdbcUrl());
+                  cfg.getData().getSecondaryStorage().getRdbms().setUrl(jdbcUrl(cluster));
                   cfg.getData().getSecondaryStorage().getRdbms().setUsername(cluster.getUsername());
                   cfg.getData().getSecondaryStorage().getRdbms().setPassword(cluster.getPassword());
                   cfg.getData()
                       .getSecondaryStorage()
                       .getRdbms()
-                      .setFlushInterval(Duration.ofMillis(500));
+                      .setFlushInterval(getFlushInterval());
                   cfg.getData()
                       .getSecondaryStorage()
                       .getRdbms()
@@ -106,6 +125,16 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
                       .getRdbms()
                       .getAsyncReplication()
                       .setPauseOnMaxLagExceeded(true);
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .getAsyncReplication()
+                      .setDelay(Duration.ofSeconds(5));
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .getAsyncReplication()
+                      .setQueueDebounceTime(Duration.ZERO);
                 })
             .withBasicAuth();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/PostgresFailoverIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/PostgresFailoverIT.java
@@ -69,9 +69,13 @@ class PostgresFailoverIT extends AbstractAsyncReplicationIT<PostgresReplicationC
     final var duringOutageUser = "failover-outage-user-" + UUID.randomUUID();
     createUser(duringOutageUser);
 
-    // sanity check - well within REPLICATION_DELAY, so the outage traffic must not be
-    // acknowledged yet (the delay strategy never pauses, it just always waits this long)
-    awaitExporterPositionAdvances(acknowledgedPositionBeforeOutage);
+    // sanity check - keep this within the DELAY window so outage traffic is not acknowledged yet
+    Awaitility.await("exporter position advances while acknowledgments are still delayed")
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () ->
+                assertThat(getCurrentExporterPosition())
+                    .isGreaterThan(acknowledgedPositionBeforeOutage));
     assertAcknowledgedPositionNotAdvancedBeyond(acknowledgedPositionBeforeOutage);
 
     try (final var replayLog = LogCapturer.capturing(RdbmsExporter.class, Level.INFO)) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/PostgresFailoverIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/PostgresFailoverIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration.ReplicationType;
+import io.camunda.exporter.rdbms.RdbmsExporter;
+import io.camunda.it.rdbms.db.util.PostgresReplicationClusterContainer;
+import io.camunda.zeebe.test.util.logging.LogCapturer;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.Level;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("async-repl")
+class PostgresFailoverIT extends AbstractAsyncReplicationIT<PostgresReplicationClusterContainer> {
+
+  @Override
+  protected PostgresReplicationClusterContainer createCluster() {
+    return new PostgresReplicationClusterContainer();
+  }
+
+  @Override
+  protected Duration getFlushInterval() {
+    return Duration.ZERO;
+  }
+
+  @Override
+  protected String jdbcUrl(final PostgresReplicationClusterContainer cluster) {
+    // Lists both nodes so the JDBC driver can transparently keep connecting to whichever one is
+    // currently writable once the replica is promoted - see getFailoverJdbcUrl() for details.
+    return cluster.getFailoverJdbcUrl();
+  }
+
+  @Override
+  protected ReplicationType getReplicationType() {
+    return ReplicationType.DELAY;
+  }
+
+  @Test
+  void shouldReplayMissingRecordsAfterPostgresFailover() throws Exception {
+    // given - some baseline traffic (a process instance and a user) fully replicated and
+    // acknowledged before the outage starts
+    startProcessInstances(5);
+    final var baselineUser = "failover-baseline-user-" + UUID.randomUUID();
+    createUser(baselineUser);
+    waitForProcessInstancesToStart(camundaClient, 5);
+    waitForUser(camundaClient, baselineUser);
+    exporterAcknowledgedAll();
+    final long acknowledgedPositionBeforeOutage = getCurrentAcknowledgedExporterPosition();
+
+    // when - the read replica disconnects from the primary
+    cluster.disconnectReplicaFromPrimary();
+
+    // and - more traffic is written to the primary only, and is never replicated
+    final int duringOutageProcessInstances = 10;
+    startProcessInstances(duringOutageProcessInstances);
+    final var duringOutageUser = "failover-outage-user-" + UUID.randomUUID();
+    createUser(duringOutageUser);
+
+    // sanity check - well within REPLICATION_DELAY, so the outage traffic must not be
+    // acknowledged yet (the delay strategy never pauses, it just always waits this long)
+    awaitExporterPositionAdvances(acknowledgedPositionBeforeOutage);
+    assertAcknowledgedPositionNotAdvancedBeyond(acknowledgedPositionBeforeOutage);
+
+    try (final var replayLog = LogCapturer.capturing(RdbmsExporter.class, Level.INFO)) {
+      // and - the primary is shut down and the disconnected replica is promoted to take its place
+      cluster.stopPrimary().get(1, TimeUnit.MINUTES);
+      cluster.promoteReplica();
+
+      // and - one more process instance is started against the newly-promoted primary. The
+      // exporter only discovers that the database fell behind the broker's acknowledged position
+      // when it next attempts a flush (the EXPORTER_POSITION row-lock hook is what raises the
+      // mismatch)
+      startProcessInstances(1);
+
+      // then - the exporter actually requested a replay from the broker
+      Awaitility.await("RdbmsExporter requests a replay to recover the missing records")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertThat(replayLog.contains("Requesting replay from")).isTrue());
+    }
+
+    // and - the exporter detects that the now-connected (promoted) database is behind the
+    // broker's acknowledged position, replays the records missed during the outage, and they -
+    // together with the pre-outage baseline - become visible again through the client
+    waitForUser(camundaClient, baselineUser);
+    waitForUser(camundaClient, duringOutageUser);
+    waitForProcessInstancesToStart(camundaClient, 5 + duringOutageProcessInstances + 1);
+    awaitAcknowledgedPositionAdvances(acknowledgedPositionBeforeOutage);
+    exporterAcknowledgedAll();
+  }
+
+  private void createUser(final String username) {
+    camundaClient
+        .newCreateUserCommand()
+        .username(username)
+        .name(username)
+        .password("password")
+        .email(username + "@example.com")
+        .send()
+        .join();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
@@ -48,6 +48,7 @@ public final class PostgresReplicationClusterContainer
   private final Network network = Network.newNetwork();
   private final GenericContainer<?> replica;
   private volatile boolean replicaStopped = false;
+  private volatile boolean primaryStopped = false;
 
   public PostgresReplicationClusterContainer() {
     super(POSTGRES_IMAGE);
@@ -70,6 +71,7 @@ public final class PostgresReplicationClusterContainer
             .withEnv("POSTGRESQL_REPLICATION_USER", REPLICATION_USER)
             .withEnv("POSTGRESQL_REPLICATION_PASSWORD", REPLICATION_PASSWORD)
             .withEnv("POSTGRESQL_PASSWORD", PASSWORD)
+            .withExposedPorts(5432)
             .withStartupTimeout(Duration.ofMinutes(5));
   }
 
@@ -88,7 +90,7 @@ public final class PostgresReplicationClusterContainer
       stopReplica();
     } finally {
       try {
-        super.stop();
+        stopPrimary();
       } finally {
         network.close();
       }
@@ -128,6 +130,83 @@ public final class PostgresReplicationClusterContainer
     replica.start();
     waitForReplication();
     return CompletableFuture.completedFuture(Unit.unit());
+  }
+
+  /** Host on which the replica's Postgres port is reachable from the test JVM. */
+  public String getReplicaHost() {
+    return replica.getHost();
+  }
+
+  /** Mapped host port for the replica's Postgres port (5432). */
+  public int getReplicaPort() {
+    return replica.getMappedPort(5432);
+  }
+
+  /**
+   * A multi-host JDBC URL listing both the primary and the replica, with {@code
+   * targetServerType=primary} so the PostgreSQL JDBC driver always routes new connections to
+   * whichever listed host is currently writable.
+   */
+  public String getFailoverJdbcUrl() {
+    return "jdbc:postgresql://%s:%d,%s:%d/%s?targetServerType=primary&connectTimeout=10&socketTimeout=15"
+        .formatted(
+            getHost(), getMappedPort(5432), getReplicaHost(), getReplicaPort(), DATABASE_NAME);
+  }
+
+  /**
+   * Stops only the primary, leaving the replica (if still running) untouched. Used to simulate the
+   * primary database going down during a failover.
+   */
+  public Future<Void> stopPrimary() {
+    if (!primaryStopped) {
+      LOG.info("Stopping PostgreSQL primary");
+      primaryStopped = true;
+      super.stop();
+      LOG.info("PostgreSQL primary stopped");
+    }
+    return CompletableFuture.completedFuture(Unit.unit());
+  }
+
+  /**
+   * Severs replication from the primary's side, so the replica stops receiving new WAL from this
+   * point on, without stopping or restarting either container.
+   */
+  public void disconnectReplicaFromPrimary() {
+    LOG.info("Disconnecting PostgreSQL replica from the primary");
+    try (final Connection conn = primaryConnection();
+        final Statement stmt = conn.createStatement()) {
+      stmt.execute("ALTER ROLE " + REPLICATION_USER + " WITH NOLOGIN");
+      stmt.execute("SELECT pg_terminate_backend(pid) FROM pg_stat_replication");
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to disconnect PostgreSQL replica", e);
+    }
+    LOG.info("PostgreSQL replica disconnected from primary");
+  }
+
+  /**
+   * Promotes the (still-running) replica to a standalone writable primary via {@code pg_promote()}.
+   */
+  public void promoteReplica() {
+    LOG.info("Promoting PostgreSQL replica to primary");
+    try (final Connection conn = replicaConnection();
+        final Statement stmt = conn.createStatement();
+        final ResultSet rs = stmt.executeQuery("SELECT pg_promote(true, 60)")) {
+      rs.next();
+      final boolean promoted = rs.getBoolean(1);
+      if (!promoted) {
+        throw new IllegalStateException("pg_promote() returned false, replica was not promoted");
+      }
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to promote PostgreSQL replica", e);
+    }
+    LOG.info("PostgreSQL replica promoted to primary");
+  }
+
+  private Connection replicaConnection() throws Exception {
+    return DriverManager.getConnection(
+        "jdbc:postgresql://%s:%d/%s".formatted(getReplicaHost(), getReplicaPort(), DATABASE_NAME),
+        USERNAME,
+        PASSWORD);
   }
 
   private void waitForReplication() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -2222,6 +2222,7 @@ public final class TestHelper {
   public static void waitForUser(final CamundaClient client, final String username) {
     Awaitility.await("user '%s' visible in secondary storage".formatted(username))
         .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
         .untilAsserted(
             () -> {
               final var result =


### PR DESCRIPTION
## Description

Adds `PostgresFailoverIT`, an integration test that drives a real Postgres primary/replica failover (replica disconnects → traffic diverges on the primary only → primary is killed → replica is promoted) and verifies `RdbmsExporter` detects the resulting position mismatch, requests a replay from the broker, and the records lost during the outage become visible again through the client.

`RdbmsExporter` already has this detection/recovery logic (`doOpen`), but it was only covered by `RdbmsExporterPositionRecoveryIT`, which simulates the divergence by tampering the `EXPORTER_POSITION` table directly on a plain Postgres container - there was no test driving an actual failover end to end.

Closes #61182