### PR TITLE
fix: drive transfer catch-up from append responses

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/CatchUpWait.java
@@ -18,18 +18,19 @@ package io.atomix.raft.rebalance;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.LeadershipTransferResult;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.roles.LeaderRole;
 import io.atomix.utils.concurrent.Scheduled;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BooleanSupplier;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Waits until the desired leader's {@code matchIndex} reaches the frozen log head, polling on the
- * Raft thread each heartbeat interval until it catches up or {@code deadlineMs} passes.
+ * Waits until the desired leader's {@code matchIndex} reaches the frozen log head (with updates
+ * driven from append responses), or {@code deadlineMs} passes.
  *
  * <p>The future returned by {@link #start()} completes with an empty {@link Optional} once the
  * desired leader is fully caught up (proceed to promotion), or with a terminal reason if there was
@@ -40,22 +41,24 @@ final class CatchUpWait implements TransferPhase {
   private static final Logger LOG = LoggerFactory.getLogger(CatchUpWait.class);
 
   private final RaftContext raft;
-  private final BooleanSupplier leaderRunning;
+  private final LeaderRole leader;
   private final MemberId desiredLeader;
   private final long targetIndex;
   private final long deadlineMs;
   private final CompletableFuture<Optional<LeadershipTransferResult>> result =
       new CompletableFuture<>();
-  private @Nullable Scheduled pollTimer;
+  private @Nullable CompletableFuture<Void> replication;
+  private @Nullable Scheduled deadlineTimer;
+  private boolean completed;
 
   CatchUpWait(
       final RaftContext raft,
-      final BooleanSupplier leaderRunning,
+      final LeaderRole leader,
       final MemberId desiredLeader,
       final long targetIndex,
       final long deadlineMs) {
     this.raft = raft;
-    this.leaderRunning = leaderRunning;
+    this.leader = leader;
     this.desiredLeader = desiredLeader;
     this.targetIndex = targetIndex;
     this.deadlineMs = deadlineMs;
@@ -63,18 +66,50 @@ final class CatchUpWait implements TransferPhase {
 
   CompletableFuture<Optional<LeadershipTransferResult>> start() {
     raft.checkThread();
-    if (isCaughtUp()) {
-      succeed();
+
+    if (!leader.isRunning()) {
+      failWith(LeadershipTransferResult.LEADER_CHANGED);
       return result;
     }
-    final var pollInterval = raft.getHeartbeatInterval();
-    pollTimer = raft.getThreadContext().schedule(pollInterval, pollInterval, this::poll);
+    if (raft.getCluster().getMemberContext(desiredLeader) == null) {
+      failWith(LeadershipTransferResult.NOT_MEMBER);
+      return result;
+    }
+    if (System.currentTimeMillis() >= deadlineMs) {
+      failWith(LeadershipTransferResult.REPLICATION_TIMED_OUT);
+      return result;
+    }
+
+    replication = leader.awaitReplication(desiredLeader, targetIndex);
+    replication.whenComplete(
+        (ignored, error) -> {
+          raft.checkThread();
+          if (completed) {
+            return;
+          }
+          if (error == null) {
+            succeed();
+          } else {
+            LOG.debug(
+                "Replication to the desired leader {} ended before it reached index {}; reporting "
+                    + "LEADER_CHANGED",
+                desiredLeader,
+                targetIndex,
+                error);
+            failWith(LeadershipTransferResult.LEADER_CHANGED);
+          }
+        });
+
+    if (!completed) {
+      final var remaining = Duration.ofMillis(deadlineMs - System.currentTimeMillis());
+      deadlineTimer = raft.getThreadContext().schedule(remaining, this::onDeadline);
+    }
     return result;
   }
 
   @Override
   public void onLeaderStopped() {
-    if (result.isDone()) {
+    if (completed) {
       return;
     }
     LOG.debug("Lost leadership while catching up the desired leader; reporting LEADER_CHANGED");
@@ -87,28 +122,17 @@ final class CatchUpWait implements TransferPhase {
     failWith(LeadershipTransferResult.PAUSE_FAILED);
   }
 
-  private void poll() {
-    if (result.isDone()) {
-      return;
-    }
-    if (!leaderRunning.getAsBoolean()) {
-      failWith(LeadershipTransferResult.LEADER_CHANGED);
-    } else if (raft.getCluster().getMemberContext(desiredLeader) == null) {
+  private void onDeadline() {
+    if (raft.getCluster().getMemberContext(desiredLeader) == null) {
+      LOG.warn("Desired leader {} left the partition while catching up", desiredLeader);
       failWith(LeadershipTransferResult.NOT_MEMBER);
-    } else if (isCaughtUp()) {
-      succeed();
-    } else if (System.currentTimeMillis() >= deadlineMs) {
+    } else {
       LOG.warn(
           "Desired leader {} did not reach index {} in time; reporting REPLICATION_TIMED_OUT",
           desiredLeader,
           targetIndex);
       failWith(LeadershipTransferResult.REPLICATION_TIMED_OUT);
     }
-  }
-
-  private boolean isCaughtUp() {
-    final var context = raft.getCluster().getMemberContext(desiredLeader);
-    return context != null && context.getMatchIndex() >= targetIndex;
   }
 
   /** The desired leader reached the frozen log head, so the transfer can carry on. */
@@ -122,10 +146,20 @@ final class CatchUpWait implements TransferPhase {
   }
 
   private void complete(final Optional<LeadershipTransferResult> failureReason) {
-    if (pollTimer != null) {
-      pollTimer.cancel();
-      pollTimer = null;
+    if (completed) {
+      return;
     }
+    completed = true;
+
+    if (deadlineTimer != null) {
+      deadlineTimer.cancel();
+      deadlineTimer = null;
+    }
+    if (replication != null) {
+      replication.cancel(false);
+      replication = null;
+    }
+
     result.complete(failureReason);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/CatchUpWait.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/CatchUpWait.java
@@ -81,9 +81,8 @@ final class CatchUpWait implements TransferPhase {
     }
 
     replication = leader.awaitReplication(desiredLeader, targetIndex);
-    replication.whenComplete(
+    replication.whenCompleteAsync(
         (ignored, error) -> {
-          raft.checkThread();
           if (completed) {
             return;
           }
@@ -98,7 +97,8 @@ final class CatchUpWait implements TransferPhase {
                 error);
             failWith(LeadershipTransferResult.LEADER_CHANGED);
           }
-        });
+        },
+        raft.getThreadContext());
 
     if (!completed) {
       final var remaining = Duration.ofMillis(deadlineMs - System.currentTimeMillis());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/rebalance/LeadershipTransferAttempt.java
@@ -189,7 +189,7 @@ final class LeadershipTransferAttempt {
     final var catchUpWait =
         new CatchUpWait(
             raft,
-            leader::isRunning,
+            leader,
             desiredLeader,
             targetIndex,
             startMs + configuration.replicationTimeout().toMillis());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -18,6 +18,7 @@ package io.atomix.raft.roles;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftException;
 import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.CommitFailedException;
@@ -76,6 +77,7 @@ final class LeaderAppender {
   private final long electionTimeout;
   private final NavigableMap<Long, CompletableFuture<Long>> appendFutures = new TreeMap<>();
   private final List<TimestampedFuture<Long>> heartbeatFutures = new ArrayList<>();
+  private final List<ReplicationWait> replicationWaits = new ArrayList<>();
   private final long heartbeatTime;
   private final int minStepDownFailureCount;
   private final long maxQuorumResponseTimeout;
@@ -266,6 +268,7 @@ final class LeaderAppender {
   private void updateMatchIndex(final RaftMemberContext member, final AppendResponse response) {
     // If the replica returned a valid match index then update the existing match index.
     member.setMatchIndex(response.lastLogIndex());
+    completeReplicationWaits(member);
     observeRemainingMemberEntries(member);
   }
 
@@ -654,6 +657,63 @@ final class LeaderAppender {
     return future;
   }
 
+  /**
+   * Observes replication to a single follower: the returned future completes once {@code memberId}
+   * acknowledges an append that carries its {@code matchIndex} to {@code targetIndex}.
+   *
+   * <p>This also triggers an immediate append for the follower, if there is anything to replicate.
+   *
+   * <p>The returned future must only be completed or cancelled on the Raft thread: cancelling it
+   * unregisters the waiter, which is a direct mutation of appender state.
+   *
+   * @return a future completing when the follower reaches {@code targetIndex}, or failing if this
+   *     leader steps down first
+   */
+  CompletableFuture<Void> awaitReplication(final MemberId memberId, final long targetIndex) {
+    raft.checkThread();
+
+    if (!open) {
+      return CompletableFuture.failedFuture(
+          new NoLeader("Cannot await replication on closed leader"));
+    }
+
+    final var member = raft.getCluster().getMemberContext(memberId);
+    if (member == null) {
+      return CompletableFuture.failedFuture(
+          new IllegalArgumentException("Unknown member " + memberId));
+    }
+
+    if (member.getMatchIndex() >= targetIndex) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var future = new CompletableFuture<Void>();
+    final var wait = new ReplicationWait(memberId, targetIndex, future);
+
+    replicationWaits.add(wait);
+    future.whenComplete((ignored, error) -> replicationWaits.remove(wait));
+
+    appendEntries(member);
+    return future;
+  }
+
+  /** Completes the waiters that {@code member}'s new match index has satisfied. */
+  private void completeReplicationWaits(final RaftMemberContext member) {
+    if (replicationWaits.isEmpty()) {
+      return;
+    }
+
+    final var memberId = member.getMember().memberId();
+    final var completed =
+        replicationWaits.stream()
+            .filter(wait -> wait.memberId().equals(memberId))
+            .filter(wait -> member.getMatchIndex() >= wait.targetIndex())
+            .toList();
+
+    replicationWaits.removeAll(completed);
+    completed.forEach(wait -> wait.future().complete(null));
+  }
+
   /** Completes append entries attempts up to the given index. */
   private void completeCommits(final long commitIndex) {
     final var completable = appendFutures.headMap(commitIndex, true);
@@ -914,6 +974,14 @@ final class LeaderAppender {
         future ->
             future.completeExceptionally(
                 new RaftException.ProtocolException("Failed to reach consensus")));
+
+    final var waits = List.copyOf(replicationWaits);
+    replicationWaits.clear();
+    waits.forEach(
+        wait ->
+            wait.future()
+                .completeExceptionally(
+                    new AppendFailureException(wait.targetIndex(), "Leader stepping down")));
   }
 
   private void tryToReplicate(final RaftMemberContext member) {
@@ -1105,6 +1173,10 @@ final class LeaderAppender {
    * heartbeat requests have {@code 0} size and retain the current position.
    */
   private record SizedAppendRequest(VersionedAppendRequest request, long size) {}
+
+  /** A one-shot observer of a single follower reaching {@code targetIndex}. */
+  private record ReplicationWait(
+      MemberId memberId, long targetIndex, CompletableFuture<Void> future) {}
 
   /** Timestamped completable future. */
   private static class TimestampedFuture<T> extends CompletableFuture<T> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -975,13 +975,12 @@ final class LeaderAppender {
             future.completeExceptionally(
                 new RaftException.ProtocolException("Failed to reach consensus")));
 
-    final var waits = List.copyOf(replicationWaits);
-    replicationWaits.clear();
-    waits.forEach(
-        wait ->
-            wait.future()
-                .completeExceptionally(
-                    new AppendFailureException(wait.targetIndex(), "Leader stepping down")));
+    while (!replicationWaits.isEmpty()) {
+      final var wait = replicationWaits.removeLast();
+      wait.future()
+          .completeExceptionally(
+              new AppendFailureException(wait.targetIndex(), "Leader stepping down"));
+    }
   }
 
   private void tryToReplicate(final RaftMemberContext member) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -467,6 +467,16 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     pauseGuard.resume();
   }
 
+  /**
+   * Completes once {@code memberId} has replicated up to {@code targetIndex}. The returned future
+   * must only be completed or cancelled on the Raft thread. See {@link
+   * LeaderAppender#awaitReplication}.
+   */
+  public CompletableFuture<Void> awaitReplication(final MemberId memberId, final long targetIndex) {
+    raft.checkThread();
+    return appender.awaitReplication(memberId, targetIndex);
+  }
+
   /** Whether the partition is currently frozen for a coordinated leadership transfer. */
   private boolean isPausedForTransfer() {
     return pauseGuard.isPaused();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftLeadershipTransferCatchUpTest.java
@@ -50,10 +50,12 @@ public class RaftLeadershipTransferCatchUpTest {
   @Test
   public void shouldReportTransferredWhenTheDesiredLeaderCatchesUpAndTakesOver() throws Exception {
     // given
-    raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
     final var driver = new CoordinatedTransferDriver(raftRule, leader);
     final var target = driver.followerOutsideCoordinator();
+    raftRule.partition(target);
+    raftRule.appendEntries(5);
+    raftRule.reconnect(target);
 
     // when
     final var ack = driver.initiate(target);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/CatchUpWaitTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/CatchUpWaitTest.java
@@ -25,7 +25,7 @@ import io.atomix.raft.roles.LeaderRole;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -33,6 +33,9 @@ public class CatchUpWaitTest {
 
   /** Ample budget, so a wait ends for the reason under test rather than for lack of time. */
   private static final Duration CATCH_UP_BUDGET = Duration.ofMinutes(1);
+
+  /** Short enough that a test can wait out the deadline, long enough not to fire prematurely. */
+  private static final Duration SHORT_CATCH_UP_BUDGET = Duration.ofSeconds(1);
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
 
@@ -44,28 +47,42 @@ public class CatchUpWaitTest {
     final var targetId = memberId(raftRule.getFollower().orElseThrow());
 
     // when
-    final var caughtUp = awaitCaughtUp(leader, targetId, committed + 5, CATCH_UP_BUDGET);
+    final var wait = awaitCaughtUp(leader, targetId, committed + 5, CATCH_UP_BUDGET);
     raftRule.appendEntries(5);
 
     // then
-    assertThat(caughtUp).succeedsWithin(Duration.ofSeconds(15)).isEqualTo(Optional.empty());
+    assertThat(wait.result()).succeedsWithin(Duration.ofSeconds(15)).isEqualTo(Optional.empty());
   }
 
   @Test
-  public void shouldReportNotMemberWhenTheDesiredLeaderLeavesThePartition() throws Exception {
+  public void shouldCompleteImmediatelyWhenTheDesiredLeaderIsAlreadyAtTheTargetIndex()
+      throws Exception {
     // given
     final long committed = raftRule.appendEntries(5);
     final var leader = raftRule.getLeader().orElseThrow();
     final var target = raftRule.getFollower().orElseThrow();
+    awaitReplicated(leader, memberId(target), committed);
 
     // when
-    final var caughtUp =
-        awaitCaughtUp(leader, memberId(target), committed + 1_000, CATCH_UP_BUDGET);
-    target.leave().get(30, TimeUnit.SECONDS);
+    final var wait = awaitCaughtUp(leader, memberId(target), committed, CATCH_UP_BUDGET);
 
     // then
-    assertThat(caughtUp)
-        .succeedsWithin(Duration.ofSeconds(15))
+    assertThat(wait.result()).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void shouldReportNotMemberWhenTheDesiredLeaderIsNotInThePartition() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+
+    // when
+    final var wait =
+        awaitCaughtUp(leader, MemberId.from("not-a-member"), committed + 1, CATCH_UP_BUDGET);
+
+    // then
+    assertThat(wait.result())
+        .succeedsWithin(Duration.ofSeconds(5))
         .isEqualTo(Optional.of(LeadershipTransferResult.NOT_MEMBER));
   }
 
@@ -77,42 +94,114 @@ public class CatchUpWaitTest {
     final var targetId = memberId(raftRule.getFollower().orElseThrow());
 
     // when
-    final var caughtUp = awaitCaughtUp(leader, targetId, committed + 1_000, Duration.ofSeconds(1));
+    final var wait = awaitCaughtUp(leader, targetId, committed + 1_000, SHORT_CATCH_UP_BUDGET);
 
     // then
-    assertThat(caughtUp)
+    assertThat(wait.result())
         .succeedsWithin(Duration.ofSeconds(15))
         .isEqualTo(Optional.of(LeadershipTransferResult.REPLICATION_TIMED_OUT));
   }
 
-  private static CompletableFuture<Optional<LeadershipTransferResult>> awaitCaughtUp(
+  @Test
+  public void shouldReportLeaderChangedWhenTheLeaderStops() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var wait = awaitCaughtUp(leader, targetId, committed + 1_000, CATCH_UP_BUDGET);
+
+    // when
+    onRaftThread(leader, wait.phase()::onLeaderStopped);
+
+    // then
+    assertThat(wait.result())
+        .succeedsWithin(Duration.ofSeconds(5))
+        .isEqualTo(Optional.of(LeadershipTransferResult.LEADER_CHANGED));
+  }
+
+  @Test
+  public void shouldReportPauseFailedWhenThePauseClears() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var targetId = memberId(raftRule.getFollower().orElseThrow());
+    final var wait = awaitCaughtUp(leader, targetId, committed + 1_000, CATCH_UP_BUDGET);
+
+    // when
+    onRaftThread(leader, wait.phase()::onPauseCleared);
+
+    // then
+    assertThat(wait.result())
+        .succeedsWithin(Duration.ofSeconds(5))
+        .isEqualTo(Optional.of(LeadershipTransferResult.PAUSE_FAILED));
+  }
+
+  @Test
+  public void shouldKeepTheSuccessfulResultWhenTheDeadlinePasses() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    awaitReplicated(leader, memberId(target), committed);
+
+    // when
+    final var wait = awaitCaughtUp(leader, memberId(target), committed, Duration.ofMillis(200));
+
+    // then
+    assertThat(wait.result()).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(Optional.empty());
+    Awaitility.await("the result stays successful past the deadline")
+        .during(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(wait.result().join()).isEqualTo(Optional.empty()));
+  }
+
+  private static void awaitReplicated(
+      final RaftServer leader, final MemberId memberId, final long index) {
+    Awaitility.await("until " + memberId + " has replicated up to " + index)
+        .atMost(Duration.ofSeconds(15))
+        .until(
+            () -> {
+              final var context = leader.getContext().getCluster().getMemberContext(memberId);
+              return context != null && context.getMatchIndex() >= index;
+            });
+  }
+
+  private static StartedWait awaitCaughtUp(
       final RaftServer leader,
       final MemberId desiredLeader,
       final long targetIndex,
       final Duration catchUpBudget) {
     final var deadlineMs = System.currentTimeMillis() + catchUpBudget.toMillis();
-    final var caughtUp = new CompletableFuture<Optional<LeadershipTransferResult>>();
+    final var result = new CompletableFuture<Optional<LeadershipTransferResult>>();
+    final var started = new CompletableFuture<CatchUpWait>();
     leader
         .getContext()
         .getThreadContext()
         .execute(
-            () ->
-                new CatchUpWait(
-                        leader.getContext(),
-                        leaderRole(leader)::isRunning,
-                        desiredLeader,
-                        targetIndex,
-                        deadlineMs)
-                    .start()
-                    .whenComplete(
-                        (result, error) -> {
-                          if (error != null) {
-                            caughtUp.completeExceptionally(error);
-                          } else {
-                            caughtUp.complete(result);
-                          }
-                        }));
-    return caughtUp;
+            () -> {
+              final var wait =
+                  new CatchUpWait(
+                      leader.getContext(),
+                      leaderRole(leader),
+                      desiredLeader,
+                      targetIndex,
+                      deadlineMs);
+              started.complete(wait);
+              wait.start()
+                  .whenComplete(
+                      (outcome, error) -> {
+                        if (error != null) {
+                          result.completeExceptionally(error);
+                        } else {
+                          result.complete(outcome);
+                        }
+                      });
+            });
+    return new StartedWait(started.join(), result);
+  }
+
+  private static void onRaftThread(final RaftServer leader, final Runnable action) {
+    CompletableFuture.runAsync(action, leader.getContext().getThreadContext()).join();
   }
 
   private static LeaderRole leaderRole(final RaftServer leader) {
@@ -122,4 +211,7 @@ public class CatchUpWaitTest {
   private static MemberId memberId(final RaftServer server) {
     return server.getContext().getCluster().getLocalMember().memberId();
   }
+
+  private record StartedWait(
+      CatchUpWait phase, CompletableFuture<Optional<LeadershipTransferResult>> result) {}
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/CatchUpWaitTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/rebalance/CatchUpWaitTest.java
@@ -136,25 +136,6 @@ public class CatchUpWaitTest {
         .isEqualTo(Optional.of(LeadershipTransferResult.PAUSE_FAILED));
   }
 
-  @Test
-  public void shouldKeepTheSuccessfulResultWhenTheDeadlinePasses() throws Exception {
-    // given
-    final long committed = raftRule.appendEntries(5);
-    final var leader = raftRule.getLeader().orElseThrow();
-    final var target = raftRule.getFollower().orElseThrow();
-    awaitReplicated(leader, memberId(target), committed);
-
-    // when
-    final var wait = awaitCaughtUp(leader, memberId(target), committed, Duration.ofMillis(200));
-
-    // then
-    assertThat(wait.result()).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(Optional.empty());
-    Awaitility.await("the result stays successful past the deadline")
-        .during(Duration.ofMillis(500))
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(() -> assertThat(wait.result().join()).isEqualTo(Optional.empty()));
-  }
-
   private static void awaitReplicated(
       final RaftServer leader, final MemberId memberId, final long index) {
     Awaitility.await("until " + memberId + " has replicated up to " + index)

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderAppenderReplicationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderAppenderReplicationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftRule;
+import io.atomix.raft.RaftServer;
+import io.atomix.raft.partition.RaftPartitionConfig;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Coverage for the per-follower replication observer. */
+public class LeaderAppenderReplicationTest {
+  private static final Duration HEARTBEAT_INTERVAL = Duration.ofSeconds(3);
+
+  @Rule
+  public RaftRule raftRule =
+      RaftRule.withBootstrappedNodes(
+          3,
+          new RaftRule.Configurator() {
+            @Override
+            public void configure(final MemberId id, final RaftServer.Builder builder) {
+              builder.withPartitionConfig(
+                  new RaftPartitionConfig()
+                      .setElectionTimeout(Duration.ofSeconds(6))
+                      .setHeartbeatInterval(HEARTBEAT_INTERVAL));
+            }
+          });
+
+  @Test
+  public void shouldCompleteImmediatelyWhenTheFollowerIsAlreadyCaughtUp() throws Exception {
+    // given
+    final long committed = raftRule.appendEntries(5);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+
+    // when
+    final var replicated = awaitReplication(leader, memberId(target), committed);
+
+    // then
+    assertThat(replicated).succeedsWithin(Duration.ofSeconds(5));
+  }
+
+  @Test
+  public void shouldCompleteOnceTheFollowerReachesTheTargetIndex() throws Exception {
+    // given
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    raftRule.partition(target);
+    final long committed = raftRule.appendEntries(5);
+    raftRule.reconnect(target);
+
+    // when
+    final var replicated = awaitReplication(leader, memberId(target), committed);
+
+    // then
+    assertThat(replicated).succeedsWithin(HEARTBEAT_INTERVAL.dividedBy(3));
+  }
+
+  @Test
+  public void shouldOnlyCompleteForTheObservedFollower() throws Exception {
+    // given
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var other = otherFollower(target);
+    raftRule.partition(target);
+
+    // when
+    final long committed = raftRule.appendEntries(5);
+    final var replicated = awaitReplication(leader, memberId(target), committed);
+    final long later = raftRule.appendEntries(1);
+
+    // then
+    assertThat(awaitReplication(leader, memberId(other), later))
+        .succeedsWithin(HEARTBEAT_INTERVAL.dividedBy(3));
+    assertThat(replicated).isNotDone();
+  }
+
+  @Test
+  public void shouldIgnoreLaterResponsesForACancelledWait() throws Exception {
+    // given
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    raftRule.partition(target);
+    final long committed = raftRule.appendEntries(5);
+    final var cancelled = awaitReplication(leader, memberId(target), committed);
+
+    // when
+    onRaftThread(leader, () -> cancelled.cancel(false));
+    raftRule.reconnect(target);
+
+    // then
+    assertThat(awaitReplication(leader, memberId(target), committed))
+        .succeedsWithin(HEARTBEAT_INTERVAL.dividedBy(3));
+    assertThat(cancelled).isCancelled();
+  }
+
+  @Test
+  public void shouldFailPendingWaitsWhenTheLeaderStepsDown() throws Exception {
+    // given
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    raftRule.partition(target);
+    final long committed = raftRule.appendEntries(5);
+    final var replicated = awaitReplication(leader, memberId(target), committed);
+
+    // when
+    leader.stepDown().get();
+
+    // then
+    assertThat(replicated).failsWithin(Duration.ofSeconds(15));
+  }
+
+  private static CompletableFuture<Void> awaitReplication(
+      final RaftServer leader, final MemberId memberId, final long targetIndex) {
+    final var started = new CompletableFuture<CompletableFuture<Void>>();
+    leader
+        .getContext()
+        .getThreadContext()
+        .execute(
+            () -> started.complete(leaderRole(leader).awaitReplication(memberId, targetIndex)));
+    return started.join();
+  }
+
+  private static void onRaftThread(final RaftServer leader, final Runnable action) {
+    CompletableFuture.runAsync(action, leader.getContext().getThreadContext()).join();
+  }
+
+  private RaftServer otherFollower(final RaftServer follower) {
+    return raftRule.getServers().stream()
+        .filter(server -> server.getRole() == RaftServer.Role.FOLLOWER)
+        .filter(server -> !memberId(server).equals(memberId(follower)))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static LeaderRole leaderRole(final RaftServer leader) {
+    return (LeaderRole) leader.getContext().getRaftRole();
+  }
+
+  private static MemberId memberId(final RaftServer server) {
+    return server.getContext().getCluster().getLocalMember().memberId();
+  }
+}


### PR DESCRIPTION
During a coordinated leadership transfer, replication to the desired leader can wait up to `heartbeatInterval` before the next append (and then only be checked by `CatchupWait` after another `heartbeatInterval` elapses). Even on the default 250ms `heartbeatInterval` this is longer than we need to wait, but with values tuned for cross-region setups it can significantly affect the partition paused time even when replication lag is very low.

To fix this, rather than scheduling a timer to check if the follower has caught up, we directly observe the updated `matchIndex` from append responses. We also trigger an append at the start of the transfer pause (if there's anything to replicate), so we don't have to wait up to the next heartbeat for it.

Closes #61394.