### PR TITLE
test: increase timeout for aws aurora tests a little

### DIFF
--- a/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-aurora-dispatch-tests.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   integration-tests:
     name: "[IT] Camunda QA Integration Module. Aurora"
-    timeout-minutes: 60
+    timeout-minutes: 70
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
this is to deal with a slowdown that seems to have happened due to mitigations related to https://github.com/camunda/camunda/issues/61009
