### PR TITLE
refactor: add JSpecify nullness annotations to zeebe-backup

### DIFF
--- a/zeebe/backup-stores/common/pom.xml
+++ b/zeebe/backup-stores/common/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/Manifest.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/Manifest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import java.time.Instant;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 @JsonSerialize(as = ManifestImpl.class)
 @JsonDeserialize(as = ManifestImpl.class)
@@ -46,7 +47,7 @@ public sealed interface Manifest {
 
   BackupIdentifierImpl id();
 
-  BackupDescriptorImpl descriptor();
+  @Nullable BackupDescriptorImpl descriptor();
 
   StatusCode statusCode();
 

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/ManifestImpl.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/ManifestImpl.java
@@ -15,16 +15,17 @@ import static io.camunda.zeebe.backup.common.Manifest.StatusCode.IN_PROGRESS;
 import io.camunda.zeebe.backup.common.BackupStoreException.InvalidPersistedManifestState;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import java.time.Instant;
+import org.jspecify.annotations.Nullable;
 
 public record ManifestImpl(
     BackupIdentifierImpl id,
-    BackupDescriptorImpl descriptor,
+    @Nullable BackupDescriptorImpl descriptor,
     StatusCode statusCode,
-    FileSet snapshot,
-    FileSet segments,
+    @Nullable FileSet snapshot,
+    @Nullable FileSet segments,
     Instant createdAt,
     Instant modifiedAt,
-    String failureReason)
+    @Nullable String failureReason)
     implements Manifest.InProgressManifest,
         Manifest.CompletedManifest,
         Manifest.FailedManifest,
@@ -42,10 +43,10 @@ public record ManifestImpl(
 
   public ManifestImpl(
       final BackupIdentifierImpl id,
-      final BackupDescriptorImpl descriptor,
+      final @Nullable BackupDescriptorImpl descriptor,
       final StatusCode statusCode,
-      final FileSet snapshot,
-      final FileSet segments,
+      final @Nullable FileSet snapshot,
+      final @Nullable FileSet segments,
       final Instant createdAt,
       final Instant modifiedAt) {
     this(id, descriptor, statusCode, snapshot, segments, createdAt, modifiedAt, null);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupDeleteRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupDeleteRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BackupDeleteRequest extends BrokerRequest<BackupStatusResponse> {
   protected final BackupRequest request = new BackupRequest();
@@ -56,7 +57,7 @@ public class BackupDeleteRequest extends BrokerRequest<BackupStatusResponse> {
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupListRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupListRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BackupListRequest extends BrokerRequest<BackupListResponse> {
 
@@ -70,7 +71,7 @@ public class BackupListRequest extends BrokerRequest<BackupListResponse> {
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupStatusRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupStatusRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BackupStatusRequest extends BrokerRequest<BackupStatusResponse> {
 
@@ -62,7 +63,7 @@ public class BackupStatusRequest extends BrokerRequest<BackupStatusResponse> {
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRangesRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRangesRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BrokerBackupRangesRequest extends BrokerRequest<BackupRangesResponse> {
 
@@ -54,7 +55,7 @@ public class BrokerBackupRangesRequest extends BrokerRequest<BackupRangesRespons
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerBackupRequest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 /** Wraps the request and response for "Take Backup" sent between gateway and broker */
 public final class BrokerBackupRequest extends BrokerRequest<BackupResponse> {
@@ -58,7 +59,7 @@ public final class BrokerBackupRequest extends BrokerRequest<BackupResponse> {
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerCheckpointStateRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerCheckpointStateRequest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateResponse> {
 
@@ -58,7 +59,7 @@ public class BrokerCheckpointStateRequest extends BrokerRequest<CheckpointStateR
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerClearBackupStateRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerClearBackupStateRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class BrokerClearBackupStateRequest extends BrokerRequest<BackupStatusResponse> {
 
@@ -49,7 +50,7 @@ public final class BrokerClearBackupStateRequest extends BrokerRequest<BackupSta
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerMetadataSyncRequest.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BrokerMetadataSyncRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class BrokerMetadataSyncRequest extends BrokerRequest<BackupRangesResponse> {
 
@@ -49,7 +50,7 @@ public final class BrokerMetadataSyncRequest extends BrokerRequest<BackupRangesR
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.client.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.backup.management;
 
+import static io.camunda.zeebe.util.Unit.unit;
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupRange;
@@ -31,6 +34,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
@@ -43,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +61,7 @@ final class BackupServiceImpl {
   private final BackupMetadataSyncer metadataSyncer;
   private final BackupStoreQueries storeQueries;
   private final int partitionId;
-  private ConcurrencyControl concurrencyControl;
+  private @Nullable ConcurrencyControl concurrencyControl;
 
   BackupServiceImpl(
       final BackupStore backupStore,
@@ -137,7 +142,7 @@ final class BackupServiceImpl {
             .addKeyValue("backup", inProgressBackup.id())
             .setMessage("Backup is already completed, will not take a new one")
             .log();
-        backupSaved.complete(null);
+        backupSaved.complete(unit());
       }
       case FAILED, IN_PROGRESS -> {
         LOG.atWarn()
@@ -177,11 +182,16 @@ final class BackupServiceImpl {
         .onComplete(
             proceed(
                 error -> failBackup(inProgressBackup, backupSaved, error),
-                () -> backupSaved.complete(null)));
+                () -> backupSaved.complete(unit())));
   }
 
   private ActorFuture<Void> saveBackup(final InProgressBackup inProgressBackup) {
-    final ActorFuture<Void> future = concurrencyControl.createFuture();
+    final var executor = concurrencyControl;
+    if (executor == null) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalStateException("concurrencyControl must be set before saving a backup"));
+    }
+    final ActorFuture<Void> future = executor.createFuture();
     final var backup = inProgressBackup.createBackup();
     LOG.atDebug().addKeyValue("backup", inProgressBackup.id()).setMessage("Saving backup").log();
     backupStore
@@ -189,12 +199,12 @@ final class BackupServiceImpl {
         .whenCompleteAsync(
             (ignore, error) -> {
               if (error == null) {
-                future.complete(null);
+                future.complete(unit());
               } else {
                 future.completeExceptionally("Failed to save backup", error);
               }
             },
-            concurrencyControl);
+            executor);
     return future;
   }
 
@@ -208,7 +218,8 @@ final class BackupServiceImpl {
         .setMessage("Marking backup as failed")
         .log();
     backupSaved.completeExceptionally(error);
-    backupStore.markFailed(inProgressBackup.id(), error.getMessage());
+    final var errorMessage = error.getMessage() != null ? error.getMessage() : error.toString();
+    backupStore.markFailed(inProgressBackup.id(), errorMessage);
   }
 
   private void closeInProgressBackup(final InProgressBackup inProgressBackup) {
@@ -252,7 +263,7 @@ final class BackupServiceImpl {
     }
   }
 
-  private BiConsumer<Void, Throwable> proceed(
+  private BiConsumer<Void, @Nullable Throwable> proceed(
       final Consumer<Throwable> onError, final Runnable nextStep) {
     return (ignore, error) -> {
       if (error != null) {
@@ -330,7 +341,8 @@ final class BackupServiceImpl {
       case Either.Left(final var error) ->
           deleteCompleted.completeExceptionally(
               new RuntimeException("Failed to write DELETE_BACKUP command: " + error));
-      case final Either.Right<WriteFailure, Long> ignoredPosition -> deleteCompleted.complete(null);
+      case final Either.Right<WriteFailure, Long> ignoredPosition ->
+          deleteCompleted.complete(unit());
     }
     return deleteCompleted;
   }
@@ -350,7 +362,8 @@ final class BackupServiceImpl {
       case Either.Left(final var error) ->
           clearCompleted.completeExceptionally(
               new RuntimeException("Failed to write CLEAR_STATE command: " + error));
-      case final Either.Right<WriteFailure, Long> ignoredPosition -> clearCompleted.complete(null);
+      case final Either.Right<WriteFailure, Long> ignoredPosition ->
+          clearCompleted.complete(unit());
     }
     return clearCompleted;
   }
@@ -420,7 +433,7 @@ final class BackupServiceImpl {
         checkpointId,
         meta.getCheckpointPosition(),
         meta.getCheckpointTimestamp(),
-        meta.getCheckpointType(),
+        requireNonNull(meta.getCheckpointType()),
         meta.getFirstLogPosition());
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.backup.management;
 
+import static io.camunda.zeebe.util.Unit.unit;
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
@@ -38,6 +41,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,11 +61,11 @@ final class InProgressBackupImpl implements InProgressBackup {
 
   // Snapshot related data
   private boolean hasSnapshot = true;
-  private Set<PersistedSnapshot> availableValidSnapshots;
-  private SnapshotReservation snapshotReservation;
-  private PersistedSnapshot reservedSnapshot;
-  private NamedFileSet snapshotFileSet;
-  private NamedFileSet segmentsFileSet;
+  private @Nullable Set<PersistedSnapshot> availableValidSnapshots;
+  private @Nullable SnapshotReservation snapshotReservation;
+  private @Nullable PersistedSnapshot reservedSnapshot;
+  private @Nullable NamedFileSet snapshotFileSet;
+  private @Nullable NamedFileSet segmentsFileSet;
   private OptionalLong firstLogPosition = OptionalLong.empty();
 
   InProgressBackupImpl(
@@ -151,7 +155,7 @@ final class InProgressBackupImpl implements InProgressBackup {
                 future.completeExceptionally(findError);
               } else if (!hasSnapshot) {
                 // No snapshot to reserve
-                future.complete(null);
+                future.complete(unit());
               } else {
                 tryReserveWithRetry(future, remainingAttempts);
               }
@@ -159,6 +163,12 @@ final class InProgressBackupImpl implements InProgressBackup {
   }
 
   private void tryReserveWithRetry(final ActorFuture<Void> future, final int remainingAttempts) {
+    if (availableValidSnapshots == null) {
+      future.completeExceptionally(
+          new IllegalStateException("availableValidSnapshots must be set by findValidSnapshot"));
+      return;
+    }
+
     // Try reserve snapshot in the order - latest snapshot first
     final var snapshotIterator =
         availableValidSnapshots.stream()
@@ -177,10 +187,16 @@ final class InProgressBackupImpl implements InProgressBackup {
 
     final ActorFuture<Void> filesCollected = concurrencyControl.createFuture();
 
-    final Path snapshotRoot = reservedSnapshot.getPath();
+    final var snapshot = reservedSnapshot;
+    if (snapshot == null) {
+      filesCollected.completeExceptionally(
+          new IllegalStateException("reservedSnapshot must be set by reserveSnapshot"));
+      return filesCollected;
+    }
+    final Path snapshotRoot = snapshot.getPath();
     try (final var stream = Files.list(snapshotRoot)) {
       final var snapshotFiles = stream.collect(Collectors.toSet());
-      final var checksumFile = reservedSnapshot.getChecksumPath();
+      final var checksumFile = snapshot.getChecksumPath();
 
       final Map<String, Path> fileSet = new HashMap<>();
       snapshotFiles.forEach(
@@ -191,20 +207,21 @@ final class InProgressBackupImpl implements InProgressBackup {
 
       fileSet.put(checksumFile.getFileName().toString(), checksumFile);
 
-      snapshotFileSet = new NamedFileSetImpl(fileSet);
+      final var collectedFileSet = new NamedFileSetImpl(fileSet);
+      snapshotFileSet = collectedFileSet;
       LOG.atTrace()
           .addKeyValue("backup", backupId)
-          .addKeyValue("snapshot", reservedSnapshot.getId())
-          .addKeyValue("files", snapshotFileSet.files()::size)
+          .addKeyValue("snapshot", snapshot.getId())
+          .addKeyValue("files", collectedFileSet.files()::size)
           .setMessage("Collected snapshot files for backup")
           .log();
 
-      filesCollected.complete(null);
+      filesCollected.complete(unit());
 
     } catch (final IOException e) {
       LOG.atError()
           .addKeyValue("backup", backupId)
-          .addKeyValue("snapshot", reservedSnapshot.getId())
+          .addKeyValue("snapshot", snapshot.getId())
           .setCause(e)
           .setMessage("Failed to collect snapshot files for backup")
           .log();
@@ -255,7 +272,7 @@ final class InProgressBackupImpl implements InProgressBackup {
                                   path -> segmentsDirectory.relativize(path).toString(),
                                   Function.identity()));
                   segmentsFileSet = new NamedFileSetImpl(map);
-                  filesCollected.complete(null);
+                  filesCollected.complete(unit());
                 }
               },
               concurrencyControl);
@@ -275,7 +292,10 @@ final class InProgressBackupImpl implements InProgressBackup {
     final Optional<String> snapshotId;
 
     if (hasSnapshot) {
-      snapshotId = Optional.of(reservedSnapshot.getId());
+      snapshotId =
+          Optional.of(
+              requireNonNull(reservedSnapshot, "reservedSnapshot must be set by reserveSnapshot")
+                  .getId());
     } else {
       snapshotId = Optional.empty();
     }
@@ -289,16 +309,23 @@ final class InProgressBackupImpl implements InProgressBackup {
             VersionUtil.getVersion(),
             backupDescriptor().checkpointTimestamp(),
             backupDescriptor().checkpointType());
-    return new BackupImpl(backupId, backupDescriptor, snapshotFileSet, segmentsFileSet);
+    return new BackupImpl(
+        backupId,
+        backupDescriptor,
+        requireNonNull(snapshotFileSet, "snapshotFileSet must be set by findSnapshotFiles"),
+        requireNonNull(segmentsFileSet, "segmentsFileSet must be set by findSegmentFiles"));
   }
 
   @Override
   public void close() {
-    if (snapshotReservation != null) {
-      snapshotReservation.release();
+    final var reservation = snapshotReservation;
+    if (reservation != null) {
+      reservation.release();
       LOG.atTrace()
           .addKeyValue("backup", backupId)
-          .addKeyValue("snapshot", reservedSnapshot.getId())
+          .addKeyValue(
+              "snapshot",
+              requireNonNull(reservedSnapshot, "reservedSnapshot must be set before releasing"))
           .setMessage("Released snapshot reservation")
           .log();
     }
@@ -441,7 +468,7 @@ final class InProgressBackupImpl implements InProgressBackup {
                 .addKeyValue("snapshot", snapshot.getId())
                 .setMessage("Reserved snapshot")
                 .log();
-            future.complete(null);
+            future.complete(unit());
           }
         });
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.management;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupRange;
@@ -68,7 +70,7 @@ public class NoopBackupManager implements BackupManager {
 
   @Override
   public ActorFuture<Void> closeAsync() {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed(unit());
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/ReadOnlyBackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/ReadOnlyBackupService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Read-only {@link ReadOnlyBackupManager} used while a partition is in recovery mode. Serves the
@@ -110,7 +111,8 @@ public final class ReadOnlyBackupService extends Actor implements ReadOnlyBackup
         new BackupIdentifierImpl(nodeId, partition.number(), checkpointId));
   }
 
-  private static Collection<BackupRangeStatus> toRangeStatuses(final BackupMetadata metadata) {
+  private static Collection<BackupRangeStatus> toRangeStatuses(
+      final @Nullable BackupMetadata metadata) {
     if (metadata == null) {
       return List.of();
     }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.management;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointBackupDeletedApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.processing;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.BackupRange;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.backup.processing.state.DbBackupRangeState;
@@ -69,10 +71,11 @@ public final class CheckpointBackupDeletedApplier {
       // backup.
       return;
     }
-    final var firstLogPosition =
-        checkpointMetadataState
-            .getCheckpoint(firstRange.orElseThrow().start())
-            .getFirstLogPosition();
+    final var firstCheckpoint =
+        requireNonNull(
+            checkpointMetadataState.getCheckpoint(firstRange.orElseThrow().start()),
+            "checkpoint metadata must exist for the first range");
+    final var firstLogPosition = firstCheckpoint.getFirstLogPosition();
     checkpointMetadataState.removeCheckpointsUntil(firstLogPosition);
   }
 
@@ -89,7 +92,7 @@ public final class CheckpointBackupDeletedApplier {
             predecessor.get(),
             predecessorMetadata.getCheckpointPosition(),
             predecessorMetadata.getCheckpointTimestamp(),
-            predecessorMetadata.getCheckpointType(),
+            requireNonNull(predecessorMetadata.getCheckpointType(), "checkpointType is null"),
             predecessorMetadata.getFirstLogPosition());
         LOG.debug(
             "Rolled back latest backup from {} to predecessor {}", checkpointId, predecessor.get());

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.processing;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
@@ -30,6 +32,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,25 +44,41 @@ public final class CheckpointRecordsProcessor
 
   private final BackupManager backupManager;
   private final boolean trackBackupMetadata;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointCreateProcessor checkpointCreateProcessor;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointConfirmBackupProcessor checkpointConfirmBackupProcessor;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointDeleteBackupProcessor checkpointDeleteBackupProcessor;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointClearStateProcessor checkpointClearStateProcessor;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointCreatedEventApplier checkpointCreatedEventApplier;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointBackupConfirmedApplier checkpointBackupConfirmedApplier;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointBackupDeletedApplier checkpointBackupDeletedApplier;
+
+  @SuppressWarnings("NullAway.Init")
   private CheckpointStateClearedApplier checkpointStateClearedApplier;
 
   //  Can be accessed concurrently by other threads to add new listeners. Hence we have to use a
   // thread safe collection
   private final Set<CheckpointListener> checkpointListeners = new CopyOnWriteArraySet<>();
   private final CheckpointMetrics metrics;
-  private DbCheckpointState checkpointState;
-  private DbCheckpointMetadataState checkpointMetadataState;
-  private DbBackupRangeState backupRangeState;
-  private ProcessingScheduleService executor;
-  private ScalingStatusSupplier scalingInProgressSupplier;
-  private PartitionCountSupplier partitionCountSupplier;
+  private @Nullable DbCheckpointState checkpointState;
+  private @Nullable DbCheckpointMetadataState checkpointMetadataState;
+  private @Nullable DbBackupRangeState backupRangeState;
+  private @Nullable ProcessingScheduleService executor;
+  private @Nullable ScalingStatusSupplier scalingInProgressSupplier;
+  private @Nullable PartitionCountSupplier partitionCountSupplier;
 
   public CheckpointRecordsProcessor(
       final BackupManager backupManager,
@@ -144,7 +163,7 @@ public final class CheckpointRecordsProcessor
 
     final long checkpointId = checkpointState.getLatestCheckpointId();
     final var checkpointType = checkpointState.getLatestCheckpointType();
-    if (checkpointId != CheckpointState.NO_CHECKPOINT) {
+    if (checkpointId != CheckpointState.NO_CHECKPOINT && checkpointType != null) {
       checkpointListeners.forEach(
           listener -> listener.onNewCheckpointCreated(checkpointId, checkpointType));
       metrics.setCheckpointId(checkpointId, checkpointState.getLatestCheckpointPosition());
@@ -241,9 +260,10 @@ public final class CheckpointRecordsProcessor
       executor.runDelayed(
           Duration.ZERO,
           () -> {
-            final var checkpointId = checkpointState.getLatestCheckpointId();
-            final var checkpointType = checkpointState.getLatestCheckpointType();
-            if (checkpointId != CheckpointState.NO_CHECKPOINT) {
+            final var state = requireNonNull(checkpointState);
+            final var checkpointId = state.getLatestCheckpointId();
+            final var checkpointType = state.getLatestCheckpointType();
+            if (checkpointId != CheckpointState.NO_CHECKPOINT && checkpointType != null) {
               checkpointListener.onNewCheckpointCreated(checkpointId, checkpointType);
             }
           });
@@ -255,6 +275,6 @@ public final class CheckpointRecordsProcessor
     // After a leader change, the new leader will not continue taking the backup initiated by
     // previous leader. So mark them as failed, so that the users do not wait forever for it to be
     // completed.
-    backupManager.failInProgressBackup(checkpointState.getLatestCheckpointId());
+    backupManager.failInProgressBackup(requireNonNull(checkpointState).getLatestCheckpointId());
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.processing;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import org.jspecify.annotations.Nullable;
 
 /** Checkpoint info stored in db in msgpack format. */
 public final class CheckpointInfo extends UnpackedObject implements DbValue {
@@ -58,7 +59,7 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public CheckpointType getType() {
+  public @Nullable CheckpointType getType() {
     return typeProperty.getValue();
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointMetadataValue.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointMetadataValue.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Full metadata for a single checkpoint, stored in the CHECKPOINTS column family. Tracks all
@@ -53,7 +54,7 @@ public final class CheckpointMetadataValue extends UnpackedObject implements DbV
     return this;
   }
 
-  public CheckpointType getCheckpointType() {
+  public @Nullable CheckpointType getCheckpointType() {
     return checkpointTypeProperty.getValue();
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.processing.state;
 
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import org.jspecify.annotations.Nullable;
 
 public interface CheckpointState {
 
@@ -31,7 +32,7 @@ public interface CheckpointState {
   long getLatestCheckpointTimestamp();
 
   /** Returns the type of the last created checkpoint. */
-  CheckpointType getLatestCheckpointType();
+  @Nullable CheckpointType getLatestCheckpointType();
 
   /**
    * Set id and position of the last created checkpoint
@@ -72,7 +73,7 @@ public interface CheckpointState {
   long getLatestBackupTimestamp();
 
   /** Returns the type of the last created backup. */
-  CheckpointType getLatestBackupType();
+  @Nullable CheckpointType getLatestBackupType();
 
   /** Returns the first log position of the last checkpoint with a successful backup. */
   long getLatestBackupFirstLogPosition();

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbBackupRangeState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.processing.state;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.BackupRange;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
@@ -136,7 +138,8 @@ public final class DbBackupRangeState {
    */
   public void updateRangeStart(final long oldStart, final long newStart) {
     rangeStartKey.wrapLong(oldStart);
-    final var endCheckpointId = rangesColumnFamily.get(rangeStartKey).getValue();
+    final var endCheckpointId =
+        requireNonNull(rangesColumnFamily.get(rangeStartKey), "range must exist").getValue();
     rangesColumnFamily.deleteExisting(rangeStartKey);
 
     rangeStartKey.wrapLong(newStart);

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointMetadataState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.processing.state;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.Checkpoint;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
@@ -18,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.collections.MutableLong;
+import org.jspecify.annotations.Nullable;
 
 /**
  * State backed by the CHECKPOINTS column family. Stores full metadata for every created markers and
@@ -74,7 +77,7 @@ public final class DbCheckpointMetadataState {
   }
 
   /** Point lookup for a single checkpoint. Returns null if not found. */
-  public CheckpointMetadataValue getCheckpoint(final long checkpointId) {
+  public @Nullable CheckpointMetadataValue getCheckpoint(final long checkpointId) {
     checkpointIdKey.wrapLong(checkpointId);
     return checkpointsColumnFamily.get(checkpointIdKey);
   }
@@ -86,7 +89,7 @@ public final class DbCheckpointMetadataState {
         (key, value) ->
             result.add(
                 new Checkpoint(
-                    value.getCheckpointType(),
+                    requireNonNull(value.getCheckpointType(), "checkpoint type"),
                     key.getValue(),
                     value.getCheckpointTimestamp(),
                     value.getCheckpointPosition(),
@@ -112,7 +115,7 @@ public final class DbCheckpointMetadataState {
     checkpointsColumnFamily.whileTrueReverse(
         checkpointIdKey,
         (key, value) -> {
-          if (value.getCheckpointType().shouldCreateBackup()) {
+          if (requireNonNull(value.getCheckpointType(), "checkpoint type").shouldCreateBackup()) {
             result.set(key.getValue());
             return false; // stop iteration
           }
@@ -137,7 +140,7 @@ public final class DbCheckpointMetadataState {
     checkpointsColumnFamily.whileTrue(
         checkpointIdKey,
         (key, value) -> {
-          if (value.getCheckpointType().shouldCreateBackup()) {
+          if (requireNonNull(value.getCheckpointType(), "checkpoint type").shouldCreateBackup()) {
             result.set(key.getValue());
             return false; // stop iteration
           }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import org.jspecify.annotations.Nullable;
 
 public final class DbCheckpointState implements CheckpointState {
   private static final String LATEST_CHECKPOINT_KEY = "checkpoint";
@@ -47,7 +48,7 @@ public final class DbCheckpointState implements CheckpointState {
   }
 
   @Override
-  public CheckpointType getLatestCheckpointType() {
+  public @Nullable CheckpointType getLatestCheckpointType() {
     return getCheckpointType(LATEST_CHECKPOINT_KEY);
   }
 
@@ -99,7 +100,7 @@ public final class DbCheckpointState implements CheckpointState {
   }
 
   @Override
-  public CheckpointType getLatestBackupType() {
+  public @Nullable CheckpointType getLatestBackupType() {
     return getCheckpointType(LATEST_BACKUP_KEY);
   }
 
@@ -138,7 +139,7 @@ public final class DbCheckpointState implements CheckpointState {
     return info != null ? info.getTimestamp() : -1L;
   }
 
-  private CheckpointType getCheckpointType(final String key) {
+  private @Nullable CheckpointType getCheckpointType(final String key) {
     checkpointInfoKey.wrapString(key);
     final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
     return info != null ? info.getType() : null;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.processing.state;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/BackupRetention.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.retention;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
@@ -198,7 +200,7 @@ public class BackupRetention extends Actor {
           if (error != null) {
             retentionFuture.completeExceptionally(error);
           } else {
-            retentionFuture.complete(null);
+            retentionFuture.complete(unit());
           }
         });
     return retentionFuture;
@@ -224,7 +226,13 @@ public class BackupRetention extends Actor {
         new BackupIdentifierWildcardImpl(
             Optional.empty(), Optional.of(partitionId), CheckpointPattern.any());
     final ActorFuture<Collection<BackupStatus>> requestFuture = createFuture();
-    backupStore
+    final var store = backupStore;
+    if (store == null) {
+      requestFuture.completeExceptionally(
+          new IllegalStateException("backupStore must be initialized before retention runs"));
+      return requestFuture;
+    }
+    store
         .list(identifier)
         .thenApplyAsync(
             backups -> backups.stream().sorted(BACKUP_STATUS_COMPARATOR).toList(), actor)
@@ -255,12 +263,12 @@ public class BackupRetention extends Actor {
     long firstAvailableBackupInNewRange = -1L;
     final var deletableBackups = new ArrayList<BackupIdentifier>();
 
-    final Instant windowBound = calculateWindowBound(latestCompletedBackup.get());
+    final var windowBound = calculateWindowBound(latestCompletedBackup.get());
 
     for (final var backup : backups) {
       final var timestamp = backupTimestamp(backup);
 
-      if (timestamp.isBefore(windowBound)) {
+      if (timestamp != null && windowBound != null && timestamp.isBefore(windowBound)) {
         if (backup.id().checkpointId() != latestCompletedBackup.get().id().checkpointId()) {
           deletableBackups.add(backup.id());
         } else {
@@ -295,8 +303,13 @@ public class BackupRetention extends Actor {
     return backups.stream().filter(backup -> backupTimestamp(backup) != null).toList();
   }
 
-  private Instant calculateWindowBound(final BackupStatus latestCompletedBackup) {
-    return backupTimestamp(latestCompletedBackup).minusSeconds(retentionWindow.toSeconds());
+  private @Nullable Instant calculateWindowBound(final BackupStatus latestCompletedBackup) {
+    final var completedTimestamp = backupTimestamp(latestCompletedBackup);
+    if (completedTimestamp != null) {
+      return completedTimestamp.minusSeconds(retentionWindow.toSeconds());
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -312,7 +325,7 @@ public class BackupRetention extends Actor {
   private CompletableActorFuture<Void> writeDeleteCommands(final RetentionContext context) {
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     if (context.deletableBackups.isEmpty()) {
-      future.complete(null);
+      future.complete(unit());
       return future;
     }
 
@@ -373,7 +386,9 @@ public class BackupRetention extends Actor {
     }
   }
 
-  private Instant backupTimestamp(final BackupStatus backup) {
+  // `@Nullable` had to be added manually:
+  // NullAway cannot infer that `orElseGet(() -> null)` is nullable
+  private @Nullable Instant backupTimestamp(final BackupStatus backup) {
     return backup
         .descriptor()
         .map(BackupDescriptor::checkpointTimestamp)
@@ -390,13 +405,13 @@ public class BackupRetention extends Actor {
       List<BackupIdentifier> deletableBackups,
       long earliestBackupInNewRange,
       int partitionId,
-      Instant windowBoundary) {
+      @Nullable Instant windowBoundary) {
 
     static RetentionContext init(
         final int partitionId,
         final List<BackupIdentifier> deletableBackups,
         final long earliestBackupInNewRange,
-        final Instant windowBoundary) {
+        final @Nullable Instant windowBoundary) {
       return new RetentionContext(
           deletableBackups, earliestBackupInNewRange, partitionId, windowBoundary);
     }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/RetentionMetrics.java
@@ -24,8 +24,13 @@ public class RetentionMetrics implements CloseableSilently {
 
   private final MeterRegistry meterRegistry;
   private final Map<Integer, PartitionMetrics> partitionMetrics = new ConcurrentHashMap<>();
+
+  @SuppressWarnings("NullAway.Init")
   private Gauge lastExecutionGauge;
+
+  @SuppressWarnings("NullAway.Init")
   private Gauge nextExecutionGauge;
+
   private long lastExecution = 0L;
   private long nextExecution = 0L;
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/retention/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.retention;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/Schedule.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/Schedule.java
@@ -18,6 +18,7 @@ import java.time.ZoneId;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /** Represents a schedule which can be either a CRON expression or an ISO8601 duration interval. */
 public sealed interface Schedule {
@@ -39,7 +40,7 @@ public sealed interface Schedule {
    * @return the typed {@link Schedule}
    * @throws IllegalArgumentException if the expression is invalid
    */
-  static Schedule parseSchedule(final String expression) throws IllegalArgumentException {
+  static Schedule parseSchedule(final @Nullable String expression) throws IllegalArgumentException {
     if (expression == null || expression.isBlank()) {
       return none();
     }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/package-info.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.schedule;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -720,7 +720,7 @@ class BackupServiceImplTest {
             new SimpleMeterRegistry());
 
     when(backupRangeState.getAllRanges()).thenReturn(List.of(new BackupRange(1L, 5L)));
-    final var firstMeta = mock(CheckpointMetadataValue.class);
+    final var firstMeta = mockCheckpointMeta(100L, 1000L, CheckpointType.MANUAL_BACKUP, 0L);
     when(checkpointMetadataState.getCheckpoint(1L)).thenReturn(firstMeta);
     when(checkpointMetadataState.getCheckpoint(5L)).thenReturn(null);
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
+import org.jspecify.annotations.Nullable;
 
 public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRecordValue {
 
@@ -59,7 +60,7 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
     return this;
   }
 
-  public CheckpointRecord setCheckpointType(final CheckpointType checkpointType) {
+  public CheckpointRecord setCheckpointType(@Nullable final CheckpointType checkpointType) {
     checkpointTypeProperty.setValue(checkpointType);
     return this;
   }


### PR DESCRIPTION
## Summary
- Mark all `zeebe/backup` packages `@NullMarked` so NullAway enforces nullness on the module.
- `refactor: use unit() instead of null when completing futures` — replace `CompletableActorFuture.completed(null)` with `completed(unit())`.
- `refactor: mark genuinely nullable state in zeebe-backup` — annotate fields/return values that were already nullable by convention but undeclared (late-init fields, actor-lifecycle-scoped fields, absent retention window bound, `BufferWriter`-returning overrides that return `null`). Null-checks on fields read inside future-returning methods fail the future instead of throwing synchronously, so callers relying on the future's error channel still see the failure.

No behavior changes — the runtime contract was already this way; the annotations just make it explicit and checked.

Closes #53242