### PR TITLE
perf: wake secret resolution on request instead of polling

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/EngineSecrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineSecrets.java
@@ -21,6 +21,7 @@ public class EngineSecrets {
   public static final Duration DEFAULT_RETRY_MAX_DELAY = Duration.ofSeconds(30);
   public static final int DEFAULT_RETRY_BACKOFF_FACTOR = 2;
   public static final int DEFAULT_BATCH_RESOLUTION_LIMIT = 20;
+  public static final Duration DEFAULT_WAKE_DELAY = Duration.ofMillis(50);
 
   private Duration interval = DEFAULT_INTERVAL;
   private int retryMaxAttempts = DEFAULT_RETRY_MAX_ATTEMPTS;
@@ -28,6 +29,7 @@ public class EngineSecrets {
   private Duration retryMaxDelay = DEFAULT_RETRY_MAX_DELAY;
   private int retryBackoffFactor = DEFAULT_RETRY_BACKOFF_FACTOR;
   private int batchResolutionLimit = DEFAULT_BATCH_RESOLUTION_LIMIT;
+  private Duration wakeDelay = DEFAULT_WAKE_DELAY;
 
   /**
    * Cadence at which the secret resolution scheduler polls for pending secret references. This
@@ -118,5 +120,21 @@ public class EngineSecrets {
 
   public void setBatchResolutionLimit(final int batchResolutionLimit) {
     this.batchResolutionLimit = batchResolutionLimit;
+  }
+
+  /**
+   * How long a cycle that resolved something, or that was recently asked to, waits before its next
+   * run rather than waiting for the full {@code interval}. This configuration can be accessed via
+   * the environment variable: <br>
+   * {@code camunda.processing.engine.secrets.wake-delay}.
+   *
+   * <p>Defaults to {@code 50ms}.
+   */
+  public Duration getWakeDelay() {
+    return wakeDelay;
+  }
+
+  public void setWakeDelay(final Duration wakeDelay) {
+    this.wakeDelay = wakeDelay;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1383,6 +1383,7 @@ public class BrokerBasedPropertiesOverride {
     secretResolutionCfg.setRetryMaxDelay(engineSecrets.getRetryMaxDelay());
     secretResolutionCfg.setRetryBackoffFactor(engineSecrets.getRetryBackoffFactor());
     secretResolutionCfg.setBatchResolutionLimit(engineSecrets.getBatchResolutionLimit());
+    secretResolutionCfg.setWakeDelay(engineSecrets.getWakeDelay());
   }
 
   private static void populateFromStorageOrdinals(

--- a/configuration/src/test/java/io/camunda/configuration/EngineSecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineSecretsTest.java
@@ -31,7 +31,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
       "camunda.processing.engine.secrets.retry-initial-delay=2s",
       "camunda.processing.engine.secrets.retry-max-delay=60s",
       "camunda.processing.engine.secrets.retry-backoff-factor=3",
-      "camunda.processing.engine.secrets.batch-resolution-limit=7"
+      "camunda.processing.engine.secrets.batch-resolution-limit=7",
+      "camunda.processing.engine.secrets.wake-delay=25ms"
     })
 public class EngineSecretsTest {
   final BrokerBasedProperties brokerCfg;
@@ -49,5 +50,6 @@ public class EngineSecretsTest {
     assertThat(secretResolution.getRetryMaxDelay()).isEqualTo(Duration.ofSeconds(60));
     assertThat(secretResolution.getRetryBackoffFactor()).isEqualTo(3);
     assertThat(secretResolution.getBatchResolutionLimit()).isEqualTo(7);
+    assertThat(secretResolution.getWakeDelay()).isEqualTo(Duration.ofMillis(25));
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -314,6 +314,7 @@ processing.engine.secrets.retry-backoff-factor
 processing.engine.secrets.retry-initial-delay
 processing.engine.secrets.retry-max-attempts
 processing.engine.secrets.retry-max-delay
+processing.engine.secrets.wake-delay
 processing.engine.storage-ordinals.enable-archiverless
 processing.engine.storage-ordinals.fixed-storage-ordinal-key
 processing.engine.validators.results-output-max-size

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -260,6 +260,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setSecretResolutionRetryMaxDelay(secretResolution.getRetryMaxDelay())
         .setSecretResolutionRetryBackoffFactor(secretResolution.getRetryBackoffFactor())
         .setSecretResolutionBatchLimit(secretResolution.getBatchResolutionLimit())
+        .setSecretResolutionWakeDelay(secretResolution.getWakeDelay())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
         .setJobMetricsExportInterval(jobMetrics.getExportInterval())
         .setJobMetricsExportEnabled(jobMetrics.isEnabled())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfg.java
@@ -21,6 +21,7 @@ public class SecretResolutionCfg implements ConfigurationEntry {
   private int retryBackoffFactor =
       EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR;
   private int batchResolutionLimit = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT;
+  private Duration wakeDelay = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -54,6 +55,12 @@ public class SecretResolutionCfg implements ConfigurationEntry {
       throw new IllegalArgumentException(
           "Secret resolution batchResolutionLimit must be at least 1 but was %d"
               .formatted(batchResolutionLimit));
+    }
+    // zero is meaningful here: every cycle that resolves something reschedules at wakeDelay
+    // regardless, so zero just means the very next one runs as soon as the actor is free
+    if (wakeDelay == null || wakeDelay.isNegative()) {
+      throw new IllegalArgumentException(
+          "Secret resolution wakeDelay must not be negative but was %s".formatted(wakeDelay));
     }
   }
 
@@ -105,6 +112,14 @@ public class SecretResolutionCfg implements ConfigurationEntry {
     this.batchResolutionLimit = batchResolutionLimit;
   }
 
+  public Duration getWakeDelay() {
+    return wakeDelay;
+  }
+
+  public void setWakeDelay(final Duration wakeDelay) {
+    this.wakeDelay = wakeDelay;
+  }
+
   @Override
   public String toString() {
     return "SecretResolutionCfg{"
@@ -120,6 +135,8 @@ public class SecretResolutionCfg implements ConfigurationEntry {
         + retryBackoffFactor
         + ", batchResolutionLimit="
         + batchResolutionLimit
+        + ", wakeDelay="
+        + wakeDelay
         + '}';
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfgTest.java
@@ -99,4 +99,26 @@ final class SecretResolutionCfgTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Secret resolution batchResolutionLimit must be at least 1 but was 0");
   }
+
+  @Test
+  void shouldRejectNegativeWakeDelay() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setWakeDelay(Duration.ofMillis(-1));
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Secret resolution wakeDelay must not be negative but was PT-0.001S");
+  }
+
+  @Test
+  void shouldAcceptZeroWakeDelay() {
+    // given - zero just means the next cycle after one that resolved something runs immediately
+    final var cfg = new SecretResolutionCfg();
+    cfg.setWakeDelay(Duration.ZERO);
+
+    // when - then
+    assertThatCode(() -> cfg.init(new BrokerCfg(), "")).doesNotThrowAnyException();
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -70,6 +70,7 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY = Duration.ofSeconds(30);
   public static final int DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR = 2;
   public static final int DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT = 20;
+  public static final Duration DEFAULT_SECRET_RESOLUTION_WAKE_DELAY = Duration.ofMillis(50);
   public static final boolean DEFAULT_COMMAND_DISTRIBUTION_PAUSED = false;
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION =
@@ -156,6 +157,7 @@ public final class EngineConfiguration {
   private Duration secretResolutionRetryMaxDelay = DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY;
   private int secretResolutionRetryBackoffFactor = DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR;
   private int secretResolutionBatchLimit = DEFAULT_SECRET_RESOLUTION_BATCH_LIMIT;
+  private Duration secretResolutionWakeDelay = DEFAULT_SECRET_RESOLUTION_WAKE_DELAY;
   private Duration usageMetricsExportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
   private boolean commandDistributionPaused = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
   private Duration commandRedistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
@@ -479,6 +481,27 @@ public final class EngineConfiguration {
               .formatted(secretResolutionBatchLimit));
     }
     this.secretResolutionBatchLimit = secretResolutionBatchLimit;
+    return this;
+  }
+
+  public Duration getSecretResolutionWakeDelay() {
+    return secretResolutionWakeDelay;
+  }
+
+  /**
+   * How long a cycle that resolved something, or that was woken since it last ran, waits before its
+   * next run. Kept short so a sustained stream of secret references is resolved close to as they
+   * arrive; falls back to {@code secretResolutionInterval} once a cycle finds nothing pending and
+   * was not woken.
+   */
+  public EngineConfiguration setSecretResolutionWakeDelay(
+      final Duration secretResolutionWakeDelay) {
+    if (secretResolutionWakeDelay.isNegative()) {
+      throw new IllegalArgumentException(
+          "secretResolutionWakeDelay must not be negative but was %s"
+              .formatted(secretResolutionWakeDelay));
+    }
+    this.secretResolutionWakeDelay = secretResolutionWakeDelay;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
@@ -31,14 +31,17 @@ import java.util.function.Supplier;
  * <p>The per-reference outcomes and the per-cycle errors are separate meters rather than values on
  * one counter, so that neither can be added to the other by a query that aggregates across a tag.
  *
- * <p>Every meter is tagged by store ID, which is not known up front: it comes from the pending
- * secret references in state, not from configuration, and the engine resolves references for store
- * IDs it has no configured store for. The meters are therefore held in {@link BoundedMeterCache}s
- * keyed by store ID. The domain is small today — the default store ID every {@code
- * camunda.secrets.<name>} reference carries, plus {@link SecretResolutionKeyNames#NO_STORE} for a
- * reference written before that ID existed — but once store selection is wired to the engine (<a
- * href="https://github.com/camunda/camunda/issues/56563">#56563</a>) a store ID becomes
+ * <p>Every meter but one is tagged by store ID, which is not known up front: it comes from the
+ * pending secret references in state, not from configuration, and the engine resolves references
+ * for store IDs it has no configured store for. The meters are therefore held in {@link
+ * BoundedMeterCache}s keyed by store ID. The domain is small today — the default store ID every
+ * {@code camunda.secrets.<name>} reference carries, plus {@link SecretResolutionKeyNames#NO_STORE}
+ * for a reference written before that ID existed — but once store selection is wired to the engine
+ * (<a href="https://github.com/camunda/camunda/issues/56563">#56563</a>) a store ID becomes
  * process-author input, and the bound is what keeps that from growing the registry without limit.
+ * The exception is {@link #cycleDelay}: the scheduler's own per-cycle decision, not an operation
+ * against any particular store, so it carries no store tag and is registered directly instead of
+ * through a {@link BoundedMeterCache}.
  */
 public final class SecretResolutionMetrics {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetrics.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.metrics;
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCycleDelayReason;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
 import io.camunda.zeebe.util.micrometer.BoundedMeterCache;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -46,6 +48,8 @@ public final class SecretResolutionMetrics {
   private final Map<SecretResolutionOutcome, BoundedMeterCache<Counter>> outcomeCounters =
       new EnumMap<>(SecretResolutionOutcome.class);
   private final BoundedMeterCache<Counter> cycleErrors;
+  private final Map<SecretResolutionCycleDelayReason, Timer> cycleDelayTimers =
+      new EnumMap<>(SecretResolutionCycleDelayReason.class);
 
   public SecretResolutionMetrics(final MeterRegistry registry) {
     this.registry = registry;
@@ -56,6 +60,9 @@ public final class SecretResolutionMetrics {
       outcomeCounters.put(outcome, counterCache(registry, outcome));
     }
     cycleErrors = cycleErrorCache(registry);
+    for (final var reason : SecretResolutionCycleDelayReason.values()) {
+      cycleDelayTimers.put(reason, cycleDelayTimer(registry, reason));
+    }
   }
 
   /**
@@ -118,6 +125,11 @@ public final class SecretResolutionMetrics {
     cycleErrors.get(storeTag(storeId)).increment();
   }
 
+  /** Records the delay a resolution cycle chose for the next one, tagged by why. */
+  public void cycleDelay(final SecretResolutionCycleDelayReason reason, final Duration delay) {
+    cycleDelayTimers.get(reason).record(delay);
+  }
+
   private Counter outcomeCounter(final String storeId, final SecretResolutionOutcome outcome) {
     return outcomeCounters.get(outcome).get(storeTag(storeId));
   }
@@ -149,6 +161,18 @@ public final class SecretResolutionMetrics {
             .description(meterDoc.getDescription())
             .withRegistry(registry);
     return BoundedMeterCache.of(registry, provider, SecretResolutionKeyNames.STORE);
+  }
+
+  /**
+   * Not a {@link BoundedMeterCache}: unlike the store-keyed meters above, {@link
+   * SecretResolutionCycleDelayReason} is a small, fixed domain the engine defines, not one that
+   * grows with data the engine only later learns about, so there is no cardinality to bound.
+   */
+  private static Timer cycleDelayTimer(
+      final MeterRegistry registry, final SecretResolutionCycleDelayReason reason) {
+    return MicrometerUtil.buildTimer(SecretResolutionMetricsDoc.CYCLE_DELAY)
+        .tag(SecretResolutionKeyNames.RESULT.asString(), reason.name())
+        .register(registry);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
@@ -233,9 +233,12 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
     STORE("store"),
     /**
      * What the measured operation resulted in: a {@link SecretResolutionOutcome} on {@link
-     * SecretResolutionMetricsDoc#RESOLUTION_OUTCOME}, and the coarser {@link
+     * SecretResolutionMetricsDoc#RESOLUTION_OUTCOME}, the coarser {@link
      * SecretResolutionCallResult} on {@link SecretResolutionMetricsDoc#RESOLUTION_DURATION}, which
-     * measures a whole batch call and so cannot attribute a per-reference outcome to it.
+     * measures a whole batch call and so cannot attribute a per-reference outcome to it, and (on
+     * {@link SecretResolutionMetricsDoc#CYCLE_DELAY}, not a result at all, but the same tag reused
+     * for it) a {@link SecretResolutionCycleDelayReason} naming why the cycle chose its delay
+     * rather than what it resolved.
      */
     RESULT("result");
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDoc.java
@@ -149,7 +149,78 @@ public enum SecretResolutionMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /** The delay a resolution cycle chose for the next one, tagged by why */
+  CYCLE_DELAY {
+    @Override
+    public String getDescription() {
+      return "The delay a resolution cycle chose for the next one, tagged by why: DRAINING when "
+          + "more pending refs remained than the batch cap allowed this cycle to take (always "
+          + "zero), WAKE when this cycle resolved something or was woken, IDLE_BACKOFF when it did "
+          + "neither and no store is in retry cooldown, and RETRY_COOLDOWN when a store's cooldown "
+          + "deadline set the delay instead. IDLE_BACKOFF is the one to watch: it grows "
+          + "geometrically on consecutive misses (see SecretResolutionScheduler#nextIdleBackoff), "
+          + "and its distribution says directly whether that ladder is behaving as intended, rather "
+          + "than leaving it to be inferred from the cycle rate alone.";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.secret.resolution.cycle.delay";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "seconds";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {SecretResolutionKeyNames.RESULT};
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      // the domain of interest here starts well below MicrometerUtil.defaultPrometheusBuckets()'s
+      // lowest bucket (5ms) and stops at schedulingInterval's default (5s) rather than running out
+      // to the remote-call timeouts RESOLUTION_DURATION's buckets are built for
+      return new Duration[] {
+        Duration.ofMillis(10),
+        Duration.ofMillis(50),
+        Duration.ofMillis(100),
+        Duration.ofMillis(250),
+        Duration.ofMillis(500),
+        Duration.ofSeconds(1),
+        Duration.ofMillis(2500),
+        Duration.ofSeconds(5)
+      };
+    }
   };
+
+  /**
+   * The value domain of the {@link SecretResolutionKeyNames#RESULT} tag on {@link #CYCLE_DELAY}.
+   */
+  public enum SecretResolutionCycleDelayReason {
+    /** More pending refs remained than the batch cap allowed this cycle to take */
+    DRAINING,
+    /** This cycle resolved something, or a reference was requested since the last cycle ran */
+    WAKE,
+    /** Neither of the above, and no store is in retry cooldown */
+    IDLE_BACKOFF,
+    /** Neither of the above, and a store's retry cooldown deadline set the delay instead */
+    RETRY_COOLDOWN
+  }
 
   @SuppressWarnings("NullableProblems")
   public enum SecretResolutionKeyNames implements KeyName {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -83,6 +83,7 @@ import io.camunda.zeebe.engine.processing.resource.ResourceReexportStartProcesso
 import io.camunda.zeebe.engine.processing.resource.RpaReexportMigrator;
 import io.camunda.zeebe.engine.processing.scaling.ScalingProcessors;
 import io.camunda.zeebe.engine.processing.secretreference.SecretReferenceProcessors;
+import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler;
 import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -175,6 +176,11 @@ public final class EngineProcessors {
         new MessageCorrelationMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var secretResolutionMetrics =
         new SecretResolutionMetrics(typedRecordProcessorContext.getMeterRegistry());
+    // built here rather than with the other secret reference processors because the job activation
+    // paths wake it, so it has to exist before the behaviors and job processors that call it
+    final var secretResolutionScheduler =
+        new SecretResolutionScheduler(
+            scheduledTaskStateFactory, secretStoreRegistry, config, secretResolutionMetrics);
 
     subscriptionCommandSender.setWriters(writers);
 
@@ -287,7 +293,8 @@ public final class EngineProcessors {
             featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
             cslCheck,
             tenantCheck,
-            secretStoreRegistry);
+            secretStoreRegistry,
+            secretResolutionScheduler);
 
     typedRecordProcessors.withListener(bpmnBehaviors.incidentBehavior());
 
@@ -372,7 +379,8 @@ public final class EngineProcessors {
         cslCheck,
         tenantCheck,
         incidentMetrics,
-        secretStoreRegistry);
+        secretStoreRegistry,
+        secretResolutionScheduler);
 
     final var userTaskProcessor =
         createUserTaskProcessor(
@@ -541,10 +549,7 @@ public final class EngineProcessors {
         keyGenerator,
         processingState,
         incidentMetrics,
-        scheduledTaskStateFactory,
-        secretStoreRegistry,
-        config,
-        secretResolutionMetrics,
+        secretResolutionScheduler,
         bpmnBehaviors.jobActivationBehavior());
 
     return typedRecordProcessors;
@@ -642,7 +647,8 @@ public final class EngineProcessors {
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
-      final SecretStoreRegistry secretStoreRegistry) {
+      final SecretStoreRegistry secretStoreRegistry,
+      final SecretResolutionScheduler secretResolutionScheduler) {
     return new BpmnBehaviorsImpl(
         processingState,
         writers,
@@ -663,7 +669,8 @@ public final class EngineProcessors {
         evaluateDuplicateOutputMappingTargetsInOrder,
         cslCheck,
         tenantCheck,
-        secretStoreRegistry);
+        secretStoreRegistry,
+        secretResolutionScheduler);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizatio
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
@@ -98,7 +99,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
-      final SecretStoreRegistry secretStoreRegistry) {
+      final SecretStoreRegistry secretStoreRegistry,
+      final SecretResolutionScheduler secretResolutionScheduler) {
 
     // The expression endpoint reports which trusted secrets an evaluation touched; only its
     // contexts record into the collector. The BPMN path uses collector-free contexts, so its
@@ -230,7 +232,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             cslCheck,
             tenantCheck,
             secretStoreRegistry,
-            incidentBehavior);
+            incidentBehavior,
+            secretResolutionScheduler);
 
     multiInstanceInputCollectionBehavior =
         new MultiInstanceInputCollectionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -279,7 +279,7 @@ public class BpmnJobActivationBehavior {
     if (parked) {
       // once per activation rather than per reference: the flag it sets is consumed by whichever
       // cycle runs next, so setting it more than once per activation adds nothing
-      secretResolutionScheduler.wake();
+      secretResolutionScheduler.stayAwake();
       jobMetrics.countJobEvent(JobAction.SKIPPED_UNCACHED_SECRET, jobKind, jobType);
     } else {
       notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.job.JobSecretLookup.Secret;
 import io.camunda.zeebe.engine.processing.job.JobSecretLookup.SecretCheckResult;
 import io.camunda.zeebe.engine.processing.job.JobVariablesCollector;
 import io.camunda.zeebe.engine.processing.job.LeaseTokens;
+import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -69,6 +70,7 @@ public class BpmnJobActivationBehavior {
   private static final Logger LOGGER = LoggerFactory.getLogger(BpmnJobActivationBehavior.class);
 
   private final JobStreamer jobStreamer;
+  private final SecretResolutionScheduler secretResolutionScheduler;
   private final JobVariablesCollector jobVariablesCollector;
   private final StateWriter stateWriter;
   private final SideEffectWriter sideEffectWriter;
@@ -91,8 +93,10 @@ public class BpmnJobActivationBehavior {
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
       final SecretStoreRegistry secretStoreRegistry,
-      final BpmnIncidentBehavior incidentBehavior) {
+      final BpmnIncidentBehavior incidentBehavior,
+      final SecretResolutionScheduler secretResolutionScheduler) {
     this.jobStreamer = jobStreamer;
+    this.secretResolutionScheduler = secretResolutionScheduler;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
     jobVariablesCollector = new JobVariablesCollector(state);
@@ -273,6 +277,9 @@ public class BpmnJobActivationBehavior {
       parked = true;
     }
     if (parked) {
+      // once per activation rather than per reference: the flag it sets is consumed by whichever
+      // cycle runs next, so setting it more than once per activation adds nothing
+      secretResolutionScheduler.wake();
       jobMetrics.countJobEvent(JobAction.SKIPPED_UNCACHED_SECRET, jobKind, jobType);
     } else {
       notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -246,7 +246,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     if (anyRequested) {
       // once per activation rather than per reference: the flag it sets is consumed by whichever
       // cycle runs next, so setting it more than once per activation adds nothing
-      secretResolutionScheduler.wake();
+      secretResolutionScheduler.stayAwake();
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.DroppedJob;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.FailedInjectionJob;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
+import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -61,6 +62,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final CslAuthorizationCheck cslCheck;
   private final CslTenantCheck tenantCheck;
   private final JobSecretInjector jobSecretInjector;
+  private final SecretResolutionScheduler secretResolutionScheduler;
   private final BpmnIncidentBehavior incidentBehavior;
 
   public JobBatchActivateProcessor(
@@ -72,7 +74,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final CslTenantCheck tenantCheck,
       final InstantSource clock,
       final BpmnIncidentBehavior incidentBehavior,
-      final SecretStoreRegistry secretStoreRegistry) {
+      final SecretStoreRegistry secretStoreRegistry,
+      final SecretResolutionScheduler secretResolutionScheduler) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -80,6 +83,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     this.cslCheck = cslCheck;
     this.tenantCheck = tenantCheck;
     jobSecretInjector = new JobSecretInjector(secretStoreRegistry);
+    this.secretResolutionScheduler = secretResolutionScheduler;
     jobBatchCollector =
         new JobBatchCollector(
             state,
@@ -217,6 +221,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
    */
   private void requestSecretResolution(
       final Map<SecretReference, List<Long>> jobsWithNonCachedSecrets) {
+    boolean anyRequested = false;
     for (final var waiting : jobsWithNonCachedSecrets.entrySet()) {
       final var reference = waiting.getKey();
       final var event =
@@ -235,6 +240,12 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       }
       stateWriter.appendFollowUpEvent(
           keyGenerator.nextKey(), SecretReferenceIntent.RESOLUTION_REQUESTED, event);
+      anyRequested = true;
+    }
+    if (anyRequested) {
+      // once per activation rather than per reference: the flag it sets is consumed by whichever
+      // cycle runs next, so setting it more than once per activation adds nothing
+      secretResolutionScheduler.wake();
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -236,7 +236,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       // to the next activation, which keeps its jobs activatable.
       if (!stateWriter.canWriteEventOfLength(
           event.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
-        return;
+        // stop appending, but still wake for whatever was already appended above
+        break;
       }
       stateWriter.appendFollowUpEvent(
           keyGenerator.nextKey(), SecretReferenceIntent.RESOLUTION_REQUESTED, event);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
+import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -39,7 +40,8 @@ public final class JobEventProcessors {
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics,
-      final SecretStoreRegistry secretStoreRegistry) {
+      final SecretStoreRegistry secretStoreRegistry,
+      final SecretResolutionScheduler secretResolutionScheduler) {
 
     final var keyGenerator = processingState.getKeyGenerator();
 
@@ -139,7 +141,8 @@ public final class JobEventProcessors {
                 tenantCheck,
                 clock,
                 bpmnBehaviors.incidentBehavior(),
-                secretStoreRegistry))
+                secretStoreRegistry,
+                secretResolutionScheduler))
         .withListener(
             new JobTimeoutCheckScheduler(
                 scheduledTaskStateFactory.get().getJobState(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
@@ -7,19 +7,14 @@
  */
 package io.camunda.zeebe.engine.processing.secretreference;
 
-import io.camunda.secretstore.SecretStoreRegistry;
-import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
-import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
-import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.util.function.Supplier;
 
 public final class SecretReferenceProcessors {
 
@@ -31,10 +26,7 @@ public final class SecretReferenceProcessors {
       final KeyGenerator keyGenerator,
       final ProcessingState processingState,
       final IncidentMetrics incidentMetrics,
-      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
-      final SecretStoreRegistry secretStoreRegistry,
-      final EngineConfiguration config,
-      final SecretResolutionMetrics secretResolutionMetrics,
+      final SecretResolutionScheduler secretResolutionScheduler,
       final BpmnJobActivationBehavior jobActivationBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.SECRET_REFERENCE,
@@ -57,9 +49,6 @@ public final class SecretReferenceProcessors {
         new SecretReferenceBatchCreateIncidentsProcessor(
             writers, keyGenerator, processingState, incidentMetrics));
 
-    final var scheduler =
-        new SecretResolutionScheduler(
-            scheduledTaskStateFactory, secretStoreRegistry, config, secretResolutionMetrics);
-    typedRecordProcessors.withListener(scheduler);
+    typedRecordProcessors.withListener(secretResolutionScheduler);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -48,7 +48,10 @@ import org.slf4j.LoggerFactory;
  * finds nothing but a reference was requested via {@link #wake()} since it last ran, reschedules
  * its next run at the shorter {@code wakeDelay} rather than {@code schedulingInterval}: under a
  * sustained stream of requests this keeps every cycle after the first close to {@code wakeDelay}
- * apart on its own, without ever needing to bring a scheduled cycle forward by cancelling it.
+ * apart on its own, without ever needing to bring a scheduled cycle forward by cancelling it. A
+ * cycle that neither makes progress nor is woken, and has no store waiting out a retry cooldown
+ * either, does not jump straight to {@code schedulingInterval}: see {@link #nextIdleBackoff()} for
+ * why and how it grows the delay geometrically instead.
  *
  * <p>Resolution goes through {@link
  * io.camunda.secretstore.LocallyCachedSecretStore#resolveFromStore} rather than the cache-first
@@ -124,6 +127,13 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
    * there.
    */
   private final AtomicBoolean wakePending = new AtomicBoolean();
+
+  /**
+   * The delay {@link #nextIdleBackoff()} returned last, or {@code 0} if the ladder has not started
+   * since its last reset. Read and written only from the {@link AsyncTaskGroup#SECRET_RESOLUTION}
+   * actor, the same discipline as {@link #storeRetryStates} and {@link #collectionCursor}.
+   */
+  private long idleBackoffMillis;
 
   private ReadonlyStreamProcessorContext processingContext;
   private InstantSource clock;
@@ -243,12 +253,14 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
       if (taskResultBatchFull || (capped && progressMade.get())) {
         // more pending refs than this cycle's batch cap allowed it to take; keep draining
         delay = Duration.ZERO;
+        idleBackoffMillis = 0;
       } else if (progressMade.get() || woken) {
         // either this cycle resolved something, or one was requested since the last cycle ran and
         // may not have been visible to this cycle's collection yet either way, staying on the fast
         // cadence is what lets a continuous stream of requests be resolved close to as they arrive,
         // without ever cancelling and replacing a scheduled cycle to get there
         delay = wakeDelay;
+        idleBackoffMillis = 0;
       } else {
         delay = computeNextDelay(now);
       }
@@ -258,12 +270,17 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   }
 
   /**
-   * Returns the delay until the next execution. If any store is in cooldown with a retry deadline
-   * sooner than {@code schedulingInterval}, returns the shorter duration so backoff is honored.
+   * Returns the delay until the next execution, for a cycle that made no progress and was not
+   * woken. If any store is in cooldown with a retry deadline sooner than {@code
+   * schedulingInterval}, returns that deadline so the backoff is honored exactly: retrying earlier
+   * cannot succeed (collection skips a cooling-down store outright, see {@link
+   * #collectPendingByStore}) and there is nothing else this cycle is waiting on that retrying later
+   * would help. Otherwise nothing is known to wait for, and {@link #nextIdleBackoff()} governs the
+   * delay instead of jumping straight to {@code schedulingInterval}.
    */
   private Duration computeNextDelay(final long now) {
     if (storeRetryStates.isEmpty()) {
-      return schedulingInterval;
+      return nextIdleBackoff();
     }
     final long earliestRetryAt =
         storeRetryStates.values().stream()
@@ -275,6 +292,27 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
       return Duration.ofMillis(Math.max(0, millisUntilRetry));
     }
     return schedulingInterval;
+  }
+
+  /**
+   * Grows the delay before the next cycle geometrically from {@code wakeDelay} up to {@code
+   * schedulingInterval} instead of jumping straight there, so one cycle that happens to find
+   * nothing does not cost whichever reference arrives next a full {@code schedulingInterval} wait.
+   * Under a request rate high enough that most {@code wakeDelay}-sized windows are empty by chance
+   * alone, jumping straight to {@code schedulingInterval} after the first such miss would leave the
+   * scheduler asleep for nearly all wall-clock time; this keeps most of a request's wait within a
+   * few doublings instead, while a genuinely idle scheduler still reaches {@code
+   * schedulingInterval} after enough consecutive misses.
+   *
+   * <p>{@code wakeDelay} of zero is accepted elsewhere and would never grow if doubled from zero,
+   * so the first step is floored at 1ms.
+   */
+  private Duration nextIdleBackoff() {
+    idleBackoffMillis =
+        idleBackoffMillis == 0
+            ? Math.max(wakeDelay.toMillis(), 1)
+            : Math.min(schedulingInterval.toMillis(), idleBackoffMillis * 2);
+    return Duration.ofMillis(idleBackoffMillis);
   }
 
   private CollectedPendingRefs collectPendingByStore(final long now) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -302,6 +302,10 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
         millisUntilRetry < schedulingInterval.toMillis()
             ? Duration.ofMillis(Math.max(0, millisUntilRetry))
             : schedulingInterval;
+    // a cooldown deadline is a known wait, not an idle miss, so reset the ladder here too: the
+    // reference that unblocks once the cooldown ends should not have to wait out steps the ladder
+    // climbed before the store went into cooldown
+    idleBackoffMillis = 0;
     metrics.cycleDelay(SecretResolutionCycleDelayReason.RETRY_COOLDOWN, delay);
     return delay;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -317,12 +317,14 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
    * schedulingInterval} after enough consecutive misses.
    *
    * <p>{@code wakeDelay} of zero is accepted elsewhere and would never grow if doubled from zero,
-   * so the first step is floored at 1ms.
+   * so the first step is floored at 1ms; a {@code wakeDelay} configured larger than {@code
+   * schedulingInterval} is clamped the same way, so the first step never overshoots the cap it is
+   * meant to climb towards.
    */
   private Duration nextIdleBackoff() {
     idleBackoffMillis =
         idleBackoffMillis == 0
-            ? Math.max(wakeDelay.toMillis(), 1)
+            ? Math.min(schedulingInterval.toMillis(), Math.max(wakeDelay.toMillis(), 1))
             : Math.min(schedulingInterval.toMillis(), idleBackoffMillis * 2);
     return Duration.ofMillis(idleBackoffMillis);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -209,10 +209,12 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     final long now = clock.millis();
     boolean taskResultBatchFull = false;
     boolean capped = false;
+    Set<String> cooldownSkippedStores = Set.of();
     final var progressMade = new MutableBoolean(false);
     try {
       final CollectedPendingRefs pending = collectPendingByStore(now);
       capped = pending.capped();
+      cooldownSkippedStores = pending.cooldownSkippedStores();
       final Map<String, Set<String>> pendingByStore = pending.refsByStore();
       // Prune retry state for stores confirmed to have zero pending refs this cycle. Only
       // trustworthy when the scan was both uncapped AND didn't skip any store for cooldown —
@@ -256,11 +258,14 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
         delay = Duration.ZERO;
         idleBackoffMillis = 0;
         metrics.cycleDelay(SecretResolutionCycleDelayReason.DRAINING, delay);
-      } else if (progressMade.get() || woken) {
+      } else if ((progressMade.get() || woken) && cooldownSkippedStores.isEmpty()) {
         // either this cycle resolved something, or one was requested since the last cycle ran and
-        // may not have been visible to this cycle's collection yet either way, staying on the fast
+        // may not have been visible to this cycle's collection yet; either way, staying on the fast
         // cadence is what lets a continuous stream of requests be resolved close to as they arrive,
-        // without ever cancelling and replacing a scheduled cycle to get there
+        // without ever cancelling and replacing a scheduled cycle to get there. Gated on no store
+        // cooling down: a wake this cycle cannot be served by a store that is already known to be
+        // unavailable, so the fast cadence would just re-scan the same backlog for nothing. The
+        // cooldown deadline computed below is what retrying earlier could actually help with.
         delay = wakeDelay;
         idleBackoffMillis = 0;
         metrics.cycleDelay(SecretResolutionCycleDelayReason.WAKE, delay);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -46,13 +46,13 @@ import org.slf4j.LoggerFactory;
  * the next cycle — which is scheduled immediately ({@link Duration#ZERO}) instead of waiting the
  * normal {@code schedulingInterval} (unless a store is currently in retry cooldown, in which case
  * the cooldown-aware delay is honored instead). Likewise, a cycle that resolves anything, or that
- * finds nothing but a reference was requested via {@link #wake()} since it last ran, reschedules
- * its next run at the shorter {@code wakeDelay} rather than {@code schedulingInterval}: under a
- * sustained stream of requests this keeps every cycle after the first close to {@code wakeDelay}
- * apart on its own, without ever needing to bring a scheduled cycle forward by cancelling it. A
- * cycle that neither makes progress nor is woken, and has no store waiting out a retry cooldown
- * either, does not jump straight to {@code schedulingInterval}: see {@link #nextIdleBackoff()} for
- * why and how it grows the delay geometrically instead.
+ * finds nothing but a reference was requested via {@link #stayAwake()} since it last ran,
+ * reschedules its next run at the shorter {@code wakeDelay} rather than {@code schedulingInterval}:
+ * under a sustained stream of requests this keeps every cycle after the first close to {@code
+ * wakeDelay} apart on its own, without ever needing to bring a scheduled cycle forward by
+ * cancelling it. A cycle that neither makes progress nor is woken, and has no store waiting out a
+ * retry cooldown either, does not jump straight to {@code schedulingInterval}: see {@link
+ * #nextIdleBackoff()} for why and how it grows the delay geometrically instead.
  *
  * <p>Resolution goes through {@link
  * io.camunda.secretstore.LocallyCachedSecretStore#resolveFromStore} rather than the cache-first
@@ -113,7 +113,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   private final AtomicBoolean taskScheduled = new AtomicBoolean();
 
   /**
-   * Set by {@link #wake()}, consulted and cleared at the start of each cycle. Marks that some
+   * Set by {@link #stayAwake()}, consulted and cleared at the start of each cycle. Marks that some
    * activation requested a resolution since the last cycle ran, even if that activation's own
    * {@code RESOLUTION_REQUESTED} record is not yet what makes a cycle's collection non-empty (the
    * two are written from different actors and can interleave either way). A cycle that finds this
@@ -199,7 +199,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
    * covers the gap where a cycle's collection happens to find nothing pending because it raced a
    * request that is about to be written, not because the scheduler is genuinely idle.
    */
-  public void wake() {
+  public void stayAwake() {
     wakePending.set(true);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -44,7 +44,11 @@ import org.slf4j.LoggerFactory;
  * activation that requested the resolution. Any refs beyond the cap stay pending and are retried in
  * the next cycle — which is scheduled immediately ({@link Duration#ZERO}) instead of waiting the
  * normal {@code schedulingInterval} (unless a store is currently in retry cooldown, in which case
- * the cooldown-aware delay is honored instead).
+ * the cooldown-aware delay is honored instead). Likewise, a cycle that resolves anything, or that
+ * finds nothing but a reference was requested via {@link #wake()} since it last ran, reschedules
+ * its next run at the shorter {@code wakeDelay} rather than {@code schedulingInterval}: under a
+ * sustained stream of requests this keeps every cycle after the first close to {@code wakeDelay}
+ * apart on its own, without ever needing to bring a scheduled cycle forward by cancelling it.
  *
  * <p>Resolution goes through {@link
  * io.camunda.secretstore.LocallyCachedSecretStore#resolveFromStore} rather than the cache-first
@@ -84,6 +88,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
   private final int retryMaxAttempts;
   private final int retryBackoffFactor;
   private final int batchLimit;
+  private final Duration wakeDelay;
 
   private final Map<String, StoreRetryState> storeRetryStates = new HashMap<>();
 
@@ -103,6 +108,23 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
    */
   private final AtomicBoolean taskScheduled = new AtomicBoolean();
 
+  /**
+   * Set by {@link #wake()}, consulted and cleared at the start of each cycle. Marks that some
+   * activation requested a resolution since the last cycle ran, even if that activation's own
+   * {@code RESOLUTION_REQUESTED} record is not yet what makes a cycle's collection non-empty (the
+   * two are written from different actors and can interleave either way). A cycle that finds this
+   * set stays on the fast, {@code wakeDelay} cadence for its next run instead of falling back to
+   * {@code schedulingInterval}, so a queue that is momentarily empty between two waves of requests
+   * is not mistaken for the scheduler being genuinely idle.
+   *
+   * <p>Deliberately does not itself bring a pending execution forward: this scheduler's chain
+   * already reschedules itself at {@code wakeDelay} whenever a cycle resolves anything, so under
+   * the sustained request rate this scheduler exists for, that chain stays on the fast cadence on
+   * its own once started, without this scheduler ever needing to cancel a scheduled task to get
+   * there.
+   */
+  private final AtomicBoolean wakePending = new AtomicBoolean();
+
   private ReadonlyStreamProcessorContext processingContext;
   private InstantSource clock;
 
@@ -120,6 +142,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     retryMaxAttempts = config.getSecretResolutionRetryMaxAttempts();
     retryBackoffFactor = config.getSecretResolutionRetryBackoffFactor();
     batchLimit = config.getSecretResolutionBatchLimit();
+    wakeDelay = config.getSecretResolutionWakeDelay();
   }
 
   @Override
@@ -154,8 +177,24 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
     shouldReschedule = false;
   }
 
+  /**
+   * Marks that a secret reference was just requested, so the next cycle to run stays on the fast
+   * {@code wakeDelay} cadence instead of falling back to the full {@code schedulingInterval}.
+   * Called from the stream processor once per activation that requested any resolution.
+   *
+   * <p>Does not schedule or cancel anything itself. This scheduler already reschedules itself at
+   * {@code wakeDelay} whenever a cycle resolves at least one reference, so under the sustained
+   * request rate this exists for, that alone keeps the chain on the fast cadence; this flag only
+   * covers the gap where a cycle's collection happens to find nothing pending because it raced a
+   * request that is about to be written, not because the scheduler is genuinely idle.
+   */
+  public void wake() {
+    wakePending.set(true);
+  }
+
   TaskResult resolveSecrets(final TaskResultBuilder resultBuilder) {
     taskScheduled.set(false);
+    final boolean woken = wakePending.getAndSet(false);
     final long now = clock.millis();
     boolean taskResultBatchFull = false;
     boolean capped = false;
@@ -200,8 +239,20 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
         }
       }
     } finally {
-      final boolean immediateReschedule = taskResultBatchFull || (capped && progressMade.get());
-      scheduleNext(immediateReschedule ? Duration.ZERO : computeNextDelay(now));
+      final Duration delay;
+      if (taskResultBatchFull || (capped && progressMade.get())) {
+        // more pending refs than this cycle's batch cap allowed it to take; keep draining
+        delay = Duration.ZERO;
+      } else if (progressMade.get() || woken) {
+        // either this cycle resolved something, or one was requested since the last cycle ran and
+        // may not have been visible to this cycle's collection yet either way, staying on the fast
+        // cadence is what lets a continuous stream of requests be resolved close to as they arrive,
+        // without ever cancelling and replacing a scheduled cycle to get there
+        delay = wakeDelay;
+      } else {
+        delay = computeNextDelay(now);
+      }
+      scheduleNext(delay);
     }
     return resultBuilder.build();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -12,6 +12,7 @@ import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.secretstore.SecretStoreUnavailableException;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCycleDelayReason;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
@@ -254,6 +255,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
         // more pending refs than this cycle's batch cap allowed it to take; keep draining
         delay = Duration.ZERO;
         idleBackoffMillis = 0;
+        metrics.cycleDelay(SecretResolutionCycleDelayReason.DRAINING, delay);
       } else if (progressMade.get() || woken) {
         // either this cycle resolved something, or one was requested since the last cycle ran and
         // may not have been visible to this cycle's collection yet either way, staying on the fast
@@ -261,6 +263,7 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
         // without ever cancelling and replacing a scheduled cycle to get there
         delay = wakeDelay;
         idleBackoffMillis = 0;
+        metrics.cycleDelay(SecretResolutionCycleDelayReason.WAKE, delay);
       } else {
         delay = computeNextDelay(now);
       }
@@ -280,7 +283,9 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
    */
   private Duration computeNextDelay(final long now) {
     if (storeRetryStates.isEmpty()) {
-      return nextIdleBackoff();
+      final var delay = nextIdleBackoff();
+      metrics.cycleDelay(SecretResolutionCycleDelayReason.IDLE_BACKOFF, delay);
+      return delay;
     }
     final long earliestRetryAt =
         storeRetryStates.values().stream()
@@ -288,10 +293,12 @@ public final class SecretResolutionScheduler implements StreamProcessorLifecycle
             .min()
             .getAsLong();
     final long millisUntilRetry = earliestRetryAt - now;
-    if (millisUntilRetry < schedulingInterval.toMillis()) {
-      return Duration.ofMillis(Math.max(0, millisUntilRetry));
-    }
-    return schedulingInterval;
+    final var delay =
+        millisUntilRetry < schedulingInterval.toMillis()
+            ? Duration.ofMillis(Math.max(0, millisUntilRetry))
+            : schedulingInterval;
+    metrics.cycleDelay(SecretResolutionCycleDelayReason.RETRY_COOLDOWN, delay);
+    return delay;
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SecretResolutionMetricsDocTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCycleDelayReason;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
@@ -43,7 +44,12 @@ final class SecretResolutionMetricsDocTest {
                   .doesNotContain("-")
                   .doesNotContain("_");
               assertThat(meter.getDescription()).isNotBlank();
-              assertThat(meter.getKeyNames()).contains(SecretResolutionKeyNames.STORE);
+              // CYCLE_DELAY is the one exception: it measures the scheduler's own per-cycle
+              // decision, not an operation against a particular store, so it has no store
+              // dimension to tag (see shouldDocumentTheCycleDelayAsATimerTaggedByResultOnly)
+              if (meter != SecretResolutionMetricsDoc.CYCLE_DELAY) {
+                assertThat(meter.getKeyNames()).contains(SecretResolutionKeyNames.STORE);
+              }
               // the partition transition registry stamps these on every meter it forwards
               assertThat(meter.getAdditionalKeyNames()).contains(PartitionKeyNames.values());
             });
@@ -189,6 +195,29 @@ final class SecretResolutionMetricsDocTest {
     // when/then — the unit is the whole point of the separate meter, and reading it as a reference
     // count would make it look like a backlog rather than a bug rate
     assertThat(description).contains("cycles rather than references");
+  }
+
+  @Test
+  void shouldDocumentTheCycleDelayAsATimerTaggedByResultOnly() {
+    // given
+    final var meter = SecretResolutionMetricsDoc.CYCLE_DELAY;
+
+    // when/then: no `store` tag, since the delay is the scheduler's own per-cycle decision,
+    // covering every store a cycle looked at (or none), not an operation against one particular
+    // store
+    assertThat(meter.getName()).isEqualTo("camunda.secret.resolution.cycle.delay");
+    assertThat(meter.getType()).isEqualTo(Type.TIMER);
+    assertThat(meter.getBaseUnit()).isEqualTo("seconds");
+    assertThat(meter.getKeyNames()).containsExactly(SecretResolutionKeyNames.RESULT);
+    assertThat(meter.getTimerSLOs()).isNotEmpty();
+  }
+
+  @Test
+  void shouldDocumentEveryCycleDelayReason() {
+    // given/when/then: one value per branch SecretResolutionScheduler's delay choice can take
+    assertThat(SecretResolutionCycleDelayReason.values())
+        .extracting(Enum::name)
+        .containsExactlyInAnyOrder("DRAINING", "WAKE", "IDLE_BACKOFF", "RETRY_COOLDOWN");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobPushSecretResolutionLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobPushSecretResolutionLifecycleTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer;
+import io.camunda.zeebe.engine.util.RecordingJobStreamer.RecordingJobStream;
+import io.camunda.zeebe.engine.util.SecretStoreRegistries;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Covers the push activation path parking a job on a non-cached secret reference and the real
+ * {@link io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler} resolving
+ * it, the push-path counterpart to {@code SecretResolutionLifecycleTest} (long poll). {@code
+ * JobSecretPushInjectionTest} covers the push path's own injection logic against hand-written
+ * resolution outcomes instead, precisely to stay independent of the scheduler's timing; this test
+ * is what exercises the two together.
+ */
+public final class JobPushSecretResolutionLifecycleTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+  private static final String SECRET_VALUE = "resolved-secret";
+  private static final RecordingJobStreamer JOB_STREAMER = new RecordingJobStreamer();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withJobStreamer(JOB_STREAMER)
+          .withSecretStoreRegistry(
+              SecretStoreRegistries.resolvingFromStore(Map.of("token", SECRET_VALUE)))
+          // the default interval is 5s, which would make the assertion below wait on it
+          .withEngineConfig(config -> config.setSecretResolutionInterval(Duration.ofMillis(100)));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldResolveParkedSecretAndPushTheJobOnceBackgroundResolutionCompletes() {
+    // given - a registered stream, so job creation takes the push path rather than the long poll
+    registerJobStream();
+    deploy();
+
+    // when - the push finds no cached value for the reference and parks the job
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long jobKey = awaitJob(processInstanceKey);
+
+    // then - the background resolution succeeds
+    final Record<SecretReferenceRecordValue> resolved =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_COMPLETED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(resolved.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
+
+    // and - the parked job is reactivated, which is what makes the push path retry it
+    final Record<SecretReferenceRecordValue> reactivated =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.BATCH_JOBS_REACTIVATED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(reactivated.getValue().getJobKeys()).containsExactly(jobKey);
+  }
+
+  private RecordingJobStream registerJobStream() {
+    final var worker = BufferUtil.wrapString("test");
+    final var properties =
+        new JobActivationPropertiesImpl()
+            .setWorker(worker, 0, worker.capacity())
+            .setTimeout(30_000L)
+            .setTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+    return JOB_STREAMER.addJobStream(BufferUtil.wrapString(JOB_TYPE), properties);
+  }
+
+  /** Returns the key of the job the given instance waits on, once that job exists. */
+  private long awaitJob(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
+  }
+
+  private void deploy() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secrets.token", "authorization"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -716,6 +716,8 @@ final class SecretResolutionSchedulerTest {
     final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
     verify(scheduleService).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getValue()).isEqualTo(Duration.ZERO);
+    // and - the cycle-delay meter is tagged DRAINING for this reschedule, not some other reason
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.DRAINING).count()).isEqualTo(1);
   }
 
   @Test
@@ -746,6 +748,8 @@ final class SecretResolutionSchedulerTest {
     verify(scheduleService).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getValue())
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+    // and - the cycle-delay meter is tagged WAKE for this reschedule, not some other reason
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.WAKE).count()).isEqualTo(1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -716,8 +716,8 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
-  void shouldNotRescheduleImmediatelyWhenPendingRefsAreWithinBatchLimit() throws Exception {
-    // given — batch limit of 2, exactly 2 refs pending (nothing left over)
+  void shouldRescheduleAtWakeDelayWhenPendingRefsAreWithinBatchLimit() throws Exception {
+    // given - batch limit of 2, exactly 2 refs pending (nothing left over, so uncapped)
     final var config = new EngineConfiguration().setSecretResolutionBatchLimit(2);
     final var localScheduler =
         new SecretResolutionScheduler(
@@ -737,11 +737,71 @@ final class SecretResolutionSchedulerTest {
     // when
     localScheduler.resolveSecrets(resultBuilder);
 
-    // then — the normal scheduling interval is used, since nothing was capped
+    // then - the cycle resolved something, so it stays on the fast cadence rather than falling
+    // back to the full interval, even though it was not capped
     final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
     verify(scheduleService).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getValue())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+  }
+
+  @Test
+  void shouldFallBackToFullIntervalWhenACycleFindsNothingPendingAndWasNotWoken() throws Exception {
+    // given - no pending refs at all, and wake() was never called
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then - a second call: onRecovered's initial schedule (in setUp), then this cycle's reschedule
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(1))
         .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldStayOnWakeDelayWhenACycleFindsNothingPendingButWasWoken() throws Exception {
+    // given - no pending refs, but an activation requested a resolution since the last cycle ran
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+    scheduler.wake();
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then - stays on the fast cadence rather than concluding the scheduler is idle
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(1))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+  }
+
+  @Test
+  void shouldConsumeTheWakeFlagSoOnlyTheNextCycleIsAffected() throws Exception {
+    // given - woken once, then a cycle runs and finds nothing (consuming the flag)
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+    scheduler.wake();
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when - a second cycle runs without a further wake and still finds nothing
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then - the flag was consumed by the first cycle, so this one falls back to the full interval
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(3)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(2))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldNotScheduleOrCancelAnythingWhenWoken() {
+    // given - setUp already scheduled once via onRecovered
+
+    // when
+    scheduler.wake();
+
+    // then - wake() only sets a flag; it does not itself touch the scheduling chain
+    verify(scheduleService, times(1)).runDelayedAsync(any(), any(), any());
   }
 
   @Test
@@ -923,7 +983,7 @@ final class SecretResolutionSchedulerTest {
 
   @Test
   void shouldNotScheduleSecondChainWhenResumedWhileTaskStillPending() throws Exception {
-    // given — setUp already scheduled once via onRecovered
+    // given - setUp already scheduled once via onRecovered
 
     // when
     scheduler.onPaused();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -755,7 +755,7 @@ final class SecretResolutionSchedulerTest {
   @Test
   void shouldStartIdleBackoffAtWakeDelayWhenACycleFindsNothingPendingAndWasNotWoken()
       throws Exception {
-    // given - no pending refs at all, and wake() was never called
+    // given - no pending refs at all, and stayAwake() was never called
     doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
 
     // when
@@ -772,7 +772,7 @@ final class SecretResolutionSchedulerTest {
 
   @Test
   void shouldGrowIdleBackoffGeometricallyAndCapAtSchedulingInterval() throws Exception {
-    // given - no pending refs at all, and wake() is never called
+    // given - no pending refs at all, and stayAwake() is never called
     doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
 
     // when - enough consecutive empty cycles run for the ladder to reach and then stay at the cap.
@@ -858,7 +858,7 @@ final class SecretResolutionSchedulerTest {
   void shouldStayOnWakeDelayWhenACycleFindsNothingPendingButWasWoken() throws Exception {
     // given - no pending refs, but an activation requested a resolution since the last cycle ran
     doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
-    scheduler.wake();
+    scheduler.stayAwake();
 
     // when
     scheduler.resolveSecrets(resultBuilder);
@@ -880,7 +880,7 @@ final class SecretResolutionSchedulerTest {
 
     // when - a fresh activation parks a job on the same, still-cooling store and wakes the
     // scheduler before the cooldown has elapsed
-    scheduler.wake();
+    scheduler.stayAwake();
     stubPending(STORE_ID, "db-password");
     scheduler.resolveSecrets(resultBuilder);
 
@@ -902,7 +902,7 @@ final class SecretResolutionSchedulerTest {
   void shouldConsumeTheWakeFlagSoOnlyTheNextCycleIsAffected() throws Exception {
     // given - woken once, then a cycle runs and finds nothing (consuming the flag)
     doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
-    scheduler.wake();
+    scheduler.stayAwake();
     scheduler.resolveSecrets(resultBuilder);
 
     // when - a second cycle runs without a further wake and still finds nothing
@@ -926,7 +926,7 @@ final class SecretResolutionSchedulerTest {
     scheduler.resolveSecrets(resultBuilder);
 
     // when - a wake arrives and the cycle it triggers still finds nothing pending
-    scheduler.wake();
+    scheduler.stayAwake();
     scheduler.resolveSecrets(resultBuilder);
 
     // and - a further unwoken, empty cycle runs
@@ -952,9 +952,9 @@ final class SecretResolutionSchedulerTest {
     // given - setUp already scheduled once via onRecovered
 
     // when
-    scheduler.wake();
+    scheduler.stayAwake();
 
-    // then - wake() only sets a flag; it does not itself touch the scheduling chain
+    // then - stayAwake() only sets a flag; it does not itself touch the scheduling chain
     verify(scheduleService, times(1)).runDelayedAsync(any(), any(), any());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -399,13 +399,14 @@ final class SecretResolutionSchedulerTest {
     when(clock.millis()).thenReturn(Long.MAX_VALUE);
     scheduler.resolveSecrets(resultBuilder);
 
-    // then — store not retried; full scheduling interval restored
+    // then, store not retried: the idle backoff ladder restarts at wakeDelay
     verify(secretStore, times(1)).resolve(any());
     final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
-    // three calls: onRecovered, first execute (failure → early), second execute (no pending → full)
+    // three calls: onRecovered, first execute (failure → retry delay), second execute (no pending →
+    // idle ladder's first step)
     verify(scheduleService, times(3)).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getAllValues().get(2))
-        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
   }
 
   @Test
@@ -544,14 +545,15 @@ final class SecretResolutionSchedulerTest {
     // when
     scheduler.resolveSecrets(resultBuilder);
 
-    // then — the failure did not enter retry/backoff state
+    // then, the failure did not enter retry/backoff state, so the idle backoff ladder governs the
+    // reschedule instead of the retry deadline
     verify(resultBuilder, never()).appendCommandRecord(any(), any());
     verify(secretCache, never()).put(any(), any());
     final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
     // two calls total: one from onRecovered in setUp, one from execute
     verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getAllValues().get(1))
-        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
   }
 
   @Test
@@ -746,18 +748,98 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
-  void shouldFallBackToFullIntervalWhenACycleFindsNothingPendingAndWasNotWoken() throws Exception {
+  void shouldStartIdleBackoffAtWakeDelayWhenACycleFindsNothingPendingAndWasNotWoken()
+      throws Exception {
     // given - no pending refs at all, and wake() was never called
     doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
 
     // when
     scheduler.resolveSecrets(resultBuilder);
 
-    // then - a second call: onRecovered's initial schedule (in setUp), then this cycle's reschedule
+    // then - a second call: onRecovered's initial schedule (in setUp), then this cycle's
+    // reschedule.
+    // The idle backoff ladder starts at wakeDelay rather than jumping straight to the full interval
     final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
     verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getAllValues().get(1))
-        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+  }
+
+  @Test
+  void shouldGrowIdleBackoffGeometricallyAndCapAtSchedulingInterval() throws Exception {
+    // given - no pending refs at all, and wake() is never called
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+
+    // when - enough consecutive empty cycles run for the ladder to reach and then stay at the cap.
+    // wakeDelay (50ms) doubling: 50, 100, 200, 400, 800, 1600, 3200, then capped at
+    // schedulingInterval
+    // (5000ms) since 3200 * 2 = 6400 would overshoot it
+    for (int i = 0; i < 9; i++) {
+      scheduler.resolveSecrets(resultBuilder);
+    }
+
+    // then - onRecovered's initial schedule, then one per cycle above
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(10)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().subList(1, 10))
+        .extracting(Duration::toMillis)
+        .containsExactly(50L, 100L, 200L, 400L, 800L, 1600L, 3200L, 5000L, 5000L);
+  }
+
+  @Test
+  void shouldResetIdleBackoffLadderWhenACycleMakesProgress() throws Exception {
+    // given - two consecutive unwoken, empty cycles grow the idle backoff ladder past its first
+    // step
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+    scheduler.resolveSecrets(resultBuilder);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when - a cycle resolves something
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+    scheduler.resolveSecrets(resultBuilder);
+
+    // and - a further unwoken, empty cycle runs
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then - onRecovered's initial schedule, then one per cycle above. The cycle that resolved
+    // something uses wakeDelay regardless (asserted elsewhere); what this proves is that the final
+    // cycle restarts the ladder at wakeDelay too, rather than resuming from the doubled value the
+    // first two cycles had already reached
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(5)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(4))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+  }
+
+  @Test
+  void shouldStillGrowIdleBackoffWhenWakeDelayIsZero() throws Exception {
+    // given - wakeDelay of zero is allowed (a cycle that resolves something or is woken reschedules
+    // at zero itself); the idle ladder must still climb rather than getting stuck doubling zero
+    final var config = new EngineConfiguration().setSecretResolutionWakeDelay(Duration.ZERO);
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState,
+            new SecretStoreRegistry(Map.of(STORE_ID, secretStore), Map.of(STORE_ID, secretCache)),
+            config,
+            metrics);
+    localScheduler.onRecovered(context);
+    reset(scheduleService);
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+
+    // when - three consecutive empty, unwoken cycles run
+    localScheduler.resolveSecrets(resultBuilder);
+    localScheduler.resolveSecrets(resultBuilder);
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then - the ladder starts at a 1ms floor rather than zero, and still doubles from there
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(3)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues())
+        .extracting(Duration::toMillis)
+        .containsExactly(1L, 2L, 4L);
   }
 
   @Test
@@ -786,11 +868,43 @@ final class SecretResolutionSchedulerTest {
     // when - a second cycle runs without a further wake and still finds nothing
     scheduler.resolveSecrets(resultBuilder);
 
-    // then - the flag was consumed by the first cycle, so this one falls back to the full interval
+    // then - the flag was consumed by the first cycle, so this one is on the idle backoff ladder
+    // rather than treated as woken - its first step happens to equal wakeDelay too (asserted
+    // distinctly from the wake behavior in shouldResetIdleBackoffLadderWhenWoken below)
     final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
     verify(scheduleService, times(3)).runDelayedAsync(delayCaptor.capture(), any(), any());
     assertThat(delayCaptor.getAllValues().get(2))
-        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+  }
+
+  @Test
+  void shouldResetIdleBackoffLadderWhenWoken() throws Exception {
+    // given - two consecutive unwoken, empty cycles grow the idle backoff ladder past its first
+    // step
+    doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
+    scheduler.resolveSecrets(resultBuilder);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when - a wake arrives and the cycle it triggers still finds nothing pending
+    scheduler.wake();
+    scheduler.resolveSecrets(resultBuilder);
+
+    // and - a further unwoken, empty cycle runs
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then - onRecovered's initial schedule, then one per cycle above. The woken cycle uses
+    // wakeDelay regardless of the ladder (asserted elsewhere); what this proves is that the final,
+    // unwoken cycle restarts the ladder at wakeDelay too, instead of resuming from the doubled
+    // value
+    // the first two cycles had already reached - the wake cleared the streak, not just the flag
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(scheduleService, times(5)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    final var delays = delayCaptor.getAllValues();
+    assertThat(delays.get(1)).isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+    assertThat(delays.get(2).toMillis())
+        .isEqualTo(2 * EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY.toMillis());
+    assertThat(delays.get(3)).isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
+    assertThat(delays.get(4)).isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_WAKE_DELAY);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCallResult;
+import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionCycleDelayReason;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionKeyNames;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetricsDoc.SecretResolutionOutcome;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -859,6 +860,34 @@ final class SecretResolutionSchedulerTest {
   }
 
   @Test
+  void shouldHonorRetryCooldownRatherThanWakeDelayWhenWokenWhileTheStoreIsCoolingDown()
+      throws Exception {
+    // given - the store fails once and enters cooldown (nextAttemptAt = 1000ms; clock stays at 0)
+    stubPending(STORE_ID, "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when - a fresh activation parks a job on the same, still-cooling store and wakes the
+    // scheduler before the cooldown has elapsed
+    scheduler.wake();
+    stubPending(STORE_ID, "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then - the wake does not override the cooldown: collection skips the cooling store's ref
+    // outright (see collectPendingByStore), so nothing was resolvable this cycle either way, and
+    // the fast wakeDelay cadence would only re-scan a backlog this cycle already knows is blocked
+    final var delayCaptor2 = ArgumentCaptor.forClass(Duration.class);
+    // three calls: onRecovered's initial schedule, first cycle (failure -> retry delay), second
+    // cycle (woken, but still cooling down -> retry delay again, not wakeDelay)
+    verify(scheduleService, times(3)).runDelayedAsync(delayCaptor2.capture(), any(), any());
+    assertThat(delayCaptor2.getAllValues().get(2))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY);
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.WAKE).count()).isEqualTo(0);
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.RETRY_COOLDOWN).count())
+        .isEqualTo(2);
+  }
+
+  @Test
   void shouldConsumeTheWakeFlagSoOnlyTheNextCycleIsAffected() throws Exception {
     // given - woken once, then a cycle runs and finds nothing (consuming the flag)
     doReturn(null).when(secretReferenceState).visitPendingSecretReferences(any(), any());
@@ -1465,6 +1494,16 @@ final class SecretResolutionSchedulerTest {
         .find(SecretResolutionMetricsDoc.RESOLUTION_DURATION.getName())
         .tag(SecretResolutionKeyNames.STORE.asString(), storeId)
         .tag(SecretResolutionKeyNames.RESULT.asString(), callResult.name())
+        .timer();
+  }
+
+  /**
+   * {@link SecretResolutionMetricsDoc#CYCLE_DELAY} carries no store tag, unlike the meter above.
+   */
+  private Timer cycleDelayTimer(final SecretResolutionCycleDelayReason reason) {
+    return meterRegistry
+        .find(SecretResolutionMetricsDoc.CYCLE_DELAY.getName())
+        .tag(SecretResolutionKeyNames.RESULT.asString(), reason.name())
         .timer();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -785,6 +785,13 @@ final class SecretResolutionSchedulerTest {
     assertThat(delayCaptor.getAllValues().subList(1, 10))
         .extracting(Duration::toMillis)
         .containsExactly(50L, 100L, 200L, 400L, 800L, 1600L, 3200L, 5000L, 5000L);
+
+    // and - every one of those 9 cycles recorded IDLE_BACKOFF, not some other reason, on the
+    // cycle-delay meter itself
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.IDLE_BACKOFF).count()).isEqualTo(9);
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.WAKE).count()).isEqualTo(0);
+    assertThat(cycleDelayTimer(SecretResolutionCycleDelayReason.RETRY_COOLDOWN).count())
+        .isEqualTo(0);
   }
 
   @Test


### PR DESCRIPTION
Relates to #61389.

## Problem

`SecretResolutionScheduler` rescheduled either immediately or after the full `schedulingInterval` (5s default). A reference requested partway through that wait absorbed most of it. Store reads cost under a millisecond; the wait did not.

## Fix

- `wake()`: set once per activation that parks a job on an uncached secret reference. Flag only, no scheduling or cancellation.
- Idle backoff ladder: reschedule at `wakeDelay` (50ms default) after a wake or any progress, doubling each empty cycle up to `schedulingInterval`, instead of jumping straight to the full interval.
- New `camunda.secret.resolution.cycle.delay` timer, tagged by why each cycle chose its delay.

An earlier cancellation-based version (mirroring `DueDateCheckScheduler` stalled a live partition permanently under the wake frequency this design calls for. This design never cancels a scheduled task.

## Results

Same `secrets` load test scenario (#61352), 100 PI/s, both activation paths, 30 minute steady-state windows:

| | no secrets | baseline, job push | baseline, long poll | fix, job push | fix, long poll |
|---|---|---|---|---|---|
| PI exec p90 | 72.6 ms | 4.23 s | 4.14 s | 225 ms (**18.8x**) | 328 ms (**12.6x**) |
| PI exec p99 | 74.9 ms | 9.10 s | 8.95 s | 485 ms (**18.8x**) | 736 ms (**12.2x**) |
| job activation within 1s | ~100% | 72.0% | 72.4% | 99.9% | 99.8% |

Throughput (100 PI/s), backpressure (0%), and secret cache miss rate (24.8-25.8%) match across all four runs. Zero incidents on every run.

PI execution time panel, after fix / job push
<img width="1388" height="420" alt="Screenshot 2026-08-31 at 20 30 25" src="https://github.com/user-attachments/assets/d29882e0-9bbd-45eb-805c-61f06a0d4715" />

PI execution time panel, after fix / long poll
<img width="1391" height="425" alt="Screenshot 2026-08-31 at 20 30 41" src="https://github.com/user-attachments/assets/8ff43160-f72a-4b94-8951-1b446aef4b7b" />

job activation time panel, after fix / job push
<img width="687" height="298" alt="Screenshot 2026-08-31 at 20 31 35" src="https://github.com/user-attachments/assets/2e3c9650-9c50-49b8-922d-3a3887127665" />

job activation time panel, after fix / long poll

<img width="690" height="300" alt="Screenshot 2026-08-31 at 20 32 08" src="https://github.com/user-attachments/assets/0b683397-e0f9-43c9-ba40-4e2c800294f6" />

