### PR TITLE
fix: skip rebalance for partitions in recovering tenants

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -29913,7 +29913,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "Outcome of each partition a rebalance attempted, within the selected range. TRANSFERRED is success; other results explain why leadership stayed put: CANCELLED means the operator stopped the rebalance first; LAG_TOO_HIGH and REPLICATION_TIMED_OUT point at the follower replication lag panel in the Raft row; NO_RESPONSE and NO_LEADER mean the leader, or the topology, never answered; PHYSICAL_TENANT_DISABLED means the partition's physical tenant was disabled after the rebalance was planned.",
+          "description": "Outcome of each partition a rebalance attempted, within the selected range. TRANSFERRED is success; other results explain why leadership stayed put: CANCELLED means the operator stopped the rebalance first; LAG_TOO_HIGH and REPLICATION_TIMED_OUT point at the follower replication lag panel in the Raft row; NO_RESPONSE and NO_LEADER mean the leader, or the topology, never answered; PHYSICAL_TENANT_DISABLED means the partition's physical tenant was disabled after the rebalance was planned; PHYSICAL_TENANT_RECOVERING means the partition's physical tenant entered recovery after the rebalance was planned.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -30261,7 +30261,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (clamp_min((zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"} - (zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"} offset $__rate_interval)) or zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"}, 0))",
+              "expr": "sum by (le) (clamp_min((zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED|PHYSICAL_TENANT_RECOVERING\"} - (zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED|PHYSICAL_TENANT_RECOVERING\"} offset $__rate_interval)) or zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED|PHYSICAL_TENANT_RECOVERING\"}, 0))",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -268,6 +268,11 @@ public record PartitionGroupConfiguration(
     return availability.state() != TenantAvailability.State.ENABLED;
   }
 
+  /** Whether any member of this group is currently in {@link Mode#RECOVERING}. */
+  public boolean isRecovering() {
+    return members.values().stream().anyMatch(member -> member.mode() == Mode.RECOVERING);
+  }
+
   /**
    * Marks this tenant as disabled, e.g. because it was removed from the local static configuration.
    * Does not change {@code version} or touch {@code members} — the partition assignment is retained

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -299,6 +299,42 @@ class PartitionGroupConfigurationTest {
   }
 
   @Nested
+  class Recovering {
+
+    @Test
+    void shouldNotBeRecoveringWithNoMembers() {
+      // given
+      final var config = group(1, Map.of());
+
+      // when / then
+      assertThat(config.isRecovering()).isFalse();
+    }
+
+    @Test
+    void shouldNotBeRecoveringWhenEveryMemberIsProcessing() {
+      // given
+      final var config = group(1, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1, 1)));
+
+      // when / then
+      assertThat(config.isRecovering()).isFalse();
+    }
+
+    @Test
+    void shouldBeRecoveringWhenAnyMemberIsRecovering() {
+      // given
+      final var config =
+          group(
+              1,
+              Map.of(
+                  MEMBER_0, broker(1, 1),
+                  MEMBER_1, broker(1, 1).setMode(Mode.RECOVERING)));
+
+      // when / then
+      assertThat(config.isRecovering()).isTrue();
+    }
+  }
+
+  @Nested
   class Availability {
 
     @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -2188,6 +2188,7 @@ components:
             - NO_RESPONSE
             - CANCELLED
             - PHYSICAL_TENANT_DISABLED
+            - PHYSICAL_TENANT_RECOVERING
 
     ClusterCompletedRebalance:
       description: >-

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceMapper.java
@@ -149,6 +149,8 @@ final class ClusterRebalanceMapper {
       case CANCELLED -> ClusterRebalanceOperationPartition.ResultEnum.CANCELLED;
       case PHYSICAL_TENANT_DISABLED ->
           ClusterRebalanceOperationPartition.ResultEnum.PHYSICAL_TENANT_DISABLED;
+      case PHYSICAL_TENANT_RECOVERING ->
+          ClusterRebalanceOperationPartition.ResultEnum.PHYSICAL_TENANT_RECOVERING;
     };
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterRebalanceControllerTest.java
@@ -494,7 +494,9 @@ class ClusterRebalanceControllerTest extends RestControllerTest {
         Arguments.of(PartitionRebalanceOutcome.NO_RESPONSE, "NO_RESPONSE"),
         Arguments.of(PartitionRebalanceOutcome.CANCELLED, "CANCELLED"),
         Arguments.of(
-            PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED, "PHYSICAL_TENANT_DISABLED"));
+            PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED, "PHYSICAL_TENANT_DISABLED"),
+        Arguments.of(
+            PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING, "PHYSICAL_TENANT_RECOVERING"));
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -517,6 +517,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-gateway-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceForwardingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceForwardingIT.java
@@ -9,13 +9,9 @@ package io.camunda.zeebe.it.cluster.clustering;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import feign.Response;
-import feign.Util;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +20,7 @@ final class ClusterRebalanceForwardingIT {
   @AutoClose private TestCluster cluster;
 
   @Test
-  void shouldForwardARequestFromANonCoordinatorToTheCoordinator() throws Exception {
+  void shouldForwardARequestFromANonCoordinatorToTheCoordinator() {
     // given
     cluster =
         TestCluster.builder()
@@ -43,19 +39,10 @@ final class ClusterRebalanceForwardingIT {
     final var coordinatorClient = ClusterRebalanceRestClient.of(coordinator.restAddress());
 
     // then
-    try (final var fromNonCoordinator = nonCoordinatorClient.getRebalance();
-        final var fromCoordinator = coordinatorClient.getRebalance()) {
-      assertThat(fromNonCoordinator.status()).isEqualTo(200);
-      final var nonCoordinatorBody = readBody(fromNonCoordinator);
-      final var coordinatorBody = readBody(fromCoordinator);
-      assertThat(nonCoordinatorBody).isEqualTo(coordinatorBody);
-    }
-  }
-
-  private static String readBody(final Response response) throws IOException {
-    if (response.body() == null) {
-      return "";
-    }
-    return Util.toString(response.body().asReader(StandardCharsets.UTF_8));
+    final var fromNonCoordinator = nonCoordinatorClient.getRebalance();
+    final var fromCoordinator = coordinatorClient.getRebalance();
+    assertThat(fromNonCoordinator.status()).isEqualTo(200);
+    assertThat(fromCoordinator.status()).isEqualTo(200);
+    assertThat(fromNonCoordinator.body()).isEqualTo(fromCoordinator.body());
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.clustering;
 
+import static io.camunda.zeebe.it.cluster.clustering.ClusterRebalanceTestUtil.awaitTerminalRebalance;
 import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertThatAllJobsCanBeCompleted;
 import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,39 +87,17 @@ final class ClusterRebalanceIT {
     return rebalanceClient.triggerRebalance();
   }
 
-  private TypedResponse<ClusterBalanceResponse> getRebalance() {
-    return rebalanceClient.getRebalance();
-  }
-
   private void awaitCompletedRebalance() {
-    Awaitility.await("the rebalance completes with at least one transferred partition")
-        .atMost(Duration.ofMinutes(1))
-        .untilAsserted(
-            () -> {
-              final var response = getRebalance();
-              assertThat(response.status())
-                  .as("rebalance status response: %s", response.body())
-                  .isEqualTo(HttpURLConnection.HTTP_OK);
-
-              final var body = response.body();
-              assertThat(body.getRunningRebalance())
-                  .as("no rebalance still running: %s", body)
-                  .isNull();
-              final var lastCompleted = body.getLastCompletedRebalance();
-              assertThat(lastCompleted)
-                  .as("a completed rebalance is present: %s", body)
-                  .isNotNull();
-              assertThat(lastCompleted.getResult())
-                  .as("rebalance result: %s", body)
-                  .isEqualTo(ClusterCompletedRebalance.ResultEnum.COMPLETED);
-              assertThat(lastCompleted.getPartitions())
-                  .as("rebalance partitions: %s", body)
-                  .isNotEmpty()
-                  .anyMatch(
-                      partition ->
-                          partition.getResult()
-                              == ClusterRebalanceOperationPartition.ResultEnum.TRANSFERRED);
-            });
+    final var completed = awaitTerminalRebalance(rebalanceClient, Duration.ofMinutes(1));
+    assertThat(completed.getResult())
+        .as("rebalance result: %s", completed)
+        .isEqualTo(ClusterCompletedRebalance.ResultEnum.COMPLETED);
+    assertThat(completed.getPartitions())
+        .as("rebalance partitions: %s", completed)
+        .isNotEmpty()
+        .anyMatch(
+            partition ->
+                partition.getResult() == ClusterRebalanceOperationPartition.ResultEnum.TRANSFERRED);
   }
 
   private void awaitBalancedTopology() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceIT.java
@@ -11,24 +11,21 @@ import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertThatAll
 import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.Response;
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.gateway.protocol.model.ClusterBalanceResponse;
+import io.camunda.gateway.protocol.model.ClusterCompletedRebalance;
+import io.camunda.gateway.protocol.model.ClusterRebalanceOperationPartition;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
+import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient.TypedResponse;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.stream.StreamSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +39,6 @@ final class ClusterRebalanceIT {
   private static final Logger LOG = LoggerFactory.getLogger(ClusterRebalanceIT.class);
   private static final String JOB_TYPE = "rebalance-test";
   private static final int PARTITION_COUNT = 3;
-  private static final ObjectMapper JSON = new ObjectMapper();
 
   @TestZeebe
   private final TestCluster cluster =
@@ -80,31 +76,18 @@ final class ClusterRebalanceIT {
     assertThatAllJobsCanBeCompleted(processInstanceKeys, client, JOB_TYPE);
   }
 
-  private void assertAccepted(final Response response) {
-    final String body = readBody(response);
+  private void assertAccepted(final TypedResponse<ClusterBalanceResponse> response) {
     assertThat(response.status())
-        .as("rebalance response: %s", body)
+        .as("rebalance response: %s", response.body())
         .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
   }
 
-  private Response triggerRebalance() {
+  private TypedResponse<ClusterBalanceResponse> triggerRebalance() {
     return rebalanceClient.triggerRebalance();
   }
 
-  private Response getRebalance() {
+  private TypedResponse<ClusterBalanceResponse> getRebalance() {
     return rebalanceClient.getRebalance();
-  }
-
-  private static String readBody(final Response response) {
-    try (response) {
-      final var body = response.body();
-      if (body == null) {
-        return "";
-      }
-      return new String(body.asInputStream().readAllBytes(), StandardCharsets.UTF_8);
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 
   private void awaitCompletedRebalance() {
@@ -113,42 +96,28 @@ final class ClusterRebalanceIT {
         .untilAsserted(
             () -> {
               final var response = getRebalance();
-              final String responseBody = readBody(response);
               assertThat(response.status())
-                  .as("rebalance status response: %s", responseBody)
+                  .as("rebalance status response: %s", response.body())
                   .isEqualTo(HttpURLConnection.HTTP_OK);
 
-              final JsonNode body = JSON.readTree(responseBody);
-              assertThat(body.has("runningRebalance"))
-                  .as("runningRebalance field present: %s", responseBody)
-                  .isTrue();
-              assertThat(body.get("runningRebalance").isNull())
-                  .as("no rebalance still running: %s", responseBody)
-                  .isTrue();
-
-              final JsonNode lastCompleted = body.get("lastCompletedRebalance");
+              final var body = response.body();
+              assertThat(body.getRunningRebalance())
+                  .as("no rebalance still running: %s", body)
+                  .isNull();
+              final var lastCompleted = body.getLastCompletedRebalance();
               assertThat(lastCompleted)
-                  .as("a completed rebalance is present: %s", responseBody)
+                  .as("a completed rebalance is present: %s", body)
                   .isNotNull();
-              assertThat(lastCompleted.isNull())
-                  .as("a completed rebalance is present: %s", responseBody)
-                  .isFalse();
-
-              assertThat(lastCompleted.path("result").asText())
-                  .as("rebalance result: %s", responseBody)
-                  .isEqualTo("COMPLETED");
-
-              final var partitions = lastCompleted.path("partitions");
-              assertThat(partitions.isArray() && partitions.size() > 0)
-                  .as("rebalance partitions present: %s", responseBody)
-                  .isTrue();
-              final boolean anyTransferred =
-                  StreamSupport.stream(partitions.spliterator(), false)
-                      .anyMatch(
-                          partition -> "TRANSFERRED".equals(partition.path("result").asText()));
-              assertThat(anyTransferred)
-                  .as("at least one partition was transferred: %s", responseBody)
-                  .isTrue();
+              assertThat(lastCompleted.getResult())
+                  .as("rebalance result: %s", body)
+                  .isEqualTo(ClusterCompletedRebalance.ResultEnum.COMPLETED);
+              assertThat(lastCompleted.getPartitions())
+                  .as("rebalance partitions: %s", body)
+                  .isNotEmpty()
+                  .anyMatch(
+                      partition ->
+                          partition.getResult()
+                              == ClusterRebalanceOperationPartition.ResultEnum.TRANSFERRED);
             });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceRecoveryModeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceRecoveryModeIT.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertThatAllJobsCanBeCompleted;
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import io.atomix.cluster.MemberId;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.zeebe.it.cluster.backup.InProcessRestoreTestUtil;
+import io.camunda.zeebe.management.cluster.BrokerState;
+import io.camunda.zeebe.management.cluster.PartitionState;
+import io.camunda.zeebe.management.cluster.PartitionStateCode;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** End-to-end coverage of the cluster rebalance interacting with recovery mode. */
+@ZeebeIntegration
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
+final class ClusterRebalanceRecoveryModeIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterRebalanceRecoveryModeIT.class);
+  private static final String JOB_TYPE = "rebalance-recovery-test";
+  private static final int PARTITION_COUNT = 3;
+
+  @TestZeebe(purgeAfterEach = false)
+  static TestCluster cluster =
+      TestCluster.builder()
+          .withEmbeddedGateway(true)
+          .withBrokersCount(3)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withReplicationFactor(3)
+          .build();
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+  @AutoClose private CamundaClient client;
+  private ClusterRebalanceRestClient rebalanceClient;
+
+  @BeforeEach
+  void setUp() {
+    // broker 1 is stopped/restarted to force an imbalance, so use another broker's client
+    client = cluster.brokers().get(MemberId.from("0")).newClientBuilder().build();
+    rebalanceClient = ClusterRebalanceRestClient.of(cluster.availableGateway());
+  }
+
+  @AfterEach
+  void leaveRecovery() {
+    ensureMode(PartitionStateCode.ACTIVE);
+  }
+
+  @Test
+  void shouldAdmitAnEmptyNoOpRebalanceWhileTheClusterIsRecovering() {
+    // given
+    ensureMode(PartitionStateCode.RECOVERING);
+    final var completedBefore = lastCompletedRebalance();
+
+    // when
+    final var triggered = rebalanceClient.triggerRebalance();
+    final var dryRun = rebalanceClient.triggerDryRun();
+
+    // then
+    assertThat(statusOf(triggered))
+        .as("recovering tenants are simply omitted from the plan, not a reason to refuse")
+        .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+    assertThat(statusOf(dryRun)).isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+
+    final var outcome = awaitTerminalRebalance(List.of("COMPLETED"));
+    assertThat(outcome).isEqualTo("COMPLETED");
+    final var completed = lastCompletedRebalance();
+    assertThat(completed.path("partitions").isEmpty())
+        .as("every tenant is recovering, so the plan is empty: %s", completed)
+        .isTrue();
+    assertThat(completedBefore.equals(completed))
+        .as("a real no-op request still records its own completed run")
+        .isFalse();
+  }
+
+  @Test
+  void shouldAdmitARebalanceOnceTheClusterProcessesAgain() {
+    // given
+    ensureMode(PartitionStateCode.RECOVERING);
+    ensureMode(PartitionStateCode.ACTIVE);
+    forceBadLeaderDistribution();
+    final var processInstanceKeys =
+        createInstanceWithAJobOnAllPartitions(client, JOB_TYPE, PARTITION_COUNT);
+
+    // when
+    assertThat(statusOf(rebalanceClient.triggerRebalance()))
+        .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+
+    // then
+    awaitTerminalRebalance(List.of("COMPLETED"));
+    awaitBalancedTopology();
+    assertThatAllJobsCanBeCompleted(processInstanceKeys, client, JOB_TYPE);
+  }
+
+  @Test
+  void shouldSkipRatherThanCancelWhenRecoveryRacesARunningRebalance() {
+    // given
+    forceBadLeaderDistribution();
+    assertThat(hasBadLeaderDistribution()).isTrue();
+    assertThat(statusOf(rebalanceClient.triggerRebalance()))
+        .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+
+    // when
+    ensureMode(PartitionStateCode.RECOVERING);
+
+    // then
+    final var outcome = awaitTerminalRebalance(List.of("COMPLETED"));
+    LOG.info("Rebalance racing recovery finished as {}", outcome);
+    final var completed = lastCompletedRebalance();
+    final var results = completed.path("partitions").findValuesAsText("result");
+    assertThat(results)
+        .as("recovery skips partitions instead of cancelling the run: %s", completed)
+        .allMatch(
+            result ->
+                result.equals("TRANSFERRED")
+                    || result.equals("PHYSICAL_TENANT_RECOVERING")
+                    || result.equals("ALREADY_LEADER"));
+
+    ensureMode(PartitionStateCode.ACTIVE);
+    final var processInstanceKeys =
+        createInstanceWithAJobOnAllPartitions(client, JOB_TYPE, PARTITION_COUNT);
+    assertThatAllJobsCanBeCompleted(processInstanceKeys, client, JOB_TYPE);
+    assertThat(statusOf(rebalanceClient.triggerRebalance()))
+        .as("a new rebalance is admitted once every tenant processes again")
+        .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+    awaitTerminalRebalance(List.of("COMPLETED"));
+  }
+
+  private void ensureMode(final PartitionStateCode target) {
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    if (everyPartitionReports(actuator, target)) {
+      return;
+    }
+    final var mode = target == PartitionStateCode.RECOVERING ? "RECOVERING" : "PROCESSING";
+    final var changeId = InProcessRestoreTestUtil.changeMode(client, mode, false);
+    Awaitility.await("the cluster transitions to " + mode)
+        .timeout(Duration.ofMinutes(2))
+        .untilAsserted(
+            () ->
+                ClusterActuatorAssert.assertThat(actuator)
+                    .hasCompletedChanges(changeId)
+                    .doesNotHavePendingChanges());
+    Awaitility.await("every partition reports " + target)
+        .timeout(Duration.ofMinutes(1))
+        .until(() -> everyPartitionReports(actuator, target));
+  }
+
+  private static boolean everyPartitionReports(
+      final ClusterActuator actuator, final PartitionStateCode target) {
+    return actuator.getTopology().getBrokers().stream()
+        .map(BrokerState::getPartitions)
+        .flatMap(List::stream)
+        .map(PartitionState::getState)
+        .allMatch(target::equals);
+  }
+
+  private String awaitTerminalRebalance(final List<String> legalResults) {
+    final var terminalStatus = new AtomicReference<JsonNode>();
+    Awaitility.await("the rebalance reaches a terminal state")
+        .atMost(Duration.ofMinutes(2))
+        .untilAsserted(
+            () -> {
+              final var status = rebalanceStatus();
+              assertThat(status.path("runningRebalance").isNull())
+                  .as("no rebalance still running: %s", status)
+                  .isTrue();
+              assertThat(status.path("lastCompletedRebalance").isNull())
+                  .as("a completed rebalance is present: %s", status)
+                  .isFalse();
+              terminalStatus.set(status);
+            });
+    final var result = terminalStatus.get().path("lastCompletedRebalance").path("result").asText();
+    assertThat(result).isIn(legalResults);
+    return result;
+  }
+
+  private JsonNode rebalanceStatus() {
+    final var response = rebalanceClient.getRebalance();
+    final var body = readBody(response);
+    assertThat(response.status())
+        .as("rebalance status response: %s", body)
+        .isEqualTo(HttpURLConnection.HTTP_OK);
+    try {
+      return JSON.readTree(body);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private JsonNode lastCompletedRebalance() {
+    return rebalanceStatus().path("lastCompletedRebalance");
+  }
+
+  private static int statusOf(final Response response) {
+    final var body = readBody(response);
+    LOG.debug("Rebalance request answered {}: {}", response.status(), body);
+    return response.status();
+  }
+
+  private static String readBody(final Response response) {
+    try (response) {
+      final var body = response.body();
+      if (body == null) {
+        return "";
+      }
+      return new String(body.asInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private void awaitBalancedTopology() {
+    Awaitility.await("the final leader distribution is round-robin across brokers 0, 1, and 2")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                    .hasLeaderForPartition(1, 0)
+                    .hasLeaderForPartition(2, 1)
+                    .hasLeaderForPartition(3, 2));
+  }
+
+  @SuppressWarnings("resource")
+  private void forceBadLeaderDistribution() {
+    if (!hasGoodLeaderDistribution()) {
+      return;
+    }
+    final var stoppedBroker = cluster.brokers().get(MemberId.from("1")).stop();
+    Awaitility.await("at least one broker is leader for more than one partition")
+        .timeout(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(this::hasBadLeaderDistribution);
+    stoppedBroker.start().await(TestHealthProbe.READY);
+    stoppedBroker.awaitCompleteTopology(
+        cluster.brokers().size(),
+        cluster.partitionsCount(),
+        cluster.replicationFactor(),
+        Duration.ofMinutes(1));
+  }
+
+  private boolean hasBadLeaderDistribution() {
+    return client.newTopologyRequest().send().join().getBrokers().stream()
+        .anyMatch(
+            broker -> broker.getPartitions().stream().filter(PartitionInfo::isLeader).count() > 1);
+  }
+
+  private boolean hasGoodLeaderDistribution() {
+    return client.newTopologyRequest().send().join().getBrokers().stream()
+        .allMatch(
+            broker -> broker.getPartitions().stream().filter(PartitionInfo::isLeader).count() == 1);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceRecoveryModeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceRecoveryModeIT.java
@@ -11,12 +11,13 @@ import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertThatAll
 import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.Response;
 import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.gateway.protocol.model.ClusterBalanceResponse;
+import io.camunda.gateway.protocol.model.ClusterCompletedRebalance;
+import io.camunda.gateway.protocol.model.ClusterRebalanceOperationPartition;
+import io.camunda.gateway.protocol.model.ClusterRebalanceOperationPartition.ResultEnum;
 import io.camunda.zeebe.it.cluster.backup.InProcessRestoreTestUtil;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.PartitionState;
@@ -27,12 +28,10 @@ import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
+import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient.TypedResponse;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +63,6 @@ final class ClusterRebalanceRecoveryModeIT {
           .withReplicationFactor(3)
           .build();
 
-  private static final ObjectMapper JSON = new ObjectMapper();
   @AutoClose private CamundaClient client;
   private ClusterRebalanceRestClient rebalanceClient;
 
@@ -96,15 +94,16 @@ final class ClusterRebalanceRecoveryModeIT {
         .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
     assertThat(statusOf(dryRun)).isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
 
-    final var outcome = awaitTerminalRebalance(List.of("COMPLETED"));
-    assertThat(outcome).isEqualTo("COMPLETED");
+    final var outcome =
+        awaitTerminalRebalance(List.of(ClusterCompletedRebalance.ResultEnum.COMPLETED));
+    assertThat(outcome).isEqualTo(ClusterCompletedRebalance.ResultEnum.COMPLETED);
     final var completed = lastCompletedRebalance();
-    assertThat(completed.path("partitions").isEmpty())
+    assertThat(completed.getPartitions())
         .as("every tenant is recovering, so the plan is empty: %s", completed)
-        .isTrue();
-    assertThat(completedBefore.equals(completed))
+        .isEmpty();
+    assertThat(completed)
         .as("a real no-op request still records its own completed run")
-        .isFalse();
+        .isNotEqualTo(completedBefore);
   }
 
   @Test
@@ -121,7 +120,7 @@ final class ClusterRebalanceRecoveryModeIT {
         .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
 
     // then
-    awaitTerminalRebalance(List.of("COMPLETED"));
+    awaitTerminalRebalance(List.of(ClusterCompletedRebalance.ResultEnum.COMPLETED));
     awaitBalancedTopology();
     assertThatAllJobsCanBeCompleted(processInstanceKeys, client, JOB_TYPE);
   }
@@ -138,17 +137,21 @@ final class ClusterRebalanceRecoveryModeIT {
     ensureMode(PartitionStateCode.RECOVERING);
 
     // then
-    final var outcome = awaitTerminalRebalance(List.of("COMPLETED"));
+    final var outcome =
+        awaitTerminalRebalance(List.of(ClusterCompletedRebalance.ResultEnum.COMPLETED));
     LOG.info("Rebalance racing recovery finished as {}", outcome);
     final var completed = lastCompletedRebalance();
-    final var results = completed.path("partitions").findValuesAsText("result");
+    final var results =
+        completed.getPartitions().stream()
+            .map(ClusterRebalanceOperationPartition::getResult)
+            .toList();
     assertThat(results)
         .as("recovery skips partitions instead of cancelling the run: %s", completed)
         .allMatch(
             result ->
-                result.equals("TRANSFERRED")
-                    || result.equals("PHYSICAL_TENANT_RECOVERING")
-                    || result.equals("ALREADY_LEADER"));
+                result == ResultEnum.TRANSFERRED
+                    || result == ResultEnum.PHYSICAL_TENANT_RECOVERING
+                    || result == ResultEnum.ALREADY_LEADER);
 
     ensureMode(PartitionStateCode.ACTIVE);
     final var processInstanceKeys =
@@ -157,7 +160,7 @@ final class ClusterRebalanceRecoveryModeIT {
     assertThat(statusOf(rebalanceClient.triggerRebalance()))
         .as("a new rebalance is admitted once every tenant processes again")
         .isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
-    awaitTerminalRebalance(List.of("COMPLETED"));
+    awaitTerminalRebalance(List.of(ClusterCompletedRebalance.ResultEnum.COMPLETED));
   }
 
   private void ensureMode(final PartitionStateCode target) {
@@ -188,59 +191,42 @@ final class ClusterRebalanceRecoveryModeIT {
         .allMatch(target::equals);
   }
 
-  private String awaitTerminalRebalance(final List<String> legalResults) {
-    final var terminalStatus = new AtomicReference<JsonNode>();
+  private ClusterCompletedRebalance.ResultEnum awaitTerminalRebalance(
+      final List<ClusterCompletedRebalance.ResultEnum> legalResults) {
+    final var terminalStatus = new AtomicReference<ClusterBalanceResponse>();
     Awaitility.await("the rebalance reaches a terminal state")
         .atMost(Duration.ofMinutes(2))
         .untilAsserted(
             () -> {
               final var status = rebalanceStatus();
-              assertThat(status.path("runningRebalance").isNull())
+              assertThat(status.getRunningRebalance())
                   .as("no rebalance still running: %s", status)
-                  .isTrue();
-              assertThat(status.path("lastCompletedRebalance").isNull())
+                  .isNull();
+              assertThat(status.getLastCompletedRebalance())
                   .as("a completed rebalance is present: %s", status)
-                  .isFalse();
+                  .isNotNull();
               terminalStatus.set(status);
             });
-    final var result = terminalStatus.get().path("lastCompletedRebalance").path("result").asText();
+    final var result = terminalStatus.get().getLastCompletedRebalance().getResult();
     assertThat(result).isIn(legalResults);
     return result;
   }
 
-  private JsonNode rebalanceStatus() {
+  private ClusterBalanceResponse rebalanceStatus() {
     final var response = rebalanceClient.getRebalance();
-    final var body = readBody(response);
     assertThat(response.status())
-        .as("rebalance status response: %s", body)
+        .as("rebalance status response: %s", response.body())
         .isEqualTo(HttpURLConnection.HTTP_OK);
-    try {
-      return JSON.readTree(body);
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return response.body();
   }
 
-  private JsonNode lastCompletedRebalance() {
-    return rebalanceStatus().path("lastCompletedRebalance");
+  private ClusterCompletedRebalance lastCompletedRebalance() {
+    return rebalanceStatus().getLastCompletedRebalance();
   }
 
-  private static int statusOf(final Response response) {
-    final var body = readBody(response);
-    LOG.debug("Rebalance request answered {}: {}", response.status(), body);
+  private static int statusOf(final TypedResponse<ClusterBalanceResponse> response) {
+    LOG.debug("Rebalance request answered {}: {}", response.status(), response.body());
     return response.status();
-  }
-
-  private static String readBody(final Response response) {
-    try (response) {
-      final var body = response.body();
-      if (body == null) {
-        return "";
-      }
-      return new String(body.asInputStream().readAllBytes(), StandardCharsets.UTF_8);
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 
   private void awaitBalancedTopology() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceRecoveryModeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceRecoveryModeIT.java
@@ -35,7 +35,6 @@ import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -193,35 +192,15 @@ final class ClusterRebalanceRecoveryModeIT {
 
   private ClusterCompletedRebalance.ResultEnum awaitTerminalRebalance(
       final List<ClusterCompletedRebalance.ResultEnum> legalResults) {
-    final var terminalStatus = new AtomicReference<ClusterBalanceResponse>();
-    Awaitility.await("the rebalance reaches a terminal state")
-        .atMost(Duration.ofMinutes(2))
-        .untilAsserted(
-            () -> {
-              final var status = rebalanceStatus();
-              assertThat(status.getRunningRebalance())
-                  .as("no rebalance still running: %s", status)
-                  .isNull();
-              assertThat(status.getLastCompletedRebalance())
-                  .as("a completed rebalance is present: %s", status)
-                  .isNotNull();
-              terminalStatus.set(status);
-            });
-    final var result = terminalStatus.get().getLastCompletedRebalance().getResult();
+    final var completed =
+        ClusterRebalanceTestUtil.awaitTerminalRebalance(rebalanceClient, Duration.ofMinutes(2));
+    final var result = completed.getResult();
     assertThat(result).isIn(legalResults);
     return result;
   }
 
-  private ClusterBalanceResponse rebalanceStatus() {
-    final var response = rebalanceClient.getRebalance();
-    assertThat(response.status())
-        .as("rebalance status response: %s", response.body())
-        .isEqualTo(HttpURLConnection.HTTP_OK);
-    return response.body();
-  }
-
   private ClusterCompletedRebalance lastCompletedRebalance() {
-    return rebalanceStatus().getLastCompletedRebalance();
+    return ClusterRebalanceTestUtil.getRebalanceStatus(rebalanceClient).getLastCompletedRebalance();
   }
 
   private static int statusOf(final TypedResponse<ClusterBalanceResponse> response) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterRebalanceTestUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.protocol.model.ClusterBalanceResponse;
+import io.camunda.gateway.protocol.model.ClusterCompletedRebalance;
+import io.camunda.zeebe.qa.util.restapi.ClusterRebalanceRestClient;
+import java.net.HttpURLConnection;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+
+final class ClusterRebalanceTestUtil {
+
+  private ClusterRebalanceTestUtil() {}
+
+  static ClusterBalanceResponse getRebalanceStatus(final ClusterRebalanceRestClient client) {
+    final var response = client.getRebalance();
+    assertThat(response.status())
+        .as("rebalance status response: %s", response.body())
+        .isEqualTo(HttpURLConnection.HTTP_OK);
+    assertThat(response.body()).as("rebalance status response has a body").isNotNull();
+    return response.body();
+  }
+
+  static ClusterCompletedRebalance awaitTerminalRebalance(
+      final ClusterRebalanceRestClient client, final Duration timeout) {
+    final var completed = new AtomicReference<ClusterCompletedRebalance>();
+    Awaitility.await("the rebalance reaches a terminal state")
+        .atMost(timeout)
+        .untilAsserted(
+            () -> {
+              final var status = getRebalanceStatus(client);
+              assertThat(status.getRunningRebalance())
+                  .as("no rebalance still running: %s", status)
+                  .isNull();
+              assertThat(status.getLastCompletedRebalance())
+                  .as("a completed rebalance is present: %s", status)
+                  .isNotNull();
+              completed.set(status.getLastCompletedRebalance());
+            });
+    return completed.get();
+  }
+}

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-gateway-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-cluster-config</artifactId>
     </dependency>
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
@@ -39,6 +39,11 @@ public interface ClusterRebalanceRestClient {
   @Headers("Accept: application/json")
   Response triggerRebalance();
 
+  /** Reports the plan a rebalance would carry out, without transferring any leadership. */
+  @RequestLine("POST ?dryRun=true")
+  @Headers("Accept: application/json")
+  Response triggerDryRun();
+
   /** Returns the status of the cluster's rebalance. */
   @RequestLine("GET")
   @Headers("Accept: application/json")

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/restapi/ClusterRebalanceRestClient.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.qa.util.restapi;
 import feign.Feign;
 import feign.Headers;
 import feign.RequestLine;
-import feign.Response;
 import feign.Retryer;
 import feign.Target.HardCodedTarget;
+import feign.codec.Decoder;
+import feign.jackson.JacksonDecoder;
+import io.camunda.gateway.protocol.model.ClusterBalanceResponse;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import java.lang.reflect.ParameterizedType;
 import java.net.URI;
 
 /**
@@ -31,21 +34,40 @@ public interface ClusterRebalanceRestClient {
         path.endsWith("/") ? restAddress : URI.create(restAddress + "/");
     final var endpoint = baseWithTrailingSlash.resolve("cluster/v2/rebalance").toString();
     final var target = new HardCodedTarget<>(ClusterRebalanceRestClient.class, endpoint);
-    return Feign.builder().retryer(Retryer.NEVER_RETRY).target(target);
+    return Feign.builder()
+        .decoder(typedResponseDecoder())
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
   }
 
   /** Triggers a rebalance of the cluster's leadership. */
   @RequestLine("POST")
   @Headers("Accept: application/json")
-  Response triggerRebalance();
+  TypedResponse<ClusterBalanceResponse> triggerRebalance();
 
   /** Reports the plan a rebalance would carry out, without transferring any leadership. */
   @RequestLine("POST ?dryRun=true")
   @Headers("Accept: application/json")
-  Response triggerDryRun();
+  TypedResponse<ClusterBalanceResponse> triggerDryRun();
 
   /** Returns the status of the cluster's rebalance. */
   @RequestLine("GET")
   @Headers("Accept: application/json")
-  Response getRebalance();
+  TypedResponse<ClusterBalanceResponse> getRebalance();
+
+  private static Decoder typedResponseDecoder() {
+    final Decoder bodyDecoder = new JacksonDecoder();
+    return (response, type) -> {
+      if (!(type instanceof final ParameterizedType parameterizedType)
+          || parameterizedType.getRawType() != TypedResponse.class) {
+        return bodyDecoder.decode(response, type);
+      }
+
+      final var bodyType = parameterizedType.getActualTypeArguments()[0];
+      final var body = response.body() == null ? null : bodyDecoder.decode(response, bodyType);
+      return new TypedResponse<>(response.status(), body);
+    };
+  }
+
+  record TypedResponse<T>(int status, T body) {}
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionBalancePlanner.java
@@ -25,6 +25,7 @@ public final class PartitionBalancePlanner {
 
   public List<PartitionRebalance> plan(final CurrentClusterConfiguration configuration) {
     return configuration.activePartitionGroups().entrySet().stream()
+        .filter(entry -> !entry.getValue().isRecovering())
         .sorted(Map.Entry.comparingByKey())
         .flatMap(entry -> planGroup(entry.getKey(), entry.getValue()))
         .toList();

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcome.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcome.java
@@ -12,8 +12,8 @@ package io.camunda.zeebe.rebalance;
  *
  * <p>Mirrors {@link io.atomix.raft.LeadershipTransferResult} so that a partition's outcome
  * preserves exactly what the leader reported. The only additions are outcomes the rebalance
- * coordinator itself produces: {@link #NO_LEADER}, {@link #NO_RESPONSE}, {@link #CANCELLED} and
- * {@link #PHYSICAL_TENANT_DISABLED}.
+ * coordinator itself produces: {@link #NO_LEADER}, {@link #NO_RESPONSE}, {@link #CANCELLED}, {@link
+ * #PHYSICAL_TENANT_DISABLED} and {@link #PHYSICAL_TENANT_RECOVERING}.
  */
 public enum PartitionRebalanceOutcome {
   /** The desired leader was promoted and took over leadership. */
@@ -61,5 +61,10 @@ public enum PartitionRebalanceOutcome {
   /** The rebalance was cancelled before this partition's transfer completed. */
   CANCELLED,
   /** The partition's physical tenant was disabled after the rebalance was planned. */
-  PHYSICAL_TENANT_DISABLED
+  PHYSICAL_TENANT_DISABLED,
+  /**
+   * The partition's physical tenant entered recovery after the rebalance was planned and before
+   * this partition's transfer began.
+   */
+  PHYSICAL_TENANT_RECOVERING
 }

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/ProtoBufRebalanceSerializer.java
@@ -318,6 +318,8 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
       case CANCELLED -> Rebalance.PartitionRebalance.Outcome.CANCELLED;
       case PHYSICAL_TENANT_DISABLED ->
           Rebalance.PartitionRebalance.Outcome.PHYSICAL_TENANT_DISABLED;
+      case PHYSICAL_TENANT_RECOVERING ->
+          Rebalance.PartitionRebalance.Outcome.PHYSICAL_TENANT_RECOVERING;
     };
   }
 
@@ -344,6 +346,7 @@ public final class ProtoBufRebalanceSerializer implements RebalanceRequestsSeria
       case NO_RESPONSE -> PartitionRebalanceOutcome.NO_RESPONSE;
       case CANCELLED -> PartitionRebalanceOutcome.CANCELLED;
       case PHYSICAL_TENANT_DISABLED -> PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED;
+      case PHYSICAL_TENANT_RECOVERING -> PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING;
       case OUTCOME_UNSPECIFIED, UNRECOGNIZED ->
           throw new DecodingFailed(
               "Partition rebalance outcome is missing or unrecognized: " + outcome);

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceCoordinator.java
@@ -49,7 +49,8 @@ public final class RebalanceCoordinator
           PartitionRebalanceOutcome.TRANSFERRED,
           PartitionRebalanceOutcome.ALREADY_LEADER,
           PartitionRebalanceOutcome.CANCELLED,
-          PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED);
+          PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED,
+          PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING);
 
   private final MemberId localMemberId;
   private final ConcurrencyControl executor;

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/RebalanceRun.java
@@ -32,6 +32,7 @@ public final class RebalanceRun {
   private final List<PartitionRebalance> partitions = new ArrayList<>();
 
   private final Set<String> disabledPhysicalTenants = new HashSet<>();
+  private final Set<String> recoveringPhysicalTenants = new HashSet<>();
 
   private long partitionStartedAtNanos = System.nanoTime();
   private boolean cancelRequested;
@@ -113,22 +114,39 @@ public final class RebalanceRun {
   }
 
   /**
-   * Notes which of the planned physical tenants {@code current} no longer runs, so that the runner
-   * can complete their partitions rather than wait out {@code leaderWaitTimeout} for a leader that
-   * will never appear.
+   * Notes which of the planned physical tenants {@code current} no longer runs, or is currently
+   * recovering, so that the runner can complete their partitions rather than wait out {@code
+   * leaderWaitTimeout} for a leader that will never appear.
    */
   public void observeConfiguration(final CurrentClusterConfiguration current) {
-    final var active = current.activePartitionGroups().keySet();
+    final var active = current.activePartitionGroups();
     disabledPhysicalTenants.clear();
+    recoveringPhysicalTenants.clear();
     partitions.stream()
         .map(PartitionRebalance::physicalTenantId)
-        .filter(physicalTenantId -> !active.contains(physicalTenantId))
-        .forEach(disabledPhysicalTenants::add);
+        .distinct()
+        .forEach(
+            physicalTenantId -> {
+              final var group = active.get(physicalTenantId);
+              if (group == null) {
+                disabledPhysicalTenants.add(physicalTenantId);
+              } else if (group.isRecovering()) {
+                recoveringPhysicalTenants.add(physicalTenantId);
+              }
+            });
   }
 
   /** Whether this physical tenant has stopped running since the rebalance was planned. */
   public boolean isPhysicalTenantDisabled(final String physicalTenantId) {
     return disabledPhysicalTenants.contains(physicalTenantId);
+  }
+
+  /**
+   * Whether this physical tenant is currently recovering. Level-triggered: a later configuration
+   * that shows the tenant processing again clears it.
+   */
+  public boolean isPhysicalTenantRecovering(final String physicalTenantId) {
+    return recoveringPhysicalTenants.contains(physicalTenantId);
   }
 
   public PartitionRebalance partition(final int index) {

--- a/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
+++ b/zeebe/rebalance/src/main/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunner.java
@@ -55,6 +55,8 @@ import org.slf4j.LoggerFactory;
  *     |                             COMPLETED(ALREADY_LEADER)  (already led by the desired leader)
  *     |                             COMPLETED(PHYSICAL_TENANT_DISABLED)  (its physical tenant
  *     |                                                                   stopped running)
+ *     |                             COMPLETED(PHYSICAL_TENANT_RECOVERING)  (its physical tenant
+ *     |                                                                     entered recovery)
  *     |
  *     | no current leader: wait for one to appear
  *     v
@@ -64,6 +66,8 @@ import org.slf4j.LoggerFactory;
  *     |                             COMPLETED(NO_LEADER)  (none appeared within leaderWaitTimeout)
  *     |                             COMPLETED(PHYSICAL_TENANT_DISABLED)  (as above, observed
  *     |                                                                   while waiting)
+ *     |                             COMPLETED(PHYSICAL_TENANT_RECOVERING)  (as above, observed
+ *     |                                                                     while waiting)
  *     |
  *     | one partition in flight at a time, in order
  *     v
@@ -181,6 +185,9 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
     if (resolveIfPhysicalTenantDisabled(rebalance, index, completion)) {
       return;
     }
+    if (resolveIfPhysicalTenantRecovering(rebalance, index, completion)) {
+      return;
+    }
     final var leader = rebalance.partition(index).currentLeader();
     if (leader == null) {
       waitForLeader(rebalance, index, Duration.ZERO, completion);
@@ -202,6 +209,22 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
         partition);
     resolveWithOutcome(
         rebalance, index, PartitionRebalanceOutcome.PHYSICAL_TENANT_DISABLED, completion);
+    return true;
+  }
+
+  private boolean resolveIfPhysicalTenantRecovering(
+      final RebalanceRun rebalance, final int index, final ActorFuture<Void> completion) {
+    final var partition = rebalance.partition(index);
+    if (!rebalance.isPhysicalTenantRecovering(partition.physicalTenantId())) {
+      return false;
+    }
+    LOG.info(
+        "Rebalance {} is leaving partition {} alone: its physical tenant entered recovery since "
+            + "the rebalance was planned",
+        rebalance.id(),
+        partition);
+    resolveWithOutcome(
+        rebalance, index, PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING, completion);
     return true;
   }
 
@@ -241,6 +264,9 @@ public final class SequentialRebalanceRunner implements RebalanceRunner {
             return;
           }
           if (resolveIfPhysicalTenantDisabled(rebalance, index, completion)) {
+            return;
+          }
+          if (resolveIfPhysicalTenantRecovering(rebalance, index, completion)) {
             return;
           }
           final var partition = rebalance.partition(index);

--- a/zeebe/rebalance/src/main/resources/proto/rebalance.proto
+++ b/zeebe/rebalance/src/main/resources/proto/rebalance.proto
@@ -116,6 +116,7 @@ message PartitionRebalance {
     NO_RESPONSE = 17;
     CANCELLED = 18;
     PHYSICAL_TENANT_DISABLED = 19;
+    PHYSICAL_TENANT_RECOVERING = 20;
   }
 
   // The partition group the partition belongs to; partition ids are unique only within a group.

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcomeAlignmentTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/PartitionRebalanceOutcomeAlignmentTest.java
@@ -47,7 +47,11 @@ final class PartitionRebalanceOutcomeAlignmentTest {
     // then
     assertThat(additionalOutcomeNames)
         .containsExactlyInAnyOrder(
-            "NO_LEADER", "NO_RESPONSE", "CANCELLED", "PHYSICAL_TENANT_DISABLED");
+            "NO_LEADER",
+            "NO_RESPONSE",
+            "CANCELLED",
+            "PHYSICAL_TENANT_DISABLED",
+            "PHYSICAL_TENANT_RECOVERING");
   }
 
   private static Set<String> namesOf(final Class<? extends Enum<?>> enumType) {

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/RebalanceCoordinatorTest.java
@@ -12,12 +12,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.ConfigurationChangeInProgressException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.NotCoordinatorException;
 import io.camunda.zeebe.rebalance.RebalanceRequestFailedException.RebalanceInProgressException;
@@ -32,6 +36,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,6 +53,7 @@ final class RebalanceCoordinatorTest {
 
   private static final MemberId LOWEST_ID_MEMBER = MemberId.from("1");
   private static final MemberId OTHER_MEMBER = MemberId.from("2");
+  private static final String OTHER_TENANT = "tenant-b";
   private static final Instant FIXED_INSTANT = Instant.parse("2024-01-01T00:00:00Z");
   private static final PartitionRebalance PLAN =
       PartitionRebalance.pending("default", 1, LOWEST_ID_MEMBER, OTHER_MEMBER);
@@ -605,6 +611,157 @@ final class RebalanceCoordinatorTest {
     assertThat(runner.invocations).isEqualTo(1);
   }
 
+  @Test
+  void shouldAdmitARebalanceWhileAPhysicalTenantIsRecovering() {
+    // given
+    final var runner = new CountingRunner();
+    final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
+    configurationWithEveryMemberRecovering(coordinator);
+
+    // when
+    final var triggered =
+        coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // then
+    assertThat(triggered.join().running().rebalanceId()).isEqualTo(100);
+    assertThat(runner.invocations).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAdmitADryRunWhileAPhysicalTenantIsRecovering() {
+    // given
+    final var runner = new CountingRunner();
+    final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
+    configurationWithARecoveringMember(coordinator);
+
+    // when
+    final var triggered =
+        coordinator.triggerRebalance(new TriggerRebalanceRequest(RebalanceOverrides.none(), true));
+
+    // then
+    assertThat(triggered.join().running().rebalanceId()).isEqualTo(100);
+    assertThat(runner.invocations).isEqualTo(1);
+  }
+
+  @Test
+  void shouldTellTheRunningRebalanceThatAPhysicalTenantIsRecovering() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // when
+    configurationWithARecoveringMember(coordinator);
+
+    // then
+    assertThat(
+            runner.rebalance.isPhysicalTenantRecovering(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isTrue();
+    assertThat(runner.rebalance.isCancelRequested())
+        .as("recovery is tracked per-partition, not by cancelling the run")
+        .isFalse();
+    assertThat(runner.rebalance.isAbandoned()).isFalse();
+  }
+
+  @Test
+  void shouldReportOnlyTheNamedTenantAsRecovering() {
+    // given
+    final var otherTenantPlan =
+        PartitionRebalance.pending(OTHER_TENANT, 1, LOWEST_ID_MEMBER, OTHER_MEMBER);
+    final var runner = new BlockedRunner(List.of(PLAN, otherTenantPlan));
+    final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
+    configurationWithBothMembers(coordinator);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // when
+    coordinator.onClusterConfigurationUpdated(
+        withRecoveringTenant(partitionedMembers(), OTHER_TENANT));
+
+    // then
+    assertThat(runner.rebalance.isPhysicalTenantRecovering(OTHER_TENANT)).isTrue();
+    assertThat(
+            runner.rebalance.isPhysicalTenantRecovering(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isFalse();
+    assertThat(runner.rebalance.isCancelRequested()).isFalse();
+  }
+
+  @Test
+  void shouldTakeNoFurtherActionOnRepeatedRecoveryConfigurationUpdates() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+    configurationWithARecoveringMember(coordinator);
+
+    // when
+    configurationWithARecoveringMember(coordinator);
+
+    // then
+    assertThat(
+            runner.rebalance.isPhysicalTenantRecovering(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isTrue();
+    final var status = coordinator.getRebalanceStatus().join();
+    assertThat(status.running().rebalanceId()).isEqualTo(100);
+    assertThat(status.lastCompleted()).isNull();
+  }
+
+  @Test
+  void shouldClearRecoveringStateWhenAPhysicalTenantReturnsToProcessing() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+    configurationWithARecoveringMember(coordinator);
+
+    // when
+    configurationWithBothMembers(coordinator);
+
+    // then
+    assertThat(
+            runner.rebalance.isPhysicalTenantRecovering(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .isFalse();
+    assertThat(runner.rebalance.isCancelRequested()).isFalse();
+  }
+
+  @Test
+  void shouldReportARebalanceThatLeftARecoveringPhysicalTenantAloneAsCompleted() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+    runner.rebalance.updatePartition(
+        0, partition -> partition.completed(PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING));
+
+    // when
+    runner.finish();
+
+    // then
+    assertThat(coordinator.getRebalanceStatus().join().lastCompleted().outcome())
+        .isEqualTo(RebalanceOutcome.COMPLETED);
+  }
+
+  @Test
+  void shouldAbandonRatherThanTrackRecoveryWhenItArrivesWithACoordinatorHandover() {
+    // given
+    final var runner = new BlockedRunner();
+    final var coordinator = coordinatingWith(runner);
+    coordinator.triggerRebalance(TriggerRebalanceRequest.withConfiguredSettings());
+
+    // when
+    coordinator.onClusterConfigurationUpdated(
+        withRecoveringTenant(aNewLowestIdMember(), OTHER_TENANT));
+
+    // then
+    assertThat(runner.rebalance.isAbandoned()).isTrue();
+    assertThat(runner.rebalance.isCancelRequested())
+        .as("abandonment, not recovery, is why the run stopped")
+        .isFalse();
+  }
+
   private RebalanceCoordinator coordinatingWith(final RebalanceRunner runner) {
     final var coordinator = startCoordinator(LOWEST_ID_MEMBER, runner);
     configurationWithBothMembers(coordinator);
@@ -624,11 +781,77 @@ final class RebalanceCoordinatorTest {
   }
 
   private void configurationWithBothMembers(final RebalanceCoordinator coordinator) {
+    coordinator.onClusterConfigurationUpdated(bothMembers());
+  }
+
+  private void configurationWithARecoveringMember(final RebalanceCoordinator coordinator) {
     coordinator.onClusterConfigurationUpdated(
         CurrentClusterConfiguration.fromLegacy(
-            ClusterConfiguration.init()
-                .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
-                .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()))));
+            partitionedMemberStates().updateMember(OTHER_MEMBER, MemberState::toRecovering)));
+  }
+
+  private void configurationWithEveryMemberRecovering(final RebalanceCoordinator coordinator) {
+    coordinator.onClusterConfigurationUpdated(
+        CurrentClusterConfiguration.fromLegacy(
+            partitionedMemberStates()
+                .updateMember(LOWEST_ID_MEMBER, MemberState::toRecovering)
+                .updateMember(OTHER_MEMBER, MemberState::toRecovering)));
+  }
+
+  private static ClusterConfiguration bothMemberStates() {
+    return ClusterConfiguration.init()
+        .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
+        .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()));
+  }
+
+  private static ClusterConfiguration partitionedMemberStates() {
+    return ClusterConfiguration.init()
+        .addMember(
+            LOWEST_ID_MEMBER,
+            MemberState.initializeAsActive(
+                Map.of(1, PartitionState.active(2, DynamicPartitionConfig.init()))))
+        .addMember(
+            OTHER_MEMBER,
+            MemberState.initializeAsActive(
+                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))));
+  }
+
+  private static CurrentClusterConfiguration bothMembers() {
+    return CurrentClusterConfiguration.fromLegacy(bothMemberStates());
+  }
+
+  private static CurrentClusterConfiguration partitionedMembers() {
+    return CurrentClusterConfiguration.fromLegacy(partitionedMemberStates());
+  }
+
+  private static CurrentClusterConfiguration aNewLowestIdMember() {
+    return CurrentClusterConfiguration.fromLegacy(
+        ClusterConfiguration.init()
+            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
+            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of())));
+  }
+
+  private static CurrentClusterConfiguration withRecoveringTenant(
+      final CurrentClusterConfiguration configuration, final String tenantId) {
+    final var recovering =
+        new PartitionGroupConfiguration(
+            PartitionGroupConfiguration.INITIAL_VERSION,
+            PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+            Map.of(
+                LOWEST_ID_MEMBER,
+                BrokerPartitionState.initialize(
+                        Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))
+                    .setMode(Mode.RECOVERING)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var groups = new HashMap<>(configuration.partitionGroups());
+    groups.put(tenantId, recovering);
+    return new CurrentClusterConfiguration(
+        configuration.version(),
+        configuration.globalConfiguration(),
+        groups,
+        configuration.phasedChangeState());
   }
 
   private void configurationWithADisabledDefaultPhysicalTenant(
@@ -644,10 +867,7 @@ final class RebalanceCoordinatorTest {
   }
 
   private void configurationWithAPendingChange(final RebalanceCoordinator coordinator) {
-    final var members =
-        ClusterConfiguration.init()
-            .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))
-            .addMember(OTHER_MEMBER, MemberState.initializeAsActive(Map.of()));
+    final var members = bothMemberStates();
     coordinator.onClusterConfigurationUpdated(
         CurrentClusterConfiguration.fromLegacy(
             ClusterConfiguration.builder()
@@ -661,11 +881,7 @@ final class RebalanceCoordinatorTest {
   }
 
   private void configurationWithANewLowestIdMember(final RebalanceCoordinator coordinator) {
-    coordinator.onClusterConfigurationUpdated(
-        CurrentClusterConfiguration.fromLegacy(
-            ClusterConfiguration.init()
-                .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()))
-                .addMember(LOWEST_ID_MEMBER, MemberState.initializeAsActive(Map.of()))));
+    coordinator.onClusterConfigurationUpdated(aNewLowestIdMember());
   }
 
   private static final class CountingRunner implements RebalanceRunner {
@@ -683,12 +899,21 @@ final class RebalanceCoordinatorTest {
   private static final class BlockedRunner implements RebalanceRunner {
 
     private final CompletableActorFuture<Void> completion = new CompletableActorFuture<>();
+    private final List<PartitionRebalance> plan;
     private RebalanceRun rebalance;
+
+    BlockedRunner() {
+      this(List.of(PLAN));
+    }
+
+    BlockedRunner(final List<PartitionRebalance> plan) {
+      this.plan = plan;
+    }
 
     @Override
     public ActorFuture<Void> run(final RebalanceRun rebalance) {
       this.rebalance = rebalance;
-      rebalance.plan(List.of(PLAN));
+      rebalance.plan(plan);
       return completion;
     }
 

--- a/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
+++ b/zeebe/rebalance/src/test/java/io/camunda/zeebe/rebalance/SequentialRebalanceRunnerTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
@@ -208,6 +209,48 @@ final class SequentialRebalanceRunnerTest {
                     "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1))),
                     "tenant-b", Map.of(MEMBER_1, Map.of(1, active(1)))))
             .updatePartitionGroupConfig("tenant-b", PartitionGroupConfiguration::disable);
+
+    // when
+    final var rebalance = planDryRun(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .map(PartitionRebalance::physicalTenantId)
+        .containsExactly("tenant-a");
+  }
+
+  @Test
+  void shouldNotPlanThePartitionsOfARecoveringPhysicalTenant() {
+    // given
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+                Map.of(
+                    "tenant-a",
+                        Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2))),
+                    "tenant-b",
+                        Map.of(MEMBER_1, Map.of(1, active(2)), MEMBER_2, Map.of(1, active(1)))))
+            .updatePartitionGroupConfig("tenant-b", SequentialRebalanceRunnerTest::recovering);
+
+    // when
+    final var rebalance = planDryRun(configuration);
+
+    // then
+    assertThat(rebalance.partitions())
+        .containsExactly(PartitionRebalance.pending("tenant-a", 1, MEMBER_1, MEMBER_2));
+  }
+
+  @Test
+  void shouldNotLookUpTheTopologyOfARecoveringPhysicalTenant() {
+    // given
+    unavailableGroups.add("tenant-b");
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+                Map.of(
+                    "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1))),
+                    "tenant-b", Map.of(MEMBER_1, Map.of(1, active(1)))))
+            .updatePartitionGroupConfig("tenant-b", SequentialRebalanceRunnerTest::recovering);
 
     // when
     final var rebalance = planDryRun(configuration);
@@ -716,6 +759,97 @@ final class SequentialRebalanceRunnerTest {
   }
 
   @Test
+  void shouldStopWaitingForALeaderOnceThePhysicalTenantIsRecovering() {
+    // given
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    final var completion = run(rebalance);
+
+    // when
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(GROUP, SequentialRebalanceRunnerTest::recovering));
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress()).isEqualTo(PartitionRebalanceProgress.COMPLETED);
+    assertThat(rebalance.partition(0).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING);
+    assertThat(transfers.initiated).isEmpty();
+    assertThat(completion.isDone()).isTrue();
+  }
+
+  @Test
+  void shouldLeaveAlonePartitionsOfAPhysicalTenantEnteringRecoveryBeforeTheRebalanceReachesThem() {
+    // given
+    leaders.computeIfAbsent("tenant-a", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    leaders.computeIfAbsent("tenant-b", ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration =
+        configurationOf(
+            Map.of(
+                "tenant-a", Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2))),
+                "tenant-b",
+                    Map.of(MEMBER_1, Map.of(1, active(1)), MEMBER_2, Map.of(1, active(2)))));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    run(rebalance);
+
+    // when
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(
+            "tenant-b", SequentialRebalanceRunnerTest::recovering));
+    transfers.accept();
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(rebalance.partition(1).outcome())
+        .isEqualTo(PartitionRebalanceOutcome.PHYSICAL_TENANT_RECOVERING);
+    assertThat(transfers.initiated)
+        .map(initiated -> initiated.physicalTenantId())
+        .containsExactly("tenant-a");
+  }
+
+  @Test
+  void shouldPreserveAnInFlightTransferWhenThePhysicalTenantEntersRecovery() {
+    // given
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    run(rebalance);
+    transfers.accept();
+
+    // when
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(GROUP, SequentialRebalanceRunnerTest::recovering));
+    transfers.report(LeadershipTransferResult.TRANSFERRED);
+
+    // then
+    assertThat(rebalance.partition(0).outcome()).isEqualTo(PartitionRebalanceOutcome.TRANSFERRED);
+  }
+
+  @Test
+  void shouldRebalanceAPhysicalTenantThatReturnsToProcessingWhileTheRebalanceRuns() {
+    // given
+    final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
+    final var rebalance =
+        new RebalanceRun(7, RebalanceOverrides.none(), false, configuration, Instant.EPOCH);
+    run(rebalance);
+    rebalance.observeConfiguration(
+        configuration.updatePartitionGroupConfig(GROUP, SequentialRebalanceRunnerTest::recovering));
+
+    // when
+    rebalance.observeConfiguration(configuration);
+    leaders.computeIfAbsent(GROUP, ignored -> new HashMap<>()).put(1, MEMBER_1);
+    executor.runAll();
+
+    // then
+    assertThat(rebalance.partition(0).progress())
+        .isEqualTo(PartitionRebalanceProgress.TRANSFERRING);
+    assertThat(transfers.lastInitiated().leader()).isEqualTo(MEMBER_1);
+  }
+
+  @Test
   void shouldRebalanceAPhysicalTenantThatIsEnabledAgainWhileTheRebalanceRuns() {
     // given
     final var configuration = groupConfiguration(GROUP, Map.of(MEMBER_1, 1, MEMBER_2, 2));
@@ -1151,6 +1285,14 @@ final class SequentialRebalanceRunnerTest {
 
   private PartitionState active(final int priority) {
     return PartitionState.active(priority, partitionConfig);
+  }
+
+  private static PartitionGroupConfiguration recovering(final PartitionGroupConfiguration group) {
+    var updated = group;
+    for (final var memberId : group.members().keySet()) {
+      updated = updated.updateMember(memberId, member -> member.setMode(Mode.RECOVERING));
+    }
+    return updated;
   }
 
   private CurrentClusterConfiguration groupConfiguration(


### PR DESCRIPTION
We already reject rebalances while a cluster configuration change is pending, but not after a physical tenant has entered recovery mode (or when it's about to).

Recovering partitions don't join their Raft groups and have no leaders, but the planner still includes their configured partitions, so they can be planned into a rebalance and will hit `leaderWaitTimeout`/`NO_LEADER` for each partition.

I've added handling so that any partition that is in a recovering tenant will be skipped, both at plan time and during execution (if it enters recovery after the rebalance starts).

Closes https://github.com/camunda/camunda/issues/61359.