### PR TITLE
docs: drop redundant existence-check ordering comment

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -123,11 +123,6 @@ public final class AgentInstanceCreateProcessor
       return;
     }
 
-    // Reject CREATE when an agent instance already exists for this element instance. The existence
-    // check runs before the active-state and element-type guards so that a late retry against an
-    // element instance that has since left ACTIVE (e.g. parked in COMPLETING behind an incident)
-    // gets ALREADY_EXISTS rather than INVALID_STATE. Both the stream rejection and the HTTP
-    // response are consistent: no success event is emitted.
     final var existingAgentInstanceKey = elementInstance.getAgentInstanceKey();
     if (existingAgentInstanceKey != -1L) {
       writeRejection(


### PR DESCRIPTION
## Description

Removes the prose comment above the existing-agent-instance check in `AgentInstanceCreateProcessor` that explained why the check runs before the active-state guard. The rationale (a retry against an element instance that left `ACTIVE`, e.g. parked in `ELEMENT_COMPLETING` behind an incident, should get `RejectionType.ALREADY_EXISTS` with the existing `agentInstanceKey` rather than a generic `RejectionType.INVALID_STATE`) is already enforced and locked in by `AgentInstanceCreateTest#shouldRejectDuplicateCreateWithAlreadyExistsEvenWhenElementInstanceLeftActive`, which I confirmed fails with `expected: ALREADY_EXISTS but was: INVALID_STATE` if the guard order is swapped. The comment was paraphrasing behavior the test already pins down, so it's dropped to remove the risk of the two drifting out of sync.

This follows the resolution of #53421 (Option B: `AgentInstance.CREATE` always rejects on existence, regardless of payload — implemented in #57956), which superseded #53418's request to invert this exact guard order.

**What it enables:** one less place (a comment) that can silently go stale relative to the behavior it describes; the test remains the single source of truth for the guard ordering.

**Out of scope:** any change to the CREATE guard ordering itself, the idempotency/conflict contract, or the REST API `409` response — all already settled in #53421/#57575/#57956. This is a comment-only change with no behavior change.

## Checklist

- Not applicable — comment-only change, no behavior, API, or schema change.

## Related issues

Related to #53418