### PR TITLE
ci: prefer REST over gRPC by default in load-tests (except 8.7)

### DIFF
--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -393,8 +393,10 @@ When `physical_tenant_count > 0`, the Makefile:
   overriding only the REST address to that tenant's path `http://camunda:8080/physical-tenants/pt<i>`.
 - Renders the `starter`/`worker` from the same chart, values, scenario and **image** as the default
   tester, renames them to `starter-pt<i>`/`worker-pt<i>`, and applies them — looped over `pt1..ptN`.
-  Each tester uses REST (`global.preferRest.enabled=true`) because gRPC only routes to the default
-  physical tenant.
+  These testers are pinned to REST (`--set global.preferRest.enabled=true`), independent of the
+  namespace default: per-tenant isolation relies on the tenant's REST base address, and the load
+  tester does not send the `Camunda-Physical-Tenant` gRPC header, so gRPC would route to the
+  default tenant.
 
 A second Helm release per tenant is not used because the `camunda-load-tests` subchart hardcodes the
 `starter`/`worker` resource names, which would collide in the same namespace. This also means each

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -277,8 +277,12 @@ generate-physical-tenant-values:
 # The camunda-load-tests subchart hardcodes the starter/worker resource names, so a second
 # Helm release per tenant would collide. Instead we render only those two templates from the
 # same chart, values, scenario and image as the default tester, rename them to *-pt<i>, and
-# apply — looped over pt1..ptN. REST is required because gRPC only routes to the default
-# physical tenant.
+# apply — looped over pt1..ptN. These testers are pinned to REST
+# (--set global.preferRest.enabled=true) regardless of the namespace default: per-tenant
+# isolation is wired solely through the tenant's REST base address (the credentials clone
+# below), and the load tester never sets a physical tenant id, so it emits no
+# Camunda-Physical-Tenant gRPC header — over gRPC the requests would fall back to the
+# default tenant.
 .PHONY: install-load-test-physical-tenants
 install-load-test-physical-tenants:
 	@for i in $$(seq 1 $(physical_tenant_count)); do \

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -29,12 +29,17 @@
 #   Set to `false` for versions without product-side physical-tenant config
 #   support, so physical_tenant_count > 0 fails fast instead of silently
 #   rendering an incomplete overlay.
+#
+# - prefer_rest
+#   Whether the load testers prefer REST over gRPC (matches the load-tester
+#   application default). Set to `false` on versions that should keep gRPC (8.7).
 
 rdbms_storages ?= postgresql mysql mariadb mssql oracle
 optimize_self_sufficient_storages ?= elasticsearch opensearch
 scenario_max_override_key ?= orchestration.extraConfiguration[1].content=
 install_storage_target ?= install-storage
 physical_tenants_supported ?= true
+prefer_rest ?= true
 
 template_output_dir ?= .
 # Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
@@ -98,6 +103,12 @@ additional_load_test_setup_configuration ?=
 # Makefile-side load-test-setup flags. Separate from `additional_load_test_setup_configuration`,
 # which CI sets on the make command line and would suppress `+=` here.
 _load_test_setup_flags =
+
+# load-tester-values-defaults.yaml defaults preferRest to true. Only emit an explicit
+# override when a version opts out of the REST default (e.g. 8.7, which keeps gRPC).
+ifneq ($(prefer_rest),true)
+_load_test_setup_flags += --set global.preferRest.enabled=$(prefer_rest)
+endif
 
 # The Docker image tag for the load test metrics exporter
 metrics_exporter_image_tag = latest

--- a/load-tests/setup/scenarios/load-tester-values-defaults.yaml
+++ b/load-tests/setup/scenarios/load-tester-values-defaults.yaml
@@ -7,7 +7,7 @@ global:
       - name: harbor-registry
 
   preferRest:
-    enabled: false
+    enabled: true
 
   nodeSelector:
     component: benchmark-n2-standard-4

--- a/load-tests/setup/stable-87/Makefile
+++ b/load-tests/setup/stable-87/Makefile
@@ -6,10 +6,12 @@ enable_optimize ?= __ENABLE_OPTIMIZE__
 # - RDBMS, OpenSearch installation, and physical tenants are not supported for this version.
 # - Optimize still needs the Elasticsearch overlay even with Elasticsearch secondary storage.
 # - The max scenario uses the 8.7 Zeebe extraConfiguration map key.
+# - 8.7 keeps gRPC (rather than the REST default of newer setups) for the load testers.
 rdbms_storages =
 optimize_self_sufficient_storages =
 scenario_max_override_key = zeebe.extraConfiguration.application-override\.yml=
 install_storage_target =
 physical_tenants_supported = false
+prefer_rest = false
 
 include ../common.mk

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=300
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/none-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/none/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/none/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=1
                 -Dzeebe.client.requestTimeout=62000
@@ -104,7 +104,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -182,7 +182,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -245,7 +245,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -316,7 +316,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -383,7 +383,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -462,7 +462,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -525,7 +525,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -596,7 +596,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -659,7 +659,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -730,7 +730,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -794,7 +794,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=300
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=1
                 -Dzeebe.client.requestTimeout=62000
@@ -104,7 +104,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -182,7 +182,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -245,7 +245,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -316,7 +316,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -383,7 +383,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -462,7 +462,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -525,7 +525,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -596,7 +596,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -659,7 +659,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -730,7 +730,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -794,7 +794,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=300
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=1
                 -Dzeebe.client.requestTimeout=62000
@@ -104,7 +104,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -182,7 +182,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -245,7 +245,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -316,7 +316,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -383,7 +383,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -462,7 +462,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -525,7 +525,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -596,7 +596,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -659,7 +659,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -730,7 +730,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -794,7 +794,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=300
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -106,7 +106,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=150
                 -Dzeebe.client.requestTimeout=62000
@@ -102,7 +102,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -103,7 +103,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dapp.starter.rate=1
                 -Dzeebe.client.requestTimeout=62000
@@ -104,7 +104,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE

--- a/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -39,7 +39,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -105,7 +105,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -182,7 +182,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -245,7 +245,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -316,7 +316,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
@@ -383,7 +383,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -462,7 +462,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -525,7 +525,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -596,7 +596,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -659,7 +659,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE
@@ -730,7 +730,7 @@ spec:
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.tls=true
-                -Dapp.preferRest=false
+                -Dapp.preferRest=true
                 -Dapp.performReadBenchmarks=false
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=30
@@ -794,7 +794,7 @@ spec:
             ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
             ##
             - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
-              value: "false"
+              value: "true"
             - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
               value: "false"
             - name: CAMUNDA_CLIENT_MODE


### PR DESCRIPTION
## Description

Make the load testers **prefer REST over gRPC by default**, so our daily/CI load tests continuously exercise the REST + job-streaming path rather than gRPC.

- `scenarios/load-tester-values-defaults.yaml`: flip `global.preferRest.enabled` to `true`. This matches the load-tester application default (`prefer-rest-over-grpc: true`); previously the deployment forced gRPC via the `CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC=false` env var.
- **8.7 keeps gRPC.** The REST + streaming performance work does not apply to 8.7 - with 8.7 REST was not yet the default, so `stable-87` opts out via a new version-overridable `prefer_rest` Makefile variable (defaults to `true`; `stable-87/Makefile` sets it to `false`). Only versions that opt out emit an explicit `--set global.preferRest.enabled=false`, routed through the `_load_test_setup_flags` accumulator so it survives CI's command-line `additional_load_test_setup_configuration`.
- Physical-tenant testers stay pinned to REST (`--set global.preferRest.enabled=true` is kept in the physical-tenant install path): they isolate tenants solely via the per-tenant REST base address and never set a physical tenant id, so over gRPC they'd emit no `Camunda-Physical-Tenant` header and route to the default tenant. The previously misleading "gRPC only routes to the default tenant" comment/README wording is corrected. Making PT tests run over gRPC too (by wiring `CAMUNDA_CLIENT_PHYSICAL_TENANT_ID` per tenant) is tracked as follow-up #61463.
- Golden files regenerated: `main`, `stable-88`, `stable-89`, `stable-810` →  REST; `stable-87` stays gRPC.

### Context / why

We want the load tests to cover the default REST + streaming code path so we can catch performance regressions there continuously.

- REST + streaming performance bottleneck fix: https://github.com/camunda/camunda/issues/59633 for 8.8-8.10
- Discussion: https://camunda.slack.com/archives/C0807665N8G/p1788160516927379

## Checklist

- [ ] ~Enable backports~ — **No backport.** Per the load-tests policy, changes under `load-tests/setup/**` are never backported; version-specific behavior (incl. 8.7 keeping gRPC) lives in the versioned setup folders on `main`.

