### PR TITLE
Serve the default physical-tenant alias from the cluster chain when no tenants are configured

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -7,11 +7,17 @@
  */
 package io.camunda.authentication.config.spi;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
+
+import io.camunda.authentication.pt.PhysicalTenantScopeProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.core.env.Environment;
 
 /**
@@ -21,8 +27,14 @@ import org.springframework.core.env.Environment;
  *
  * <p>Construct only via {@link #fromEnvironment(Environment)}, so {@link #webappPaths()} always
  * reports the gate as configuration resolves it rather than as a caller asserts it.
+ *
+ * <p>With no physical tenant configured, the API and webapp sets also carry {@code
+ * /physical-tenants/default}-prefixed variants so the cluster chain serves the alias.
  */
 public final class SecurityPathAdapter implements SecurityPathPort {
+
+  private static final String DEFAULT_ALIAS_PREFIX =
+      PHYSICAL_TENANTS_PATH_SEGMENT + DEFAULT_PHYSICAL_TENANT_ID;
 
   private static final Set<String> WEBAPP_PATHS =
       Set.of(
@@ -87,9 +99,11 @@ public final class SecurityPathAdapter implements SecurityPathPort {
           "/admin/assets");
 
   private final boolean webappEnabled;
+  private final boolean serveDefaultAlias;
 
-  private SecurityPathAdapter(final boolean webappEnabled) {
+  private SecurityPathAdapter(final boolean webappEnabled, final boolean serveDefaultAlias) {
     this.webappEnabled = webappEnabled;
+    this.serveDefaultAlias = serveDefaultAlias;
   }
 
   /**
@@ -107,17 +121,29 @@ public final class SecurityPathAdapter implements SecurityPathPort {
         environment.getProperty(
             CamundaSecurityFilterChainConstants.WEBAPP_ENABLED_PROPERTY,
             Boolean.class,
-            AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED));
+            AuthenticationConfiguration.DEFAULT_WEBAPP_ENABLED),
+        !PhysicalTenantScopeProvider.hasConfiguredPhysicalTenants(environment));
+  }
+
+  /**
+   * Adds {@code /physical-tenants/default}-prefixed copies when no physical tenant is configured.
+   */
+  private Set<String> withDefaultAlias(final Set<String> paths) {
+    if (!serveDefaultAlias) {
+      return paths;
+    }
+    return Stream.concat(paths.stream(), paths.stream().map(p -> DEFAULT_ALIAS_PREFIX + p))
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   @Override
   public Set<String> apiPaths() {
-    return SecurityPaths.API_PATHS;
+    return withDefaultAlias(SecurityPaths.API_PATHS);
   }
 
   @Override
   public Set<String> unprotectedApiPaths() {
-    return SecurityPaths.UNPROTECTED_API_PATHS;
+    return withDefaultAlias(SecurityPaths.UNPROTECTED_API_PATHS);
   }
 
   @Override
@@ -132,7 +158,7 @@ public final class SecurityPathAdapter implements SecurityPathPort {
    */
   @Override
   public Set<String> webappPaths() {
-    return webappEnabled ? WEBAPP_PATHS : Set.of();
+    return webappEnabled ? withDefaultAlias(WEBAPP_PATHS) : Set.of();
   }
 
   @Override
@@ -142,7 +168,7 @@ public final class SecurityPathAdapter implements SecurityPathPort {
 
   @Override
   public Set<String> unauthenticatedWebappPaths() {
-    return UNAUTHENTICATED_WEBAPP_PATHS;
+    return withDefaultAlias(UNAUTHENTICATED_WEBAPP_PATHS);
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
@@ -16,13 +16,9 @@ import java.util.Set;
  */
 public final class SecurityPaths {
 
-  // Tenant-prefixed paths (/physical-tenants/<id>/...) are deliberately NOT listed here. They are
-  // owned exclusively by the per-tenant scoped security chains that PhysicalTenantScopeProvider
-  // contributes (CSL derives each scope's matcher as basePath + these apiPaths, e.g.
-  // /physical-tenants/<id>/v2/**). The cluster chain and a scoped chain share ORDER_API, so
-  // listing the tenant prefix here would let the cluster chain also match a tenant request and, if
-  // it wins the same-order tie-break, validate the token against the cluster's providers instead of
-  // the tenant's — breaking per-tenant audience isolation. Keep this list cluster-only.
+  // Cluster paths only — never add a tenant prefix here. SecurityPathAdapter adds the
+  // /physical-tenants/default versions instead, and only when no physical tenant is configured, so
+  // the alias is served by one mechanism, never both.
   public static final Set<String> API_PATHS =
       Set.of("/api/**", "/v1/**", "/v2/**", "/mcp/**", "/.well-known/oauth-protected-resource/**");
 

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantScopeProvider.java
@@ -24,7 +24,7 @@ import org.springframework.core.env.Environment;
 /**
  * {@link CamundaSecurityScopeProvider} that emits one {@link ScopedSecurityDescriptor} per
  * explicitly configured physical tenant, plus an alias descriptor for the implicit {@code default}
- * tenant, which is always emitted.
+ * tenant — or nothing at all when no physical tenant is configured.
  *
  * <p>Each descriptor carries:
  *
@@ -38,10 +38,15 @@ import org.springframework.core.env.Environment;
  *       one.
  * </ul>
  *
- * <p><b>Default alias:</b> a descriptor for the implicit {@code default} tenant is always emitted
- * at {@code /physical-tenants/default}, built from {@code forPhysicalTenant("default")}, so the
- * root tenant is addressable both unprefixed ({@code /v2/...}) and through the alias, and the
- * descriptor list is never empty.
+ * <p><b>Default alias:</b> when at least one physical tenant is configured, a descriptor for the
+ * implicit {@code default} tenant is emitted at {@code /physical-tenants/default}, built from
+ * {@code forPhysicalTenant("default")}, so the root tenant is addressable both unprefixed ({@code
+ * /v2/...}) and through the alias.
+ *
+ * <p>With none configured this provider emits nothing and the cluster chain serves the alias paths
+ * from its own {@code /physical-tenants/default}-prefixed path sets. CSL builds two chains per
+ * descriptor, each resolving its own {@code ClientRegistration} through a blocking discovery call,
+ * so emitting no descriptor saves two such calls per provider at startup.
  */
 public final class PhysicalTenantScopeProvider implements CamundaSecurityScopeProvider {
 
@@ -62,13 +67,12 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
 
   /**
    * Whether any physical tenant is configured (any key under {@code
-   * camunda.physical-tenants.<id>.*} with a valid id). When {@code true}, the cluster {@code /v2}
-   * chain must be unified with the default tenant's resolved config (see {@code
-   * PhysicalTenantSecurityConfiguration}), which is the only thing this gates.
+   * camunda.physical-tenants.<id>.*} with a valid id).
    *
-   * <p>It does <em>not</em> gate the {@code /physical-tenants/default} alias, which is always
-   * emitted. With no {@code camunda.physical-tenants.*} keys the overlay bind is a no-op, so the
-   * alias and the cluster chain resolve to equivalent config without the unification step.
+   * <p>Two things depend on this and must agree: whether the cluster {@code /v2} chain uses the
+   * default tenant's config (see {@code PhysicalTenantSecurityConfiguration}), and whether scoped
+   * descriptors are emitted. Always call this instead of checking the config yourself — if the two
+   * ever disagreed, a scoped chain would prefix a path that already has the prefix.
    */
   public static boolean hasConfiguredPhysicalTenants(final Environment environment) {
     return !discoverExplicitTenantIds(environment).isEmpty();
@@ -84,13 +88,19 @@ public final class PhysicalTenantScopeProvider implements CamundaSecurityScopePr
   }
 
   /**
-   * Every explicitly configured tenant, plus {@code default} — added unconditionally, so never
-   * empty. The add is idempotent when {@code default} is also configured explicitly, and always
+   * Every explicitly configured tenant, plus the {@code default} alias — or an empty set when no
+   * tenant is configured, which is a supported outcome: CSL registers no scoped chains and the
+   * cluster chain serves the alias paths itself.
+   *
+   * <p>The alias add is idempotent when {@code default} is also configured explicitly, and always
    * buildable, because a cluster serving the unprefixed {@code /v2} surface necessarily configures
    * its root provider.
    */
   private Set<String> descriptorTenantIds() {
     final Set<String> tenantIds = discoverExplicitTenantIds(environment);
+    if (tenantIds.isEmpty()) {
+      return tenantIds;
+    }
     tenantIds.add(DEFAULT_PHYSICAL_TENANT_ID);
     return tenantIds;
   }

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -14,23 +14,47 @@ import org.springframework.mock.env.MockEnvironment;
 
 class SecurityPathAdapterTest {
 
-  // No webapp-enabled property set, so the adapter resolves CSL's default (enabled) and the
-  // webappPaths() assertion below pins the enabled set.
-  private final SecurityPathAdapter port =
+  private static final String DEFAULT_TENANT_PREFIX = "/physical-tenants/default";
+
+  // Neither sets webapp-enabled, so both get CSL's default (enabled). The only difference is
+  // whether a physical tenant is configured — the gate on the prefixed paths.
+  private final SecurityPathAdapter defaultTenantPort =
       SecurityPathAdapter.fromEnvironment(new MockEnvironment());
 
+  private final SecurityPathAdapter clusterOnlyPort =
+      SecurityPathAdapter.fromEnvironment(
+          new MockEnvironment()
+              .withProperty(
+                  "camunda.physical-tenants.tenanta.security.authentication.method", "oidc"));
+
   @Test
-  void shouldExposeApiPaths() {
-    // Tenant-prefixed paths are intentionally absent — per-tenant scoped chains own them; listing
-    // them here would let the cluster chain shadow a scoped chain and break audience isolation.
-    assertThat(port.apiPaths())
+  void shouldExposeApiPathsWithoutDefaultTenantPrefixWhenTenantConfigured() {
+    // A scoped chain owns /physical-tenants/<id>/**, deriving its matchers as basePath + these.
+    assertThat(clusterOnlyPort.apiPaths())
         .containsExactlyInAnyOrder(
             "/api/**", "/v1/**", "/v2/**", "/mcp/**", "/.well-known/oauth-protected-resource/**");
   }
 
   @Test
-  void shouldExposeUnprotectedApiPaths() {
-    assertThat(port.unprotectedApiPaths())
+  void shouldAddDefaultTenantPrefixToApiPathsWhenNoTenantConfigured() {
+    // No scoped chain exists to serve /physical-tenants/default, so the cluster chain carries it.
+    assertThat(defaultTenantPort.apiPaths())
+        .containsExactlyInAnyOrder(
+            "/api/**",
+            "/v1/**",
+            "/v2/**",
+            "/mcp/**",
+            "/.well-known/oauth-protected-resource/**",
+            DEFAULT_TENANT_PREFIX + "/api/**",
+            DEFAULT_TENANT_PREFIX + "/v1/**",
+            DEFAULT_TENANT_PREFIX + "/v2/**",
+            DEFAULT_TENANT_PREFIX + "/mcp/**",
+            DEFAULT_TENANT_PREFIX + "/.well-known/oauth-protected-resource/**");
+  }
+
+  @Test
+  void shouldExposeUnprotectedApiPathsWithoutDefaultTenantPrefixWhenTenantConfigured() {
+    assertThat(clusterOnlyPort.unprotectedApiPaths())
         .containsExactlyInAnyOrder(
             "/v2/license",
             "/v2/setup/user",
@@ -40,12 +64,30 @@ class SecurityPathAdapterTest {
   }
 
   @Test
+  void shouldAddDefaultTenantPrefixToUnprotectedApiPathsWhenNoTenantConfigured() {
+    // Parity for the prefixed unprotected surface: /physical-tenants/default/v2/status must be
+    // reachable unauthenticated exactly as /v2/status is, which PhysicalTenantStatusScopeFilter
+    // deliberately admits for the default tenant.
+    assertThat(defaultTenantPort.unprotectedApiPaths())
+        .containsExactlyInAnyOrder(
+            "/v2/license",
+            "/v2/setup/user",
+            "/v2/status",
+            "/v1/external/process/**",
+            "/.well-known/oauth-protected-resource/**",
+            DEFAULT_TENANT_PREFIX + "/v2/license",
+            DEFAULT_TENANT_PREFIX + "/v2/setup/user",
+            DEFAULT_TENANT_PREFIX + "/v2/status",
+            DEFAULT_TENANT_PREFIX + "/v1/external/process/**",
+            DEFAULT_TENANT_PREFIX + "/.well-known/oauth-protected-resource/**");
+  }
+
+  @Test
   void shouldExposeUnprotectedPaths() {
     // /cluster/v2/status is here rather than in unprotectedApiPaths() on purpose: it must be served
     // by a chain with no authentication filter, so a credential the cluster-admin chain would
-    // reject
-    // is ignored instead of turning a health check into a 401.
-    assertThat(port.unprotectedPaths())
+    // reject is ignored instead of turning a health check into a 401.
+    assertThat(defaultTenantPort.unprotectedPaths())
         .containsExactlyInAnyOrder(
             "/error",
             "/actuator/**",
@@ -57,8 +99,8 @@ class SecurityPathAdapterTest {
   }
 
   @Test
-  void shouldExposeWebappPaths() {
-    assertThat(port.webappPaths())
+  void shouldExposeWebappPathsWithoutDefaultTenantPrefixWhenTenantConfigured() {
+    assertThat(clusterOnlyPort.webappPaths())
         .containsExactlyInAnyOrder(
             "/login/**",
             "/logout",
@@ -88,13 +130,41 @@ class SecurityPathAdapterTest {
   }
 
   @Test
-  void shouldExposeWebComponentNames() {
-    assertThat(port.webComponentNames()).containsExactlyInAnyOrder("admin", "operate", "tasklist");
+  void shouldAddDefaultTenantPrefixToEveryWebappPathWhenNoTenantConfigured() {
+    final var base = clusterOnlyPort.webappPaths();
+
+    assertThat(defaultTenantPort.webappPaths())
+        .hasSize(base.size() * 2)
+        .containsAll(base)
+        .contains(
+            DEFAULT_TENANT_PREFIX + "/login/**",
+            DEFAULT_TENANT_PREFIX + "/operate/**",
+            DEFAULT_TENANT_PREFIX + "/v3/api-docs/**");
   }
 
   @Test
-  void shouldExposeUnauthenticatedWebappPaths() {
-    assertThat(port.unauthenticatedWebappPaths())
+  void shouldPrefixWebappRootToATrailingSlashPattern() {
+    // "/" prefixes to /physical-tenants/default/ — matching that root only WITH a trailing
+    // slash, never without. Mirrors what CSL's scoped webapp chain already produces, so this pins
+    // existing behaviour rather than new. The matching consequence is characterised at chain level.
+    assertThat(defaultTenantPort.webappPaths()).contains(DEFAULT_TENANT_PREFIX + "/");
+  }
+
+  @Test
+  void shouldPrefixRegexWebappPattern() {
+    // Regex patterns survive prefixing; only "/" is special.
+    assertThat(defaultTenantPort.webappPaths()).contains(DEFAULT_TENANT_PREFIX + "/{regex:[\\d]+}");
+  }
+
+  @Test
+  void shouldExposeWebComponentNames() {
+    assertThat(defaultTenantPort.webComponentNames())
+        .containsExactlyInAnyOrder("admin", "operate", "tasklist");
+  }
+
+  @Test
+  void shouldExposeUnauthenticatedWebappPathsWithoutDefaultTenantPrefixWhenTenantConfigured() {
+    assertThat(clusterOnlyPort.unauthenticatedWebappPaths())
         .containsExactlyInAnyOrder(
             "/post-logout",
             "/default-ui.css",
@@ -113,15 +183,27 @@ class SecurityPathAdapterTest {
   }
 
   @Test
+  void shouldAddDefaultTenantPrefixToEveryUnauthenticatedWebappPathWhenNoTenantConfigured() {
+    final var base = clusterOnlyPort.unauthenticatedWebappPaths();
+
+    assertThat(defaultTenantPort.unauthenticatedWebappPaths())
+        .hasSize(base.size() * 2)
+        .containsAll(base)
+        .contains(DEFAULT_TENANT_PREFIX + "/assets/**", DEFAULT_TENANT_PREFIX + "/post-logout");
+  }
+
+  @Test
   void shouldExposeAdminFilterBypassPaths() {
-    assertThat(port.adminFilterBypassPaths())
+    assertThat(defaultTenantPort.adminFilterBypassPaths())
         .containsExactlyInAnyOrder(
             "/login", "/logout", "/sso-callback", "/post-logout", "/admin/setup", "/admin/assets");
   }
 
   @Test
-  void shouldReportNoWebappPathsWhenWebappDisabled() {
+  void shouldReportNoWebappPathsWhenWebappDisabledEvenWithoutPhysicalTenants() {
     // given
+    // No physical tenant configured, so the prefixed variants would otherwise apply — the
+    // webapp gate must win over them.
     final var environment =
         new MockEnvironment()
             .withProperty("camunda.security.authentication.webapp-enabled", "false");

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAliasCoverageIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAliasCoverageIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.security.spring.CamundaSecurityConfiguration;
+import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
+import io.camunda.security.spring.scope.ScopedSecurityChainConfiguration;
+import io.camunda.security.spring.security.BaseSecurityConfiguration;
+import io.camunda.security.spring.security.BasicAuthApiSecurityConfiguration;
+import io.camunda.security.spring.security.BasicAuthWebappSecurityConfiguration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Checks that the {@code default} physical-tenant alias is served in both cluster shapes — by a
+ * scoped chain when tenants are configured, by the cluster chain's prefixed paths when none are —
+ * and that neither mechanism reaches further than it should.
+ *
+ * <p>BASIC mode throughout: these tests only ask which chain matches a path, never whether a token
+ * is valid, so no IdP is needed and no OIDC discovery happens.
+ */
+class PhysicalTenantAliasCoverageIT {
+
+  // Matches "/**" by design, so it would claim every path asked about here. Without excluding it
+  // from chainsClaiming(), every assertion below would pass vacuously.
+  private static final String CATCH_ALL_CHAIN = "protectedUnhandledPathsSecurityFilterChain";
+
+  private static final String TENANT_A =
+      "camunda.physical-tenants.tenanta.security.authentication.method=basic";
+
+  static Stream<Arguments> bothClusterShapes() {
+    return Stream.of(
+        Arguments.of("no physical tenants", new String[] {}),
+        Arguments.of("one physical tenant", new String[] {TENANT_A}));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothClusterShapes")
+  void shouldClaimDefaultAliasInBothClusterShapes(final String shape, final String[] properties) {
+    runnerWith(properties)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(chainsClaiming(ctx, "/physical-tenants/default/v2/topology"))
+                  .as("some chain must claim the default alias, whichever mechanism serves it")
+                  .isNotEmpty();
+            });
+  }
+
+  @Test
+  void shouldBuildNoScopedChainsWhenNoPhysicalTenantsConfigured() {
+    // The observable effect of the descriptor gate: with nothing emitted, CSL registers no scoped
+    // chains at all. That is what avoids building a second pair of chains per provider on an OIDC
+    // cluster, though this BASIC-mode context cannot see the discovery calls themselves.
+    runnerWith()
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(ctx.getBeanNamesForType(SecurityFilterChain.class))
+                  .noneMatch(name -> name.startsWith("scoped"));
+            });
+  }
+
+  @Test
+  void shouldClaimNoPathCarryingTheDefaultTenantPrefixTwice() {
+    // A scoped chain prefixes the host's paths with its own base path, so exposing the prefixed
+    // variants while descriptors exist would prefix them twice.
+    runnerWith(TENANT_A)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(
+                      chainsClaiming(
+                          ctx, "/physical-tenants/tenanta/physical-tenants/default/v2/topology"))
+                  .isEmpty();
+            });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothClusterShapes")
+  void shouldClaimNoPathForAnUnconfiguredTenant(final String shape, final String[] properties) {
+    // An unknown tenant must fall through to the catch-all in both shapes. This is what stops the
+    // prefixed cluster paths from answering for every tenant id — they carry the literal "default",
+    // never a wildcard.
+    runnerWith(properties)
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(chainsClaiming(ctx, "/physical-tenants/unconfigured/v2/topology"))
+                  .isEmpty();
+            });
+  }
+
+  @Test
+  void shouldClaimAliasRootOnlyWithTrailingSlash() {
+    // Pre-existing: CSL's scoped webapp chain already derives "/" as basePath + "/", so the
+    // prefixed cluster sets inherit it.
+    runnerWith()
+        .run(
+            ctx -> {
+              assertThat(ctx).hasNotFailed();
+              assertThat(chainsClaiming(ctx, "/physical-tenants/default/")).isNotEmpty();
+              assertThat(chainsClaiming(ctx, "/physical-tenants/default")).isEmpty();
+            });
+  }
+
+  /**
+   * Names of the chains claiming {@code path}, excluding CSL's match-everything catch-all. Returned
+   * as names rather than a boolean so a failure reports which chains matched.
+   */
+  private static List<String> chainsClaiming(
+      final AssertableWebApplicationContext ctx, final String path) {
+    final var request = new MockHttpServletRequest("GET", path);
+    return Arrays.stream(ctx.getBeanNamesForType(SecurityFilterChain.class))
+        .filter(name -> !CATCH_ALL_CHAIN.equals(name))
+        .filter(name -> ctx.getBean(name, SecurityFilterChain.class).matches(request))
+        .toList();
+  }
+
+  private WebApplicationContextRunner runnerWith(final String... properties) {
+    return new WebApplicationContextRunner()
+        .withUserConfiguration(TestBeansConfig.class, OcPathsConfig.class)
+        .withConfiguration(
+            AutoConfigurations.of(
+                CamundaSecurityConfiguration.class,
+                BaseSecurityConfiguration.class,
+                BasicAuthApiSecurityConfiguration.class,
+                BasicAuthWebappSecurityConfiguration.class,
+                ScopedSecurityChainConfiguration.class,
+                AuthFailureHandlerConfiguration.class,
+                PhysicalTenantSecurityConfiguration.class))
+        .withPropertyValues("camunda.security.authentication.method=basic")
+        .withPropertyValues(properties);
+  }
+
+  // Deliberately not @Configuration. Spring component-scans an annotated inner class in this
+  // package into other tests' contexts, where a stray UserDetailsService backs CSL's own
+  // basic-auth beans off.
+  static class TestBeansConfig {
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+
+    @Bean
+    UserDetailsService userDetailsService() {
+      return new InMemoryUserDetailsManager();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+      return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantDefaultAliasChainIT.java
@@ -12,7 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityConfiguration;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
 import io.camunda.security.spring.oidc.JWSKeySelectorFactory;
 import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
@@ -22,12 +24,16 @@ import io.camunda.security.spring.oidc.TokenValidatorFactory;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilder;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilderConfiguration;
 import io.camunda.security.spring.security.BaseSecurityConfiguration;
+import io.camunda.security.spring.security.DefaultWebSessionFilterConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
@@ -40,20 +46,37 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.session.web.http.SessionRepositoryFilter;
 
 /**
- * Integration test for the implicit {@code default} physical-tenant alias on a cluster with
- * <b>no</b> {@code camunda.physical-tenants.*} entries configured.
+ * Integration test for the reachability of the implicit {@code default} physical-tenant alias, in
+ * both cluster shapes: served by the cluster API chain's prefixed path sets when no {@code
+ * camunda.physical-tenants.*} entries exist, and by its own scoped chain when they do.
+ *
+ * <p>Asserts a real bearer token is <em>accepted</em>, not merely that some chain claims the path —
+ * {@link PhysicalTenantAliasCoverageIT} covers claiming, and a chain can claim a path and then
+ * answer 401.
  *
  * <p>Distinct from {@link PhysicalTenantApiChainIsolationIT}, which covers isolation
  * <em>between</em> explicitly configured tenants and therefore runs with an empty root OIDC config.
- * Here the root config is the only config there is, and the subject under test is whether {@code
+ * Here the root config always carries the provider, and the subject under test is whether {@code
  * /physical-tenants/default} is reachable at all.
  */
 class PhysicalTenantDefaultAliasChainIT {
 
   /** basePath + the host's apiPaths() = /physical-tenants/default/v2/** */
   private static final String DEFAULT_ALIAS_PATH = "/physical-tenants/default/v2/resource";
+
+  // At least one key under camunda.physical-tenants.<id>.* so the tenant is discovered, which is
+  // what makes the provider emit descriptors — the default alias among them.
+  private static final String PHYSICAL_TENANT =
+      "camunda.physical-tenants.tenanta.security.authentication.method=oidc";
+
+  static Stream<Arguments> bothClusterShapes() {
+    return Stream.of(
+        Arguments.of("no physical tenants", new String[] {}),
+        Arguments.of("one physical tenant", new String[] {PHYSICAL_TENANT}));
+  }
 
   private static JwksTestServer rootServer;
 
@@ -69,13 +92,18 @@ class PhysicalTenantDefaultAliasChainIT {
     }
   }
 
-  @Test
-  void defaultAliasShouldAcceptRootIssuerTokenWhenNoPhysicalTenantsConfigured() {
-    buildRunner()
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothClusterShapes")
+  void shouldAcceptRootIssuerTokenOnDefaultAlias(
+      final String shape, final String[] shapeProperties) {
+    // Whichever mechanism serves the alias, a root-issuer bearer token must authenticate. That is
+    // the behaviour this alias exists for: the mechanism differs per shape, the outcome must not.
+    final var properties = propertiesFor(shapeProperties);
+    buildRunner(properties)
         .run(
             ctx -> {
-              // given — a cluster with a root OIDC provider and no physical tenants
-              final var proxy = new FilterChainProxy(buildChains(ctx, rootOnlyEnv()));
+              // given — a cluster with a root OIDC provider
+              final var proxy = new FilterChainProxy(buildChains(ctx, envWith(properties)));
               final var request = new MockHttpServletRequest("GET", DEFAULT_ALIAS_PATH);
               request.addHeader(
                   "Authorization",
@@ -102,15 +130,17 @@ class PhysicalTenantDefaultAliasChainIT {
             });
   }
 
-  @Test
-  void unknownPhysicalTenantShouldReturn404WhenNoPhysicalTenantsConfigured() {
-    // The default alias is the only scoped chain on this cluster; an unrelated tenant id must still
-    // fall through to the catch-all rather than matching it.
-    buildRunner()
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothClusterShapes")
+  void shouldReturn404ForUnknownPhysicalTenant(final String shape, final String[] shapeProperties) {
+    // The prefixed cluster paths carry the literal "default", never a wildcard — so an unrelated
+    // tenant id still falls through to the catch-all in both shapes.
+    final var properties = propertiesFor(shapeProperties);
+    buildRunner(properties)
         .run(
             ctx -> {
               // given
-              final var proxy = new FilterChainProxy(buildChains(ctx, rootOnlyEnv()));
+              final var proxy = new FilterChainProxy(buildChains(ctx, envWith(properties)));
               final var request =
                   new MockHttpServletRequest("GET", "/physical-tenants/nonexistent/v2/resource");
               final var response = new MockHttpServletResponse();
@@ -130,11 +160,12 @@ class PhysicalTenantDefaultAliasChainIT {
   // =========================================================================
 
   /**
-   * The method is set here <em>and</em> on the {@link MockEnvironment} in {@link #rootOnlyEnv()} on
-   * purpose: this one configures CSL's properties bean in the context, that one is what the scope
-   * provider reads. They are two separate consumers, not a duplicated setting.
+   * The same property array feeds this context and the {@link MockEnvironment} in {@link #envWith}.
+   * They are two separate consumers — CSL's properties bean and the {@link SecurityPathPort} read
+   * the context, the scope provider reads the environment — and for the PT-configured shape both
+   * must agree, or the port would prefix paths a scoped chain already owns.
    */
-  private WebApplicationContextRunner buildRunner() {
+  private WebApplicationContextRunner buildRunner(final String... properties) {
     return new WebApplicationContextRunner()
         .withUserConfiguration(ObjectMapperConfig.class, OcPathsConfig.class)
         .withConfiguration(
@@ -142,8 +173,24 @@ class PhysicalTenantDefaultAliasChainIT {
                 CamundaSecurityConfiguration.class,
                 BaseSecurityConfiguration.class,
                 ScopedApiSecurityChainBuilderConfiguration.class,
+                DefaultWebSessionFilterConfiguration.class,
                 AuthFailureHandlerConfiguration.class))
-        .withPropertyValues("camunda.security.authentication.method=oidc");
+        .withPropertyValues(properties);
+  }
+
+  /** Root OIDC config plus the shape's extra keys. */
+  private String[] propertiesFor(final String... shapeProperties) {
+    return Stream.concat(
+            Stream.of(
+                "camunda.security.authentication.method=oidc",
+                "camunda.security.authentication.oidc.client-id=root-client",
+                "camunda.security.authentication.oidc.issuer-uri=" + rootServer.issuerUri(),
+                "camunda.security.authentication.oidc.jwk-set-uri="
+                    + rootServer.issuerUri()
+                    + "/jwks",
+                "camunda.security.authentication.oidc.redirect-uri={baseUrl}/sso-callback"),
+            Stream.of(shapeProperties))
+        .toArray(String[]::new);
   }
 
   /**
@@ -179,7 +226,23 @@ class PhysicalTenantDefaultAliasChainIT {
         throw new IllegalStateException("Failed to build chain for " + descriptor.basePath(), ex);
       }
     }
-    // A request matching no scoped chain lands here: `/**` denyAll, answered as 404.
+    // The cluster API chain, assembled exactly as OidcApiSecurityConfiguration does — its matchers
+    // come from the real SecurityPathPort, so with no physical tenant configured they carry the
+    // /physical-tenants/default-prefixed variants. This is what serves the alias in that shape.
+    final var pathPort = ctx.getBean(SecurityPathPort.class);
+    final var clusterAuth = ctx.getBean(CamundaSecurityLibraryProperties.class).getAuthentication();
+    try {
+      chains.add(
+          chainBuilder.buildOidcApiChain(
+              ctx.getBean(HttpSecurity.class),
+              pathPort.apiPaths(),
+              pathPort.unprotectedApiPaths(),
+              scopedJwtDecoderFactory.buildIssuerAwareDecoder(clusterAuth),
+              ctx.getBean(SessionRepositoryFilter.class)));
+    } catch (final Exception ex) {
+      throw new IllegalStateException("Failed to build the cluster API chain", ex);
+    }
+    // A request matching neither lands here: `/**` denyAll, answered as 404.
     chains.add(
         ctx.getBean("protectedUnhandledPathsSecurityFilterChain", SecurityFilterChain.class));
     return chains;
@@ -189,15 +252,15 @@ class PhysicalTenantDefaultAliasChainIT {
   // Environment builders
   // =========================================================================
 
-  /** Root/cluster OIDC provider only — deliberately no {@code camunda.physical-tenants.*} keys. */
-  private MockEnvironment rootOnlyEnv() {
+  /**
+   * The same {@code key=value} properties the context gets, as the scope provider's environment.
+   */
+  private MockEnvironment envWith(final String... properties) {
     final var env = new MockEnvironment();
-    env.setProperty("camunda.security.authentication.method", "oidc");
-    env.setProperty("camunda.security.authentication.oidc.client-id", "root-client");
-    env.setProperty("camunda.security.authentication.oidc.issuer-uri", rootServer.issuerUri());
-    env.setProperty(
-        "camunda.security.authentication.oidc.jwk-set-uri", rootServer.issuerUri() + "/jwks");
-    env.setProperty("camunda.security.authentication.oidc.redirect-uri", "{baseUrl}/sso-callback");
+    for (final String property : properties) {
+      final int separator = property.indexOf('=');
+      env.setProperty(property.substring(0, separator), property.substring(separator + 1));
+    }
     return env;
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopeProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopeProviderTest.java
@@ -26,15 +26,18 @@ import org.springframework.mock.env.MockEnvironment;
  *
  * <p>All tests bind config from a {@link MockEnvironment} — no Spring context is loaded.
  *
- * <p>Semantics under test: every discovered tenant id yields a descriptor; per-PT provider
- * selection ({@code assigned}) has been dropped.
+ * <p>Semantics under test: every discovered tenant id yields a descriptor, plus the {@code default}
+ * alias once any tenant is configured; per-PT provider selection ({@code assigned}) has been
+ * dropped.
  */
 class PhysicalTenantScopeProviderTest {
 
   @Test
-  void shouldEmitOnlyDefaultAliasWhenNoPhysicalTenantsConfigured() {
-    // Without a descriptor the route is registered but matches no scoped chain, so the catch-all
-    // answers 404.
+  void shouldEmitNoDescriptorsWhenNoPhysicalTenantsConfigured() {
+    // The gate short-circuits before any per-tenant config is built, so nothing is emitted even
+    // though the cluster declares an auth method. The alias stays reachable because
+    // SecurityPathAdapter gives the cluster chain /physical-tenants/default-prefixed paths for
+    // exactly this case.
     // given - no camunda.physical-tenants.* properties
     final var env = env(Map.of("camunda.security.authentication.method", "oidc"));
 
@@ -42,9 +45,7 @@ class PhysicalTenantScopeProviderTest {
     final var provider = new PhysicalTenantScopeProvider(env);
 
     // then
-    assertThat(provider.get())
-        .extracting(ScopedSecurityDescriptor::basePath)
-        .containsExactly("/physical-tenants/default");
+    assertThat(provider.get()).isEmpty();
   }
 
   @Test
@@ -187,32 +188,6 @@ class PhysicalTenantScopeProviderTest {
   }
 
   @Test
-  void shouldEmitDefaultAliasCarryingRootConfigWhenNoPhysicalTenantsConfigured() {
-    // Zero-tenant counterpart to shouldEmitDefaultAliasDescriptorFromRootConfigWhenPtModeActive:
-    // the alias must carry the root/cluster providers, not an empty config. Field-wise equality
-    // with the cluster bind is pinned in PhysicalTenantAuthConfigurationsTest.
-    // given
-    final var env =
-        env(
-            Map.of(
-                "camunda.security.authentication.method", "oidc",
-                "camunda.security.authentication.oidc.client-id", "root-client",
-                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root",
-                "camunda.security.authentication.oidc.audiences[0]", "root-aud"));
-
-    // when
-    final var descriptors = new PhysicalTenantScopeProvider(env).get();
-
-    // then
-    assertThat(descriptors).hasSize(1);
-    final var defaultAlias = descriptors.getFirst();
-    assertThat(defaultAlias.basePath()).isEqualTo("/physical-tenants/default");
-    assertThat(defaultAlias.authentication().getOidc()).isNotNull();
-    assertThat(defaultAlias.authentication().getOidc().getClientId()).isEqualTo("root-client");
-    assertThat(defaultAlias.authentication().getOidc().getAudiences()).containsExactly("root-aud");
-  }
-
-  @Test
   void shouldFailStartupWhenPhysicalTenantConfigCannotBeBuilt() {
     // given — an invalid enum value for `method` under a PT overlay causes Binder to throw
     final var env =
@@ -250,14 +225,8 @@ class PhysicalTenantScopeProviderTest {
         .hasMessageContaining("default");
   }
 
-  static Stream<Arguments> clusterShapes() {
+  static Stream<Arguments> ptConfiguredShapes() {
     return Stream.of(
-        Arguments.of(
-            "no physical tenants",
-            Map.of(
-                "camunda.security.authentication.method", "oidc",
-                "camunda.security.authentication.oidc.client-id", "root-client",
-                "camunda.security.authentication.oidc.issuer-uri", "http://idp/root")),
         Arguments.of(
             "one explicit tenant",
             Map.of(
@@ -278,20 +247,18 @@ class PhysicalTenantScopeProviderTest {
                     "http://idp/tenanta",
                 "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.client-id",
                     "pt-tenanta-client",
-                "camunda.physical-tenants.default.security.authentication.method", "oidc")),
-        Arguments.of(
-            "basic auth, no tenants", Map.of("camunda.security.authentication.method", "basic")));
+                "camunda.physical-tenants.default.security.authentication.method", "oidc")));
   }
 
   /**
-   * Every tenant the config layer knows about gets a descriptor, and nothing else does. The config
-   * layer always knows about {@code default}; this provider once did not.
+   * Once any physical tenant is configured, every tenant the config layer knows about gets a
+   * descriptor and nothing else does — including {@code default}, which this provider once omitted.
    *
-   * <p>Not circular: both start from {@code discoverExplicitTenantIds}, but only the config layer
-   * added {@code default} unconditionally.
+   * <p>The two sides compute the same set here, so this is a drift guard rather than an independent
+   * derivation: it fails if either layer changes which tenants it knows about without the other.
    */
   @ParameterizedTest(name = "[{index}] {0}")
-  @MethodSource("clusterShapes")
+  @MethodSource("ptConfiguredShapes")
   void shouldEmitOneDescriptorPerKnownPhysicalTenant(
       final String shape, final Map<String, String> properties) {
     // given

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantScopedChainStartupIT.java
@@ -32,9 +32,14 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
- * Startup behaviour of the scoped chains on a cluster with no {@code camunda.physical-tenants.*}
- * entries, through the real {@code ScopedSecurityChainRegistrar} — which builds a webapp chain as
- * well as an API chain for every descriptor.
+ * Startup behaviour of the scoped chains on a cluster that <em>has</em> a physical tenant
+ * configured, through the real {@code ScopedSecurityChainRegistrar} — which builds a webapp chain
+ * as well as an API chain for every descriptor.
+ *
+ * <p>The configured tenant is load-bearing: with none, no scoped chain is built at all and every
+ * assertion here would pass or fail for the wrong reason. That zero-tenant shape — where the
+ * cluster chain's prefixed path sets serve the alias instead — is covered by {@link
+ * PhysicalTenantAliasCoverageIT}.
  *
  * <p>{@link PhysicalTenantDefaultAliasChainIT} builds API chains by hand to check request outcomes,
  * so it never sees the webapp chain. This one does.
@@ -43,6 +48,11 @@ class PhysicalTenantScopedChainStartupIT {
 
   private static final String SCOPED_LOGIN = "/physical-tenants/default/login";
   private static final String SCOPED_API = "/physical-tenants/default/v2/resource";
+
+  // At least one key under camunda.physical-tenants.<id>.* so the tenant is discovered, which is
+  // what makes the provider emit descriptors — the default alias among them.
+  private static final String PHYSICAL_TENANT =
+      "camunda.physical-tenants.tenanta.security.authentication.method=oidc";
 
   private static final String[] OIDC_PROVIDER = {
     "camunda.security.authentication.method=oidc",
@@ -74,6 +84,11 @@ class PhysicalTenantScopedChainStartupIT {
         .run(
             ctx -> {
               assertThat(ctx).hasNotFailed();
+              // Without this precondition the assertion below is satisfied by two different causes:
+              // the gate emptying webappPaths(), or no scoped chain having been built at all.
+              assertThat(ctx.getBeanNamesForType(SecurityFilterChain.class))
+                  .as("the gate is only observable if scoped chains were actually built")
+                  .anyMatch(name -> name.startsWith("scoped"));
               assertThat(matchesAnyChain(ctx, SCOPED_LOGIN))
                   .as("no scoped chain may serve the scoped login path when the webapp is disabled")
                   .isFalse();
@@ -127,6 +142,7 @@ class PhysicalTenantScopedChainStartupIT {
             () ->
                 new InMemoryUserDetailsManager(
                     User.withUsername("test").password("{noop}test").authorities("USER").build()))
+        .withPropertyValues(PHYSICAL_TENANT)
         .withPropertyValues(properties);
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfigurationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantSecurityConfigurationTest.java
@@ -38,13 +38,11 @@ class PhysicalTenantSecurityConfigurationTest {
   }
 
   @Test
-  void shouldReturnOnlyDefaultAliasDescriptorWhenNoPhysicalTenantsConfigured() {
+  void shouldReturnNoDescriptorsWhenNoPhysicalTenantsConfigured() {
     runner.run(
         context -> {
           final var provider = context.getBean(CamundaSecurityScopeProvider.class);
-          assertThat(provider.get())
-              .extracting(ScopedSecurityDescriptor::basePath)
-              .containsExactly("/physical-tenants/default");
+          assertThat(provider.get()).isEmpty();
         });
   }
 
@@ -61,8 +59,7 @@ class PhysicalTenantSecurityConfigurationTest {
               final var provider = context.getBean(CamundaSecurityScopeProvider.class);
               // The explicit tenant plus the default alias (the root declares a usable oidc slot).
               assertThat(provider.get())
-                  .extracting(
-                      io.camunda.security.api.model.config.ScopedSecurityDescriptor::basePath)
+                  .extracting(ScopedSecurityDescriptor::basePath)
                   .containsExactlyInAnyOrder(
                       "/physical-tenants/tenanta", "/physical-tenants/default");
             });


### PR DESCRIPTION
---WIP---
---DO NOT MERGE---
---WE MIGHT WANT TO MAKE CSL CHANGE INSTEAD---

## Description

#60682 made `/physical-tenants/default/**` reachable by always emitting the `default` scoped
security descriptor. CSL builds two chains per descriptor, each resolving its own
`ClientRegistration` through a blocking `fromIssuerLocation` GET — so clusters with an
`issuer-uri` went from one discovery call per provider at startup to three.

The descriptor is now emitted only when a physical tenant is configured. With none,
`SecurityPathAdapter` gives the cluster chain `/physical-tenants/default`-prefixed variants of the
four path sets CSL prefixes per scope, using the same `basePath + pattern` derivation — so the
patterns match what a scoped chain would have produced. The two mechanisms are mutually exclusive
by construction; the code comments explain why.

Two accepted limitations at zero tenants. The cluster chain's login endpoint, authorization URI,
callback and post-logout redirect stay unprefixed, being single-valued per chain: a deep link
returns into the prefix via the saved request, but post-logout lands on `/post-logout` and
`/physical-tenants/default/login` bounces to `/login`. And `/physical-tenants/default` without a
trailing slash still 404s — pre-existing, and now characterised by a test rather than fixed.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #61283
