### PR TITLE
test: remove orphaned owner-combobox helpers and harden tenant assign-user wait

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -16,9 +16,7 @@ export class IdentityAuthorizationsPage {
   readonly createAuthorizationButton: Locator;
   readonly authorizationsList: Locator;
   readonly createAuthorizationModal: Locator;
-  readonly createAuthorizationOwnerComboBox: Locator;
   readonly createAuthorizationOwnerSearchInput: Locator;
-  readonly createAuthorizationOwnerOption: (name: string) => Locator;
   readonly createAuthorizationResourceIdField: Locator;
   readonly createAuthorizationAccessPermission: (name: string) => Locator;
   readonly accessPermissionCheckbox: (name: string) => Locator;
@@ -52,14 +50,8 @@ export class IdentityAuthorizationsPage {
     this.createAuthorizationModal = page.getByRole('dialog', {
       name: 'Create authorization',
     });
-    this.createAuthorizationOwnerComboBox =
-      this.createAuthorizationModal.getByPlaceholder('Select an owner');
     this.createAuthorizationOwnerSearchInput =
       this.createAuthorizationModal.getByPlaceholder('Search by owner ID');
-    this.createAuthorizationOwnerOption = (name) =>
-      this.createAuthorizationModal.getByRole('option', {
-        name,
-      });
     this.createAuthorizationResourceIdField =
       this.createAuthorizationModal.getByRole('textbox', {
         name: 'Resource ID',
@@ -118,13 +110,6 @@ export class IdentityAuthorizationsPage {
 
   async clickCreateAuthorizationButton() {
     await this.createAuthorizationButton.click();
-  }
-
-  async clickOwnerDropdown() {
-    await this.createAuthorizationOwnerComboBox.click();
-  }
-  async selectOwnerFromDropdown(name: string) {
-    await this.createAuthorizationOwnerOption(name).click();
   }
 
   async clickOwnerTypeDropdown() {
@@ -250,36 +235,15 @@ export class IdentityAuthorizationsPage {
   }
 
   async selectAuthorizationOwner(authorization: {ownerId: string}) {
-    if (await this.createAuthorizationOwnerSearchInput.isVisible()) {
-      await this.createAuthorizationOwnerSearchInput.fill(
-        authorization.ownerId,
-      );
-      // The owner search is debounced + server-driven; the menu item for a
-      // just-created user can take longer than 20s to surface under load.
-      const ownerOption = this.createAuthorizationModal
-        .locator('.cds--list-box__menu-item')
-        .filter({hasText: authorization.ownerId})
-        .first();
-      await expect(ownerOption).toBeVisible({timeout: 60000});
-      await ownerOption.click({timeout: 20000, force: true});
-      return;
-    }
-
-    await this.createAuthorizationOwnerComboBox.click();
-    try {
-      await this.createAuthorizationOwnerOption(authorization.ownerId).click({
-        timeout: 60000,
-        force: true,
-      });
-    } catch (error) {
-      // Fall back to free-typing the owner id for owners that are not a
-      // selectable option (e.g. a not-yet-persisted owner used only to reach a
-      // later validation step). Reloading here would close the modal, so keep
-      // the dialog open and type the value directly.
-      console.log('Error while selecting owner' + error);
-      await this.createAuthorizationOwnerComboBox.fill(authorization.ownerId);
-      await this.createAuthorizationOwnerComboBox.press('Tab');
-    }
+    await this.createAuthorizationOwnerSearchInput.fill(authorization.ownerId);
+    // The owner search is debounced + server-driven; the menu item for a
+    // just-created user can take longer than 20s to surface under load.
+    const ownerOption = this.createAuthorizationModal
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: authorization.ownerId})
+      .first();
+    await expect(ownerOption).toBeVisible({timeout: 60000});
+    await ownerOption.click({timeout: 20000, force: true});
   }
 
   async findAuthorizationInPaginatedList(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -176,7 +176,11 @@ export class IdentityTenantsPage {
     // The assign-user search filters users by `username` and renders the
     // username as the option title, so `user.id` drives both steps.
     await this.fillAssignUserSearch(user.id);
-    await this.assignUserOption(user.id).click();
+    // The assign-user search is debounced + server-driven, so the option can
+    // outlast the 10s default actionTimeout on a loaded cluster.
+    const userOption = this.assignUserOption(user.id);
+    await expect(userOption).toBeVisible({timeout: 60000});
+    await userOption.click();
     await this.confirmAssignmentButton.click();
     await expect(this.assignUserModal).toBeHidden();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -34,7 +34,7 @@ export class IdentityTenantsPage {
   readonly assignUserButton: Locator;
   readonly assignUserModal: Locator;
   readonly assignUserSearchbox: Locator;
-  readonly assignUserNameOption: (name: string) => Locator;
+  readonly assignUserOption: (username: string) => Locator;
   readonly confirmAssignmentButton: Locator;
   readonly openTenantDetails: (rowName: string) => Locator;
   readonly removeUserButton: (rowName?: string) => Locator;
@@ -122,9 +122,9 @@ export class IdentityTenantsPage {
     this.assignUserSearchbox = this.assignUserModal.getByRole('searchbox', {
       name: 'Search by username',
     });
-    this.assignUserNameOption = (name) =>
+    this.assignUserOption = (username) =>
       this.assignUserModal.locator('.cds--list-box__menu-item', {
-        hasText: name,
+        hasText: username,
       });
     this.confirmAssignmentButton = this.assignUserModal.getByRole('button', {
       name: 'Assign user',
@@ -166,18 +166,17 @@ export class IdentityTenantsPage {
     await this.tenantDescriptionField.fill(description);
   }
 
-  async fillAssignUserName(userName: string) {
-    await this.assignUserSearchbox.fill(userName);
+  async fillAssignUserSearch(username: string) {
+    await this.assignUserSearchbox.fill(username);
   }
 
-  async assignUserToTenant(user: {id: string; name: string}) {
+  async assignUserToTenant(user: {id: string}) {
     await this.assignUserButton.click();
     await expect(this.assignUserModal).toBeVisible();
-    // The assign-user search (#51442) filters users by `username` and lists the
-    // username as the option title; search and select by `id` (the username),
-    // not the display name.
-    await this.fillAssignUserName(user.id);
-    await this.assignUserNameOption(user.id).click();
+    // The assign-user search filters users by `username` and renders the
+    // username as the option title, so `user.id` drives both steps.
+    await this.fillAssignUserSearch(user.id);
+    await this.assignUserOption(user.id).click();
     await this.confirmAssignmentButton.click();
     await expect(this.assignUserModal).toBeHidden();
   }


### PR DESCRIPTION
## Description

Follow-up cleanup to #61339, which realigned the Identity owner/user pickers
with the entity-search UI. That PR is correct; this removes fallout it left
behind and closes one robustness gap it introduced asymmetrically.

**1. Remove the now-unreachable owner-combobox fallback.**
#61339 made `selectAuthorizationOwnerType` wait unconditionally for the
"Search by owner ID" input. That wait throws when the input is absent, so
`selectAuthorizationOwner` can only ever run with the search field already
visible — its `isVisible()` guard is always true and the combobox fallback
behind it is dead. The locators that fallback used still targeted the
"Select an owner" placeholder, which the product no longer renders, and
`clickOwnerDropdown` / `selectOwnerFromDropdown` had no callers at all.

Deleting it rather than keeping a guard that advertises a recovery path it
can no longer take. A future owner type that renders a plain `TextField` —
`CLIENT`, `USER` under OIDC, `GROUP` with Camunda groups disabled, all still
live branches in `owner-selection/index.tsx` — now fails on a named locator
instead of silently falling through to a widget that does not exist.

**2. Wait for the tenant assign-user option before clicking it.**
`assign a user` clicked the menu item with no explicit wait, so it got only
the 10s default `actionTimeout`. That item does not exist until
`DropdownSearch`'s debounce elapses and the v2 users search returns. This
mirrors the 60s guard `selectAuthorizationOwner` already applies to the same
Carbon widget — whose comment records that 20s was not enough under load.

**3. Narrow `assignUserToTenant` to what it reads.**
It stopped using `user.name` when it switched to searching by username, and
its helpers still said "name" while carrying a username — the exact
confusion #61339 exists to fix. Renamed to `fillAssignUserSearch` /
`assignUserOption`; both are file-private, no spec references them.

No spec files and no product code change. Net: 23 insertions, 56 deletions.

### Verification

Ran the four affected spec files locally against `scripts/start-verify-env.sh es v2`
on image revision `39642cae` (this branch's merge base):

```
26 passed, 1 skipped, 0 failed (4.0m)
```

All five tests #61339 targeted pass on first attempt, no retries:

- `authorizations.spec.ts:77` › tries to create an authorization with invalid id
- `tenants.spec.ts:89` › assign a user
- `groups.spec.ts:147` › create a group with particular permissions and assign it to Test user
- `authorizations.spec.ts:436` › grants SECRET READ and REVEAL to a role for a single secret reference
- `identity-users-flows.spec.ts:265` › New user can inherit permissions when assigned to a group

**Note on stale images:** a first local run failed all five tests against a
cached `camunda/camunda:SNAPSHOT` built at revision `937fce3c`, which predates
the entity-search-for-all-owner-types change and still renders the old
combobox. `start-verify-env.sh` runs `docker compose up -d` with no `pull`, so
it silently verifies against whatever image is cached locally. Worth fixing
separately; happy to open that as its own PR.

## Checklist

- [ ] Enable backports when necessary. **Not needed** — this depends on #61339,
  which is main-only; the stable branches still carry the pre-#61339 conditional,
  where the fallback is live and must stay.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite),
  the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml)
  before requesting review. [Here](https://github.com/camunda/camunda/actions/runs/33162094022). Failed tests will be handled separately, not changes related
## Related issues

No issue. Follow-up to #61339.
