### PR TITLE
fix: skip disabled partition groups when rebalancing

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -29913,7 +29913,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Outcome of each partition a rebalance attempted, within the selected range. TRANSFERRED is success; other results explain why leadership stayed put: CANCELLED means the operator stopped the rebalance first; LAG_TOO_HIGH and REPLICATION_TIMED_OUT point at the follower replication lag panel in the Raft row; NO_RESPONSE and NO_LEADER mean the leader, or the topology, never answered.",
+          "description": "Outcome of each partition a rebalance attempted, within the selected range. TRANSFERRED is success; other results explain why leadership stayed put: CANCELLED means the operator stopped the rebalance first; LAG_TOO_HIGH and REPLICATION_TIMED_OUT point at the follower replication lag panel in the Raft row; NO_RESPONSE and NO_LEADER mean the leader, or the topology, never answered; PHYSICAL_TENANT_DISABLED means the partition's physical tenant was disabled after the rebalance was planned.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -30261,7 +30261,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (clamp_min((zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED\"} - (zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED\"} offset $__rate_interval)) or zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED\"}, 0))",
+              "expr": "sum by (le) (clamp_min((zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"} - (zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"} offset $__rate_interval)) or zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"}, 0))",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -2166,6 +2166,7 @@ components:
             - NO_LEADER
             - NO_RESPONSE
             - CANCELLED
+            - PHYSICAL_TENANT_DISABLED
 
     ClusterCompletedRebalance:
       description: >-

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
@@ -147,6 +147,8 @@ final class ClusterRebalanceMapper {
       case NO_LEADER -> ClusterRebalanceOperationPartition.ResultEnum.NO_LEADER;
       case NO_RESPONSE -> ClusterRebalanceOperationPartition.ResultEnum.NO_RESPONSE;
       case CANCELLED -> ClusterRebalanceOperationPartition.ResultEnum.CANCELLED;
+      case PHYSICAL_TENANT_DISABLED ->
+          ClusterRebalanceOperationPartition.ResultEnum.PHYSICAL_TENANT_DISABLED;
     };
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
@@ -492,7 +492,9 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
         Arguments.of(PartitionRebalanceOutcome.LEADER_CHANGED, "LEADER_CHANGED"),
         Arguments.of(PartitionRebalanceOutcome.NO_LEADER, "NO_LEADER"),
         Arguments.of(PartitionRebalanceOutcome.NO_RESPONSE, "NO_RESPONSE"),
-        Arguments.of(PartitionRebalanceOutcome.CANCELLED, "CANCELLED"));
+        Arguments.of(PartitionRebalanceOutcome.CANCELLED, "CANCELLED"),
+        Arguments.of(
+            PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED, "PHYSICAL_TENANT_DISABLED"));
   }
 
   @ParameterizedTest

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalanceMetrics.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalanceMetrics.java
@@ -52,7 +52,7 @@ public final class PartitionBalanceMetrics implements ClusterConfigurationUpdate
     }
     configuration = updated;
     final Set<PartitionId> current =
-        updated.partitionGroups().entrySet().stream()
+        updated.activePartitionGroups().entrySet().stream()
             .flatMap(
                 entry ->
                     entry
@@ -87,7 +87,7 @@ public final class PartitionBalanceMetrics implements ClusterConfigurationUpdate
       return false;
     }
     final var group = known.partitionGroups().get(partition.group());
-    if (group == null) {
+    if (group == null || group.isDisabled()) {
       return false;
     }
     final var desiredLeader = group.getDesiredLeader(partition.number());

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
@@ -24,7 +24,7 @@ public final class PartitionBalancePlanner {
   }
 
   public List<PartitionRebalance> plan(final CurrentClusterConfiguration configuration) {
-    return configuration.partitionGroups().entrySet().stream()
+    return configuration.activePartitionGroups().entrySet().stream()
         .sorted(Map.Entry.comparingByKey())
         .flatMap(entry -> planGroup(entry.getKey(), entry.getValue()))
         .toList();

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcome.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcome.java
@@ -12,7 +12,8 @@ package io.camunda.zeebe.rebalance;
  *
  * <p>Mirrors {@link io.atomix.raft.LeadershipTransferResult} so that a partition's outcome
  * preserves exactly what the leader reported. The only additions are outcomes the rebalance
- * coordinator itself produces: {@link #NO_LEADER}, {@link #NO_RESPONSE} and {@link #CANCELLED}.
+ * coordinator itself produces: {@link #NO_LEADER}, {@link #NO_RESPONSE}, {@link #CANCELLED} and
+ * {@link #PHYSICAL_TENANT_DISABLED}.
  */
 public enum PartitionRebalanceOutcome {
   /** The desired leader was promoted and took over leadership. */
@@ -58,5 +59,7 @@ public enum PartitionRebalanceOutcome {
   /** The partition's leader could not be reached to ask for the transfer. */
   NO_RESPONSE,
   /** The rebalance was cancelled before this partition's transfer completed. */
-  CANCELLED
+  CANCELLED,
+  /** The partition's physical tenant was disabled after the rebalance was planned. */
+  PHYSICAL_TENANT_DISABLED
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -316,6 +316,8 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
       case NO_LEADER -> Rebalance.PartitionRebalance.Outcome.NO_LEADER;
       case NO_RESPONSE -> Rebalance.PartitionRebalance.Outcome.NO_RESPONSE;
       case CANCELLED -> Rebalance.PartitionRebalance.Outcome.CANCELLED;
+      case PHYSICAL_TENANT_DISABLED ->
+          Rebalance.PartitionRebalance.Outcome.PHYSICAL_TENANT_DISABLED;
     };
   }
 
@@ -341,6 +343,7 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
       case NO_LEADER -> PartitionRebalanceOutcome.NO_LEADER;
       case NO_RESPONSE -> PartitionRebalanceOutcome.NO_RESPONSE;
       case CANCELLED -> PartitionRebalanceOutcome.CANCELLED;
+      case PHYSICAL_TENANT_DISABLED -> PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED;
       case OUTCOME_UNSPECIFIED, UNRECOGNIZED ->
           throw new DecodingFailed(
               "Partition rebalance outcome is missing or unrecognized: " + outcome);

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -20,7 +20,9 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Nulls;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.LongSupplier;
 import org.jspecify.annotations.Nullable;
@@ -41,6 +43,13 @@ public final class RebalanceCoordinator
     implements RebalanceApi, ClusterConfigurationUpdateListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(RebalanceCoordinator.class);
+
+  private static final Set<PartitionRebalanceOutcome> SUCCESSFUL_PARTITION_OUTCOMES =
+      EnumSet.of(
+          PartitionRebalanceOutcome.TRANSFERRED,
+          PartitionRebalanceOutcome.ALREADY_LEADER,
+          PartitionRebalanceOutcome.CANCELLED,
+          PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED);
 
   private final MemberId localMemberId;
   private final ConcurrencyControl executor;
@@ -247,11 +256,7 @@ public final class RebalanceCoordinator
         rebalance.partitions().stream()
             .filter(partition -> partition.progress() == PartitionRebalanceProgress.COMPLETED)
             .map(PartitionRebalance::outcome)
-            .anyMatch(
-                outcome ->
-                    outcome != PartitionRebalanceOutcome.TRANSFERRED
-                        && outcome != PartitionRebalanceOutcome.ALREADY_LEADER
-                        && outcome != PartitionRebalanceOutcome.CANCELLED);
+            .anyMatch(outcome -> !SUCCESSFUL_PARTITION_OUTCOMES.contains(outcome));
     if (anyUnsuccessful) {
       return RebalanceOutcome.FAILED;
     }
@@ -276,6 +281,10 @@ public final class RebalanceCoordinator
       }
     }
     configuration = nowCoordinating ? clusterConfiguration : null;
+    final var inFlight = running;
+    if (inFlight != null) {
+      inFlight.observeConfiguration(clusterConfiguration);
+    }
   }
 
   private void discardState() {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 import org.jspecify.annotations.Nullable;
 
@@ -28,6 +30,8 @@ public final class RebalanceRun {
   private final CurrentClusterConfiguration configuration;
   private final Instant startedAt;
   private final List<PartitionRebalance> partitions = new ArrayList<>();
+
+  private final Set<String> disabledPhysicalTenants = new HashSet<>();
 
   private long partitionStartedAtNanos = System.nanoTime();
   private boolean cancelRequested;
@@ -106,6 +110,25 @@ public final class RebalanceRun {
   public void plan(final List<PartitionRebalance> planned) {
     partitions.clear();
     partitions.addAll(planned);
+  }
+
+  /**
+   * Notes which of the planned physical tenants {@code current} no longer runs, so that the runner
+   * can complete their partitions rather than wait out {@code leaderWaitTimeout} for a leader that
+   * will never appear.
+   */
+  public void observeConfiguration(final CurrentClusterConfiguration current) {
+    final var active = current.activePartitionGroups().keySet();
+    disabledPhysicalTenants.clear();
+    partitions.stream()
+        .map(PartitionRebalance::physicalTenantId)
+        .filter(physicalTenantId -> !active.contains(physicalTenantId))
+        .forEach(disabledPhysicalTenants::add);
+  }
+
+  /** Whether this physical tenant has stopped running since the rebalance was planned. */
+  public boolean isPhysicalTenantDisabled(final String physicalTenantId) {
+    return disabledPhysicalTenants.contains(physicalTenantId);
   }
 
   public PartitionRebalance partition(final int index) {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
  *     |                               |
  *     |                               v
  *     |                             COMPLETED(ALREADY_LEADER)  (already led by the desired leader)
+ *     |                             COMPLETED(PHYSICAL_TENANT_DISABLED)  (its physical tenant
+ *     |                                                                   stopped running)
  *     |
  *     | no current leader: wait for one to appear
  *     v
@@ -60,6 +62,8 @@ import org.slf4j.LoggerFactory;
  *     |                               |
  *     |                               v
  *     |                             COMPLETED(NO_LEADER)  (none appeared within leaderWaitTimeout)
+ *     |                             COMPLETED(PHYSICAL_TENANT_DISABLED)  (as above, observed
+ *     |                                                                   while waiting)
  *     |
  *     | one partition in flight at a time, in order
  *     v
@@ -69,6 +73,8 @@ import org.slf4j.LoggerFactory;
  *     |                              COMPLETED(<PartitionRebalanceOutcome>)
  *     |                              COMPLETED(NO_RESPONSE)  (no report, no topology move, watchdog
  *     |                                                       expired)
+ *     |                              COMPLETED(PHYSICAL_TENANT_DISABLED)  (as above, observed
+ *     |                                                                    mid-transfer)
  *     |
  *     | leader reports TRANSFERRED, or the topology confirms the desired leader first
  *     v
@@ -172,13 +178,31 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
 
   private void initiate(
       final RebalanceRun rebalance, final int index, final ActorFuture<Void> completion) {
-    final var partition = rebalance.partition(index);
-    final var leader = partition.currentLeader();
+    if (resolveIfPhysicalTenantDisabled(rebalance, index, completion)) {
+      return;
+    }
+    final var leader = rebalance.partition(index).currentLeader();
     if (leader == null) {
       waitForLeader(rebalance, index, Duration.ZERO, completion);
       return;
     }
     beginTransfer(rebalance, index, leader, completion);
+  }
+
+  private boolean resolveIfPhysicalTenantDisabled(
+      final RebalanceRun rebalance, final int index, final ActorFuture<Void> completion) {
+    final var partition = rebalance.partition(index);
+    if (!rebalance.isPhysicalTenantDisabled(partition.physicalTenantId())) {
+      return false;
+    }
+    LOG.info(
+        "Rebalance {} is leaving partition {} alone: its physical tenant has been disabled since "
+            + "the rebalance was planned",
+        rebalance.id(),
+        partition);
+    resolveWithOutcome(
+        rebalance, index, PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED, completion);
+    return true;
   }
 
   /**
@@ -214,6 +238,9 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
           }
           if (rebalance.isCancelRequested()) {
             transferFrom(rebalance, index, completion);
+            return;
+          }
+          if (resolveIfPhysicalTenantDisabled(rebalance, index, completion)) {
             return;
           }
           final var partition = rebalance.partition(index);
@@ -296,6 +323,9 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
         () -> {
           if (isOver(rebalance, completion)
               || rebalance.partition(index).progress() != PartitionRebalanceProgress.TRANSFERRING) {
+            return;
+          }
+          if (resolveIfPhysicalTenantDisabled(rebalance, index, completion)) {
             return;
           }
           final var partition = rebalance.partition(index);

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -115,6 +115,7 @@ message PartitionRebalance {
     NO_LEADER = 16;
     NO_RESPONSE = 17;
     CANCELLED = 18;
+    PHYSICAL_TENANT_DISABLED = 19;
   }
 
   // The partition group the partition belongs to; partition ids are unique only within a group.

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionBalanceMetricsTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionBalanceMetricsTest.java
@@ -12,8 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.HashMap;
@@ -110,6 +112,22 @@ final class PartitionBalanceMetricsTest {
         .isNull();
     assertThat(registry.find("zeebe.cluster.partition.balanced").tag("partition", "1").gauge())
         .isNotNull();
+  }
+
+  @Test
+  void shouldStopReportingOnThePartitionsOfADisabledPhysicalTenant() {
+    // given
+    leaders.put(1, MEMBER_2);
+    final var configuration =
+        CurrentClusterConfiguration.fromLegacy(configurationWithPriorities(Map.of(MEMBER_1, 1)));
+    metrics.onClusterConfigurationUpdated(configuration);
+
+    // when
+    metrics.onClusterConfigurationUpdated(
+        configuration.updatePartitionGroupConfig(GROUP, PartitionGroupConfiguration::disable));
+
+    // then
+    assertThat(registry.find("zeebe.cluster.partition.balanced").gauges()).isEmpty();
   }
 
   private double balanced(final int partitionId) {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcomeAlignmentTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcomeAlignmentTest.java
@@ -46,7 +46,8 @@ final class PartitionRebalanceOutcomeAlignmentTest {
 
     // then
     assertThat(additionalOutcomeNames)
-        .containsExactlyInAnyOrder("NO_LEADER", "NO_RESPONSE", "CANCELLED");
+        .containsExactlyInAnyOrder(
+            "NO_LEADER", "NO_RESPONSE", "CANCELLED", "PHYSICAL_TENANT_DISABLED");
   }
 
   private static Set<String> namesOf(final Class<? extends Enum<?>> enumType) {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
@@ -11,10 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationChangeInProgressException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
@@ -292,6 +294,39 @@ final class RebalanceCoordinatorTest {
         .isEqualTo(
             new RebalanceStatus.Completed(
                 100, RebalanceOutcome.FAILED, List.of(PLAN), FIXED_INSTANT, FIXED_INSTANT));
+  }
+
+  @Test
+  void shouldTellTheRunningRebalanceThatAPhysicalTenantStoppedRunning() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // when
+    configurationWithADisabledDefaultPhysicalTenant(coordinator);
+
+    // then
+    assertThat(
+            runner.rebalance.isPhysicalTenantDisabled(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isTrue();
+  }
+
+  @Test
+  void shouldReportARebalanceThatLeftADisabledPhysicalTenantAloneAsCompleted() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+    runner.rebalance.updatePartition(
+        0, partition -> partition.completed(PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED));
+
+    // when
+    runner.finish();
+
+    // then
+    assertThat(coordinator.getRebalanceStatus().join().lastCompleted().outcome())
+        .isEqualTo(RebalanceOutcome.COMPLETED);
   }
 
   @Test
@@ -594,6 +629,18 @@ final class RebalanceCoordinatorTest {
             ClusterConfiguration.init()
                 .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
                 .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()))));
+  }
+
+  private void configurationWithADisabledDefaultPhysicalTenant(
+      final RebalanceCoordinator coordinator) {
+    coordinator.onClusterConfigurationUpdated(
+        CurrentClusterConfiguration.fromLegacy(
+                ClusterConfiguration.init()
+                    .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
+                    .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of())))
+            .updatePartitionGroupConfig(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                PartitionGroupConfiguration::disable));
   }
 
   private void configurationWithAPendingChange(final RebalanceCoordinator coordinator) {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -645,6 +645,98 @@ final class SequentialRebalanceRunnerTest {
   }
 
   @Test
+  void shouldStopWaitingForALeaderOnceThePhysicalTenantIsDisabled() {
+    // given
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    final var completion = run(rebalance);
+
+    // when
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(GROUP, PartitionGroupConfiguration::disable));
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED);
+    assertThat(transfers.initiated).isEmpty();
+    assertThat(completion.isDone()).isTrue();
+  }
+
+  @Test
+  void shouldLeaveAlonePartitionsOfAPhysicalTenantDisabledBeforeTheRebalanceReachesThem() {
+    // given
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    leaders.computeIfAbsent("tenant-b", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+            Map.of(
+                "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2))),
+                "tenant-b",
+                    Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2)))));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    run(rebalance);
+
+    // when
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig("tenant-b", PartitionGroupConfiguration::disable));
+    transfers.accept();
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(rebalance.partition(1).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED);
+    assertThat(transfers.initiated)
+        .map(initiated -> initiated.physicalTenantId())
+        .containsExactly("tenant-a");
+  }
+
+  @Test
+  void shouldStopWatchingATransferOnceThePhysicalTenantIsDisabled() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    final var completion = run(rebalance);
+    transfers.accept();
+
+    // when
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(GROUP, PartitionGroupConfiguration::disable));
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED);
+    assertThat(completion.isDone()).isTrue();
+  }
+
+  @Test
+  void shouldRebalanceAPhysicalTenantThatIsEnabledAgainWhileTheRebalanceRuns() {
+    // given
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    run(rebalance);
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(GROUP, PartitionGroupConfiguration::disable));
+
+    // when
+    rebalance.observeConfiguration(configuration);
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.lastInitiated().leader()).isEqualTo(MEMBER_1);
+  }
+
+  @Test
   void shouldResolveImmediatelyWithNoLeaderWhenLeaderWaitTimeoutIsZero() {
     // given
     final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -177,6 +177,48 @@ final class SequentialRebalanceRunnerTest {
   }
 
   @Test
+  void shouldNotPlanThePartitionsOfADisabledPhysicalTenant() {
+    // given
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+                Map.of(
+                    "tenant-a",
+                        Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2))),
+                    "tenant-b",
+                        Map.of(MEMBER_1, Map.of(1, active(2)), MEMBER_2, Map.of(1, active(1)))))
+            .updatePartitionGroupConfig("tenant-b", PartitionGroupConfiguration::disable);
+
+    // when
+    final var rebalance = planDryRun(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .containsExactly(PartitionRebalance.pending("tenant-a", 1, MEMBER_1, MEMBER_2));
+  }
+
+  @Test
+  void shouldNotLookUpTheTopologyOfADisabledPhysicalTenant() {
+    // given
+    unavailableGroups.add("tenant-b");
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+                Map.of(
+                    "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1))),
+                    "tenant-b", Map.of(MEMBER_1, Map.of(1, active(1)))))
+            .updatePartitionGroupConfig("tenant-b", PartitionGroupConfiguration::disable);
+
+    // when
+    final var rebalance = planDryRun(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .map(PartitionRebalance::physicalTenantId)
+        .containsExactly("tenant-a");
+  }
+
+  @Test
   void shouldPlanATransferWithNoOutcomeYet() {
     // given / when
     final var rebalance = planDryRun(groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2)));


### PR DESCRIPTION
Disabled partition groups are still visible in the cluster configuration, but the partitions aren't actually run on any brokers. Rebalances weren't aware of this, so they'd:
1) treat them as unbalanced
2) wait up to `leaderWaitTimeout` for a leader to appear for each partition
3) after timing out, report `NO_LEADER` for the partition

This wouldn't cause any other partitions to fail balancing or leave any partition in an invalid state, but it would slow down rebalances and report misleading status to the operator.

I've now added handling so that disabled partition groups won't appear in the balance status, won't be planned for rebalancing, and will skip past leader-wait if they become disabled after the rebalance starts. This includes a new `PHYSICAL_TENANT_DISABLED` outcome code for partitions that do get planned and later skipped for this reason.

Closes #61358.