### PR TITLE
ci: load-test: disable Renovate for load-tests on stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -823,6 +823,20 @@
       ],
       allowedVersions: "<4",
     },
+
+    {
+      // Disable Renovate for load tests on stable branches.
+      // Once a stable branch is branched off main, all load test dependencies
+      // under load-tests/ in stable branches are unused and unmaintained and
+      // should not be updated anymore.
+      // Only the code in the main branch is relevant and should receive
+      // updates.
+      // This is not part of .github/renovate/team-reliability-testing.json5 as
+      // matchBaseBranches needs to have baseBranchPatterns configured beforehand.
+      matchFileNames: ["load-tests/**"],
+      matchBaseBranches: ["/^stable\\/8\\..*/"],
+      enabled: false,
+    },
   ],
   dockerfile: {
     managerFilePatterns: [


### PR DESCRIPTION
## Description

Follow-up of #61273 but on the `main` branch instead.

Renovate doesn't take into account the configuration from #61273 as it gets its configuration from the `main` branch.
This fix is similar to other related fixes: [example](https://github.com/camunda/camunda/blob/0f12edf1f93f51a7df5c723225c6999850ea5c09/.github/renovate.json5#L106-L116)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
