### PR TITLE
fix: upgrade micrometer to 1.16.7 to remediate CVE-2026-59295 and CVE-2026-59296 (stable/optimize-8.7)

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -340,7 +340,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>1.13.4</version>
+      <version>${micrometer.version}</version>
     </dependency>
 
     <!--Lucene dependencies-->

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -63,6 +63,11 @@
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.137.Final</netty.version>
     <log4j2.version>2.25.4</log4j2.version>
+    <!-- Override Spring Boot's micrometer version to address CVE-2026-59295.
+         The 1.15.x fix (1.15.13) is Spring Enterprise-only, so we move to the 1.16.x OSS line. -->
+    <micrometer.version>1.16.7</micrometer.version>
+    <!-- Must match what micrometer-registry-prometheus 1.16.x requires -->
+    <prometheus-metrics.version>1.4.3</prometheus-metrics.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.37</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -150,6 +155,21 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- Must be declared before spring-boot-dependencies so this version wins -->
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>prometheus-metrics-bom</artifactId>
+        <version>${prometheus-metrics.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${micrometer.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -84,7 +84,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.5</version.protobuf>
     <version.protobuf-common>2.45.0</version.protobuf-common>
-    <version.micrometer>1.13.4</version.micrometer>
+    <version.micrometer>1.16.7</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.1</version.sbe>
     <version.scala>2.13.15</version.scala>
@@ -1021,6 +1021,19 @@
         <scope>import</scope>
       </dependency>
 
+      <!--
+        Override Spring Boot's micrometer version to address CVE-2026-59295.
+        The 1.15.x fix (1.15.13) is Spring Enterprise-only, so we move to the 1.16.x OSS line.
+        Must be declared before spring-boot-dependencies so this version wins.
+      -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
@@ -1304,14 +1317,6 @@
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
         <version>${version.reactor-netty}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${version.micrometer}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What

Bumps `io.micrometer` from **1.13.4 → 1.16.7** on `stable/optimize-8.7`, and fixes the BOM import ordering so the override actually takes effect. Verified before/after with `mvn dependency:tree -Dincludes=io.micrometer`.

## Why

Root cause: `parent/pom.xml`'s `micrometer-bom` import sat **after** `spring-boot-dependencies`, so it never took effect — Spring Boot's own managed micrometer (**1.15.12**) won instead of the intended 1.13.4. Confirmed with `mvn dependency:tree -pl optimize/util/optimize-commons -Dincludes=io.micrometer` before this change.

Two CVEs affect the resulting 1.15.12 (and the nominal 1.13.4 pin):

- **CVE-2026-59295** (CWE-401, CVSS 5.9): `MicrometerHttpClientInterceptor` leaks tracking state for async HTTP requests that fail before a response arrives, eventually exhausting the heap. The 1.15.x fix (`1.15.13`) is Spring Enterprise-only, not published to Maven Central.
- **CVE-2026-59296** (CWE-93, CVSS 8.2): `micrometer-core` does not sanitize line terminators in metric names/tags, enabling metric/log line injection via the StatsD or `LoggingMeterRegistry` sinks.

**Exploitability: Not Affected for both.** Neither the vulnerable interceptor (`MicrometerHttpClientInterceptor`) nor the vulnerable sinks (`micrometer-registry-statsd`, `LoggingMeterRegistry`) are used anywhere in this repo. This is dependency hygiene — the 1.13.4/1.15.12 lines are past their OSS support window with no patched release available, so this closes the exposure ahead of any future CVE landing in a code path we do use (Prometheus registry).

## Changes

- `parent/pom.xml`: move the `micrometer-bom` import ahead of `spring-boot-dependencies` ("first-import-wins"), bump `version.micrometer` to `1.16.7`.
- `optimize/pom.xml`: Optimize is a separate reactor root with its own Spring Boot BOM import, so it needs the same override, plus `prometheus-metrics-bom:1.4.3` — `micrometer-registry-prometheus:1.16.7` declares `prometheus-metrics 1.4.3`, while Spring Boot 3.5.15 pins `1.3.10`, which would otherwise silently downgrade it.
- `optimize/backend/pom.xml`: hardcoded `micrometer-registry-prometheus:1.13.4` replaced with `${micrometer.version}` so it can't drift again.

**No protobuf bump needed** (unlike the equivalent stable/8.7 and stable/8.8 fixes, #61194/#61198): this branch has no `micrometer-registry-otlp` usage anywhere in the repo (verified via `git grep`), so the OTel-proto-gencode/protobuf-runtime mismatch that broke those earlier attempts doesn't apply here.

## Verification

- `mvn dependency:tree -Dincludes=io.micrometer`:
  - **Before:** `optimize-commons` → `1.15.12`
  - **After:** `optimize-commons`, `zeebe-broker`, `zeebe-transport`, `zeebe-gateway`, `zeebe-broker-client`, `clients/java` all → **`1.16.7`**
- `mvn install -Dquickly` green for `zeebe/broker`, `clients/java`, `optimize/util/optimize-commons`.
- `optimize/backend` and `dist` could not be built locally in this environment due to an unrelated 401 against the private `camunda-cpm` artifactory (`org.camunda.bpm:camunda-license-check`) — the same limitation noted in the original attempt at this fix. CI has valid credentials for that repository and should build both; please confirm CI is green there, especially any Optimize startup/backup-restore integration tests exercising the metrics/actuator stack.

## Related

- Supersedes #61149 (closed pending an internal discussion without a documented technical blocker) — this covers the same micrometer bump plus CVE-2026-59296, which shares the same fix.
- Companion fixes on other branches: #61194 (stable/8.7), #61198 (stable/8.8)
- CVE-2026-59295 — https://spring.io/security/cve-2026-59295
- CVE-2026-59296 — https://nvd.nist.gov/vuln/detail/CVE-2026-59296