### PR TITLE
ci: raise Maven artifact-lock timeout on stable/8.7 to match other branches

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -43,7 +43,7 @@ runs:
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav
         -D aether.syncContext.named.factory=file-lock
-        -D aether.syncContext.named.time=120
+        -D aether.syncContext.named.time=180
         -D maven.artifact.threads=32
         -D aether.dependencyCollector.impl=bf
         EOF


### PR DESCRIPTION
## What

Raise the Maven artifact-lock acquisition timeout in
`.github/actions/setup-maven-cache/action.yaml` on `stable/8.7`:

- **Before:** `-D aether.syncContext.named.time=120`
- **After:** `-D aether.syncContext.named.time=180`

## Why

`main`, `stable/8.8`, and `stable/8.9` already run this setting at `180`
seconds. `stable/8.7` was left on the older `120` value — this looks like a
missed backport rather than an intentional difference. This PR closes that gap.

The larger timeout gives Maven's dependency-lock acquisition more headroom under
concurrent artifact resolution, which should reduce the frequency of:

```
org.eclipse.aether.SyncContext$FailedToAcquireLockException: Could not acquire
shared/exclusive lock for artifacts ... in 120 SECONDS
```

## Scope / caveats

This is a **partial mitigation, not a full fix**. `stable/8.8` already runs at
`180` and still hits the same error under load — the deeper cause is lock
contention from build concurrency, tracked separately. This PR is deliberately
scoped to the single timeout value (no changes to `maven.artifact.threads`,
`-T1C`, or any other setting) to keep it trivially reviewable during an active
incident.

Related to INC-7474.
