### PR TITLE
fix: keep job dispatch from blocking the client's transport thread

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/worker/BlockingExecutor.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/BlockingExecutor.java
@@ -26,6 +26,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * An executor that only takes a command when it has capacity to run it, waiting up to a fixed time
  * for capacity to become available.
  *
+ * <p>Waiting blocks the calling thread, so it is only for a caller that has nothing better to do
+ * with that thread. A caller that carries a response of the client on it uses {@link
+ * #executeWithoutWaiting(Runnable)} instead.
+ *
  * <p>A command is either handed to the wrapped executor or refused with a {@link
  * RejectedExecutionException}; it is never dropped without notice.
  *
@@ -34,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * What callers can rely on is the capacity: every command takes one slot and gives it back exactly
  * once, whether it ran or was refused.
  */
-final class BlockingExecutor implements Executor {
+final class BlockingExecutor implements JobExecutor {
   private static final TimeUnit TIMEOUT_UNIT = TimeUnit.MILLISECONDS;
 
   private final Executor wrappedExecutor;
@@ -51,7 +55,23 @@ final class BlockingExecutor implements Executor {
   @Override
   public void execute(final Runnable command) throws RejectedExecutionException {
     acquireCapacity();
+    dispatch(command);
+  }
 
+  @Override
+  public void executeWithoutWaiting(final Runnable command) throws RejectedExecutionException {
+    if (!semaphore.tryAcquire()) {
+      throw new RejectedExecutionException("Not able to acquire a lease without waiting for one");
+    }
+    dispatch(command);
+  }
+
+  @Override
+  public int freeCapacity() {
+    return semaphore.availablePermits();
+  }
+
+  private void dispatch(final Runnable command) {
     // The wrapped executor may run the command on the calling thread. A command that fails then
     // looks exactly like a command the executor refused, so both paths below can be taken for the
     // same command. The flag makes sure its capacity is given back only once, as giving it back

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobExecutor.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobExecutor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.worker;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * The executor a job worker hands its jobs to, with the two things the worker needs on top of a
+ * plain {@link Executor}: how much work it can take right now, and a way to hand over a job that
+ * never waits.
+ *
+ * <p>An executor that does not limit how much work it takes needs neither, which is why both come
+ * with a default.
+ */
+@FunctionalInterface
+interface JobExecutor extends Executor {
+
+  /**
+   * @return how many jobs the executor can take right now, or {@link Integer#MAX_VALUE} if it does
+   *     not limit how many jobs it takes at a time
+   */
+  default int freeCapacity() {
+    return Integer.MAX_VALUE;
+  }
+
+  /**
+   * Hands a job over, refusing it right away when there is no capacity for it instead of waiting
+   * for capacity to free up.
+   *
+   * @throws RejectedExecutionException if the executor has no capacity for the job right now
+   */
+  default void executeWithoutWaiting(final Runnable command) {
+    execute(command);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -37,7 +37,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
@@ -240,7 +239,7 @@ public final class JobWorkerBuilderImpl
             maxJobsActive,
             withLease);
 
-    final Executor jobExecutor;
+    final JobExecutor jobExecutor;
     if (enableStreaming) {
       if (streamTimeout != null) {
         ensurePositive("streamTimeout", streamTimeout);
@@ -274,7 +273,9 @@ public final class JobWorkerBuilderImpl
       jobExecutor = new BlockingExecutor(jobHandlingExecutor, maxJobsActive, timeout);
     } else {
       jobStreamer = JobStreamer.noop();
-      jobExecutor = jobHandlingExecutor;
+      // without job push nothing else takes the executor's capacity, so the worker's own count of
+      // the jobs it activated is all it needs to keep within maxJobsActive
+      jobExecutor = jobHandlingExecutor::execute;
     }
 
     final JobWorkerImpl jobWorker =

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerImpl.java
@@ -24,7 +24,6 @@ import io.camunda.client.impl.Loggers;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 /**
@@ -45,9 +45,12 @@ import org.slf4j.Logger;
  * <p>If a poll successfully provides jobs, the worker submits each job to the job handler. Every
  * time a job is completed, the worker checks if it still has enough jobs to work on. If not, it
  * will poll for new jobs. To determine what is considered enough jobs it compares its number of
- * {@code remainingJobs} with the {@code activationThreshold}. If the executor refuses a job, the
- * worker frees up that job's capacity immediately, so that a refused job never takes up capacity
- * for good. Each job's capacity is freed up exactly once, whether the job ran or was refused.
+ * {@code remainingJobs} with the {@code activationThreshold}. A poll only asks for as many jobs as
+ * the executor can take at that moment, which is not the same as the number of jobs the worker has
+ * left to run: jobs the broker pushes to the worker take capacity too, and those it does not count.
+ * If the executor refuses a job, the worker frees up that job's capacity immediately, so that a
+ * refused job never takes up capacity for good. Each job's capacity is freed up exactly once,
+ * whether the job ran or was refused.
  *
  * <p>If a poll fails with an error response, a retry is scheduled with a delay using the {@code
  * retryDelaySupplier} to ask for a new {@code pollInterval}. By default, this retry delay supplier
@@ -80,7 +83,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   private final AtomicInteger refusedJobsInPoll = new AtomicInteger(0);
 
   // job execution facilities
-  private final Executor executor;
+  private final JobExecutor executor;
   private final JobClient jobClient;
   private final JobRunnableFactory jobHandlerFactory;
   private final long initialPollInterval;
@@ -108,7 +111,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       final BackoffSupplier backoffSupplier,
       final BackoffSupplier streamNoJobsBackoffSupplier,
       final JobWorkerMetrics metrics,
-      final Executor jobExecutor) {
+      final JobExecutor jobExecutor) {
     this.maxJobsActive = maxJobsActive;
     activationThreshold = Math.round(maxJobsActive * 0.3f);
     remainingJobs = new AtomicInteger(0);
@@ -208,7 +211,19 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
       schedulePoll();
       return;
     }
-    final int maxJobsToActivate = maxJobsActive - actualRemainingJobs;
+    final int freeCapacity = executor.freeCapacity();
+    if (freeCapacity <= 0) {
+      // Everything this worker can run at a time is taken, in most cases by jobs the broker pushed
+      // to it, which the count above does not see. Jobs activated now would be handed straight back
+      // to the broker, so no request goes out at all and the next attempt waits for the poll
+      // interval.
+      LOG.trace(
+          "Expected to activate jobs, but the job handler executor is full. Reschedule poll.");
+      releaseJobPoller(jobPoller);
+      schedulePoll();
+      return;
+    }
+    final int maxJobsToActivate = Math.min(maxJobsActive - actualRemainingJobs, freeCapacity);
     refusedJobsInPoll.set(0);
     jobPoller.poll(
         maxJobsToActivate,
@@ -300,7 +315,11 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     // The flag makes sure the slot taken above is given back only once, as giving it back twice
     // would let the worker ask the broker for more jobs than it is allowed to run at a time.
     final AtomicBoolean capacityHeld = new AtomicBoolean(true);
-    if (!handleActivatedJob(job, () -> handleJobFinished(capacityHeld), this::returnJobToBroker)) {
+    if (!handleActivatedJob(
+        job,
+        executor::executeWithoutWaiting,
+        () -> handleJobFinished(capacityHeld),
+        this::returnJobToBroker)) {
       if (releaseCapacity(capacityHeld)) {
         // Only a job whose slot was still held never ran, and only those say anything about
         // whether the executor is taking work. Counting them lets the poll that activated them
@@ -311,12 +330,18 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
   }
 
   private void handleStreamedJob(final ActivatedJob job) {
-    handleActivatedJob(job, this::handleStreamJobFinished, this::leaveStreamedJobToBroker);
+    handleActivatedJob(
+        job, executor::execute, this::handleStreamJobFinished, this::leaveStreamedJobToBroker);
   }
 
   /**
    * Hands the job over to the executor that runs the job handler.
    *
+   * @param dispatch how the job is handed over to the executor. A job the worker asked for is
+   *     refused right away when there is no capacity for it, because waiting would block the thread
+   *     that carries the activation response, and with it every other request the client sends over
+   *     the same connection. A job the broker pushed waits for capacity instead, since a blocked
+   *     push is what tells the broker to offer the job to somebody else.
    * @param onRefused what to do with a job the executor would not take, which differs between a job
    *     the worker asked for and one the broker pushed to it. It is also what tells the user about
    *     the refusal, since the two paths leave the job in very different places.
@@ -327,6 +352,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
    */
   private boolean handleActivatedJob(
       final ActivatedJob job,
+      final Consumer<Runnable> dispatch,
       final Runnable finalizer,
       final BiConsumer<ActivatedJob, RejectedExecutionException> onRefused) {
     metrics.jobActivated(1);
@@ -336,7 +362,7 @@ public final class JobWorkerImpl implements JobWorker, Closeable {
     final AtomicBoolean handlerStarted = new AtomicBoolean(false);
     try {
       final Runnable jobRunnable = jobHandlerFactory.create(job, finalizer);
-      executor.execute(
+      dispatch.accept(
           () -> {
             handlerStarted.set(true);
             jobRunnable.run();

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/BlockingExecutorTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/BlockingExecutorTest.java
@@ -166,4 +166,58 @@ public class BlockingExecutorTest {
       wrappedExecutor.shutdownNow();
     }
   }
+
+  @Test
+  public void shouldRefuseCommandRightAwayWhenThereIsNoCapacityLeft() {
+    // given an executor whose only capacity is taken, and that is allowed to wait a long time for
+    // capacity to free up
+    final Executor dropsCommands = command -> {};
+    final BlockingExecutor executor = new BlockingExecutor(dropsCommands, 1, Duration.ofMinutes(5));
+    executor.execute(() -> {});
+
+    // when a command is handed over without waiting
+    final long startedAt = System.nanoTime();
+    assertThatThrownBy(() -> executor.executeWithoutWaiting(() -> {}))
+        .isInstanceOf(RejectedExecutionException.class);
+
+    // then it is refused on the spot instead of holding on to the calling thread
+    assertThat(Duration.ofNanos(System.nanoTime() - startedAt)).isLessThan(Duration.ofMinutes(1));
+  }
+
+  @Test
+  public void shouldRunCommandWithoutWaitingWhenThereIsCapacityLeft() {
+    // given
+    final AtomicBoolean executed = new AtomicBoolean(false);
+    final BlockingExecutor executor = new BlockingExecutor(Runnable::run, 1, Duration.ofMillis(10));
+
+    // when
+    executor.executeWithoutWaiting(() -> executed.set(true));
+
+    // then
+    assertThat(executed).isTrue();
+  }
+
+  @Test
+  public void shouldReportTheCapacityItHasLeft() {
+    // given
+    final CountDownLatch releaseCommand = new CountDownLatch(1);
+    final ExecutorService wrappedExecutor = Executors.newSingleThreadExecutor();
+    try {
+      final BlockingExecutor executor =
+          new BlockingExecutor(wrappedExecutor, 2, Duration.ofSeconds(1));
+      assertThat(executor.freeCapacity()).isEqualTo(2);
+
+      // when a command takes one of the two slots
+      executor.execute(() -> Uninterruptibles.awaitUninterruptibly(releaseCommand));
+
+      // then that slot is gone until the command is done with it
+      assertThat(executor.freeCapacity()).isEqualTo(1);
+      releaseCommand.countDown();
+      Awaitility.await("Capacity should be free again once the command is done")
+          .untilAsserted(() -> assertThat(executor.freeCapacity()).isEqualTo(2));
+    } finally {
+      releaseCommand.countDown();
+      wrappedExecutor.shutdownNow();
+    }
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -88,6 +88,8 @@ final class JobWorkerImplTest {
 
   private static final JobHandler NOOP_JOB_HANDLER = (client, job) -> {};
   private static final long SLOW_POLL_DELAY_IN_MS = 1_000L;
+  // keeps the keys of pushed jobs apart from those of the polled ones
+  private static final long STREAMED_JOB_KEY_OFFSET = 100L;
   private static final Duration SLOW_POLL_THRESHOLD = Duration.ofMillis(SLOW_POLL_DELAY_IN_MS / 2);
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
@@ -413,6 +415,167 @@ final class JobWorkerImplTest {
   }
 
   @Test
+  void shouldAskOnlyForTheCapacityThatPushedJobsLeave() {
+    // given a worker whose capacity is partly taken by jobs the broker pushed to it
+    final int maxJobsActive = 4;
+    final int pushedJobs = 3;
+    final AtomicInteger runningJobs = new AtomicInteger();
+    final CountDownLatch releaseHandlers = new CountDownLatch(1);
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = Executors.newFixedThreadPool(maxJobsActive);
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(
+                    (c, job) -> {
+                      runningJobs.incrementAndGet();
+                      Uninterruptibles.awaitUninterruptibly(releaseHandlers);
+                    })
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .streamEnabled(true)
+                .open()) {
+
+      try {
+        Awaitility.await("Stream should be open").until(() -> !gateway.openStreams.isEmpty());
+        pushJobsInBackground(pushedJobs);
+        Awaitility.await("Pushed jobs should occupy the worker")
+            .untilAtomic(runningJobs, Matchers.is(pushedJobs));
+
+        // when the worker polls again
+        // then it asks only for the jobs it can still run. Its own count of activated jobs says
+        // every slot is free, since the jobs holding them were pushed and never counted.
+        Awaitility.await("Worker should ask for its free capacity only")
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(
+                () -> assertThat(lastRequestedJobCount()).isEqualTo(maxJobsActive - pushedJobs));
+      } finally {
+        // also when the check above failed: a handler left waiting keeps its thread alive and
+        // holds up closing the client for 15 seconds
+        releaseHandlers.countDown();
+      }
+    }
+  }
+
+  @Test
+  void shouldNotAskForJobsWhileItCannotRunAnyMore() {
+    // given a worker whose capacity is taken in full by jobs the broker pushed to it
+    final int maxJobsActive = 2;
+    final AtomicInteger runningJobs = new AtomicInteger();
+    final CountDownLatch releaseHandlers = new CountDownLatch(1);
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = Executors.newFixedThreadPool(maxJobsActive);
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(
+                    (c, job) -> {
+                      runningJobs.incrementAndGet();
+                      Uninterruptibles.awaitUninterruptibly(releaseHandlers);
+                    })
+                .maxJobsActive(maxJobsActive)
+                .pollInterval(Duration.ofMillis(50))
+                .streamEnabled(true)
+                .open()) {
+
+      try {
+        Awaitility.await("Stream should be open").until(() -> !gateway.openStreams.isEmpty());
+        pushJobsInBackground(maxJobsActive);
+        Awaitility.await("Pushed jobs should occupy the worker")
+            .untilAtomic(runningJobs, Matchers.is(maxJobsActive));
+        final int pollsBeforeItIsFull = gateway.getRequestedJobCounts().size();
+
+        // when several poll intervals pass
+        // then no request goes out, since every job it activated would go straight back
+        Awaitility.await("Worker should stop asking for jobs it cannot run")
+            .pollDelay(Duration.ofMillis(500))
+            .atMost(Duration.ofSeconds(10))
+            .untilAsserted(
+                () ->
+                    assertThat(gateway.getRequestedJobCounts())
+                        .hasSizeLessThanOrEqualTo(pollsBeforeItIsFull + 1));
+      } finally {
+        releaseHandlers.countDown();
+      }
+    }
+  }
+
+  @Test
+  void shouldHandBackAPolledJobWithoutWaitingForCapacity() {
+    // given a worker that waits up to a job timeout for capacity, with most of its capacity taken
+    // by jobs the broker pushed to it
+    final int maxJobsActive = 4;
+    final int pushedJobs = 3;
+    final Duration jobTimeout = Duration.ofSeconds(30);
+    final AtomicInteger runningJobs = new AtomicInteger();
+    final CountDownLatch releaseHandlers = new CountDownLatch(1);
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService jobHandlingExecutor = Executors.newFixedThreadPool(maxJobsActive);
+
+    try (final CamundaClient client =
+            new CamundaClientImpl(
+                new CamundaClientBuilderImpl().preferRestOverGrpc(false).build().getConfiguration(),
+                channel,
+                GatewayGrpc.newStub(channel),
+                new JobWorkerExecutors(scheduler, true, jobHandlingExecutor, true));
+        final JobWorker ignored =
+            client
+                .newWorker()
+                .jobType("test")
+                .handler(
+                    (c, job) -> {
+                      runningJobs.incrementAndGet();
+                      Uninterruptibles.awaitUninterruptibly(releaseHandlers);
+                    })
+                .maxJobsActive(maxJobsActive)
+                .timeout(jobTimeout)
+                .pollInterval(Duration.ofMillis(50))
+                .streamEnabled(true)
+                .open()) {
+
+      try {
+        Awaitility.await("Stream should be open").until(() -> !gateway.openStreams.isEmpty());
+        pushJobsInBackground(pushedJobs);
+        Awaitility.await("Pushed jobs should occupy the worker")
+            .untilAtomic(runningJobs, Matchers.is(pushedJobs));
+
+        // when a poll brings back more jobs than the worker has capacity for, which happens when
+        // the broker pushes a job while the response is on its way
+        gateway.respondWith(TestData.jobs(maxJobsActive));
+
+        // then the jobs it cannot run are handed back right away. Waiting for capacity would hold
+        // on to the thread that carries the activation response for a job timeout per job, and
+        // that thread carries the rest of the client's requests as well.
+        Awaitility.await("Refused jobs should go back to the broker without waiting for capacity")
+            .atMost(jobTimeout.dividedBy(3))
+            .untilAsserted(
+                () ->
+                    assertThat(gateway.getFailedJobs())
+                        .extracting(FailJobRequest::getJobKey)
+                        .contains(1L, 2L, 3L));
+      } finally {
+        releaseHandlers.countDown();
+      }
+    }
+  }
+
+  @Test
   void shouldFailRejectedJobsBackToTheBroker() {
     // given a worker whose handler executor refuses every job
     final int maxJobsActive = 4;
@@ -696,6 +859,27 @@ final class JobWorkerImplTest {
    * java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy} behaves this way when it is shut down
    * while the caller is running the command.
    */
+  /**
+   * Pushes jobs on the open stream from another thread, since a worker that has no capacity left
+   * makes the pushing thread wait for it.
+   */
+  private void pushJobsInBackground(final int numberOfJobs) {
+    new Thread(
+            () -> {
+              for (int i = 0; i < numberOfJobs; i++) {
+                gateway.pushJob(TestData.job(STREAMED_JOB_KEY_OFFSET + i));
+              }
+            })
+        .start();
+  }
+
+  private Integer lastRequestedJobCount() {
+    final List<Integer> requestedJobCounts = gateway.getRequestedJobCounts();
+    return requestedJobCounts.isEmpty()
+        ? null
+        : requestedJobCounts.get(requestedJobCounts.size() - 1);
+  }
+
   private static final class RunsThenRefusesExecutor extends AbstractExecutorService {
     @Override
     public void shutdown() {}

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerMetricsTest.java
@@ -25,7 +25,6 @@ import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.response.ActivatedJobImpl;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,7 +40,7 @@ import org.mockito.Mockito;
 final class JobWorkerMetricsTest {
 
   private static final int AUTO_COMPLETE_ALL_JOBS = 0;
-  private static final Executor REFUSING_EXECUTOR =
+  private static final JobExecutor REFUSING_EXECUTOR =
       command -> {
         throw new RejectedExecutionException("The executor has no capacity");
       };
@@ -64,7 +63,7 @@ final class JobWorkerMetricsTest {
       final JobPoller poller,
       final JobStreamer streamer,
       final JobWorkerMetrics metrics) {
-    return createWorker(autoCompleteCount, poller, streamer, metrics, executor);
+    return createWorker(autoCompleteCount, poller, streamer, metrics, executor::execute);
   }
 
   private JobWorkerImpl createWorker(
@@ -72,7 +71,7 @@ final class JobWorkerMetricsTest {
       final JobPoller poller,
       final JobStreamer streamer,
       final JobWorkerMetrics metrics,
-      final Executor jobExecutor) {
+      final JobExecutor jobExecutor) {
     return new JobWorkerImpl(
         32,
         executor,


### PR DESCRIPTION
> Draft, stacked on #61195. Base branch is that PR's branch, so the diff here is only the change on top of it.

## Why

A job worker with job push enabled loses most of its throughput over REST once its handler executor fills up, and the capacity warnings never stop. On the branch of #61195 the worker settled at **2 process instances per second**, against about 20 without that PR and 50 for the same workload over gRPC.

The worker dispatches a poll response from the thread that completed it: `JobPollerImpl` hands the response to `jobs.forEach(jobConsumer)` inside `thenApply`. `BlockingExecutor` then parks that thread until capacity frees up, for up to a whole job timeout, once per job in the response.

On gRPC that costs nothing, its executor is an unbounded cached pool. On REST the client dispatches on a small fixed IO reactor whose threads carry every request the client sends, so parking one holds up the job completions, the fail commands and the next activation behind it. The worker log of that run says it plainly:

```
1611 capacity refusals, a steady 30 polled + 30 streamed per minute over 27 minutes

 807 polled    returnJobToBroker         all on httpclient-dispatch-1
 804 streamed  leaveStreamedJobToBroker  spread over 12 grpc-default-executor-N

 196 TimeoutException from the worker's own message publication
```

`httpclient-dispatch-1` is the only dispatch thread in that log, so the whole polled path runs through one IO reactor thread, and each refusal costs it the full acquire deadline of 1800 ms.

Two things keep the worker there. It waits for capacity on a thread it must not hold, and it asks for more jobs than it can run: the poll budget is `maxJobsActive - remainingJobs`, and `remainingJobs` counts only the jobs the worker activated itself, not the ones the broker pushed to it, even though both take capacity from the same executor. That is #59632, and it is what drives the worker into the refusal path in the first place.

#61195 is not the cause. The blocking dispatch predates it. What that PR removes is a capacity leak
that used to stop the worker from polling after a handful of refusals, which also stopped the blocking, so the damage was capped at one short burst. With the accounting fixed the worker keeps polling and the blocking becomes the steady state.

## What

**A poll asks only for the jobs the executor can take right now**, and skips the request entirely while the executor is full. A worker whose capacity is held by pushed jobs stops asking for jobs it would only hand straight back.

**A polled job that still finds no capacity is refused on the spot** and handed back to the broker, instead of waiting for capacity to free up. This can still happen, since a push can take the capacity while the activation response is on its way. Pushed jobs keep waiting, because a blocked push is what tells the broker to offer the job to another worker.

The worker learns both from a small package-private `JobExecutor` interface it now takes instead of a plain `Executor`. An executor that does not limit what it takes, which is what a worker without job push has, inherits defaults that behave exactly as before. No public API changes.

## Validated in the benchmark

The same benchmark now runs at [**50 PI/s**](https://dashboard.benchmark.camunda.cloud/d/sefc9kn/zeebe-with-gateway-rest?from=2026-08-28T06:54:57.780Z&to=2026-08-28T07:07:16.910Z&timezone=browser&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-namespace=c8-meg-61336-rest&var-pod=$__all&var-partition=$__all&var-memory_state=committed&refresh=auto), which is where gRPC sits, so the gap closes. It peaks around 70 early in the run before settling there. Setup: REST with job streaming enabled, `maxJobsActive` 60, 30 handler threads, a handler of about 300 ms. The capacity warnings are gone from the worker log, and `camunda.client.worker.job.refused` from #61195 stays near zero.

## Testing

Three tests in `JobWorkerImplTest`, each verified to fail without the change:

- `shouldAskOnlyForTheCapacityThatPushedJobsLeave`, a worker with three of four slots held by pushed jobs asks for one job, not four.
- `shouldNotAskForJobsWhileItCannotRunAnyMore`, a worker with no free capacity sends no activation request at all.
- `shouldHandBackAPolledJobWithoutWaitingForCapacity`, with a job timeout of 30 seconds the refused jobs are back at the broker within 10. Without the change the run needs a job timeout per refused job and the test times out.

Three more in `BlockingExecutorTest` cover the non waiting handover and the free capacity it reports. Full `clients/java` suite green, 2088 tests.

## Not in this PR

- The `onScheduledPoll` path still returns without rescheduling when it decides not to poll, which is what made the stall in #59633 permanent rather than temporary. It is asked for in that issue as defence in depth and is left to #61195.
- The acquire deadline of `BlockingExecutor` is the worker's job timeout, so a pushed job that waits for capacity waits until its own deadline at the broker has all but passed. Worth a separate look.
