### PR TITLE
refactor: add jspecify `@Nullable` annotation to `zeebe-restore` and `zeebe-restore-standalone`

### DIFF
--- a/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/package-info.java
+++ b/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.restore;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.restore;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
@@ -33,7 +35,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,7 @@ public class PartitionRestoreService {
     rootDirectory = partition.dataDirectory().toPath();
     this.partition = partition;
     this.brokerId = brokerId;
-    this.fileInfoProvider = Objects.requireNonNull(fileInfoProvider);
+    this.fileInfoProvider = requireNonNull(fileInfoProvider);
     this.meterRegistry = meterRegistry;
   }
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -36,6 +36,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,7 +138,7 @@ public class PartitionRestoreService {
    * index of the source journal.
    */
   private void copyBetweenCheckpoints(
-      final Backup previousBackup,
+      final @Nullable Backup previousBackup,
       final Backup sourceBackup,
       final Path sourceDirectory,
       final Journal targetJournal) {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/package-info.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.restore;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.restore.validation;
 
 import static io.camunda.zeebe.backup.management.BackupMetadataSyncer.MAPPER;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -150,7 +150,7 @@ public final class RestoreValidator
   private Map<Integer, long[]> resolveBackupsByPartition(final List<Long> backupIds) {
     final var ids = backupIds.stream().mapToLong(Long::longValue).sorted().toArray();
     final var store =
-        Objects.requireNonNull(backupStore, "Backup store must be configured to load backups");
+        requireNonNull(backupStore, "Backup store must be configured to load backups");
     return awaitResult(
             FuturesUtil.parTraverse(
                 IntStream.rangeClosed(1, partitionCount).boxed().toList(),
@@ -231,7 +231,7 @@ public final class RestoreValidator
 
   private List<BackupMetadata> loadMetadataForAllPartitions(final int partitionCount) {
     final var store =
-        Objects.requireNonNull(backupStore, "Backup store must be configured to load backups");
+        requireNonNull(backupStore, "Backup store must be configured to load backups");
     final var metadataByPartition =
         awaitResult(
             FuturesUtil.parTraverse(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/package-info.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.restore.validation;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Description

Add jspecify `@Nullable` annotations to `zeebe-restore` and `zeebe-restore-standalone`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53262 
