### PR TITLE
ci: retry deploy-snapshots on transient Artifactory 500s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2840,7 +2840,9 @@ jobs:
     name: Deploy snapshot artifacts
     needs: [ check-results, build-platform-frontend, utils-get-concurrency-group-for-maven-snapshot ]
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 25
+    # 30 min (the policy ceiling) covers the one-time checkout/setup/build overhead plus up to 2
+    # attempts of the deploy step below; the retry only re-runs that step, not this whole job.
+    timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
@@ -2886,7 +2888,17 @@ jobs:
       # matching the central-sonatype-publish release path. Without it, snapshots ship the raw reactor
       # POM whose parent chain (zeebe-parent) must be resolved by external consumers to build the
       # effective model; the flattened POM is self-contained, exactly as published releases are.
-      - run: ./mvnw -B -T1C -D skipTests -D skipChecks -PskipFrontendBuild -Dflatten.updatePomFile=true compile generate-sources source:jar javadoc:jar deploy
+      # Artifactory intermittently returns a transient 500 on artifact/metadata upload (INC-6737,
+      # INC-7541); a bare re-run of this exact command succeeded both times with no other change, so
+      # retrying automates that recovery. Deploying the same SNAPSHOT version twice is safe/idempotent.
+      - name: Compile and deploy snapshot artifacts
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 2
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 13
+          command: ./mvnw -B -T1C -D skipTests -D skipChecks -PskipFrontendBuild -Dflatten.updatePomFile=true compile generate-sources source:jar javadoc:jar deploy
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

The `deploy-snapshots` job on `main`/`stable/*` failed twice in the past month (INC-6737, INC-7541) with a **500 from Artifactory** while uploading a Maven snapshot artifact/metadata via `nexus-staging-maven-plugin`. Both times a bare re-run of the exact same job succeeded with no other change — a transient blip on Artifactory's side, not a deterministic build bug.

The other `deploy-snapshots` incidents in the same window (INC-6632/6628, INC-6922, INC-7016, INC-7026, INC-7031) do **not** share this signature — they're a separate, already-diagnosed problem (GitHub Actions shared-artifact TTL expiring before a delayed job retry, with a fix already proposed in INC-7026; or, in one case, an unrelated PR regression). Increasing that TTL would not have prevented this failure.

Since retrying already fixes it and redeploying the same SNAPSHOT version is safe/idempotent, this wraps the deploy step in `nick-fields/retry` — the same mechanism this file already uses for an equivalent transient failure (npm registry resolution in the Validate Renovate config step, INC-6869). `timeout-minutes` goes from 25 to 30 (the policy ceiling) to give a retry attempt room; the retry only re-runs the deploy step, not the job's checkout/setup/download.

## Related issues

- INC-6737
- INC-7541