### PR TITLE
feat: add input-comparison-mode diagnostic flag (ComparingMappingResolver)

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.configuration;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Defines configuration for the engine's mapping resolution strategy. The prefix for this class is
  * camunda.processing.engine.mappings.
@@ -14,6 +16,16 @@ package io.camunda.configuration;
 public class EngineMappings {
 
   private InputMode inputMode = InputMode.COMBINED;
+
+  /**
+   * When set, evaluates input mappings with both the primary resolver ({@code inputMode}) and this
+   * comparison resolver, then logs a warning if their results differ. Intended for diagnostic use
+   * only: each activation evaluates mappings with both resolvers and compares the result documents,
+   * which adds overhead for large mapping sets.
+   *
+   * <p>Has no effect when null (default) or when set to the same value as {@code inputMode}.
+   */
+  @Nullable private InputMode inputComparisonMode = null;
 
   public enum InputMode {
     ORDERED,
@@ -39,8 +51,11 @@ public class EngineMappings {
     this.inputMode = inputMode;
   }
 
-  @Override
-  public String toString() {
-    return "EngineMappings{inputMode=" + inputMode + '}';
+  public @Nullable InputMode getInputComparisonMode() {
+    return inputComparisonMode;
+  }
+
+  public void setInputComparisonMode(final @Nullable InputMode inputComparisonMode) {
+    this.inputComparisonMode = inputComparisonMode;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -58,4 +58,13 @@ public class EngineMappings {
   public void setInputComparisonMode(final @Nullable InputMode inputComparisonMode) {
     this.inputComparisonMode = inputComparisonMode;
   }
+
+  @Override
+  public String toString() {
+    return "EngineMappings{inputMode="
+        + inputMode
+        + ", inputComparisonMode="
+        + inputComparisonMode
+        + '}';
+  }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -12,7 +12,7 @@ import io.camunda.configuration.Azure;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
-import io.camunda.configuration.EngineMappings;
+import io.camunda.configuration.EngineMappings.InputMode;
 import io.camunda.configuration.EngineStorageOrdinals;
 import io.camunda.configuration.Export;
 import io.camunda.configuration.Exporter;
@@ -69,7 +69,7 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.broker.system.configuration.partitioning.ZoneAwareCfg;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
-import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
 import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
@@ -81,6 +81,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
@@ -290,10 +291,21 @@ public class BrokerBasedPropertiesOverride {
         .getExperimental()
         .getEngine()
         .setInputMappingMode(
-            camunda.getProcessing().getEngine().getMappings().getInputMode()
-                    == EngineMappings.InputMode.COMBINED
-                ? EngineConfiguration.InputMappingMode.COMBINED
-                : EngineConfiguration.InputMappingMode.ORDERED);
+            toEngineMode(camunda.getProcessing().getEngine().getMappings().getInputMode()));
+
+    override
+        .getExperimental()
+        .getEngine()
+        .setInputComparisonMode(
+            toEngineMode(
+                camunda.getProcessing().getEngine().getMappings().getInputComparisonMode()));
+  }
+
+  private static InputMappingMode toEngineMode(final @Nullable InputMode mode) {
+    if (mode == null) {
+      return null;
+    }
+    return mode == InputMode.COMBINED ? InputMappingMode.COMBINED : InputMappingMode.ORDERED;
   }
 
   private static void populateFromDistribution(

--- a/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
@@ -69,4 +69,31 @@ public class EngineMappingsTest {
           .isEqualTo(EngineConfiguration.InputMappingMode.ORDERED);
     }
   }
+
+  @Nested
+  @DisplayName("Comparison mode")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    BrokerBasedPropertiesOverride.class,
+    UnifiedConfigurationHelper.class
+  })
+  @ActiveProfiles("broker")
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.mappings.input-mode=COMBINED",
+        "camunda.processing.engine.mappings.input-comparison-mode=ORDERED",
+      })
+  class ComparisonMode {
+    final BrokerBasedProperties brokerCfg;
+
+    ComparisonMode(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetInputComparisonMode() {
+      assertThat(brokerCfg.getExperimental().getEngine().getInputComparisonMode())
+          .isEqualTo(EngineConfiguration.InputMappingMode.ORDERED);
+    }
+  }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -303,6 +303,7 @@ processing.engine.evaluate-duplicate-output-mapping-targets-in-order
 processing.engine.job.include-variables-in-job-completed-event
 processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval
+processing.engine.mappings.input-comparison-mode
 processing.engine.mappings.input-mode
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1338,6 +1338,11 @@ camunda: # Type: io.camunda.configuration.Camunda
         # declaration order) or COMBINED (default, legacy combined-FEEL-context behavior restoring
         # the pre-baddd911435 single-expression evaluation).
         input-mode: COMBINED # Type: InputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_INPUTMODE
+        # When set, also evaluates input mappings with this second resolver and logs a warning
+        # if the results differ from the primary resolver. Intended for migration diagnostics
+        # only: each activation evaluates mappings with both resolvers and compares the
+        # result documents, which adds overhead for large mapping sets.
+        input-comparison-mode: ~ # Type: InputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_INPUTCOMPARISONMODE
 
     flow-control: # Type: io.camunda.configuration.FlowControl
       request: # Type: io.camunda.configuration.Limit

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.broker.system.configuration.engine;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
+import org.jspecify.annotations.Nullable;
 
 public final class EngineCfg implements ConfigurationEntry {
 
@@ -25,6 +27,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
   private EngineConfiguration.InputMappingMode inputMappingMode =
       EngineConfiguration.InputMappingMode.COMBINED;
+  private @Nullable InputMappingMode inputComparisonMode = null;
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
@@ -129,6 +132,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.inputMappingMode = inputMappingMode;
   }
 
+  public @Nullable InputMappingMode getInputComparisonMode() {
+    return inputComparisonMode;
+  }
+
+  public void setInputComparisonMode(final @Nullable InputMappingMode inputComparisonMode) {
+    this.inputComparisonMode = inputComparisonMode;
+  }
+
   public GlobalListenersCfg getGlobalListeners() {
     return globalListeners;
   }
@@ -212,6 +223,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + storageOrdinals
         + ", inputMappingMode="
         + inputMappingMode
+        + ", inputComparisonMode="
+        + inputComparisonMode
         + '}';
   }
 
@@ -274,6 +287,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setEnableRpaReexportMigration(startup.isRpaReexportMigrationEnabled())
         .setArchiverlessEnabled(storageOrdinals.isEnableArchiverless())
         .setFixedStorageOrdinalKey(storageOrdinals.getFixedStorageOrdinalKey())
-        .setInputMappingMode(inputMappingMode);
+        .setInputMappingMode(inputMappingMode)
+        .setInputComparisonMode(inputComparisonMode);
   }
 }

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -272,6 +272,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine;
 
 import java.time.Duration;
+import org.jspecify.annotations.Nullable;
 
 public final class EngineConfiguration {
 
@@ -167,6 +168,7 @@ public final class EngineConfiguration {
       DEFAULT_JOBS_INCLUDE_VARIABLES_IN_JOB_COMPLETED_EVENT;
   private boolean enableRpaReexportMigration = DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION;
   private InputMappingMode inputMappingMode = InputMappingMode.COMBINED;
+  private @Nullable InputMappingMode inputComparisonMode = null;
 
   /**
    * Controls uniqueness enforcement of business IDs across active process instances.
@@ -755,6 +757,16 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setInputMappingMode(final InputMappingMode inputMappingMode) {
     this.inputMappingMode = inputMappingMode;
+    return this;
+  }
+
+  public @Nullable InputMappingMode getInputComparisonMode() {
+    return inputComparisonMode;
+  }
+
+  public EngineConfiguration setInputComparisonMode(
+      final @Nullable InputMappingMode inputComparisonMode) {
+    this.inputComparisonMode = inputComparisonMode;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -38,8 +38,7 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
-import io.camunda.zeebe.engine.processing.variable.CombinedMappingResolver;
-import io.camunda.zeebe.engine.processing.variable.OrderedMappingResolver;
+import io.camunda.zeebe.engine.processing.variable.MappingResolvers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -185,9 +184,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             variableBehavior,
             eventTriggerBehavior,
             evaluateDuplicateOutputMappingTargetsInOrder,
-            config.getInputMappingMode() == EngineConfiguration.InputMappingMode.COMBINED
-                ? new CombinedMappingResolver()
-                : new OrderedMappingResolver());
+            MappingResolvers.forMode(
+                config.getInputMappingMode(), config.getInputComparisonMode()));
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -16,10 +16,11 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
+import io.camunda.zeebe.engine.processing.variable.MappingContext;
+import io.camunda.zeebe.engine.processing.variable.MappingExpressionProcessor;
 import io.camunda.zeebe.engine.processing.variable.MappingResolver;
 import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
 import io.camunda.zeebe.engine.processing.variable.OutputMappingResultBuilder;
-import io.camunda.zeebe.engine.processing.variable.ScopedExpressionProcessor;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -87,8 +88,6 @@ public final class BpmnVariableMappingBehavior {
    */
   public Either<Failure, Void> applyInputMappings(
       final BpmnElementContext context, final ExecutableFlowNode element) {
-    final long scopeKey = context.getElementInstanceKey();
-    final String tenantId = context.getTenantId();
     final Optional<InputMappings> inputMappings = element.getInputMappings();
 
     if (inputMappings.isEmpty()) {
@@ -97,10 +96,17 @@ public final class BpmnVariableMappingBehavior {
 
     // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
     // for input mappings, so a modeled reference survives evaluation instead of nulling
+    final var mappingContext =
+        new MappingContext(
+            element.getId(),
+            context.getElementInstanceKey(),
+            context.getProcessInstanceKey(),
+            context.getProcessDefinitionKey(),
+            context.getTenantId());
     final var result =
         inputMappingResolver.resolveInputMappings(
             inputMappings.get(),
-            new ScopedExpressionProcessor(inputMappingExpressionProcessor, scopeKey, tenantId));
+            new MappingExpressionProcessor(inputMappingExpressionProcessor, mappingContext));
     if (result.isLeft()) {
       return Either.left(result.getLeft());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/CombinedMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/CombinedMappingResolver.java
@@ -41,7 +41,7 @@ public final class CombinedMappingResolver implements MappingResolver {
 
   @Override
   public Either<Failure, DirectBuffer> resolveInputMappings(
-      final InputMappings inputMappings, final ScopedExpressionProcessor processor) {
+      final InputMappings inputMappings, final MappingExpressionProcessor processor) {
     return processor.evaluateVariableMappingExpression(inputMappings.combinedExpression());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link MappingResolver} that runs a primary resolver and a comparison resolver, logging a
+ * warning when their results differ. The primary result is always returned and applied.
+ *
+ * <p>Both resolvers are always run — even when the primary fails — so that divergences between
+ * failure and success outcomes are also detected and logged.
+ */
+@NullMarked
+public final class ComparingMappingResolver implements MappingResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ComparingMappingResolver.class);
+  private static final ObjectMapper MSGPACK_MAPPER = new ObjectMapper(new MessagePackFactory());
+
+  // 1/s throttle per instance; one engine instance → one resolver → effective global rate limit
+  private final Logger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(1));
+
+  private final MappingResolver primary;
+  private final MappingResolver comparison;
+
+  public ComparingMappingResolver(final MappingResolver primary, final MappingResolver comparison) {
+    this.primary = primary;
+    this.comparison = comparison;
+  }
+
+  @Override
+  public Either<Failure, DirectBuffer> resolveInputMappings(
+      final InputMappings inputMappings, final MappingExpressionProcessor processor) {
+    final var primaryResult = primary.resolveInputMappings(inputMappings, processor);
+
+    try {
+      // Snapshot before the comparison run: CombinedMappingResolver returns a view into a
+      // shared evaluation buffer that the comparison resolver will overwrite.
+      final var snapshot = snapshot(primaryResult);
+      final var comparisonResult = comparison.resolveInputMappings(inputMappings, processor);
+
+      if (!equivalent(snapshot, comparisonResult)) {
+        throttledLog.warn(
+            "Input mapping results differ between {} and {} resolvers [{}].",
+            primary.getClass().getSimpleName(),
+            comparison.getClass().getSimpleName(),
+            processor.getMappingContext());
+      }
+    } catch (final Exception e) {
+      LOG.warn(
+          "Comparison resolver {} threw unexpectedly [{}]; primary {} result is applied.",
+          comparison.getClass().getSimpleName(),
+          processor.getMappingContext(),
+          primaryResult.isRight() ? "success" : "failure",
+          e);
+    }
+
+    return primaryResult;
+  }
+
+  private static Either<Failure, DirectBuffer> snapshot(
+      final Either<Failure, DirectBuffer> result) {
+    return result.isRight() ? Either.right(BufferUtil.cloneBuffer(result.get())) : result;
+  }
+
+  private static boolean equivalent(
+      final Either<Failure, DirectBuffer> a, final Either<Failure, DirectBuffer> b) {
+    if (a.isLeft() && b.isLeft()) {
+      return a.getLeft().equals(b.getLeft());
+    }
+    if (a.isRight() && b.isRight()) {
+      return documentsEqual(a.get(), b.get());
+    }
+    return false; // one succeeded, one failed
+  }
+
+  private static boolean documentsEqual(final DirectBuffer a, final DirectBuffer b) {
+    if (a.capacity() != b.capacity()) {
+      return false;
+    }
+    if (BufferUtil.equals(a, b)) {
+      return true;
+    }
+    try {
+      return MSGPACK_MAPPER
+          .readTree(BufferUtil.bufferAsArray(a))
+          .equals(MSGPACK_MAPPER.readTree(BufferUtil.bufferAsArray(b)));
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
@@ -49,10 +49,12 @@ public final class ComparingMappingResolver implements MappingResolver {
       final InputMappings inputMappings, final MappingExpressionProcessor processor) {
     final var primaryResult = primary.resolveInputMappings(inputMappings, processor);
 
+    // Snapshot before the comparison run: CombinedMappingResolver returns a view into a shared
+    // evaluation buffer that the comparison resolver will overwrite on its own evaluation pass.
+    // Returning the snapshot (a clone) instead of primaryResult shields the caller from corruption.
+    final var snapshot = snapshot(primaryResult);
+
     try {
-      // Snapshot before the comparison run: CombinedMappingResolver returns a view into a
-      // shared evaluation buffer that the comparison resolver will overwrite.
-      final var snapshot = snapshot(primaryResult);
       final var comparisonResult = comparison.resolveInputMappings(inputMappings, processor);
 
       if (!equivalent(snapshot, comparisonResult)) {
@@ -71,7 +73,7 @@ public final class ComparingMappingResolver implements MappingResolver {
           e);
     }
 
-    return primaryResult;
+    return snapshot;
   }
 
   private static Either<Failure, DirectBuffer> snapshot(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Per-activation context passed to {@link MappingResolver} so implementations that need element
+ * identity (e.g. {@link ComparingMappingResolver}) can log meaningful diagnostics without receiving
+ * the information at construction time.
+ *
+ * <p>{@code elementId} is kept as a {@link DirectBuffer} to avoid a String allocation on every
+ * activation; the conversion happens only when this context is included in a log message.
+ */
+@NullMarked
+public record MappingContext(
+    DirectBuffer elementId,
+    long scopeKey,
+    long processInstanceKey,
+    long processDefinitionKey,
+    String tenantId) {
+
+  @Override
+  public String toString() {
+    return "MappingContext[elementId="
+        + BufferUtil.bufferAsString(elementId)
+        + ", scopeKey="
+        + scopeKey
+        + ", processInstanceKey="
+        + processInstanceKey
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", tenantId="
+        + tenantId
+        + "]";
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingExpressionProcessor.java
@@ -25,20 +25,40 @@ import org.jspecify.annotations.Nullable;
  * ScopedEvaluationContext#getVariable} directly without calling {@code processScoped} themselves.
  */
 @NullMarked
-public final class ScopedExpressionProcessor {
+public final class MappingExpressionProcessor {
 
   private final ExpressionProcessor processor;
   private final ScopedEvaluationContext scopedContext;
   private final long scopeKey;
   private final String tenantId;
+  private final MappingContext mappingContext;
 
-  public ScopedExpressionProcessor(
-      final ExpressionProcessor processor, final long scopeKey, final String tenantId) {
+  public MappingExpressionProcessor(
+      final ExpressionProcessor processor, final MappingContext mappingContext) {
     this.processor = processor;
+    this.mappingContext = mappingContext;
+    this.scopeKey = mappingContext.scopeKey();
+    this.tenantId = mappingContext.tenantId();
+    this.scopedContext =
+        processor.getEvaluationContext().processScoped(scopeKey).tenantScoped(tenantId);
+  }
+
+  private MappingExpressionProcessor(
+      final ExpressionProcessor processor,
+      final MappingContext mappingContext,
+      final long scopeKey,
+      final String tenantId) {
+    this.processor = processor;
+    this.mappingContext = mappingContext;
     this.scopeKey = scopeKey;
     this.tenantId = tenantId;
     this.scopedContext =
         processor.getEvaluationContext().processScoped(scopeKey).tenantScoped(tenantId);
+  }
+
+  /** Returns the mapping context associated with this activation. */
+  public MappingContext getMappingContext() {
+    return mappingContext;
   }
 
   /**
@@ -62,14 +82,15 @@ public final class ScopedExpressionProcessor {
   }
 
   /**
-   * Returns a new {@link ScopedExpressionProcessor} with {@code ctx} prepended to the underlying
+   * Returns a new {@link MappingExpressionProcessor} with {@code ctx} prepended to the underlying
    * processor's evaluation context chain, preserving the same scope key and tenant binding.
    *
    * @param ctx the evaluation context to prepend (e.g. an in-flight result accumulator)
    * @return a new scoped processor with {@code ctx} as the outermost context layer
    */
-  public ScopedExpressionProcessor prependContext(final ScopedEvaluationContext ctx) {
-    return new ScopedExpressionProcessor(processor.prependContext(ctx), scopeKey, tenantId);
+  public MappingExpressionProcessor prependContext(final ScopedEvaluationContext ctx) {
+    return new MappingExpressionProcessor(
+        processor.prependContext(ctx), mappingContext, scopeKey, tenantId);
   }
 
   /**
@@ -80,7 +101,7 @@ public final class ScopedExpressionProcessor {
    * @param lookup maps a variable name to its value, or {@code null} if absent
    * @return a new scoped processor with the lookup as the outermost context layer
    */
-  public ScopedExpressionProcessor prependContext(
+  public MappingExpressionProcessor prependContext(
       final Function<String, @Nullable DirectBuffer> lookup) {
     return prependContext((ScopedEvaluationContext) name -> Either.left(lookup.apply(name)));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolver.java
@@ -28,11 +28,12 @@ public interface MappingResolver {
    *
    * @param inputMappings the element's input mappings, in modeling order
    * @param processor the pre-scoped expression processor; its evaluation context is already scoped
-   *     to the element instance, so implementations can call {@link
-   *     ScopedExpressionProcessor#getEvaluationContext()}.getVariable() directly
+   *     to the element instance, and carries {@link MappingExpressionProcessor#getMappingContext()}
+   *     with element identity (element ID, scope key, process instance key, process definition key,
+   *     tenant ID) for diagnostic use
    * @return either the resolved result document, or the failure of the first mapping that failed to
    *     evaluate
    */
   Either<Failure, DirectBuffer> resolveInputMappings(
-      InputMappings inputMappings, ScopedExpressionProcessor processor);
+      InputMappings inputMappings, MappingExpressionProcessor processor);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolvers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolvers.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.engine.processing.variable;
 
 import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /** Utility methods for working with {@link MappingResolver} instances. */
+@NullMarked
 public final class MappingResolvers {
 
   private MappingResolvers() {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolvers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolvers.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
+import org.jspecify.annotations.Nullable;
+
+/** Utility methods for working with {@link MappingResolver} instances. */
+public final class MappingResolvers {
+
+  private MappingResolvers() {}
+
+  /**
+   * Returns a resolver for the given input mode. If {@code comparisonMode} is non-null and
+   * different from {@code inputMode}, wraps both in a {@link ComparingMappingResolver} that logs a
+   * warning when results differ.
+   */
+  public static MappingResolver forMode(
+      final InputMappingMode inputMode, final @Nullable InputMappingMode comparisonMode) {
+    final var primary = singleResolver(inputMode);
+    if (comparisonMode == null || comparisonMode == inputMode) {
+      return primary;
+    }
+    return new ComparingMappingResolver(primary, singleResolver(comparisonMode));
+  }
+
+  private static MappingResolver singleResolver(final InputMappingMode mode) {
+    return switch (mode) {
+      case COMBINED -> new CombinedMappingResolver();
+      case ORDERED -> new OrderedMappingResolver();
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedMappingResolver.java
@@ -26,7 +26,7 @@ public final class OrderedMappingResolver implements MappingResolver {
 
   @Override
   public Either<Failure, DirectBuffer> resolveInputMappings(
-      final InputMappings inputMappings, final ScopedExpressionProcessor processor) {
+      final InputMappings inputMappings, final MappingExpressionProcessor processor) {
     final var resultBuilder =
         new InputMappingResultBuilder(
             name -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.test.util.logging.RecordingAppender;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class ComparingMappingResolverTest {
+
+  private static final MappingContext CONTEXT =
+      new MappingContext(BufferUtil.wrapString("element-1"), 100L, 200L, 300L, "default");
+
+  private static final InputMappings INPUT_MAPPINGS = mock(InputMappings.class);
+  private static final MappingExpressionProcessor PROCESSOR =
+      mock(MappingExpressionProcessor.class);
+
+  private final RecordingAppender recorder = new RecordingAppender();
+  private Logger log4jLogger;
+
+  @BeforeEach
+  void setUp() {
+    log4jLogger = (Logger) LogManager.getLogger(ComparingMappingResolver.class);
+    recorder.start();
+    log4jLogger.addAppender(recorder);
+    log4jLogger.setLevel(Level.WARN);
+    when(PROCESSOR.getMappingContext()).thenReturn(CONTEXT);
+  }
+
+  @AfterEach
+  void tearDown() {
+    recorder.stop();
+    log4jLogger.removeAppender(recorder);
+  }
+
+  private static DirectBuffer bufferOf(final String s) {
+    return BufferUtil.wrapString(s);
+  }
+
+  /** Produces a real MsgPack buffer from a JSON string for structural comparison tests. */
+  private static DirectBuffer msgPackOf(final String json) {
+    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(json));
+  }
+
+  @Test
+  void shouldReturnPrimaryResultWhenBothSucceedWithEqualBytes() {
+    final var buf = bufferOf("same");
+    final MappingResolver primary = (m, p) -> Either.right(buf);
+    final MappingResolver comparison = (m, p) -> Either.right(buf);
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo(buf);
+    assertThat(recorder.getAppendedEvents()).isEmpty();
+  }
+
+  @Test
+  void shouldLogWarnWhenPrimarySucceedsButComparisonFails() {
+    final var buf = bufferOf("value");
+    final MappingResolver primary = (m, p) -> Either.right(buf);
+    final MappingResolver comparison = (m, p) -> Either.left(new Failure("comparison failed"));
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo(buf);
+
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            e -> {
+              assertThat(e.getLevel()).isEqualTo(Level.WARN);
+              assertThat(e.getMessage().getFormattedMessage())
+                  .contains("Input mapping results differ");
+            });
+  }
+
+  @Test
+  void shouldLogWarnWhenPrimaryFailsAndComparisonSucceeds() {
+    final var buf = bufferOf("value");
+    final MappingResolver primary = (m, p) -> Either.left(new Failure("primary failed"));
+    final MappingResolver comparison = (m, p) -> Either.right(buf);
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage()).isEqualTo("primary failed");
+
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            e -> {
+              assertThat(e.getLevel()).isEqualTo(Level.WARN);
+              assertThat(e.getMessage().getFormattedMessage())
+                  .contains("Input mapping results differ");
+            });
+  }
+
+  @Test
+  void shouldNotLogWarnWhenBothFailWithSameFailure() {
+    final MappingResolver primary = (m, p) -> Either.left(new Failure("same error"));
+    final MappingResolver comparison = (m, p) -> Either.left(new Failure("same error"));
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage()).isEqualTo("same error");
+
+    assertThat(recorder.getAppendedEvents()).isEmpty();
+  }
+
+  @Test
+  void shouldLogWarnWhenBothFailWithDifferentMessages() {
+    final MappingResolver primary = (m, p) -> Either.left(new Failure("error A"));
+    final MappingResolver comparison = (m, p) -> Either.left(new Failure("error B"));
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage()).isEqualTo("error A");
+
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(e -> assertThat(e.getLevel()).isEqualTo(Level.WARN));
+  }
+
+  @Test
+  void shouldLogWarnWhenBothSucceedWithDifferentDocuments() {
+    final MappingResolver primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
+    final MappingResolver comparison = (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+  }
+
+  @Test
+  void shouldNotLogWarnWhenBothSucceedWithEqualNestedDocuments() {
+    final var buf = msgPackOf("{\"a\":{\"b\":1,\"c\":2},\"d\":3}");
+    final MappingResolver primary = (m, p) -> Either.right(buf);
+    final MappingResolver comparison = (m, p) -> Either.right(buf);
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents()).isEmpty();
+  }
+
+  @Test
+  void shouldLogWarnWhenBothSucceedWithDifferentNestedValues() {
+    final MappingResolver primary = (m, p) -> Either.right(msgPackOf("{\"a\":{\"b\":1}}"));
+    final MappingResolver comparison = (m, p) -> Either.right(msgPackOf("{\"a\":{\"b\":99}}"));
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+  }
+
+  @Test
+  void shouldNotLogWarnWhenDocumentsHaveSameContentButDifferentKeyOrder() {
+    // Tests the deep (order-insensitive) comparison path — same key-value pairs,
+    // different insertion order → different bytes but semantically equal
+    final MappingResolver primary = (m, p) -> Either.right(msgPackOf("{\"a\":1,\"b\":2}"));
+    final MappingResolver comparison = (m, p) -> Either.right(msgPackOf("{\"b\":2,\"a\":1}"));
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents()).isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.logging.RecordingAppender;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -205,5 +206,59 @@ final class ComparingMappingResolverTest {
 
     assertThat(result.isRight()).isTrue();
     assertThat(recorder.getAppendedEvents()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnOriginalPrimaryContentWhenComparisonOverwritesSharedBuffer() {
+    // Simulates CombinedMappingResolver returning a view into a shared write buffer.
+    // When the comparison resolver runs, it overwrites the shared buffer's backing bytes.
+    // The resolver must return the snapshot (clone taken before comparison), not the live view.
+    final var original = msgPackOf("{\"a\":1}");
+    final var different = msgPackOf("{\"a\":2}");
+
+    // Use a mutable UnsafeBuffer wrapping original's bytes
+    final var sharedView = new UnsafeBuffer(BufferUtil.cloneBuffer(original));
+
+    final MappingResolver primary = (m, p) -> Either.right(sharedView);
+    final MappingResolver comparison =
+        (m, p) -> {
+          // Overwrite the shared buffer's backing bytes in-place, as the FEEL engine does
+          sharedView.putBytes(0, BufferUtil.bufferAsArray(different), 0, different.capacity());
+          return Either.right(different);
+        };
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    // The returned buffer must contain the snapshot (original), not the overwritten bytes
+    MsgPackUtil.assertEquality(result.get(), "{'a':1}");
+    // Confirm sharedView was actually mutated, proving the snapshot was load-bearing
+    assertThat(BufferUtil.equals(sharedView, original)).isFalse();
+    // Divergence (original a:1 vs comparison a:2) should be logged
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+  }
+
+  @Test
+  void shouldReturnPrimaryResultAndLogWarnWhenComparisonThrows() {
+    final var buf = bufferOf("value");
+    final MappingResolver primary = (m, p) -> Either.right(buf);
+    final MappingResolver comparison =
+        (m, p) -> {
+          throw new RuntimeException("unexpected comparison failure");
+        };
+    final var resolver = new ComparingMappingResolver(primary, comparison);
+
+    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            e -> {
+              assertThat(e.getLevel()).isEqualTo(Level.WARN);
+              assertThat(e.getMessage().getFormattedMessage()).contains("threw unexpectedly");
+            });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -55,6 +55,7 @@ final class ComparingMappingResolverTest {
   void tearDown() {
     recorder.stop();
     log4jLogger.removeAppender(recorder);
+    log4jLogger.setLevel(null); // restore inherited level so other tests in the fork are unaffected
   }
 
   private static DirectBuffer bufferOf(final String s) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/MappingResolverComparisonTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.Arrays;
@@ -662,7 +663,7 @@ class MappingResolverComparisonTest {
     }
 
     private static ResolverResults resolveAt(
-        final List<ZeebeMapping> mappings, final ScopedExpressionProcessor processor) {
+        final List<ZeebeMapping> mappings, final MappingExpressionProcessor processor) {
       final var inputMappings =
           new VariableMappingTransformer().transformInputMappings(mappings, EXPRESSION_LANGUAGE);
       return new ResolverResults(
@@ -677,7 +678,7 @@ class MappingResolverComparisonTest {
      * {@code null} (absent) if the name appears in none.
      */
     @SafeVarargs
-    private static ScopedExpressionProcessor buildProcessor(final Map<String, Object>... scopes) {
+    private static MappingExpressionProcessor buildProcessor(final Map<String, Object>... scopes) {
       final List<Map<String, DirectBuffer>> encoded =
           Arrays.stream(scopes)
               .map(
@@ -702,11 +703,10 @@ class MappingResolverComparisonTest {
           };
       // scopeKey=-1 → ExpressionProcessor uses the context directly (no processScoped call),
       // which is correct: the in-memory context owns its own lookup and ignores the key
-      return new ScopedExpressionProcessor(
+      return new MappingExpressionProcessor(
           new ExpressionProcessor(EXPRESSION_LANGUAGE, context, DEFAULT_TIMEOUT)
               .withSecretReferenceContext(),
-          -1L,
-          "");
+          new MappingContext(BufferUtil.wrapString("test-element"), -1L, -1L, -1L, ""));
     }
 
     /** Asserts both resolvers gave the exact same result document. */


### PR DESCRIPTION
Stacked on #61375 (must merge first).

## Summary

- Adds `camunda.processing.engine.mappings.input-comparison-mode` config flag: when set, runs both the primary and a second resolver on every input-mapping activation and logs a WARN if results differ
- Adds `ComparingMappingResolver` — wraps two `MappingResolver` instances, snapshots the primary result before the comparison run to prevent shared-buffer corruption, uses order-insensitive MsgPack comparison
- Adds `MappingResolverComparisonTest` — integration-level test covering all divergence/equivalence cases
- Fixes silent buffer corruption: `CombinedMappingResolver` returns a view into a shared write buffer; the comparison pass overwrites it — resolver now returns the snapshot clone
- Renames `ScopedExpressionProcessor` → `MappingExpressionProcessor`; adds `MappingContext` carrying element identity for diagnostic logging
- Adds `toString` to `EngineMappings` (both fields) and `EngineCfg`

## Test plan

- [ ] Set `input-comparison-mode=ORDERED` with `input-mode=COMBINED` and verify WARN logs on divergent mappings
- [ ] Confirm no WARN when results match


relates to https://github.com/camunda/camunda/issues/60556