### PR TITLE
refactor: migrate Admin groups to new design system

### DIFF
--- a/identity/client/src/pages/groups/ListV2.tsx
+++ b/identity/client/src/pages/groups/ListV2.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Edit, TrashCan } from "@carbon/react/icons";
+import { Pencil, Trash2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
@@ -86,10 +86,10 @@ const List: FC = () => {
         onAddEntity={addGroup}
         loading={loading}
         menuItems={[
-          { label: t("edit"), icon: Edit, onClick: updateGroup },
+          { label: t("edit"), icon: Pencil, onClick: updateGroup },
           {
             label: t("delete"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: deleteGroup,
           },

--- a/identity/client/src/pages/groups/ListV2.tsx
+++ b/identity/client/src/pages/groups/ListV2.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Edit, TrashCan } from "@carbon/react/icons";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { groupQueries } from "src/utility/api/groups/queries";
+import Page, { PageHeader } from "src/components/layoutV2/Page";
+import EntityList from "src/components/entityListV2";
+import { useNavigate } from "react-router-dom";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import useModal, { useEntityModal } from "src/components/modalV2/useModal";
+import EditModal from "src/pages/groups/modalsV2/EditModal";
+import DeleteModal from "src/pages/groups/modalsV2/DeleteModal";
+import AddModal from "src/pages/groups/modalsV2/AddModal";
+import PageEmptyState from "src/components/layoutV2/PageEmptyState";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const List: FC = () => {
+  const { t } = useTranslate("groups");
+  const navigate = useNavigate();
+  const noop = () => {};
+
+  const { pageParams, page, search, ...paginationCallbacks } = usePagination();
+  const {
+    data: groupSearchResults,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...groupQueries.search(pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((item) => ({ ...item, id: item.groupId })),
+    }),
+  });
+
+  const [addGroup, addModal] = useModal(AddModal, noop);
+  const [updateGroup, editModal] = useEntityModal(EditModal, noop);
+  const [deleteGroup, deleteModal] = useEntityModal(DeleteModal, noop);
+  const showDetails = ({ groupId }: Group) => navigate(groupId);
+
+  const shouldShowEmptyState =
+    success && !search && !groupSearchResults?.items.length;
+
+  const pageHeader = (
+    <PageHeader
+      title={t("groups")}
+      linkText={t("groups").toLowerCase()}
+      docsLinkPath="/components/admin/group/"
+      shouldShowDocumentationLink={!shouldShowEmptyState}
+    />
+  );
+
+  if (shouldShowEmptyState) {
+    return (
+      <Page>
+        {pageHeader}
+        <PageEmptyState
+          resourceTypeTranslationKey={"group"}
+          docsLinkPath="/components/admin/group/"
+          handleClick={addGroup}
+        />
+        {addModal}
+      </Page>
+    );
+  }
+  return (
+    <Page>
+      {pageHeader}
+      <EntityList
+        data={groupSearchResults == null ? [] : groupSearchResults.items}
+        headers={[
+          { header: t("groupId"), key: "groupId", isSortable: true },
+          { header: t("groupName"), key: "name", isSortable: true },
+        ]}
+        onEntityClick={showDetails}
+        addEntityLabel={t("createGroup")}
+        onAddEntity={addGroup}
+        loading={loading}
+        menuItems={[
+          { label: t("edit"), icon: Edit, onClick: updateGroup },
+          {
+            label: t("delete"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: deleteGroup,
+          },
+        ]}
+        searchPlaceholder={t("searchByGroupId")}
+        searchKey="groupId"
+        page={{ ...page, ...groupSearchResults?.page }}
+        {...paginationCallbacks}
+      />
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("groupsListCouldNotLoad")}
+          actionButton={{
+            label: t("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+      <>
+        {addModal}
+        {editModal}
+        {deleteModal}
+      </>
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/groups/detailV2/clients/AssignClientsModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/clients/AssignClientsModal.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import FormModal from "src/components/modalV2/FormModal";
+import TextField from "src/components/formV2/TextField";
+import { UseEntityModalProps } from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import type {
+  Group,
+  TenantClient,
+} from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignClientsModal: FC<
+  UseEntityModalProps<{ groupId: Group["groupId"] }>
+> = ({ entity: { groupId }, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+  const [clientId, setClientId] = useState<TenantClient["clientId"]>("");
+  const qc = useQueryClient();
+  const { mutate, isPending: loadingAssignClient } = useMutation(
+    groupMutations.assignClient(qc),
+  );
+
+  const canSubmit = groupId && clientId.length;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    mutate(
+      { clientId, groupId },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("clientAssigned"),
+            subtitle: t("clientAssignedSuccessfully"),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (open) {
+      setClientId("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignClient")}
+      confirmLabel={t("assignClient")}
+      loading={loadingAssignClient}
+      loadingDescription={t("assigningClient")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("assignClientToGroup")}</p>
+      <TextField
+        label={t("clientId")}
+        placeholder={t("enterClientId")}
+        onChange={setClientId}
+        value={clientId}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignClientsModal;

--- a/identity/client/src/pages/groups/detailV2/clients/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/clients/DeleteModal.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import type {
+  Group,
+  TenantClient,
+} from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveGroupClientModalProps = UseEntityModalCustomProps<
+  TenantClient,
+  {
+    groupId: Group["groupId"];
+  }
+>;
+
+const DeleteModal: FC<RemoveGroupClientModalProps> = ({
+  entity: client,
+  open,
+  onClose,
+  onSuccess,
+  groupId,
+}) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    groupMutations.unassignClient(qc),
+  );
+
+  const handleSubmit = () => {
+    if (groupId && client) {
+      mutate(
+        { groupId, clientId: client.clientId },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("groupClientRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeClient")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingClient")}
+      onClose={onClose}
+      confirmLabel={t("removeClient")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeClientFromGroup"
+          values={{ clientId: client.clientId }}
+        >
+          Are you sure you want to remove <strong>{client.clientId}</strong>{" "}
+          from this group?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/groups/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/clients/index.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+// TODO: Replace with `ErrorInlineNotification`.
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import useTranslate from "src/utility/localization";
+import { useQuery } from "@tanstack/react-query";
+import { usePagination } from "src/utility/api";
+import { groupQueries } from "src/utility/api/groups/queries";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import DeleteModal from "src/pages/groups/detailV2/clients/DeleteModal";
+import AssignClientsModal from "src/pages/groups/detailV2/clients/AssignClientsModal";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type ClientsProps = {
+  groupId: Group["groupId"];
+};
+
+const Clients: FC<ClientsProps> = ({ groupId }) => {
+  const { t } = useTranslate("groups");
+  const noop = () => {};
+
+  const { pageParams, page, ...paginationCallbacks } = usePagination();
+  const {
+    data,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...groupQueries.clients(groupId, pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((client) => ({ ...client, id: client.clientId })),
+    }),
+  });
+
+  const assignedClients = data && Array.isArray(data.items) ? data.items : [];
+
+  const [assignClient, assignClientModal] = useEntityModal(
+    AssignClientsModal,
+    noop,
+  );
+  const openAssignModal = () => assignClient({ groupId });
+  const [unassignClient, unassignClientModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    { groupId },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("client").toLowerCase(),
+        })}
+        button={{
+          label: t("retry"),
+          onClick: () => {
+            void reload();
+          },
+        }}
+      />
+    );
+
+  if (success && assignedClients.length === 0)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"client"}
+          parentResourceTypeTranslationKey={"group"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/client/"
+        />
+        {assignClientModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={assignedClients}
+        headers={[{ header: t("clientId"), key: "clientId", isSortable: true }]}
+        loading={loading}
+        addEntityLabel={t("assignClient")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByClientId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignClient,
+          },
+        ]}
+        page={{ ...page, ...data?.page }}
+        {...paginationCallbacks}
+      />
+      {assignClientModal}
+      {unassignClientModal}
+    </>
+  );
+};
+
+export default Clients;

--- a/identity/client/src/pages/groups/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/clients/index.tsx
@@ -7,15 +7,14 @@
  */
 
 import { FC } from "react";
-// TODO: Replace with `ErrorInlineNotification`.
-import { C3EmptyState } from "@camunda/camunda-composite-components";
-import { TrashCan } from "@carbon/react/icons";
+import { Trash2 } from "lucide-react";
 import useTranslate from "src/utility/localization";
 import { useQuery } from "@tanstack/react-query";
 import { usePagination } from "src/utility/api";
 import { groupQueries } from "src/utility/api/groups/queries";
 import EntityList from "src/components/entityListV2";
 import { useEntityModal } from "src/components/modalV2";
+import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
 import DeleteModal from "src/pages/groups/detailV2/clients/DeleteModal";
 import AssignClientsModal from "src/pages/groups/detailV2/clients/AssignClientsModal";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
@@ -58,12 +57,12 @@ const Clients: FC<ClientsProps> = ({ groupId }) => {
 
   if (!loading && !success)
     return (
-      <C3EmptyState
-        heading={t("somethingsWrong")}
-        description={t("unableToLoadResource", {
+      <ErrorInlineNotification
+        title={t("somethingsWrong")}
+        subtitle={t("unableToLoadResource", {
           resourceType: t("client").toLowerCase(),
         })}
-        button={{
+        actionButton={{
           label: t("retry"),
           onClick: () => {
             void reload();
@@ -97,7 +96,7 @@ const Clients: FC<ClientsProps> = ({ groupId }) => {
         menuItems={[
           {
             label: t("remove"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: unassignClient,
           },

--- a/identity/client/src/pages/groups/detailV2/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/index.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { OverflowMenu, OverflowMenuItem, Section, Stack } from "@carbon/react";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { groupQueries } from "src/utility/api/groups/queries";
+import NotFound from "src/pages/not-foundV2";
+import { Breadcrumbs, StackPage } from "src/components/layoutV2/Page";
+import { DetailPageHeaderFallback } from "src/components/fallbacksV2";
+// TODO: Replace with Tailwind classes.
+import Flex from "src/components/layout/Flex";
+// TODO: Replace with PageHeader during migration. See roles/detailV2/index.tsx for example.
+import PageHeadline from "src/components/layoutV2/PageHeadline";
+// TODO: Replace with V2 tabs. See roles/detailV2/index.tsx for example.
+import Tabs from "src/components/tabs";
+import { useEntityModal } from "src/components/modalV2";
+import EditModal from "src/pages/groups/modalsV2/EditModal";
+import DeleteModal from "src/pages/groups/modalsV2/DeleteModal";
+// TODO: Remove during migration. See roles/detailV2/index.tsx for example.
+import { Description } from "src/components/layout/DetailsPageDescription";
+import Members from "src/pages/groups/detailV2/members";
+import Roles from "src/pages/groups/detailV2/roles";
+import MappingRules from "src/pages/groups/detailV2/mapping-rules";
+import Clients from "src/pages/groups/detailV2/clients";
+
+type DetailsProps = {
+  isOIDC: boolean;
+};
+
+const Details: FC<DetailsProps> = ({ isOIDC }) => {
+  const navigate = useNavigate();
+  const { t } = useTranslate("groups");
+  const { id = "", tab = "details" } = useParams<{
+    id: string;
+    tab: string;
+  }>();
+
+  const { data: group, isLoading: loading } = useQuery(groupQueries.detail(id));
+  const [editGroup, editModal] = useEntityModal(EditModal, () => {});
+  const [deleteGroup, deleteModal] = useEntityModal(DeleteModal, () =>
+    navigate("..", { replace: true }),
+  );
+
+  if (!loading && !group) return <NotFound />;
+
+  return (
+    <StackPage>
+      <>
+        <Stack gap="2">
+          <Breadcrumbs items={[{ href: "/groups", title: t("groups") }]} />
+          {loading && !group ? (
+            <DetailPageHeaderFallback hasOverflowMenu={false} />
+          ) : (
+            <Flex>
+              {group && (
+                <Stack gap="3">
+                  <Stack orientation="horizontal" gap="1">
+                    <PageHeadline>{group.name}</PageHeadline>
+                    <OverflowMenu ariaLabel={t("openGroupContextMenu")}>
+                      <OverflowMenuItem
+                        itemText={t("edit")}
+                        onClick={() => {
+                          editGroup(group);
+                        }}
+                      />
+                      <OverflowMenuItem
+                        itemText={t("delete")}
+                        isDelete
+                        onClick={() => {
+                          deleteGroup(group);
+                        }}
+                      />
+                    </OverflowMenu>
+                  </Stack>
+                  <p>
+                    {t("groupId")}: {group.groupId}
+                  </p>
+                  {group.description && (
+                    <Description>
+                      {t("description")}: {group.description}
+                    </Description>
+                  )}
+                </Stack>
+              )}
+            </Flex>
+          )}
+        </Stack>
+        {group && (
+          <Section>
+            <Tabs
+              tabs={[
+                {
+                  key: "users",
+                  label: t("users"),
+                  content: <Members groupId={group.groupId} isOIDC={isOIDC} />,
+                },
+                {
+                  key: "roles",
+                  label: t("roles"),
+                  content: <Roles groupId={group.groupId} />,
+                },
+                ...(isOIDC
+                  ? [
+                      {
+                        key: "mapping-rules",
+                        label: t("mappingRules"),
+                        content: <MappingRules groupId={group.groupId} />,
+                      },
+                      {
+                        key: "clients",
+                        label: t("clients"),
+                        content: <Clients groupId={group?.groupId} />,
+                      },
+                    ]
+                  : []),
+              ]}
+              selectedTabKey={tab}
+              path={`../${id}`}
+            />
+          </Section>
+        )}
+        {editModal}
+        {deleteModal}
+      </>
+    </StackPage>
+  );
+};
+
+export default Details;

--- a/identity/client/src/pages/groups/detailV2/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/index.tsx
@@ -8,24 +8,18 @@
 
 import { FC } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { OverflowMenu, OverflowMenuItem, Section, Stack } from "@carbon/react";
 import { useQuery } from "@tanstack/react-query";
+import { Pencil, Trash2 } from "lucide-react";
+import { Button, PageHeader } from "@camunda/design-system";
 import useTranslate from "src/utility/localization";
 import { groupQueries } from "src/utility/api/groups/queries";
 import NotFound from "src/pages/not-foundV2";
 import { Breadcrumbs, StackPage } from "src/components/layoutV2/Page";
 import { DetailPageHeaderFallback } from "src/components/fallbacksV2";
-// TODO: Replace with Tailwind classes.
-import Flex from "src/components/layout/Flex";
-// TODO: Replace with PageHeader during migration. See roles/detailV2/index.tsx for example.
-import PageHeadline from "src/components/layoutV2/PageHeadline";
-// TODO: Replace with V2 tabs. See roles/detailV2/index.tsx for example.
-import Tabs from "src/components/tabs";
+import { Tabs, TabsContent, TabsHeaderList } from "src/components/tabsV2";
 import { useEntityModal } from "src/components/modalV2";
 import EditModal from "src/pages/groups/modalsV2/EditModal";
 import DeleteModal from "src/pages/groups/modalsV2/DeleteModal";
-// TODO: Remove during migration. See roles/detailV2/index.tsx for example.
-import { Description } from "src/components/layout/DetailsPageDescription";
 import Members from "src/pages/groups/detailV2/members";
 import Roles from "src/pages/groups/detailV2/roles";
 import MappingRules from "src/pages/groups/detailV2/mapping-rules";
@@ -54,47 +48,10 @@ const Details: FC<DetailsProps> = ({ isOIDC }) => {
   return (
     <StackPage>
       <>
-        <Stack gap="2">
-          <Breadcrumbs items={[{ href: "/groups", title: t("groups") }]} />
-          {loading && !group ? (
-            <DetailPageHeaderFallback hasOverflowMenu={false} />
-          ) : (
-            <Flex>
-              {group && (
-                <Stack gap="3">
-                  <Stack orientation="horizontal" gap="1">
-                    <PageHeadline>{group.name}</PageHeadline>
-                    <OverflowMenu ariaLabel={t("openGroupContextMenu")}>
-                      <OverflowMenuItem
-                        itemText={t("edit")}
-                        onClick={() => {
-                          editGroup(group);
-                        }}
-                      />
-                      <OverflowMenuItem
-                        itemText={t("delete")}
-                        isDelete
-                        onClick={() => {
-                          deleteGroup(group);
-                        }}
-                      />
-                    </OverflowMenu>
-                  </Stack>
-                  <p>
-                    {t("groupId")}: {group.groupId}
-                  </p>
-                  {group.description && (
-                    <Description>
-                      {t("description")}: {group.description}
-                    </Description>
-                  )}
-                </Stack>
-              )}
-            </Flex>
-          )}
-        </Stack>
-        {group && (
-          <Section>
+        {loading && !group ? (
+          <DetailPageHeaderFallback hasOverflowMenu={false} />
+        ) : (
+          group && (
             <Tabs
               tabs={[
                 {
@@ -124,12 +81,49 @@ const Details: FC<DetailsProps> = ({ isOIDC }) => {
               ]}
               selectedTabKey={tab}
               path={`../${id}`}
-            />
-          </Section>
+            >
+              <PageHeader
+                title={group.name}
+                description={group.description}
+                breadcrumb={
+                  <Breadcrumbs
+                    items={[
+                      { href: "..", title: t("groups") },
+                      { title: group.groupId },
+                    ]}
+                  />
+                }
+                actions={
+                  <>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => editGroup(group)}
+                    >
+                      <Pencil aria-hidden="true" />
+                      {t("editGroup")}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => deleteGroup(group)}
+                    >
+                      <Trash2 aria-hidden="true" />
+                      {t("delete")}
+                    </Button>
+                  </>
+                }
+                tabs={<TabsHeaderList />}
+              />
+              <TabsContent />
+            </Tabs>
+          )
         )}
-        {editModal}
-        {deleteModal}
       </>
+      {editModal}
+      {deleteModal}
     </StackPage>
   );
 };

--- a/identity/client/src/pages/groups/detailV2/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/mapping-rules/AssignMappingRulesModal.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import { MappingRuleMultiSelect } from "src/components/formV2/entitySelection/MappingRuleSelection";
+import FormModal from "src/components/modalV2/FormModal";
+import { useNotifications } from "src/components/notifications";
+import type { Group, MappingRule } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignMappingRulesModal: FC<
+  UseEntityModalCustomProps<
+    { id: Group["groupId"] },
+    { assignedMappingRules: MappingRule[] }
+  >
+> = ({ entity: group, assignedMappingRules, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+  const [selectedMappingRules, setSelectedMappingRules] = useState<
+    MappingRule[]
+  >([]);
+  const [loadingAssignMappingRule, setLoadingAssignMappingRule] =
+    useState(false);
+
+  const qc = useQueryClient();
+  const { mutateAsync: callAssignMappingRule } = useMutation(
+    groupMutations.assignMappingRule(qc),
+  );
+
+  const canSubmit = group && selectedMappingRules.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignMappingRule(true);
+    try {
+      await Promise.all(
+        selectedMappingRules.map(({ mappingRuleId }) =>
+          callAssignMappingRule({
+            mappingRuleId: mappingRuleId,
+            groupId: group.id,
+          }),
+        ),
+      );
+      if (selectedMappingRules.length === 1) {
+        enqueueNotification({
+          kind: "success",
+          title: t("mappingRuleAssigned"),
+          subtitle: t("mappingRuleAssignedSuccessfully"),
+        });
+      } else {
+        enqueueNotification({
+          kind: "success",
+          title: t("mappingRulesAssigned"),
+          subtitle: t("mappingRulesAssignedSuccessfully"),
+        });
+      }
+      onSuccess();
+    } catch {
+      // error handled globally
+    } finally {
+      setLoadingAssignMappingRule(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedMappingRules([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignMappingRule")}
+      confirmLabel={t("assignMappingRule")}
+      loading={loadingAssignMappingRule}
+      loadingDescription={t("assigningMappingRule")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>
+        <Translate i18nKey="searchAndAssignMappingRuleToGroup">
+          Search and assign mapping rule to group
+        </Translate>
+      </p>
+      <MappingRuleMultiSelect
+        value={selectedMappingRules}
+        onChange={setSelectedMappingRules}
+        excluded={assignedMappingRules}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignMappingRulesModal;

--- a/identity/client/src/pages/groups/detailV2/mapping-rules/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/mapping-rules/DeleteModal.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import type { MappingRule } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveGroupMappingRuleModalProps = UseEntityModalCustomProps<
+  MappingRule,
+  {
+    groupId: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveGroupMappingRuleModalProps> = ({
+  entity: mappingRule,
+  open,
+  onClose,
+  onSuccess,
+  groupId,
+}) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    groupMutations.unassignMappingRule(qc),
+  );
+
+  const handleSubmit = () => {
+    if (groupId && mappingRule) {
+      mutate(
+        { groupId, mappingRuleId: mappingRule.mappingRuleId },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("groupMappingRuleRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeMappingRule")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingMappingRule")}
+      onClose={onClose}
+      confirmLabel={t("removeMappingRule")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeMappingRuleConfirmation"
+          values={{ mappingRuleId: mappingRule.mappingRuleId }}
+        >
+          Are you sure you want to remove{" "}
+          <strong>{mappingRule.mappingRuleId}</strong> from this group?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/groups/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/mapping-rules/index.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+// TODO: Replace with `ErrorInlineNotification`.
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { groupQueries } from "src/utility/api/groups/queries";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import DeleteModal from "src/pages/groups/detailV2/mapping-rules/DeleteModal";
+import AssignMappingRulesModal from "src/pages/groups/detailV2/mapping-rules/AssignMappingRulesModal.tsx";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+
+type MappingRulesProps = {
+  groupId: string;
+};
+
+const MappingRules: FC<MappingRulesProps> = ({ groupId }) => {
+  const { t } = useTranslate("groups");
+  const noop = () => {};
+
+  const { pageParams, page, ...paginationCallbacks } = usePagination();
+  const {
+    data: mappingRules,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...groupQueries.mappingRules(groupId, pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((rule) => ({ ...rule, id: rule.mappingRuleId })),
+    }),
+  });
+
+  const isMappingRulesListEmpty =
+    !mappingRules || mappingRules.items?.length === 0;
+
+  const [assignMappingRules, assignMappingRulesModal] = useEntityModal(
+    AssignMappingRulesModal,
+    noop,
+    {
+      assignedMappingRules: mappingRules?.items || [],
+    },
+  );
+  const openAssignModal = () => assignMappingRules({ id: groupId });
+  const [unassignMappingRule, unassignMappingRuleModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    {
+      groupId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("mappingRule").toLowerCase(),
+        })}
+        button={{
+          label: t("retry"),
+          onClick: () => {
+            void reload();
+          },
+        }}
+      />
+    );
+
+  if (success && isMappingRulesListEmpty)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"mappingRule"}
+          parentResourceTypeTranslationKey={"group"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/mapping-rules/"
+        />
+        {assignMappingRulesModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={mappingRules?.items}
+        headers={[
+          {
+            header: t("mappingRuleId"),
+            key: "mappingRuleId",
+            isSortable: true,
+          },
+          { header: t("mappingRuleName"), key: "name", isSortable: true },
+          { header: t("claimName"), key: "claimName", isSortable: true },
+          { header: t("claimValue"), key: "claimValue", isSortable: true },
+        ]}
+        loading={loading}
+        addEntityLabel={t("assignMappingRule")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByMappingRuleId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignMappingRule,
+          },
+        ]}
+        page={{ ...page, ...mappingRules?.page }}
+        {...paginationCallbacks}
+      />
+      {assignMappingRulesModal}
+      {unassignMappingRuleModal}
+    </>
+  );
+};
+
+export default MappingRules;

--- a/identity/client/src/pages/groups/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/mapping-rules/index.tsx
@@ -7,15 +7,14 @@
  */
 
 import { FC } from "react";
-// TODO: Replace with `ErrorInlineNotification`.
-import { C3EmptyState } from "@camunda/camunda-composite-components";
-import { TrashCan } from "@carbon/react/icons";
+import { Trash2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
 import { groupQueries } from "src/utility/api/groups/queries";
 import EntityList from "src/components/entityListV2";
 import { useEntityModal } from "src/components/modalV2";
+import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
 import DeleteModal from "src/pages/groups/detailV2/mapping-rules/DeleteModal";
 import AssignMappingRulesModal from "src/pages/groups/detailV2/mapping-rules/AssignMappingRulesModal.tsx";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
@@ -63,12 +62,12 @@ const MappingRules: FC<MappingRulesProps> = ({ groupId }) => {
 
   if (!loading && !success)
     return (
-      <C3EmptyState
-        heading={t("somethingsWrong")}
-        description={t("unableToLoadResource", {
+      <ErrorInlineNotification
+        title={t("somethingsWrong")}
+        subtitle={t("unableToLoadResource", {
           resourceType: t("mappingRule").toLowerCase(),
         })}
-        button={{
+        actionButton={{
           label: t("retry"),
           onClick: () => {
             void reload();
@@ -111,7 +110,7 @@ const MappingRules: FC<MappingRulesProps> = ({ groupId }) => {
         menuItems={[
           {
             label: t("remove"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: unassignMappingRule,
           },

--- a/identity/client/src/pages/groups/detailV2/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/AssignMemberModal.tsx
@@ -15,8 +15,6 @@ import FormModal from "src/components/modalV2/FormModal";
 import TextField from "src/components/formV2/TextField";
 import { useNotifications } from "src/components/notifications";
 import { DocumentationLink } from "src/components/documentationV2";
-// TODO: Remove this import during migration. Reference roles/detailsV2/members for a solution.
-import { Caption } from "src/pages/authorizations/modals/components.tsx";
 import type { Group, User } from "@camunda/camunda-api-zod-schemas/8.10";
 
 const AssignMemberModal: FC<
@@ -75,18 +73,16 @@ const AssignMemberModal: FC<
         placeholder={t("typeUsername")}
         onChange={setUsername}
         helperText={
-          <Caption>
-            <Translate i18nKey="usernameDescription">
-              Check the documentation for{" "}
-              <DocumentationLink
-                path="/components/admin/group/#assign-users-to-a-group"
-                withIcon
-              >
-                how to reference users
-              </DocumentationLink>{" "}
-              .
-            </Translate>
-          </Caption>
+          <Translate i18nKey="usernameDescription">
+            Check the documentation for{" "}
+            <DocumentationLink
+              path="/components/admin/group/#assign-users-to-a-group"
+              withIcon
+            >
+              how to reference users
+            </DocumentationLink>{" "}
+            .
+          </Translate>
         }
         value={username}
         autoFocus

--- a/identity/client/src/pages/groups/detailV2/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/AssignMemberModal.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { membershipMutations } from "src/utility/api/membership/mutations";
+import useTranslate from "src/utility/localization";
+import FormModal from "src/components/modalV2/FormModal";
+import TextField from "src/components/formV2/TextField";
+import { useNotifications } from "src/components/notifications";
+import { DocumentationLink } from "src/components/documentationV2";
+// TODO: Remove this import during migration. Reference roles/detailsV2/members for a solution.
+import { Caption } from "src/pages/authorizations/modals/components.tsx";
+import type { Group, User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignMemberModal: FC<
+  UseEntityModalCustomProps<
+    { groupId: Group["groupId"] },
+    { assignedUsers: User[] }
+  >
+> = ({ entity: { groupId }, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+  const [username, setUsername] = useState("");
+  const qc = useQueryClient();
+  const { mutate, isPending: loadingAssignUser } = useMutation(
+    membershipMutations.assignGroupMember(qc),
+  );
+
+  const canSubmit = groupId && username;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    mutate(
+      { username, groupId },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("userAssigned"),
+            subtitle: t("userAssignedSuccessfully"),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    if (open) {
+      setUsername("");
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignUser")}
+      confirmLabel={t("assignUser")}
+      loading={loadingAssignUser}
+      loadingDescription={t("assigningUser")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("assignUsersToGroup")}</p>
+      <TextField
+        label={t("username")}
+        placeholder={t("typeUsername")}
+        onChange={setUsername}
+        helperText={
+          <Caption>
+            <Translate i18nKey="usernameDescription">
+              Check the documentation for{" "}
+              <DocumentationLink
+                path="/components/admin/group/#assign-users-to-a-group"
+                withIcon
+              >
+                how to reference users
+              </DocumentationLink>{" "}
+              .
+            </Translate>
+          </Caption>
+        }
+        value={username}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignMemberModal;

--- a/identity/client/src/pages/groups/detailV2/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/AssignMembersModal.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { membershipMutations } from "src/utility/api/membership/mutations";
+import { UserMultiSelect } from "src/components/formV2/entitySelection/UserSelection";
+import FormModal from "src/components/modalV2/FormModal";
+import { useNotifications } from "src/components/notifications";
+import type { Group, User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignMembersModal: FC<
+  UseEntityModalCustomProps<
+    { groupId: Group["groupId"] },
+    { assignedUsers: User[] }
+  >
+> = ({ entity: { groupId }, assignedUsers, onSuccess, open, onClose }) => {
+  const { t } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
+  const [loadingAssignUser, setLoadingAssignUser] = useState(false);
+
+  const qc = useQueryClient();
+  const { mutateAsync: callAssignUser } = useMutation(
+    membershipMutations.assignGroupMember(qc),
+  );
+
+  const canSubmit = groupId && selectedUsers.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignUser(true);
+    try {
+      await Promise.all(
+        selectedUsers.map(({ username }) =>
+          callAssignUser({ username, groupId }),
+        ),
+      );
+      if (selectedUsers.length === 1) {
+        enqueueNotification({
+          kind: "success",
+          title: t("userAssigned"),
+          subtitle: t("userAssignedSuccessfully"),
+        });
+      } else {
+        enqueueNotification({
+          kind: "success",
+          title: t("usersAssigned"),
+          subtitle: t("usersAssignedSuccessfully"),
+        });
+      }
+      onSuccess();
+    } catch {
+      // error notification handled globally
+    } finally {
+      setLoadingAssignUser(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedUsers([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignUser")}
+      confirmLabel={t("assignUser")}
+      loading={loadingAssignUser}
+      loadingDescription={t("assigningUser")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>{t("searchAndAssignUserToGroup")}</p>
+      <UserMultiSelect
+        value={selectedUsers}
+        onChange={setSelectedUsers}
+        excluded={assignedUsers}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignMembersModal;

--- a/identity/client/src/pages/groups/detailV2/members/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/DeleteModal.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { membershipMutations } from "src/utility/api/membership/mutations";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveGroupMemberModalProps = UseEntityModalCustomProps<
+  User,
+  {
+    groupId: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveGroupMemberModalProps> = ({
+  entity: user,
+  open,
+  onClose,
+  onSuccess,
+  groupId,
+}) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    membershipMutations.unassignGroupMember(qc),
+  );
+
+  const handleSubmit = () => {
+    if (groupId && user) {
+      mutate(
+        { groupId, username: user.username },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("groupMemberRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeUser")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingUser")}
+      onClose={onClose}
+      confirmLabel={t("removeUser")}
+    >
+      <p>
+        <Translate
+          i18nKey="removeUserConfirmation"
+          values={{ username: user.username }}
+        >
+          Are you sure you want to remove <strong>{user.username}</strong> from
+          this group?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/groups/detailV2/members/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/index.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { TrashCan } from "@carbon/react/icons";
+// TODO: Replace with `ErrorInlineNotification`.
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import useTranslate from "src/utility/localization";
+import { searchMembersByGroup } from "src/utility/api/membership";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import AssignMembersModal from "src/pages/groups/detailV2/members/AssignMembersModal";
+import AssignMemberModal from "src/pages/groups/detailV2/members/AssignMemberModal";
+import DeleteModal from "src/pages/groups/detailV2/members/DeleteModal";
+import { useEnrichedUsers } from "src/components/global/useEnrichUsers";
+import { UserKeys } from "src/utility/api/users";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+
+type MembersProps = {
+  groupId: string;
+  isOIDC: boolean;
+};
+
+const Members: FC<MembersProps> = ({ groupId, isOIDC }) => {
+  const { t } = useTranslate("groups");
+
+  const { users, loading, success, reload, paginationProps } = useEnrichedUsers(
+    "groups",
+    searchMembersByGroup,
+    {
+      groupId,
+    },
+    isOIDC,
+  );
+
+  const isUsersListEmpty = !users || users.length === 0;
+  const noop = () => {};
+  const [assignUsers, assignUsersModal] = useEntityModal(
+    isOIDC ? AssignMemberModal : AssignMembersModal,
+    noop,
+    { assignedUsers: users },
+  );
+  const openAssignModal = () => assignUsers({ groupId });
+  const [unassignMember, unassignMemberModal] = useEntityModal(
+    DeleteModal,
+    noop,
+    {
+      groupId,
+    },
+  );
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("user").toLowerCase(),
+        })}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && isUsersListEmpty)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"user"}
+          parentResourceTypeTranslationKey={"group"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/user/"
+        />
+        {assignUsersModal}
+      </>
+    );
+
+  type MembersListHeaders = {
+    header: string;
+    key: UserKeys;
+    isSortable?: boolean;
+  }[];
+
+  const membersListHeaders: MembersListHeaders = isOIDC
+    ? [{ header: t("username"), key: "username", isSortable: true }]
+    : [
+        { header: t("username"), key: "username", isSortable: true },
+        { header: t("name"), key: "name" },
+        { header: t("email"), key: "email" },
+      ];
+
+  return (
+    <>
+      <EntityList
+        data={users}
+        headers={membersListHeaders}
+        loading={loading}
+        addEntityLabel={t("assignUser")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByUsername")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignMember,
+          },
+        ]}
+        {...paginationProps}
+      />
+      {assignUsersModal}
+      {unassignMemberModal}
+    </>
+  );
+};
+
+export default Members;

--- a/identity/client/src/pages/groups/detailV2/members/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/members/index.tsx
@@ -7,13 +7,12 @@
  */
 
 import { FC } from "react";
-import { TrashCan } from "@carbon/react/icons";
-// TODO: Replace with `ErrorInlineNotification`.
-import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { Trash2 } from "lucide-react";
 import useTranslate from "src/utility/localization";
 import { searchMembersByGroup } from "src/utility/api/membership";
 import EntityList from "src/components/entityListV2";
 import { useEntityModal } from "src/components/modalV2";
+import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
 import AssignMembersModal from "src/pages/groups/detailV2/members/AssignMembersModal";
 import AssignMemberModal from "src/pages/groups/detailV2/members/AssignMemberModal";
 import DeleteModal from "src/pages/groups/detailV2/members/DeleteModal";
@@ -55,12 +54,17 @@ const Members: FC<MembersProps> = ({ groupId, isOIDC }) => {
   );
   if (!loading && !success)
     return (
-      <C3EmptyState
-        heading={t("somethingsWrong")}
-        description={t("unableToLoadResource", {
+      <ErrorInlineNotification
+        title={t("somethingsWrong")}
+        subtitle={t("unableToLoadResource", {
           resourceType: t("user").toLowerCase(),
         })}
-        button={{ label: t("retry"), onClick: reload }}
+        actionButton={{
+          label: t("retry"),
+          onClick: () => {
+            void reload();
+          },
+        }}
       />
     );
 
@@ -103,7 +107,7 @@ const Members: FC<MembersProps> = ({ groupId, isOIDC }) => {
         menuItems={[
           {
             label: t("remove"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: unassignMember,
           },

--- a/identity/client/src/pages/groups/detailV2/roles/AssignRolesModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/roles/AssignRolesModal.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { UseEntityModalCustomProps } from "src/components/modalV2";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import { RoleMultiSelect } from "src/components/formV2/entitySelection/RoleSelection";
+import FormModal from "src/components/modalV2/FormModal";
+import { useNotifications } from "src/components/notifications";
+import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const AssignRolesModal: FC<
+  UseEntityModalCustomProps<{ id: Group["groupId"] }, { assignedRoles: Role[] }>
+> = ({ entity: group, assignedRoles, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+  const [selectedRoles, setSelectedRoles] = useState<Role[]>([]);
+  const [loadingAssignRole, setLoadingAssignRole] = useState(false);
+
+  const qc = useQueryClient();
+  const { mutateAsync: callAssignRole } = useMutation(
+    groupMutations.assignRole(qc),
+  );
+
+  const canSubmit = group && selectedRoles.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignRole(true);
+    try {
+      await Promise.all(
+        selectedRoles.map(({ roleId }) =>
+          callAssignRole({ roleId, groupId: group.id }),
+        ),
+      );
+      if (selectedRoles.length === 1) {
+        enqueueNotification({
+          kind: "success",
+          title: t("roleAssigned"),
+          subtitle: t("roleAssignedSuccessfully"),
+        });
+      } else {
+        enqueueNotification({
+          kind: "success",
+          title: t("rolesAssigned"),
+          subtitle: t("rolesAssignedSuccessfully"),
+        });
+      }
+      onSuccess();
+    } catch {
+      // error handled globally
+    } finally {
+      setLoadingAssignRole(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedRoles([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignRole")}
+      confirmLabel={t("assignRole")}
+      loading={loadingAssignRole}
+      loadingDescription={t("assigningRole")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+    >
+      <p>
+        <Translate i18nKey="searchAndAssignRoleToGroup">
+          Search and assign role to group
+        </Translate>
+      </p>
+      <RoleMultiSelect
+        value={selectedRoles}
+        onChange={setSelectedRoles}
+        excluded={assignedRoles}
+        autoFocus
+      />
+    </FormModal>
+  );
+};
+
+export default AssignRolesModal;

--- a/identity/client/src/pages/groups/detailV2/roles/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detailV2/roles/DeleteModal.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modalV2";
+import { useNotifications } from "src/components/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type RemoveGroupRoleModalProps = UseEntityModalCustomProps<
+  Role,
+  {
+    groupId: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveGroupRoleModalProps> = ({
+  entity: { roleId },
+  open,
+  onClose,
+  onSuccess,
+  groupId,
+}) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(
+    groupMutations.unassignRole(qc),
+  );
+
+  const handleSubmit = () => {
+    if (groupId && roleId) {
+      mutate(
+        { groupId, roleId },
+        {
+          onSuccess: () => {
+            enqueueNotification({
+              kind: "success",
+              title: t("groupRoleRemoved"),
+            });
+            onSuccess();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeRole")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingRole")}
+      onClose={onClose}
+      confirmLabel={t("removeRole")}
+    >
+      <p>
+        <Translate i18nKey="removeRoleConfirmation" values={{ roleId }}>
+          Are you sure you want to remove <strong>{roleId}</strong> from this
+          group?
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/groups/detailV2/roles/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/roles/index.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+// TODO: Replace with `ErrorInlineNotification`.
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import { useQuery } from "@tanstack/react-query";
+import useTranslate from "src/utility/localization";
+import { usePagination } from "src/utility/api";
+import { groupQueries } from "src/utility/api/groups/queries";
+import EntityList from "src/components/entityListV2";
+import { useEntityModal } from "src/components/modalV2";
+import DeleteModal from "src/pages/groups/detailV2/roles/DeleteModal";
+import AssignRolesModal from "src/pages/groups/detailV2/roles/AssignRolesModal";
+import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+
+type RolesProps = {
+  groupId: string;
+};
+
+const Roles: FC<RolesProps> = ({ groupId }) => {
+  const { t } = useTranslate("groups");
+  const noop = () => {};
+
+  const { pageParams, page, ...paginationCallbacks } = usePagination();
+  const {
+    data: roles,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery({
+    ...groupQueries.roles(groupId, pageParams),
+    select: (data) => ({
+      ...data,
+      items: data.items.map((role) => ({ ...role, id: role.roleId })),
+    }),
+  });
+
+  const isRolesListEmpty = !roles || roles.items?.length === 0;
+
+  const [assignRoles, assignRolesModal] = useEntityModal(
+    AssignRolesModal,
+    noop,
+    {
+      assignedRoles: roles?.items || [],
+    },
+  );
+  const openAssignModal = () => assignRoles({ id: groupId });
+  const [unassignRole, unassignRoleModal] = useEntityModal(DeleteModal, noop, {
+    groupId,
+  });
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadResource", {
+          resourceType: t("role").toLowerCase(),
+        })}
+        button={{
+          label: t("retry"),
+          onClick: () => {
+            void reload();
+          },
+        }}
+      />
+    );
+
+  if (success && isRolesListEmpty)
+    return (
+      <>
+        <TabEmptyState
+          childResourceTypeTranslationKey={"role"}
+          parentResourceTypeTranslationKey={"group"}
+          handleClick={openAssignModal}
+          docsLinkPath="/components/admin/role/"
+        />
+        {assignRolesModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={roles?.items}
+        headers={[
+          { header: t("roleId"), key: "roleId", isSortable: true },
+          { header: t("roleName"), key: "name", isSortable: true },
+        ]}
+        loading={loading}
+        addEntityLabel={t("assignRole")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByRoleId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignRole,
+          },
+        ]}
+        page={{ ...page, ...roles?.page }}
+        {...paginationCallbacks}
+      />
+      {assignRolesModal}
+      {unassignRoleModal}
+    </>
+  );
+};
+
+export default Roles;

--- a/identity/client/src/pages/groups/detailV2/roles/index.tsx
+++ b/identity/client/src/pages/groups/detailV2/roles/index.tsx
@@ -7,15 +7,14 @@
  */
 
 import { FC } from "react";
-// TODO: Replace with `ErrorInlineNotification`.
-import { C3EmptyState } from "@camunda/camunda-composite-components";
-import { TrashCan } from "@carbon/react/icons";
+import { Trash2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import useTranslate from "src/utility/localization";
 import { usePagination } from "src/utility/api";
 import { groupQueries } from "src/utility/api/groups/queries";
 import EntityList from "src/components/entityListV2";
 import { useEntityModal } from "src/components/modalV2";
+import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
 import DeleteModal from "src/pages/groups/detailV2/roles/DeleteModal";
 import AssignRolesModal from "src/pages/groups/detailV2/roles/AssignRolesModal";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
@@ -58,12 +57,12 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
 
   if (!loading && !success)
     return (
-      <C3EmptyState
-        heading={t("somethingsWrong")}
-        description={t("unableToLoadResource", {
+      <ErrorInlineNotification
+        title={t("somethingsWrong")}
+        subtitle={t("unableToLoadResource", {
           resourceType: t("role").toLowerCase(),
         })}
-        button={{
+        actionButton={{
           label: t("retry"),
           onClick: () => {
             void reload();
@@ -100,7 +99,7 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
         menuItems={[
           {
             label: t("remove"),
-            icon: TrashCan,
+            icon: Trash2,
             isDangerous: true,
             onClick: unassignRole,
           },

--- a/identity/client/src/pages/groups/index.tsx
+++ b/identity/client/src/pages/groups/index.tsx
@@ -8,10 +8,15 @@
 
 import { FC, lazy, Suspense } from "react";
 import { ListPageFallback } from "src/components/fallbacks";
+import { ListPageFallback as ListPageFallbackV2 } from "src/components/fallbacksV2";
 import PageRoutes from "src/components/router/PageRoutes";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "src/feature-flags";
 import Detail from "src/pages/groups/detail";
+import DetailV2 from "src/pages/groups/detailV2";
 
-const List = lazy(() => import("./List"));
+const List = lazy(() =>
+  IS_NEW_DESIGN_SYSTEM_ENABLED ? import("./ListV2") : import("./List"),
+);
 
 type GroupsProps = {
   isOIDC: boolean;
@@ -20,11 +25,25 @@ type GroupsProps = {
 const Groups: FC<GroupsProps> = ({ isOIDC }) => (
   <PageRoutes
     indexElement={
-      <Suspense fallback={<ListPageFallback />}>
+      <Suspense
+        fallback={
+          IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+            <ListPageFallbackV2 />
+          ) : (
+            <ListPageFallback />
+          )
+        }
+      >
         <List />
       </Suspense>
     }
-    detailElement={<Detail isOIDC={isOIDC} />}
+    detailElement={
+      IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+        <DetailV2 isOIDC={isOIDC} />
+      ) : (
+        <Detail isOIDC={isOIDC} />
+      )
+    }
   />
 );
 

--- a/identity/client/src/pages/groups/modals/EditModal.tsx
+++ b/identity/client/src/pages/groups/modals/EditModal.tsx
@@ -81,7 +81,7 @@ const EditModal: FC<UseEntityModalProps<Group>> = ({
           validateGroupId(value);
           setGroupId(value);
         }}
-        errors={!isGroupIdValid ? [t("pleaseEnterValidGroupId")] : []}
+        errors={!isGroupIdValid ? t("pleaseEnterValidGroupId") : undefined}
         readOnly
       />
       <TextField

--- a/identity/client/src/pages/groups/modalsV2/AddModal.tsx
+++ b/identity/client/src/pages/groups/modalsV2/AddModal.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FormModal, UseModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import TextField from "src/components/formV2/TextField";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import { useNotifications } from "src/components/notifications";
+import { getIdPattern, isValidId } from "src/utility/validate.ts";
+
+const AddModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
+  const { t } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(groupMutations.create(qc));
+  type FormData = {
+    groupId: string;
+    groupName: string;
+    description: string;
+  };
+
+  const { control, handleSubmit } = useForm<FormData>({
+    defaultValues: {
+      groupId: "",
+      groupName: "",
+      description: "",
+    },
+    mode: "all",
+  });
+
+  const onSubmit = (data: FormData) => {
+    mutate(
+      {
+        name: data.groupName,
+        groupId: data.groupId,
+        description: data.description,
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("groupCreated"),
+            subtitle: t("groupCreatedSuccessfully", {
+              groupName: data.groupName,
+            }),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("createGroup")}
+      onClose={onClose}
+      onSubmit={handleSubmit(onSubmit)}
+      loading={loading}
+      error={error}
+      loadingDescription={t("creatingGroup")}
+      confirmLabel={t("createGroup")}
+    >
+      <Controller
+        name="groupId"
+        control={control}
+        rules={{
+          required: t("groupIdRequired"),
+          validate: (value) =>
+            isValidId(value) ||
+            t("pleaseEnterValidGroupId", {
+              pattern: getIdPattern(),
+            }),
+        }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("groupId")}
+            placeholder={t("groupIdPlaceholder")}
+            helperText={t("groupIdHelperText")}
+            errors={fieldState.error?.message}
+            autoFocus
+          />
+        )}
+      />
+      <Controller
+        name="groupName"
+        control={control}
+        rules={{ required: t("groupNameRequired") }}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            label={t("groupName")}
+            placeholder={t("groupNamePlaceholder")}
+            errors={fieldState.error?.message}
+          />
+        )}
+      />
+      <Controller
+        name="description"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            label={t("description")}
+            placeholder={t("groupDescriptionPlaceholder")}
+            cols={2}
+            enableCounter
+          />
+        )}
+      />
+    </FormModal>
+  );
+};
+
+export default AddModal;

--- a/identity/client/src/pages/groups/modalsV2/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/modalsV2/DeleteModal.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  DeleteModal as Modal,
+  UseEntityModalProps,
+} from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useNotifications } from "src/components/notifications";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const DeleteModal: FC<UseEntityModalProps<Group>> = ({
+  entity: { groupId },
+  open,
+  onClose,
+  onSuccess,
+}) => {
+  const { t, Translate } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const { mutate, isPending: loading } = useMutation(groupMutations.delete(qc));
+
+  const handleSubmit = () => {
+    mutate(
+      { groupId },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("groupHasBeenDeleted"),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("deleteGroup")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("deletingGroup")}
+      onClose={onClose}
+      confirmLabel={t("deleteGroup")}
+    >
+      <p>
+        <Translate i18nKey="deleteGroupConfirmation" values={{ groupId }}>
+          Are you sure you want to delete <strong>{groupId}</strong>? This
+          action cannot be undone.
+        </Translate>
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/groups/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/groups/modalsV2/EditModal.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FormModal, UseEntityModalProps } from "src/components/modalV2";
+import useTranslate from "src/utility/localization";
+import { useNotifications } from "src/components/notifications";
+import { groupMutations } from "src/utility/api/groups/mutations";
+import TextField from "src/components/formV2/TextField";
+import { isValidId } from "src/utility/validate.ts";
+import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
+
+const EditModal: FC<UseEntityModalProps<Group>> = ({
+  entity: group,
+  open,
+  onClose,
+  onSuccess,
+}) => {
+  const { t } = useTranslate("groups");
+  const { enqueueNotification } = useNotifications();
+
+  const qc = useQueryClient();
+  const {
+    mutate,
+    isPending: loading,
+    error,
+  } = useMutation(groupMutations.update(qc));
+
+  const [groupName, setGroupName] = useState(group.name);
+  const [groupId, setGroupId] = useState(group.groupId);
+  const [description, setDescription] = useState(group.description);
+  const [isGroupIdValid, setIsGroupIdValid] = useState(true);
+
+  const handleSubmit = () => {
+    mutate(
+      {
+        groupId: group.groupId,
+        name: groupName,
+        description: description,
+      },
+      {
+        onSuccess: () => {
+          enqueueNotification({
+            kind: "success",
+            title: t("groupHasBeenUpdated"),
+          });
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  const validateGroupId = (id: string) => {
+    setIsGroupIdValid(isValidId(id));
+  };
+
+  return (
+    <FormModal
+      size="sm"
+      open={open}
+      headline={t("editGroup")}
+      onSubmit={handleSubmit}
+      onClose={onClose}
+      loading={loading}
+      error={error}
+      loadingDescription={t("updatingGroup")}
+      confirmLabel={t("editGroup")}
+      submitDisabled={!groupName || !groupId || !isGroupIdValid}
+    >
+      <TextField
+        label={t("groupId")}
+        value={groupId}
+        placeholder={t("groupIdPlaceholder")}
+        onChange={(value) => {
+          validateGroupId(value);
+          setGroupId(value);
+        }}
+        errors={!isGroupIdValid ? [t("pleaseEnterValidGroupId")] : []}
+        readOnly
+      />
+      <TextField
+        label={t("groupName")}
+        value={groupName}
+        placeholder={t("groupNamePlaceholder")}
+        onChange={setGroupName}
+        autoFocus
+      />
+      <TextField
+        label={t("description")}
+        value={description || ""}
+        placeholder={t("groupDescriptionPlaceholder")}
+        onChange={setDescription}
+        cols={2}
+        enableCounter
+      />
+    </FormModal>
+  );
+};
+
+export default EditModal;

--- a/identity/client/src/pages/groups/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/groups/modalsV2/EditModal.tsx
@@ -62,7 +62,6 @@ const EditModal: FC<UseEntityModalProps<Group>> = ({
 
   return (
     <FormModal
-      size="sm"
       open={open}
       headline={t("editGroup")}
       onSubmit={handleSubmit}


### PR DESCRIPTION
## Description

This PR migrates the Admin groups page to the new design system. **The first commit prepares the migration for the feature flag and updates imports to v2. It causes the most changes.** Follow-up commits are actual migration changes required that go beyond changing the import to a shared v2 component.

The migration did not contain anything unexpected. It maps to the "roles" page pretty well, and work done during its migration was reusable here.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60633
