### PR TITLE
feat: add utility to simulate replication delay in postgres cluster

### DIFF
--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -246,6 +246,7 @@ services:
       - POSTGRESQL_MASTER_HOST=postgres-primary
       - POSTGRESQL_REPLICATION_USER=repl_user
       - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
+      - POSTGRESQL_EXTRA_FLAGS=-c recovery_min_apply_delay=${POSTGRES_REPLICA_APPLY_DELAY:-0}
     networks:
       - pgnet
     healthcheck:
@@ -267,6 +268,7 @@ services:
       - POSTGRESQL_MASTER_HOST=postgres-primary
       - POSTGRESQL_REPLICATION_USER=repl_user
       - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
+      - POSTGRESQL_EXTRA_FLAGS=-c recovery_min_apply_delay=${POSTGRES_REPLICA_APPLY_DELAY:-0}
     networks:
       - pgnet
     healthcheck:

--- a/db/scripts/postgres-replica-lag.sh
+++ b/db/scripts/postgres-replica-lag.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./postgres-replica-lag.sh status [all|postgres-replica-1|postgres-replica-2|pg-replica1|pg-replica2]
+  ./postgres-replica-lag.sh set <delay> [all|postgres-replica-1|postgres-replica-2|pg-replica1|pg-replica2]
+  ./postgres-replica-lag.sh reset [all|postgres-replica-1|postgres-replica-2|pg-replica1|pg-replica2]
+
+Examples:
+  ./postgres-replica-lag.sh set 5s
+  ./postgres-replica-lag.sh set 30s postgres-replica-1
+  ./postgres-replica-lag.sh status
+  ./postgres-replica-lag.sh reset all
+
+The delay is PostgreSQL's recovery_min_apply_delay on the standby. It delays replaying
+commits on replicas, which makes replica reads intentionally stale while primary writes continue.
+USAGE
+}
+
+command=${1:-status}
+shift || true
+
+postgres_user=${POSTGRES_SUPERUSER:-postgres}
+postgres_password=${POSTGRES_SUPERUSER_PASSWORD:-camunda}
+postgres_database=${POSTGRES_DATABASE:-postgres}
+
+resolve_targets() {
+  local target=${1:-all}
+  case "${target}" in
+    all)
+      printf '%s\n' pg-replica1 pg-replica2
+      ;;
+    postgres-replica-1|pg-replica1)
+      printf '%s\n' pg-replica1
+      ;;
+    postgres-replica-2|pg-replica2)
+      printf '%s\n' pg-replica2
+      ;;
+    *)
+      echo "Unknown replica target: ${target}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+run_psql() {
+  local container=$1
+  local sql=$2
+  docker exec \
+    -e "PGPASSWORD=${postgres_password}" \
+    "${container}" \
+    psql \
+      -U "${postgres_user}" \
+      -d "${postgres_database}" \
+      -v ON_ERROR_STOP=1 \
+      -X \
+      -q \
+      -c "${sql}"
+}
+
+status() {
+  local container=$1
+  echo "== ${container} =="
+  run_psql "${container}" "SHOW recovery_min_apply_delay;"
+  run_psql "${container}" "SELECT COALESCE((now() - pg_last_xact_replay_timestamp())::text, 'no replay timestamp yet') AS observed_replay_lag;"
+}
+
+set_delay() {
+  local delay=$1
+  local container=$2
+  if [[ ! ${delay} =~ ^(0|[0-9]+(ms|s|min|h|d))$ ]]; then
+    echo "Invalid delay '${delay}'. Use values like 0, 500ms, 5s, 1min, 1h, or 1d." >&2
+    exit 2
+  fi
+
+  echo "Setting recovery_min_apply_delay=${delay} on ${container}"
+  run_psql "${container}" "ALTER SYSTEM SET recovery_min_apply_delay = '${delay}';"
+  run_psql "${container}" "SELECT pg_reload_conf();"
+  status "${container}"
+}
+
+reset_delay() {
+  local container=$1
+  echo "Resetting recovery_min_apply_delay on ${container}"
+  run_psql "${container}" "ALTER SYSTEM RESET recovery_min_apply_delay;"
+  run_psql "${container}" "SELECT pg_reload_conf();"
+  status "${container}"
+}
+
+case "${command}" in
+  status)
+    target=${1:-all}
+    while IFS= read -r container; do
+      status "${container}"
+    done < <(resolve_targets "${target}")
+    ;;
+  set)
+    delay=${1:-}
+    target=${2:-all}
+    if [[ -z ${delay} ]]; then
+      usage >&2
+      exit 2
+    fi
+    while IFS= read -r container; do
+      set_delay "${delay}" "${container}"
+    done < <(resolve_targets "${target}")
+    ;;
+  reset)
+    target=${1:-all}
+    while IFS= read -r container; do
+      reset_delay "${container}"
+    done < <(resolve_targets "${target}")
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: ${command}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+


### PR DESCRIPTION
This pull request introduces improvements for managing and simulating PostgreSQL replica lag in the development environment. The main changes add the ability to control and inspect the `recovery_min_apply_delay` parameter on replica containers, which helps test replica lag scenarios.

**PostgreSQL replica lag control and observability:**

* Added a new script `db/scripts/postgres-replica-lag.sh` that provides commands to check, set, and reset the `recovery_min_apply_delay` on replica containers, making it easier to simulate and observe replica lag for development and testing purposes.
* Updated the `db/docker-compose.yml` configuration for both `postgres-replica-1` and `postgres-replica-2` services to accept a `POSTGRESQL_EXTRA_FLAGS` environment variable, defaulting `recovery_min_apply_delay` to the value of `${POSTGRES_REPLICA_APPLY_DELAY:-0}` for flexible configuration. [[1]](diffhunk://#diff-ccbfed3db78a2b4d9c48c36e0e426e06f4e6b9075cc626d74dfad5beff7c9b72R249) [[2]](diffhunk://#diff-ccbfed3db78a2b4d9c48c36e0e426e06f4e6b9075cc626d74dfad5beff7c9b72R271)