### PR TITLE
ci: fix stale owner metadata on profile-load-test.yml

### DIFF
--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -11,7 +11,7 @@
 # called-by: camunda-pr-load-test.yml, stress-load-test.yml (itself called by
 #            camunda-daily-load-tests.yml)
 # type: CI
-# owner: @camunda/zeebe-distributed-platform
+# owner: @camunda/reliability-testing
 name: Profile running load test
 run-name: "Profile running load test: ${{ inputs.name }}"
 
@@ -70,6 +70,7 @@ defaults:
     shell: bash
 
 env:
+  TEST_OWNER: '@camunda/reliability-testing'
   CLUSTER: camunda-benchmark-prod
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 


### PR DESCRIPTION
## Summary
- `profile-load-test.yml` never set `TEST_OWNER`, unlike every other load-test workflow — the alert for INC-7452 showed "Owner: Unknown" and was auto-routed with only medium confidence as a result.
- The header comment still pointed at `@camunda/zeebe-distributed-platform`, which was renamed/split into Distributed Systems & Performance; load-test ownership moved to the dedicated `@camunda/reliability-testing` team. CODEOWNERS already reflects this correctly for this file — only the workflow's own metadata was stale.
- Sets `TEST_OWNER: '@camunda/reliability-testing'` (matching sibling load-test workflows) and updates the owner comment, so future alerts on this job route correctly without manual intervention.

Closes the ownership-routing gap identified while triaging INC-7452.

## Test plan
- [x] `actionlint .github/workflows/profile-load-test.yml` — clean
- [x] `conftest test --rego-version v0 -o github --policy .github .github/workflows/profile-load-test.yml` — 19/19 checks passed
- [x] `./mvnw spotless:apply -T1C` — no formatting changes needed
- Not act-testable (Tier 3): the change is metadata-only and doesn't touch any executed step — `TEST_OWNER` is read only by the external alerting/incident-routing pipeline, and the rest of the workflow's logic (Teleport auth, `kubectl exec` into a live `camunda-benchmark-prod` cluster, async-profiler) depends on infrastructure `act` cannot simulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)