### PR TITLE
Prevent AGENT_HISTORY:DISCARD commands from being keyed by an unrelated jobKey

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -829,10 +829,8 @@ public final class BpmnJobBehavior {
         // The job is destroyed without completing — discard all its pending history items. The
         // lease is left empty on purpose: the whole job is gone, so every activation's items must
         // be discarded regardless of the lease they were created with.
-        commandWriter.appendFollowUpCommand(
-            jobKey,
-            AgentHistoryIntent.DISCARD,
-            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+        commandWriter.appendNewCommand(
+            AgentHistoryIntent.DISCARD, new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -69,10 +69,8 @@ public final class JobCancelProcessor
         // The job is destroyed without completing — discard all its pending history items. The
         // lease is left empty on purpose: the whole job is gone, so every activation's items must
         // be discarded regardless of the lease they were created with.
-        commandWriter.appendFollowUpCommand(
-            jobKey,
-            AgentHistoryIntent.DISCARD,
-            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+        commandWriter.appendNewCommand(
+            AgentHistoryIntent.DISCARD, new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
       }
     } else {
       rejectionWriter.appendRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -215,10 +215,8 @@ public class JobThrowErrorProcessor
         // The error was caught, so the job is deleted without completing — discard all its pending
         // history items. The lease is left empty on purpose: the whole job is gone, so every
         // activation's items must be discarded regardless of the lease they were created with.
-        commandWriter.appendFollowUpCommand(
-            jobKey,
-            AgentHistoryIntent.DISCARD,
-            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+        commandWriter.appendNewCommand(
+            AgentHistoryIntent.DISCARD, new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -169,10 +169,8 @@ public class ProcessInstanceMigrationUserTaskBehavior {
       // discarded regardless of the lease they were created with. Today the cancelled job is a
       // user-task job (never agentic), so this is a no-op; kept to future-proof job-worker user
       // tasks that carry an associated agent instance.
-      commandWriter.appendFollowUpCommand(
-          jobKey,
-          AgentHistoryIntent.DISCARD,
-          new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
+      commandWriter.appendNewCommand(
+          AgentHistoryIntent.DISCARD, new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -218,6 +218,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
             .withJobKey(jobKey)
             .getFirst();
     assertThat(discardCommand.getRecordType()).isEqualTo(RecordType.COMMAND);
+    assertThat(discardCommand.getKey()).isEqualTo(-1L);
     assertThat(discardCommand.getValue().getJobLease()).isEmpty();
 
     // and the pending item is discarded


### PR DESCRIPTION
## Description

### What changed

`AGENT_HISTORY:DISCARD` follow-up commands are now issued via `TypedCommandWriter#appendNewCommand` instead of `appendFollowUpCommand(jobKey, ...)`, at all 4 emission sites (`BpmnJobBehavior`, `JobCancelProcessor`, `ProcessInstanceMigrationUserTaskBehavior`, `JobThrowErrorProcessor`), so the command now carries an unset key (`-1`) instead of an unrelated `JOB` key. A regression test now asserts the command's key.

### Why

The command doesn't identify a single `AgentHistory` entity — `AgentHistoryDiscardProcessor` fans out to discard every pending item for a job (or lease) in one command. Keying it by `jobKey` violated `Record#getKey()`'s documented contract that a record's key identifies the entity it belongs to, and all 4 emission sites made this same mistake.

### What this enables

A self-consistent `AGENT_HISTORY:DISCARD` record shape. No behavioral change to when or how agent history is discarded.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #57563
