### PR TITLE
fix: pin camunda/optimize e2e compose image tags to 8.10-SNAPSHOT

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
   camunda:
     container_name: camunda
-    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}
+    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:8.10-SNAPSHOT}
     environment:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
       - ZEEBE_BROKER_NETWORK_HOST=camunda
@@ -153,7 +153,7 @@ services:
   # is provisioned; startup and readiness do not depend on the realm existing.
   optimize:
     container_name: optimize
-    image: ${OPTIMIZE_DOCKER_IMAGE:-camunda/optimize:SNAPSHOT}
+    image: ${OPTIMIZE_DOCKER_IMAGE:-camunda/optimize:8.10-SNAPSHOT}
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
## What changed?

`qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml`'s default image tags for `camunda` and `optimize` are pinned to `8.10-SNAPSHOT` instead of a bare `SNAPSHOT`.

## Why?

A bare `:SNAPSHOT` tag is correct on `main` (the bleeding-edge build), but on `stable/8.10` it resolves to whatever `main` last pushed to `camunda/camunda:SNAPSHOT` / `camunda/optimize:SNAPSHOT` — not an image built from this branch. `stable/8.9` and `stable/8.8` already pin the `camunda` image to their own `8.9-SNAPSHOT` / `8.8-SNAPSHOT`; this branch's copy was never updated to match at cut time (the `optimize` service doesn't exist on those older branches at all, so this is the first branch where its default needed the same fix).

Confirmed directly against each branch's own copy of this file:

| Branch | `camunda` default | `optimize` default |
|---|---|---|
| `main` | `SNAPSHOT` (correct — bleeding edge) | `SNAPSHOT` (correct) |
| `stable/8.9` | `8.9-SNAPSHOT` | *(no optimize service)* |
| `stable/8.8` | `8.8-SNAPSHOT` | *(no optimize service)* |
| `stable/8.10` (before this PR) | `SNAPSHOT` ❌ | `SNAPSHOT` ❌ |
| `stable/8.10` (after this PR) | `8.10-SNAPSHOT` | `8.10-SNAPSHOT` |

## How to verify

Run the e2e suite against this branch without overriding `CAMUNDA_DOCKER_IMAGE`/`OPTIMIZE_DOCKER_IMAGE` and confirm `docker compose config` (or the actual pulled images) resolve to `camunda/camunda:8.10-SNAPSHOT` and `camunda/optimize:8.10-SNAPSHOT`.

## Verification

- `docker-compose.yml` parses as valid YAML.
- Diffed against `stable/8.9`/`stable/8.8`'s own copies of this file to confirm the `X.Y-SNAPSHOT` pinning convention this PR restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
