### PR TITLE
fix: allow re-deleting a process definition to clear remaining resources

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/rest/PublicApiProcessDefinitionDeletionIT.java
@@ -80,7 +80,7 @@ public class PublicApiProcessDefinitionDeletionIT extends AbstractCCSMIT {
     seedProcessDefinition(processDefinitionKey);
     embeddedOptimizeExtension
         .getBean(ProcessDefinitionWriter.class)
-        .markDefinitionAsDeleted(processDefinitionKey);
+        .softDeleteDefinition(processDefinitionKey);
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // when
@@ -130,15 +130,12 @@ public class PublicApiProcessDefinitionDeletionIT extends AbstractCCSMIT {
     assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = JobStatus.class,
-      names = {"QUEUED", "COMPLETED"})
-  public void shouldReturn409WhenBlockingEntryAlreadyExists(final JobStatus blockingStatus) {
+  @Test
+  public void shouldReturn409WhenBlockingQueuedEntryExists() {
     // given
     final String processDefinitionKey = "100000000000003";
     seedProcessDefinition(processDefinitionKey);
-    seedJobRegistryEntry(processDefinitionKey, blockingStatus);
+    seedJobRegistryEntry(processDefinitionKey, JobStatus.QUEUED);
 
     // when
     final Response response =
@@ -177,12 +174,16 @@ public class PublicApiProcessDefinitionDeletionIT extends AbstractCCSMIT {
     assertThat(secondResponse.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
   }
 
-  @Test
-  public void shouldReturn202AndQueueNewJobWhenExistingEntryHasFailedStatus() {
+  @ParameterizedTest
+  @EnumSource(
+      value = JobStatus.class,
+      names = {"COMPLETED", "FAILED"})
+  public void shouldReturn202AndQueueNewJobWhenExistingEntryHasCompletedOrFailedStatus(
+      final JobStatus nonBlockingStatus) {
     // given
     final String processDefinitionKey = "100000000000004";
     seedProcessDefinition(processDefinitionKey);
-    seedJobRegistryEntry(processDefinitionKey, JobStatus.FAILED);
+    seedJobRegistryEntry(processDefinitionKey, nonBlockingStatus);
 
     // when
     final Response response =

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerIT.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
 import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
 import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
@@ -103,7 +104,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionIdV1)).isEmpty();
+    assertThat(isDeleted(definitionIdV1)).isTrue();
     assertThat(getProcessDefinition(definitionIdV2)).isPresent();
 
     final List<ProcessInstanceDto> remainingInstances =
@@ -132,8 +133,33 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
     assertThat(processOverviewReader.getProcessOverviewByKey(bpmnProcessId)).isPresent();
+  }
+
+  @Test
+  void shouldClearTheDefinitionsDataWhenSoftDeleted() {
+    // given
+    final String bpmnProcessId = "definition-deletion-own-xml-test-" + UUID.randomUUID();
+    final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
+    final ProcessDefinitionOptimizeDto definition = definitionFor(bpmnProcessId, definitionId, "1");
+    definition.setFlowNodeData(
+        List.of(new FlowNodeDataDto("task-1", "Review by Jane Doe", "userTask")));
+    definition.setUserTaskNames(Map.of("task-1", "Review by Jane Doe"));
+    persistProcessDefinitions(List.of(definition));
+    refreshAllIndices();
+
+    // when
+    handler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then
+    final ProcessDefinitionOptimizeDto softDeleted =
+        processDefinitionReader.getProcessDefinition(definitionId, true).orElseThrow();
+    assertThat(softDeleted.isDeleted()).isTrue();
+    assertThat(softDeleted.getBpmn20Xml()).isNull();
+    assertThat(softDeleted.getFlowNodeData()).isEmpty();
+    assertThat(softDeleted.getUserTaskNames()).isEmpty();
   }
 
   @Test
@@ -150,7 +176,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
     assertThat(getCachedXml(reportId)).isNull();
   }
 
@@ -197,7 +223,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionIdTenantA)).isEmpty();
+    assertThat(isDeleted(definitionIdTenantA)).isTrue();
     assertThat(getProcessDefinition(definitionIdTenantB)).isPresent();
     assertThat(getCachedXml(reportId)).isNull();
   }
@@ -222,7 +248,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionIdTenantA)).isEmpty();
+    assertThat(isDeleted(definitionIdTenantA)).isTrue();
     assertThat(getProcessDefinition(definitionIdTenantB)).isPresent();
     assertThat(getCachedXml(reportId)).isNull();
   }
@@ -249,7 +275,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionIdTenantA)).isEmpty();
+    assertThat(isDeleted(definitionIdTenantA)).isTrue();
     assertThat(getProcessDefinition(definitionIdTenantB)).isPresent();
     assertThat(getCachedXml(reportIdTenantA)).isNull();
     assertThat(getCachedXml(reportIdTenantB)).isEqualTo("<definitions>cached</definitions>");
@@ -278,7 +304,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
     assertThat(getCachedXml(reportId)).isNull();
   }
 
@@ -304,7 +330,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
     assertThat(getCachedXml(reportId)).isEqualTo("<definitions>cached</definitions>");
   }
 
@@ -392,23 +418,39 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     // when / then
     assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
     refreshAllIndices();
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
   }
 
   @Test
-  void shouldBeIdempotentWhenReInvokedAgainstAlreadyDeletedData() {
+  void shouldClearLeftoverXmlOnASecondDeleteRequestForTheSameDefinition() {
     // given
-    final String bpmnProcessId = "definition-deletion-idempotency-test-" + UUID.randomUUID();
+    final String bpmnProcessId = "definition-deletion-second-request-test-" + UUID.randomUUID();
     final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
     persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
+    final String reportId = createSingleProcessReportWithCachedXml(bpmnProcessId);
     refreshAllIndices();
 
     handler.handle(job(definitionId));
     refreshAllIndices();
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
+    assertThat(getCachedXml(reportId)).isNull();
 
-    // when / then -- re-invoking against already-deleted data is a no-op, not an exception
-    assertThatCode(() -> handler.handle(job(definitionId))).doesNotThrowAnyException();
+    // simulate the leftover: a concurrent report evaluation re-writes the XML after the clear
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setProcessDefinitionKey(bpmnProcessId);
+    reportData.setTenantIds(new ArrayList<>(List.of(ZEEBE_DEFAULT_TENANT_ID)));
+    reportData.getConfiguration().setXml("<definitions>cached</definitions>");
+    reportWriter.createOrUpdateSingleProcessReport(
+        reportId, "demo", reportData, "Test Report", null, null);
+    refreshAllIndices();
+    assertThat(getCachedXml(reportId)).isEqualTo("<definitions>cached</definitions>");
+
+    // when -- the user re-requests deletion for the same (already soft-deleted) definition
+    handler.handle(job(definitionId));
+    refreshAllIndices();
+
+    // then -- the leftover XML is cleared again
+    assertThat(getCachedXml(reportId)).isNull();
   }
 
   @Test
@@ -437,7 +479,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
   @Test
   void shouldLeaveDefinitionResumableAfterATerminalFailureAndCompleteCleanupOnRetry() {
     // given -- the deletion job will fail terminally right after the definition instances are
-    // deleted, before the remaining-versions check, XML clear, cache eviction, and hard-delete run
+    // deleted, before the remaining-versions check, XML clear, and cache eviction run
     final String bpmnProcessId = "definition-deletion-resume-test-" + UUID.randomUUID();
     final String definitionId = bpmnProcessId + ":1:" + UUID.randomUUID();
     persistProcessInstances(List.of(instanceFor(bpmnProcessId, definitionId, "1")));
@@ -480,8 +522,8 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     resumableHandler.handle(job(definitionId));
     refreshAllIndices();
 
-    // then -- the remainder of the cleanup tail, including the final hard-delete, now completes
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    // then -- the remainder of the cleanup tail now completes
+    assertThat(isDeleted(definitionId)).isTrue();
     assertThat(getCachedXml(reportId)).isNull();
   }
 
@@ -502,7 +544,7 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
     refreshAllIndices();
 
     // then
-    assertThat(getProcessDefinition(definitionId)).isEmpty();
+    assertThat(isDeleted(definitionId)).isTrue();
     final JobRegistryReader jobRegistryReader =
         embeddedOptimizeExtension.getBean(JobRegistryReader.class);
     final var found =
@@ -515,6 +557,12 @@ public class ProcessDefinitionDeletionJobHandlerIT extends AbstractBrokerlessZee
 
   private Optional<ProcessDefinitionOptimizeDto> getProcessDefinition(final String definitionId) {
     return processDefinitionReader.getProcessDefinition(definitionId, false);
+  }
+
+  private boolean isDeleted(final String definitionId) {
+    return getProcessDefinition(definitionId)
+        .map(ProcessDefinitionOptimizeDto::isDeleted)
+        .orElse(false);
   }
 
   private String createSingleProcessReportWithCachedXml(final String bpmnProcessId) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ProcessDefinitionWriterES.java
@@ -9,23 +9,19 @@ package io.camunda.optimize.service.db.es.writer;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_INDEX_NAME;
-import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.DECISION_DEFINITION_ID;
-import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.DECISION_DEFINITION_KEY;
-import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.DECISION_DEFINITION_VERSION;
-import static io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex.TENANT_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.FLOW_NODE_DATA;
 import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_KEY;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_XML;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.USER_TASK_NAMES;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch._types.ScriptLanguage;
-import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
-import io.camunda.optimize.service.db.es.builders.OptimizeDeleteRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeUpdateRequestBuilderES;
 import io.camunda.optimize.service.db.repository.es.TaskRepositoryES;
 import io.camunda.optimize.service.db.writer.DeletedProcessDefinitionFilter;
@@ -33,11 +29,8 @@ import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
-import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -48,7 +41,20 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
     implements ProcessDefinitionWriter {
 
   private static final Script MARK_AS_DELETED_SCRIPT =
-      Script.of(s -> s.lang(ScriptLanguage.Painless).source("ctx._source.deleted = true"));
+      Script.of(
+          s ->
+              s.lang(ScriptLanguage.Painless)
+                  .source(
+                      "ctx._source.deleted = true;"
+                          + " ctx._source."
+                          + PROCESS_DEFINITION_XML
+                          + " = null;"
+                          + " ctx._source."
+                          + FLOW_NODE_DATA
+                          + " = null;"
+                          + " ctx._source."
+                          + USER_TASK_NAMES
+                          + " = null"));
 
   private static final Script MARK_AS_ONBOARDED_SCRIPT =
       Script.of(s -> s.lang(ScriptLanguage.Painless).source("ctx._source.onboarded = true"));
@@ -79,8 +85,8 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
   }
 
   @Override
-  public void markDefinitionAsDeleted(final String definitionId) {
-    LOG.debug("Marking process definition with ID {} as deleted", definitionId);
+  public void softDeleteDefinition(final String definitionId) {
+    LOG.debug("Soft-deleting process definition with ID {}", definitionId);
     try {
       // Refresh immediately: callers rely on a subsequent search seeing this update right away
       esClient.update(
@@ -95,89 +101,10 @@ public class ProcessDefinitionWriterES extends AbstractProcessDefinitionWriterES
     } catch (final Exception e) {
       throw new OptimizeRuntimeException(
           String.format(
-              "There was a problem when trying to mark process definition with ID %s as deleted",
+              "There was a problem when trying to soft-delete process definition with ID %s",
               definitionId),
           e);
     }
-  }
-
-  @Override
-  public void deleteDefinition(final String definitionId) {
-    LOG.debug("Deleting process definition with ID {}", definitionId);
-    try {
-      // Refresh immediately: callers rely on a subsequent search seeing this delete right away
-      esClient.delete(
-          OptimizeDeleteRequestBuilderES.of(
-              d ->
-                  d.optimizeIndex(esClient, PROCESS_DEFINITION_INDEX_NAME)
-                      .id(definitionId)
-                      .refresh(Refresh.True)));
-    } catch (final IOException e) {
-      throw new OptimizeRuntimeException(
-          String.format(
-              "There was a problem when trying to delete process definition with ID %s",
-              definitionId),
-          e);
-    }
-  }
-
-  @Override
-  public boolean markRedeployedDefinitionsAsDeleted(
-      final List<ProcessDefinitionOptimizeDto> importedDefinitions) {
-    final AtomicBoolean definitionsUpdated = new AtomicBoolean(false);
-    // We must partition this into batches to avoid the maximum ES boolQuery clause limit being
-    // reached
-    Lists.partition(importedDefinitions, 1000)
-        .forEach(
-            partition -> {
-              final BoolQuery.Builder definitionsToDeleteQueryBuilder = new BoolQuery.Builder();
-              final Set<String> processDefIds = new HashSet<>();
-              partition.forEach(
-                  definition -> {
-                    final BoolQuery.Builder matchingDefinitionQuery =
-                        new BoolQuery.Builder()
-                            .must(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(DECISION_DEFINITION_KEY)
-                                                .value(definition.getKey())))
-                            .must(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(DECISION_DEFINITION_VERSION)
-                                                .value(definition.getVersion())))
-                            .mustNot(
-                                m ->
-                                    m.term(
-                                        t ->
-                                            t.field(DECISION_DEFINITION_ID)
-                                                .value(definition.getId())));
-                    processDefIds.add(definition.getId());
-                    if (definition.getTenantId() != null) {
-                      matchingDefinitionQuery.must(
-                          m -> m.term(t -> t.field(TENANT_ID).value(definition.getTenantId())));
-                    } else {
-                      matchingDefinitionQuery.mustNot(m -> m.exists(t -> t.field(TENANT_ID)));
-                    }
-                    definitionsToDeleteQueryBuilder.should(
-                        s -> s.bool(matchingDefinitionQuery.build()));
-                  });
-              final boolean deleted =
-                  taskRepositoryES.tryUpdateByQueryRequest(
-                      String.format("%d process definitions", processDefIds.size()),
-                      MARK_AS_DELETED_SCRIPT,
-                      Query.of(q -> q.bool(definitionsToDeleteQueryBuilder.build())),
-                      PROCESS_DEFINITION_INDEX_NAME);
-              if (deleted && !definitionsUpdated.get()) {
-                definitionsUpdated.set(true);
-              }
-            });
-    if (definitionsUpdated.get()) {
-      LOG.debug("Marked old process definitions with new deployments as deleted");
-    }
-    return definitionsUpdated.get();
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ProcessDefinitionWriterOS.java
@@ -9,16 +9,15 @@ package io.camunda.optimize.service.db.os.writer;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
 import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITION_INDEX_NAME;
-import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.FLOW_NODE_DATA;
 import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_KEY;
-import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_VERSION;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.PROCESS_DEFINITION_XML;
+import static io.camunda.optimize.service.db.schema.index.ProcessDefinitionIndex.USER_TASK_NAMES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.client.dsl.QueryDSL;
-import io.camunda.optimize.service.db.schema.index.DecisionDefinitionIndex;
 import io.camunda.optimize.service.db.writer.DeletedProcessDefinitionFilter;
 import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -26,12 +25,10 @@ import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondit
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
-import org.opensearch.client.opensearch.core.DeleteRequest;
 import org.opensearch.client.opensearch.core.UpdateRequest;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
@@ -44,7 +41,17 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
 
   private static final Script MARK_AS_DELETED_SCRIPT =
       OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams(
-          "ctx._source.deleted = true", Collections.emptyMap());
+          "ctx._source.deleted = true;"
+              + " ctx._source."
+              + PROCESS_DEFINITION_XML
+              + " = null;"
+              + " ctx._source."
+              + FLOW_NODE_DATA
+              + " = null;"
+              + " ctx._source."
+              + USER_TASK_NAMES
+              + " = null",
+          Collections.emptyMap());
 
   private static final Script MARK_AS_ONBOARDED_SCRIPT =
       OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams(
@@ -75,8 +82,8 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
   }
 
   @Override
-  public void markDefinitionAsDeleted(final String definitionId) {
-    LOG.debug("Marking process definition with ID {} as deleted", definitionId);
+  public void softDeleteDefinition(final String definitionId) {
+    LOG.debug("Soft-deleting process definition with ID {}", definitionId);
     // Refresh immediately: callers rely on a subsequent search seeing this delete right away
     final UpdateRequest.Builder updateReqBuilder =
         new UpdateRequest.Builder<>()
@@ -87,72 +94,9 @@ public class ProcessDefinitionWriterOS extends AbstractProcessDefinitionWriterOS
             .refresh(Refresh.True);
     final String errorMessage =
         String.format(
-            "There was a problem when trying to mark process definition with ID %s as deleted",
+            "There was a problem when trying to soft-delete process definition with ID %s",
             definitionId);
     osClient.update(updateReqBuilder, errorMessage);
-  }
-
-  @Override
-  public void deleteDefinition(final String definitionId) {
-    LOG.debug("Deleting process definition with ID {}", definitionId);
-    // Refresh immediately: callers rely on a subsequent search seeing this delete right away
-    final DeleteRequest.Builder request =
-        new DeleteRequest.Builder()
-            .index(PROCESS_DEFINITION_INDEX_NAME)
-            .id(definitionId)
-            .refresh(Refresh.True);
-    osClient.delete(
-        request,
-        String.format(
-            "There was a problem when trying to delete process definition with ID %s",
-            definitionId));
-  }
-
-  @Override
-  public boolean markRedeployedDefinitionsAsDeleted(
-      final List<ProcessDefinitionOptimizeDto> importedDefinitions) {
-    final AtomicBoolean definitionsUpdated = new AtomicBoolean(false);
-    // We must partition this into batches to avoid the maximum OS boolQuery clause limit being
-    // reached
-    // OS counts the clauses in a different way to ES: 300 is roughly equivalent to 1000 in ES
-    // The issue was reproduced locally with 300 partition size so reduced to 100
-    Lists.partition(importedDefinitions, 100)
-        .forEach(
-            partition -> {
-              final BoolQuery.Builder definitionsToDeleteQuery = new BoolQuery.Builder();
-              partition.forEach(
-                  definition -> {
-                    final BoolQuery.Builder matchingDefinitionQuery =
-                        new BoolQuery.Builder()
-                            .must(QueryDSL.term(PROCESS_DEFINITION_KEY, definition.getKey()))
-                            .must(
-                                QueryDSL.term(PROCESS_DEFINITION_VERSION, definition.getVersion()))
-                            .mustNot(QueryDSL.term(PROCESS_DEFINITION_ID, definition.getId()));
-                    if (definition.getTenantId() != null) {
-                      matchingDefinitionQuery.must(
-                          QueryDSL.term(
-                              DecisionDefinitionIndex.TENANT_ID, definition.getTenantId()));
-                    } else {
-                      matchingDefinitionQuery.mustNot(
-                          QueryDSL.exists(DecisionDefinitionIndex.TENANT_ID));
-                    }
-                    definitionsToDeleteQuery.should(matchingDefinitionQuery.build().toQuery());
-                  });
-
-              final long deleted =
-                  osClient.updateByQuery(
-                      PROCESS_DEFINITION_INDEX_NAME,
-                      definitionsToDeleteQuery.build().toQuery(),
-                      MARK_AS_DELETED_SCRIPT);
-
-              if (deleted > 0 && !definitionsUpdated.get()) {
-                definitionsUpdated.set(true);
-              }
-            });
-    if (definitionsUpdated.get()) {
-      LOG.debug("Marked old process definitions with new deployments as deleted");
-    }
-    return definitionsUpdated.get();
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessDefinitionWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ProcessDefinitionWriter.java
@@ -31,12 +31,7 @@ public interface ProcessDefinitionWriter {
 
   void importProcessDefinitions(List<ProcessDefinitionOptimizeDto> procDefs);
 
-  void markDefinitionAsDeleted(final String definitionId);
-
-  void deleteDefinition(final String definitionId);
-
-  boolean markRedeployedDefinitionsAsDeleted(
-      final List<ProcessDefinitionOptimizeDto> importedDefinitions);
+  void softDeleteDefinition(final String definitionId);
 
   void markDefinitionKeysAsOnboarded(final Set<String> definitionKeys);
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestService.java
@@ -78,7 +78,7 @@ public class ProcessDefinitionDeletionRequestService {
         jobRegistryReader.findLastByJobTypeAndEntityId(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, processDefinitionId);
     final boolean deleteJobAlreadyExists =
-        existingEntry.filter(entry -> entry.getStatus() != JobStatus.FAILED).isPresent();
+        existingEntry.filter(entry -> entry.getStatus() == JobStatus.QUEUED).isPresent();
     if (deleteJobAlreadyExists) {
       throw new OptimizeConflictException(
           String.format(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandler.java
@@ -116,10 +116,10 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
     final String tenantId = definition.get().getTenantId();
     final String version = definition.get().getVersion();
 
-    // Soft-delete first so a terminal failure anywhere below leaves the deletion retriable
+    // Soft-delete first
     withRetry(
-        "mark process definition as deleted " + definitionId,
-        () -> processDefinitionWriter.markDefinitionAsDeleted(definitionId));
+        "soft-delete process definition " + definitionId,
+        () -> processDefinitionWriter.softDeleteDefinition(definitionId));
     withRetry(
         "delete process instances for definition " + definitionId,
         () -> processInstanceWriter.deleteInstancesByDefinitionId(bpmnProcessId, definitionId));
@@ -149,11 +149,6 @@ public class ProcessDefinitionDeletionJobHandler implements JobHandler {
           "clear cached XML for reports referencing " + bpmnProcessId,
           () -> reportService.clearCachedReportXml(bpmnProcessId, tenantId));
     }
-
-    // Hard-delete last
-    withRetry(
-        "delete process definition " + definitionId,
-        () -> processDefinitionWriter.deleteDefinition(definitionId));
   }
 
   private void withRetry(final String description, final Runnable runnable) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/definition/ProcessDefinitionDeletionRequestServiceTest.java
@@ -104,17 +104,14 @@ public class ProcessDefinitionDeletionRequestServiceTest {
     verify(jobRegistryWriter, never()).createJobEntry(any(), any(), any());
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = JobStatus.class,
-      names = {"QUEUED", "COMPLETED"})
-  public void shouldRejectWhenBlockingEntryAlreadyExists(final JobStatus blockingStatus) {
+  @Test
+  public void shouldRejectWhenBlockingQueuedEntryExists() {
     // given
     when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(true);
     final JobRegistryEntryDto existingEntry =
         new JobRegistryEntryDto(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
-    existingEntry.setStatus(blockingStatus);
+    existingEntry.setStatus(JobStatus.QUEUED);
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID))
         .thenReturn(Optional.of(existingEntry));
@@ -128,17 +125,21 @@ public class ProcessDefinitionDeletionRequestServiceTest {
     verify(jobRegistryWriter, never()).createJobEntry(any(), any(), any());
   }
 
-  @Test
-  public void shouldQueueNewJobWhenExistingEntryHasFailedStatus() {
+  @ParameterizedTest
+  @EnumSource(
+      value = JobStatus.class,
+      names = {"COMPLETED", "FAILED"})
+  public void shouldQueueNewJobWhenExistingEntryHasCompletedOrFailedStatus(
+      final JobStatus nonBlockingStatus) {
     // given
     when(processDefinitionReader.processDefinitionExists(PROCESS_DEFINITION_ID)).thenReturn(true);
-    final JobRegistryEntryDto failedEntry =
+    final JobRegistryEntryDto existingEntry =
         new JobRegistryEntryDto(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID);
-    failedEntry.setStatus(JobStatus.FAILED);
+    existingEntry.setStatus(nonBlockingStatus);
     when(jobRegistryReader.findLastByJobTypeAndEntityId(
             JobType.DELETE, EntityType.PROCESS_DEFINITION, PROCESS_DEFINITION_ID))
-        .thenReturn(Optional.of(failedEntry));
+        .thenReturn(Optional.of(existingEntry));
 
     // when
     underTest.queueProcessDefinitionDeletion(PROCESS_DEFINITION_ID);

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/job/ProcessDefinitionDeletionJobHandlerTest.java
@@ -96,7 +96,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
   }
 
   @Test
-  void shouldDeleteInstancesAndDefinitionWhenDefinitionExists() {
+  void shouldSoftDeleteDefinitionAndDeleteInstancesWhenDefinitionExists() {
     // given
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
@@ -105,13 +105,12 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
-    verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
+    verify(processDefinitionWriter).softDeleteDefinition(DEFINITION_ID);
     verify(processInstanceWriter).deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
-  void shouldMarkDefinitionAsDeletedBeforeDeletingInstancesAndHardDeletingLast() {
+  void shouldSoftDeleteDefinitionBeforeDeletingInstances() {
     // given
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
@@ -121,11 +120,10 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
     // then
     final var order = inOrder(processDefinitionWriter, processInstanceWriter);
-    order.verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
+    order.verify(processDefinitionWriter).softDeleteDefinition(DEFINITION_ID);
     order
         .verify(processInstanceWriter)
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -138,30 +136,28 @@ class ProcessDefinitionDeletionJobHandlerTest {
     handler.handle(job());
 
     // then
-    verify(processDefinitionWriter, never()).markDefinitionAsDeleted(anyString());
+    verify(processDefinitionWriter, never()).softDeleteDefinition(anyString());
     verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
-    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
     verify(reportService, never()).clearCachedReportXml(anyString(), any());
     verify(definitionService, never())
         .invalidateProcessDefinitionIfLatest(anyString(), any(), anyString());
   }
 
   @Test
-  void shouldRetryOnRetryableErrorWhenMarkingDefinitionAsDeleted() {
+  void shouldRetryOnRetryableErrorWhenSoftDeletingDefinition() {
     // given
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
         .thenReturn(Optional.of(definition()));
     doThrow(new OptimizeRuntimeException("transient", new SocketTimeoutException("boom")))
         .doNothing()
         .when(processDefinitionWriter)
-        .markDefinitionAsDeleted(DEFINITION_ID);
+        .softDeleteDefinition(DEFINITION_ID);
 
     // when
     handler.handle(job());
 
     // then
-    verify(processDefinitionWriter, times(2)).markDefinitionAsDeleted(DEFINITION_ID);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
+    verify(processDefinitionWriter, times(2)).softDeleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -253,15 +249,14 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
     // then
     final var order = inOrder(definitionReader, processDefinitionWriter);
-    order.verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
+    order.verify(processDefinitionWriter).softDeleteDefinition(DEFINITION_ID);
     order
         .verify(definitionReader)
         .getDefinitionVersions(DefinitionType.PROCESS, BPMN_PROCESS_ID, Set.of(TENANT_ID));
-    order.verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
-  void shouldRetryOnByQueryVersionConflictAndOnlyDeleteDefinitionAfterSuccessfulRetry() {
+  void shouldRetryOnByQueryVersionConflictAndEventuallySucceed() {
     // given -- simulates the conflict a concurrent write raises on the underlying delete-by-query
     // task, which the repository layer surfaces as OptimizeByQueryFailureException
     when(processDefinitionReader.getProcessDefinition(DEFINITION_ID, false))
@@ -277,7 +272,6 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(processInstanceWriter, times(2))
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -297,7 +291,6 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(processInstanceWriter, times(3))
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -313,7 +306,6 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(processDefinitionReader, times(2)).getProcessDefinition(DEFINITION_ID, false);
     verify(processInstanceWriter).deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -326,7 +318,6 @@ class ProcessDefinitionDeletionJobHandlerTest {
     assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(OptimizeRuntimeException.class);
     verify(processDefinitionReader, times(3)).getProcessDefinition(DEFINITION_ID, false);
     verify(processInstanceWriter, never()).deleteInstancesByDefinitionId(anyString(), anyString());
-    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
   }
 
   @Test
@@ -348,7 +339,6 @@ class ProcessDefinitionDeletionJobHandlerTest {
     // then
     verify(processInstanceWriter, times(2))
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   @Test
@@ -362,7 +352,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
 
     // when / then
     assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(OptimizeRuntimeException.class);
-    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+    verify(reportService, never()).clearCachedReportXml(anyString(), any());
   }
 
   @Test
@@ -378,7 +368,6 @@ class ProcessDefinitionDeletionJobHandlerTest {
     assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(IllegalStateException.class);
     verify(processInstanceWriter, times(1))
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
-    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
   }
 
   @Test
@@ -391,8 +380,7 @@ class ProcessDefinitionDeletionJobHandlerTest {
         .when(processInstanceWriter)
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
     assertThatThrownBy(() -> handler.handle(job())).isInstanceOf(IllegalStateException.class);
-    verify(processDefinitionWriter).markDefinitionAsDeleted(DEFINITION_ID);
-    verify(processDefinitionWriter, never()).deleteDefinition(anyString());
+    verify(processDefinitionWriter).softDeleteDefinition(DEFINITION_ID);
 
     // when -- the job is retried: the definition lookup still finds the soft-deleted definition
     // and this time the instance deletion succeeds
@@ -401,11 +389,10 @@ class ProcessDefinitionDeletionJobHandlerTest {
         .deleteInstancesByDefinitionId(BPMN_PROCESS_ID, DEFINITION_ID);
     handler.handle(job());
 
-    // then -- the remainder of the cleanup tail, including the final hard-delete, now completes
+    // then -- the remainder of the cleanup tail now completes
     verify(reportService).clearCachedReportXml(BPMN_PROCESS_ID, TENANT_ID);
     verify(definitionService)
         .invalidateProcessDefinitionIfLatest(BPMN_PROCESS_ID, TENANT_ID, VERSION);
-    verify(processDefinitionWriter).deleteDefinition(DEFINITION_ID);
   }
 
   private JobRegistryEntryDto job() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Clearing report XML on the last-version deletion of a process definition (#61024) isn't transactional, so a concurrent report
evaluation can write cached XML back right after it was cleared. A user could re-issue a process definition request to clear the remaining data. However, this is currently has two blockers:

- A new delete request is rejected whenever the last job for that definition is anything but FAILED, so there is no way to trigger a cleanup rerun once a job had already finished successfully.
- The definition is hard-deleted as the job's last step, so once deleted it could never be found again, and a re-request always 404'd.

Loosen the blocking check to only reject while a job is actively QUEUED. Drop the hard-delete step entirely: the definition is already soft-deleted earlier in the job, and staying soft-deleted keeps it invisible to normal reads while remaining a valid target for a future request.

Since the definition document is never removed, its own bpmn20Xml, flowNodeData, and userTaskNames fields would otherwise linger indefinitely. Clear all three alongside the deleted flag.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
