### PR TITLE
[Backport stable/8.10] ci: retry setup-java to survive transient infra blips

### DIFF
--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -35,29 +35,12 @@ runs:
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
     - name: Authenticate to GCS via WIF
-      # wretry retries WIF auth through transient network/STS failures (INC-7417). Same pattern as
-      # build-platform-docker; `_js_action` pin lets the *_context inputs be blanked (auth has no
-      # `${{ }}` defaults). Each attempt mints a fresh OIDC token, so retrying is side-effect-free.
+      # Not wrapped in wretry: it blanks INPUT_SERVICE_ACCOUNT before auth reads it, dropping SA
+      # impersonation so gcloud runs as the bare WIF identity and every storage call 403s (INC-7417).
       if: steps.is-fork.outputs.is-fork != 'true'
-      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
       with:
-        # Full semver (not `# v3`) so the wretry-wrapped-action Renovate regex manager tracks it.
-        action: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        attempt_limit: 3
-        attempt_delay: 10000
-        github_token: ${{ github.token }}
-        github_context: '{}'
-        env_context: '{}'
-        job_context: '{}'
-        matrix_context: '{}'
-        with: |
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-    # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
-    - name: Clear auth inputs leaked into the job environment by wretry
-      if: always() && steps.is-fork.outputs.is-fork != 'true'
-      shell: bash
-      run: |
-        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
+        workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+        service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
     - if: steps.is-fork.outputs.is-fork != 'true'
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -35,10 +35,29 @@ runs:
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
           secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
     - name: Authenticate to GCS via WIF
+      # wretry retries WIF auth through transient network/STS failures (INC-7417). Same pattern as
+      # build-platform-docker; `_js_action` pin lets the *_context inputs be blanked (auth has no
+      # `${{ }}` defaults). Each attempt mints a fresh OIDC token, so retrying is side-effect-free.
       if: steps.is-fork.outputs.is-fork != 'true'
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
       with:
-        workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-        service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+        # Full semver (not `# v3`) so the wretry-wrapped-action Renovate regex manager tracks it.
+        action: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        attempt_limit: 3
+        attempt_delay: 10000
+        github_token: ${{ github.token }}
+        github_context: '{}'
+        env_context: '{}'
+        job_context: '{}'
+        matrix_context: '{}'
+        with: |
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+    # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
+    - name: Clear auth inputs leaked into the job environment by wretry
+      if: always() && steps.is-fork.outputs.is-fork != 'true'
+      shell: bash
+      run: |
+        env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
     - if: steps.is-fork.outputs.is-fork != 'true'
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -155,10 +155,29 @@ runs:
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
   - name: Setup Java
-    uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+    # wretry retries setup-java through transient network/setup failures (INC-7417). Same pattern
+    # as build-platform-docker; `_js_action` pin lets the *_context inputs be overridden.
+    # `token` is passed explicitly since github_context is blanked (setup-java defaults it from it).
+    uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
     with:
-      distribution: ${{ inputs.java-distribution }}
-      java-version: ${{ inputs.java-version }}
+      action: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      attempt_limit: 3
+      attempt_delay: 10000
+      github_token: ${{ github.token }}
+      github_context: '{}'
+      env_context: '{}'
+      job_context: '{}'
+      matrix_context: '{}'
+      with: |
+        distribution: ${{ inputs.java-distribution }}
+        java-version: ${{ inputs.java-version }}
+        token: ${{ github.token }}
+  # wretry leaks the wrapped action's INPUT_* vars into GITHUB_ENV; blank them (cannot unset).
+  - name: Clear setup-java inputs leaked into the job environment by wretry
+    if: always()
+    shell: bash
+    run: |
+      env | grep -o '^INPUT_[^=]*' | sed 's/$/=/' >> "$GITHUB_ENV" || true
   - name: Register Maven problem matcher
     shell: bash
     run: echo "::add-matcher::.github/maven-matcher.json"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -199,7 +199,6 @@
       matchFileNames: [
         ".github/actions/build-platform-docker/action.yml",
         ".github/actions/setup-build/action.yml",
-        ".github/actions/gcs-build-cache-auth/action.yml",
       ],
       matchPackageNames: [
         "Wandalen/wretry.action",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -198,6 +198,8 @@
       description: "Wandalen/wretry.action releases a `vX.Y.Z` composite tag and a paired `vX.Y.Z_js_action` tag together (the composite's own dependency); we pin the latter (see PR #60406). Renovate's versioning strips the `_js_action` suffix and can't tell the two tags apart, so digest updates resolve to the composite's commit instead. Scope this dependency to only consider `_js_action`-suffixed tags.",
       matchFileNames: [
         ".github/actions/build-platform-docker/action.yml",
+        ".github/actions/setup-build/action.yml",
+        ".github/actions/gcs-build-cache-auth/action.yml",
       ],
       matchPackageNames: [
         "Wandalen/wretry.action",


### PR DESCRIPTION
Backport of #61190 to `stable/8.10`.

The automated backport by [backport-action](https://github.com/korthout/backport-action) failed because the source range included an empty `ci: update branch` commit (`c337820`), which aborts an automated `git cherry-pick` sequence. The empty commit was skipped during the manual cherry-pick; the two meaningful commits applied cleanly with no conflicts.

Verified: the net diff of this branch against `stable/8.10` is identical to the original PR's net diff (same 3 files, +25/-3).

relates to #61190
