### PR TITLE
feat: add opt-in PgBouncer connection pooling for load-test Postgres storage

### DIFF
--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -345,6 +345,29 @@ make template-load-test-setup-chaos
 
 In the GitHub workflow, set the `enable-chaos` input to `true`.
 
+#### Optional PostgreSQL connection pooling (PgBouncer)
+
+For `secondary_storage=postgresql`, each broker pod opens one connection pool per physical
+tenant, so client connections to Postgres scale as (broker pods x physical tenants) and can
+exceed Postgres's default `max_connections` under a large fleet (e.g. 10 brokers x 10
+tenants). Enabling this option deploys a CNPG `Pooler` (PgBouncer, transaction-pooling mode)
+in front of the PostgreSQL cluster and points Camunda's JDBC URL at it instead of the
+cluster's `-rw` Service — see [Connection pooling
+(PgBouncer)](charts/load-test-setup/README.md#connection-pooling-pgbouncer) for the full
+rationale.
+
+This is opt-in and off by default; only supported with `secondary_storage=postgresql`.
+
+```sh
+make install secondary_storage=postgresql postgres_pooler=true
+```
+
+To preview the rendered manifests before installing:
+
+```sh
+make template-load-test-setup-pooler
+```
+
 #### Optional physical tenants (pt1..ptN)
 
 A load test can exercise **N extra physical tenants** (`pt1`, `pt2`, ..., `ptN`) alongside the

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -357,15 +357,18 @@ cluster's `-rw` Service — see [Connection pooling
 rationale.
 
 This is opt-in and off by default; only supported with `secondary_storage=postgresql`.
+Pass `--use-pgbouncer` to `newLoadTest.sh` when scaffolding the namespace:
 
 ```sh
-make install secondary_storage=postgresql postgres_pooler=true
+./newLoadTest.sh <namespace> postgresql 1 true --use-pgbouncer
+cd <namespace>
+make install
 ```
 
 To preview the rendered manifests before installing:
 
 ```sh
-make template-load-test-setup-pooler
+make template-load-test-setup
 ```
 
 #### Optional physical tenants (pt1..ptN)

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -361,14 +361,6 @@ Pass `--use-pgbouncer` to `newLoadTest.sh` when scaffolding the namespace:
 
 ```sh
 ./newLoadTest.sh <namespace> postgresql 1 true --use-pgbouncer
-cd <namespace>
-make install
-```
-
-To preview the rendered manifests before installing:
-
-```sh
-make template-load-test-setup
 ```
 
 #### Optional physical tenants (pt1..ptN)

--- a/load-tests/setup/charts/load-test-setup/README.md
+++ b/load-tests/setup/charts/load-test-setup/README.md
@@ -172,3 +172,25 @@ described above.
 > test namespace and doesn't deploy or require resources outside of that
 > namespace (except for the CNPG Operator, indirectly).
 
+### Connection pooling (PgBouncer)
+
+Each broker pod opens one connection pool per physical tenant, so client connections to
+Postgres scale as (broker pods x physical tenants) — a 10-broker, 10-tenant load test
+produces a structural floor of ~200 mostly-idle connections, which exceeds Postgres's
+default `max_connections=100` under load.
+
+Setting `postgresql.pooler.enabled=true` deploys a CNPG [`Pooler`
+resource](https://cloudnative-pg.io/docs/1.30/connection_pooling) (PgBouncer, transaction
+pooling mode) in front of the Cluster above. A GKE benchmark trial confirmed this collapses
+steady-state Postgres connections by roughly an order of magnitude, with zero client
+queueing and zero connection timeouts, without raising `max_connections` — including through a
+full simultaneous restart of all broker pods.
+
+This is opt-in and off by default. Enabling it also requires switching
+`orchestration.data.secondaryStorage.rdbms.url` (in the platform values) to the Pooler's
+Service and appending `?prepareThreshold=0` — see `postgres_pooler=true` in
+[`../../common.mk`](../../common.mk), which does both. Setting `postgresql.pooler.enabled`
+directly (e.g. via `additional_load_test_setup_configuration`) without the matching JDBC URL
+change leaves Camunda connected straight to the Cluster's `-rw` Service — the Pooler
+deploys but nothing routes through it.
+

--- a/load-tests/setup/charts/load-test-setup/README.md
+++ b/load-tests/setup/charts/load-test-setup/README.md
@@ -188,9 +188,10 @@ full simultaneous restart of all broker pods.
 
 This is opt-in and off by default. Enabling it also requires switching
 `orchestration.data.secondaryStorage.rdbms.url` (in the platform values) to the Pooler's
-Service and appending `?prepareThreshold=0` — see `postgres_pooler=true` in
-[`../../common.mk`](../../common.mk), which does both. Setting `postgresql.pooler.enabled`
-directly (e.g. via `additional_load_test_setup_configuration`) without the matching JDBC URL
-change leaves Camunda connected straight to the Cluster's `-rw` Service — the Pooler
-deploys but nothing routes through it.
+Service and appending `?prepareThreshold=0` — see `--use-pgbouncer` in
+[`../../newLoadTest.sh`](../../newLoadTest.sh), which does both at namespace scaffold time.
+Setting `postgresql.pooler.enabled` directly (e.g. via
+`additional_load_test_setup_configuration`) without the matching JDBC URL change leaves
+Camunda connected straight to the Cluster's `-rw` Service — the Pooler deploys but nothing
+routes through it.
 

--- a/load-tests/setup/charts/load-test-setup/templates/postgresql-pooler.yaml
+++ b/load-tests/setup/charts/load-test-setup/templates/postgresql-pooler.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.pooler.enabled -}}
+---
+# Configure a CNPG Pooler (PgBouncer, transaction-pooling mode) in front of the
+# PostgreSQL cluster above, so many mostly-idle client connections (one pool per
+# broker pod x physical tenant) multiplex onto a handful of real PostgreSQL
+# server connections instead of exhausting `max_connections`. See
+# `postgresql.pooler` in values.yaml for background.
+#
+# The CNPG Operator names the generated Kubernetes Service after this
+# resource's `metadata.name`; the JDBC URL in the platform values must be kept
+# in sync with it (same convention as `postgresql.clusterName` and the `-rw`
+# Service today).
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/connection_pooling
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: {{ .Values.postgresql.clusterName }}-pooler
+spec:
+  cluster:
+    name: {{ .Values.postgresql.clusterName }}
+  instances: {{ .Values.postgresql.pooler.instances }}
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      {{- toYaml .Values.postgresql.pooler.pgbouncer.parameters | nindent 6 }}
+{{- end -}}

--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -480,8 +480,8 @@ postgresql:
   # this Pooler's Service (`<clusterName>-pooler`) instead of the Cluster's `-rw`
   # Service, with `?prepareThreshold=0` appended: pgjdbc defaults to server-side
   # prepared statements after 5 uses of the same statement, which do not survive
-  # PgBouncer's transaction-mode connection swapping. The `postgres_pooler=true`
-  # Makefile variable (see `../../common.mk`) does both for you.
+  # PgBouncer's transaction-mode connection swapping. The `--use-pgbouncer` flag
+  # to `../../newLoadTest.sh` does both for you at namespace scaffold time.
   #
   # Reference: https://cloudnative-pg.io/docs/1.30/connection_pooling
   pooler:

--- a/load-tests/setup/charts/load-test-setup/values.yaml
+++ b/load-tests/setup/charts/load-test-setup/values.yaml
@@ -461,3 +461,40 @@ postgresql:
       operator: Equal
       value: n2-standard-4
       effect: NoSchedule
+
+  # -- Configure a CNPG `Pooler` (PgBouncer, transaction-pooling mode) in front of
+  # this PostgreSQL cluster. Opt-in and disabled by default: existing rdbms load
+  # tests keep connecting straight to the `-rw` Service unless this is turned on.
+  #
+  # Why: each broker pod opens one connection pool per physical tenant, so client
+  # connections to Postgres scale as (broker pods x physical tenants) and quickly
+  # exceed Postgres's default `max_connections` (a 10 brokers x 10 tenants load
+  # test produces a structural floor of ~200 mostly-idle connections). A GKE
+  # benchmark trial confirmed that routing broker traffic through PgBouncer in
+  # transaction-pooling mode collapses steady-state Postgres connections by an
+  # order of magnitude, with zero client queueing and zero connection timeouts,
+  # while Postgres stays at its default `max_connections=100`.
+  #
+  # When enabling this, also point
+  # `orchestration.data.secondaryStorage.rdbms.url` (in the platform values) at
+  # this Pooler's Service (`<clusterName>-pooler`) instead of the Cluster's `-rw`
+  # Service, with `?prepareThreshold=0` appended: pgjdbc defaults to server-side
+  # prepared statements after 5 uses of the same statement, which do not survive
+  # PgBouncer's transaction-mode connection swapping. The `postgres_pooler=true`
+  # Makefile variable (see `../../common.mk`) does both for you.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/connection_pooling
+  pooler:
+    # -- Set to true to deploy the CNPG Pooler alongside the PostgreSQL cluster above.
+    enabled: false
+
+    # -- Number of PgBouncer pod replicas.
+    instances: 1
+
+    pgbouncer:
+      # -- PgBouncer parameters passed through to the CNPG Pooler resource.
+      # `max_client_conn` is raised well above PgBouncer's default (100): every
+      # broker pod x physical tenant combination opens its own client connection,
+      # and the default is not enough headroom for this scenario's connection count.
+      parameters:
+        max_client_conn: "1000"

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -46,12 +46,6 @@ chaos ?= false
 # by REST-routing/authorization only).
 # Pass directly: make install physical_tenant_count=3 secondary_storage=postgresql
 physical_tenant_count ?= 0
-# Route Postgres traffic through a CNPG Pooler (PgBouncer, transaction-pooling mode)
-# instead of connecting straight to the Cluster's `-rw` Service. Opt-in and off by
-# default; only supported with secondary_storage=postgresql. See "Connection pooling
-# (PgBouncer)" in charts/load-test-setup/README.md for why this exists.
-# Pass directly: make install secondary_storage=postgresql postgres_pooler=true
-postgres_pooler ?= false
 # Optional: additional Helm configuration for the Camunda Platform release.
 # Use this to pass extra `--set`/`-f` flags, for example:
 #   make install additional_platform_configuration="--set zeebeGateway.env[0].name=FOO --set zeebeGateway.env[0].value=bar"
@@ -117,14 +111,6 @@ $(error physical_tenant_count > 0 is not supported for this Camunda version)
 endif
 endif
 
-# postgres_pooler=true only makes sense against the postgresql secondary storage.
-# (Nested conditionals are left-aligned: a leading tab would make `$(error ...)` look like a recipe.)
-ifeq ($(postgres_pooler),true)
-ifneq ($(secondary_storage),postgresql)
-$(error postgres_pooler=true requires secondary_storage=postgresql)
-endif
-endif
-
 # Add secondary storage values
 ifneq ($(filter $(secondary_storage),$(rdbms_storages)),)
 	platform_values += -f camunda-platform-values-rdbms.yaml
@@ -132,16 +118,6 @@ else ifeq ($(secondary_storage),none)
 	_load_test_setup_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
 endif
 platform_values += -f camunda-platform-values-$(secondary_storage).yaml
-
-# Route through the CNPG Pooler: deploy it (load-test-setup chart) and point the
-# JDBC URL at its Service instead of the Cluster's `-rw` Service, with
-# `prepareThreshold=0` — pgjdbc's server-side prepared statements (enabled by
-# default after 5 uses of the same statement) don't survive PgBouncer's
-# transaction-mode connection swapping.
-ifeq ($(postgres_pooler),true)
-	_load_test_setup_flags += --set postgresql.pooler.enabled=true
-	platform_values += --set-string 'orchestration.data.secondaryStorage.rdbms.url=jdbc:postgresql://postgresql-pooler:5432/camunda?prepareThreshold=0'
-endif
 
 # Layer the pt1..ptN physical-tenant overlay on top, generated at install/template time
 # (not scaffold time) so re-running `make install` with a different physical_tenant_count
@@ -382,12 +358,6 @@ template-load-test-setup:
 .PHONY: template-load-test-setup-chaos
 template-load-test-setup-chaos:
 	$(MAKE) template-load-test-setup chaos=true
-
-# Renders the load-test-setup chart with the Postgres CNPG Pooler enabled.
-# Requires the namespace's secondary_storage to be postgresql (see postgres_pooler above).
-.PHONY: template-load-test-setup-pooler
-template-load-test-setup-pooler:
-	$(MAKE) template-load-test-setup postgres_pooler=true
 
 # Print the resolved scenario flags without running any Helm commands
 .PHONY: print-scenario

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -46,6 +46,12 @@ chaos ?= false
 # by REST-routing/authorization only).
 # Pass directly: make install physical_tenant_count=3 secondary_storage=postgresql
 physical_tenant_count ?= 0
+# Route Postgres traffic through a CNPG Pooler (PgBouncer, transaction-pooling mode)
+# instead of connecting straight to the Cluster's `-rw` Service. Opt-in and off by
+# default; only supported with secondary_storage=postgresql. See "Connection pooling
+# (PgBouncer)" in charts/load-test-setup/README.md for why this exists.
+# Pass directly: make install secondary_storage=postgresql postgres_pooler=true
+postgres_pooler ?= false
 # Optional: additional Helm configuration for the Camunda Platform release.
 # Use this to pass extra `--set`/`-f` flags, for example:
 #   make install additional_platform_configuration="--set zeebeGateway.env[0].name=FOO --set zeebeGateway.env[0].value=bar"
@@ -111,6 +117,14 @@ $(error physical_tenant_count > 0 is not supported for this Camunda version)
 endif
 endif
 
+# postgres_pooler=true only makes sense against the postgresql secondary storage.
+# (Nested conditionals are left-aligned: a leading tab would make `$(error ...)` look like a recipe.)
+ifeq ($(postgres_pooler),true)
+ifneq ($(secondary_storage),postgresql)
+$(error postgres_pooler=true requires secondary_storage=postgresql)
+endif
+endif
+
 # Add secondary storage values
 ifneq ($(filter $(secondary_storage),$(rdbms_storages)),)
 	platform_values += -f camunda-platform-values-rdbms.yaml
@@ -118,6 +132,16 @@ else ifeq ($(secondary_storage),none)
 	_load_test_setup_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
 endif
 platform_values += -f camunda-platform-values-$(secondary_storage).yaml
+
+# Route through the CNPG Pooler: deploy it (load-test-setup chart) and point the
+# JDBC URL at its Service instead of the Cluster's `-rw` Service, with
+# `prepareThreshold=0` — pgjdbc's server-side prepared statements (enabled by
+# default after 5 uses of the same statement) don't survive PgBouncer's
+# transaction-mode connection swapping.
+ifeq ($(postgres_pooler),true)
+	_load_test_setup_flags += --set postgresql.pooler.enabled=true
+	platform_values += --set-string 'orchestration.data.secondaryStorage.rdbms.url=jdbc:postgresql://postgresql-pooler:5432/camunda?prepareThreshold=0'
+endif
 
 # Layer the pt1..ptN physical-tenant overlay on top, generated at install/template time
 # (not scaffold time) so re-running `make install` with a different physical_tenant_count
@@ -358,6 +382,12 @@ template-load-test-setup:
 .PHONY: template-load-test-setup-chaos
 template-load-test-setup-chaos:
 	$(MAKE) template-load-test-setup chaos=true
+
+# Renders the load-test-setup chart with the Postgres CNPG Pooler enabled.
+# Requires the namespace's secondary_storage to be postgresql (see postgres_pooler above).
+.PHONY: template-load-test-setup-pooler
+template-load-test-setup-pooler:
+	$(MAKE) template-load-test-setup postgres_pooler=true
 
 # Print the resolved scenario flags without running any Helm commands
 .PHONY: print-scenario

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -87,11 +87,17 @@ Arguments:
 Options:
   --target-version|-t <version>    Version-specific setup to use. Default: main.
                                     Available versions: ${AVAILABLE_VERSIONS[*]}
+  --use-pgbouncer                  Route Postgres traffic through a CNPG Pooler (PgBouncer,
+                                    transaction-pooling mode) instead of connecting straight
+                                    to the Cluster's \`-rw\` Service. Requires
+                                    secondary_storage=postgresql. See "Connection pooling
+                                    (PgBouncer)" in charts/load-test-setup/README.md.
   -h, --help                       Show this help message.
 
 Examples:
   ./newLoadTest.sh ${prefix}demo
   ./newLoadTest.sh ${prefix}perf elasticsearch 3 true
+  ./newLoadTest.sh ${prefix}perf postgresql 3 true --use-pgbouncer
 
 This script scaffolds the per-namespace folder (Makefile, values files). The
 cluster itself is unchanged by this script — the namespace and the
@@ -103,11 +109,16 @@ stays in sync with \`load-tester-values-defaults.yaml\`.
 EOF
 }
 
+use_pgbouncer=false
 remaining_args=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target-version|-t)
       shift 2
+      ;;
+    --use-pgbouncer)
+      use_pgbouncer=true
+      shift
       ;;
     -h|--help)
       usage
@@ -153,6 +164,11 @@ namespace="$(parse_namespace "${remaining_args[0]}")"
 secondary_storage="$(parse_secondary_storage "${remaining_args[1]:-elasticsearch}" "${allowed_storage[@]}")"
 ttl_days="$(parse_ttl "${remaining_args[2]:-1}")"
 enable_optimize="$(parse_bool "${remaining_args[3]:-true}")"
+
+if [[ "$use_pgbouncer" == "true" && "$secondary_storage" != "postgresql" ]]; then
+  echo "Error: --use-pgbouncer requires secondary_storage=postgresql (got: $secondary_storage)." >&2
+  exit 1
+fi
 
 # `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
 # the values files matches any re-applied manifest after TTL deletion. Every
@@ -209,6 +225,15 @@ case "$secondary_storage" in
 
     if [ "$secondary_storage" = "postgresql" ]; then
       postgresqlEnabled=true
+
+      if [[ "$use_pgbouncer" == "true" ]]; then
+        # Point the JDBC URL at the CNPG Pooler's Service instead of the Cluster's
+        # `-rw` Service, with `prepareThreshold=0` — pgjdbc's server-side prepared
+        # statements (enabled by default after 5 uses of the same statement) don't
+        # survive PgBouncer's transaction-mode connection swapping.
+        sed_inplace 's#jdbc:postgresql://postgresql-rw:5432/camunda#jdbc:postgresql://postgresql-pooler:5432/camunda?prepareThreshold=0#' \
+          "$TARGET_DIRECTORY/camunda-platform-values-postgresql.yaml"
+      fi
     fi
 
     secondary_storage_config_file="$VERSION_DIR/databases/${secondary_storage}.yaml"
@@ -354,6 +379,12 @@ EOF
 postgresql:
   enabled: $postgresqlEnabled
 EOF
+  if [[ "$use_pgbouncer" == "true" ]]; then
+    cat <<EOF
+  pooler:
+    enabled: true
+EOF
+  fi
 } > load-test-setup-values.yaml
 
 # Add/update helm repositories. Skippable via LOAD_TEST_SKIP_REPO_UPDATE for

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Celp3%HidoBiva"
+  identity-admin-client-token: "Foma6@YuryHoft"
+  identity-firstuser-password: "TojuHebdBoso8?"
+  identity-keycloak-admin-password: "Wosa6-DafeBobk"
+  identity-optimize-client-token: "Sujc8@NedeQayo"
+  identity-optimize-loadtest-client-secret: "Lice6=MojuZavu"
+  identity-postgresql-admin-password: "QexuBabbRitq7_"
+  identity-postgresql-user-password: "KagaXewa3)Rajs"
+  orchestration-security-authentication-oidc-secret: "MiqeXulo7;Dihj"

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-main-rdbms-pooler-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-main-rdbms-pooler"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "V29zYTYtRGFmZUJvYms="

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-main-rdbms-pooler
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-main-rdbms-pooler"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-main-rdbms-pooler-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-main-rdbms-pooler/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-main-rdbms-pooler-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-main-rdbms-pooler-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-main-rdbms-pooler"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-c"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-main-rdbms-pooler-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "Q2Vqakd1cm83OkRlcnA="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-main-rdbms-pooler-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-main-rdbms-pooler/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-main-rdbms-pooler"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "Q2Vqakd1cm83OkRlcnA="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "MiqeXulo7;Dihj"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-main-rdbms-pooler.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-main-rdbms-pooler"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-pooler.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-pooler.yaml
@@ -1,0 +1,27 @@
+---
+# Source: load-test-setup/templates/postgresql-pooler.yaml
+# Configure a CNPG Pooler (PgBouncer, transaction-pooling mode) in front of the
+# PostgreSQL cluster above, so many mostly-idle client connections (one pool per
+# broker pod x physical tenant) multiplex onto a handful of real PostgreSQL
+# server connections instead of exhausting `max_connections`. See
+# `postgresql.pooler` in values.yaml for background.
+#
+# The CNPG Operator names the generated Kubernetes Service after this
+# resource's `metadata.name`; the JDBC URL in the platform values must be kept
+# in sync with it (same convention as `postgresql.clusterName` and the `-rw`
+# Service today).
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/connection_pooling
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgresql-pooler
+spec:
+  cluster:
+    name: postgresql
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-pooler/load-test-setup/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+---
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  description: PostgreSQL cluster for Camunda secondary storage
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
+
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+    requests:
+      cpu: 3000m
+      memory: 8Gi
+
+  storage:
+    size: 256Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-c"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
+    # The PostgreSQL configuration flags.
+    parameters:
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
+
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Camunda to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: camunda
+      owner: camunda
+      secret:
+        name: postgresql-camunda-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Ruhe9,FedeRubx"
+  identity-admin-client-token: "TukuPeskKipi4'"
+  identity-firstuser-password: "DiviGobf8$Jago"
+  identity-keycloak-admin-password: "YezeQasbPorb5^"
+  identity-optimize-client-token: "MebnCeki7~Piyn"
+  identity-optimize-loadtest-client-secret: "LohaBifnFolv9("
+  identity-postgresql-admin-password: "FidmLoyn8(Hata"
+  identity-postgresql-user-password: "Yata9:JotoDocv"
+  orchestration-security-authentication-oidc-secret: "FidcRivoMami2$"

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-pooler-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-pooler"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "WWV6ZVFhc2JQb3JiNV4="

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-810-rdbms-pooler
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-pooler"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-810-rdbms-pooler-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-810-rdbms-pooler/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-810-rdbms-pooler-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-810-rdbms-pooler-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-810-rdbms-pooler"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-810-rdbms-pooler-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "UWl2YVdpZmUxOkZvcmE="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-810-rdbms-pooler-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-810-rdbms-pooler/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-810-rdbms-pooler"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "UWl2YVdpZmUxOkZvcmE="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "FidcRivoMami2$"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-810-rdbms-pooler.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-810-rdbms-pooler"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-pooler.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-pooler.yaml
@@ -1,0 +1,27 @@
+---
+# Source: load-test-setup/templates/postgresql-pooler.yaml
+# Configure a CNPG Pooler (PgBouncer, transaction-pooling mode) in front of the
+# PostgreSQL cluster above, so many mostly-idle client connections (one pool per
+# broker pod x physical tenant) multiplex onto a handful of real PostgreSQL
+# server connections instead of exhausting `max_connections`. See
+# `postgresql.pooler` in values.yaml for background.
+#
+# The CNPG Operator names the generated Kubernetes Service after this
+# resource's `metadata.name`; the JDBC URL in the platform values must be kept
+# in sync with it (same convention as `postgresql.clusterName` and the `-rw`
+# Service today).
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/connection_pooling
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgresql-pooler
+spec:
+  cluster:
+    name: postgresql
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-pooler/load-test-setup/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+---
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  description: PostgreSQL cluster for Camunda secondary storage
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
+
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+    requests:
+      cpu: 3000m
+      memory: 8Gi
+
+  storage:
+    size: 256Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
+    # The PostgreSQL configuration flags.
+    parameters:
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
+
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Camunda to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: camunda
+      owner: camunda
+      secret:
+        name: postgresql-camunda-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,43 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Vaga6/XogeTatz"
+  identity-admin-client-token: "ZomcKikc9.Wexe"
+  identity-firstuser-password: "WogxXubgMapi3%"
+  identity-keycloak-admin-password: "XakaQaniCajr3]"
+  identity-optimize-client-token: "ZodyMiloLemu6*"
+  identity-optimize-loadtest-client-secret: "RiqiDoslGefj1&"
+  identity-postgresql-admin-password: "MebeNono3+Bown"
+  identity-postgresql-user-password: "Curq2/WozoFaxu"
+  orchestration-security-authentication-oidc-secret: "PofpPurc8[Gaxu"

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/keycloak-user-admin.yaml
@@ -1,0 +1,20 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak-user-admin.yaml
+# This configures the "admin" credentials for Keycloak itself.
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-89-rdbms-pooler-admin"
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-89-rdbms-pooler"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "YWRtaW4="
+  password: "WGFrYVFhbmlDYWpyM10="

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/keycloak.yaml
@@ -1,0 +1,91 @@
+---
+# Source: load-test-setup/templates/keycloak/keycloak.yaml
+apiVersion: k8s.keycloak.org/v2beta1
+kind: Keycloak
+metadata:
+  namespace: keycloak-operator
+  name: c8-golden-stable-89-rdbms-pooler
+  labels:
+    # The load test namespace this Keycloak CR belongs to (the CR itself lives
+    # in the shared keycloak-operator namespace, named after it).
+    camunda.io/load-test-namespace: "c8-golden-stable-89-rdbms-pooler"
+    # Same convention/key as the load test namespace's own deadline-date label,
+    # so this CR can be found/cleaned up the same way.
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/camunda/keycloak:quay-optimized-26.6.4"
+
+  imagePullSecrets:
+    # Required if the image is stored on Harbor.
+    - name: harbor-registry
+
+  bootstrapAdmin:
+    user:
+      secret: "c8-golden-stable-89-rdbms-pooler-admin"
+
+  # Configure the access to the underlying PostgreSQL database.
+  db:
+    # The "aws-wrapper" driver should be compatible with Plain PostgreSQL.
+    url: "jdbc:aws-wrapper:postgresql://postgresql-keycloak-rw.c8-golden-stable-89-rdbms-pooler/keycloak"
+    # Configure the credentials to authenticate to PostgreSQL.
+    usernameSecret:
+      name: "c8-golden-stable-89-rdbms-pooler-postgresql"
+      key: username
+    passwordSecret:
+      name: "c8-golden-stable-89-rdbms-pooler-postgresql"
+      key: password
+
+  http:
+    httpEnabled: true
+    # Use a non-default port to avoid conflict with Zeebe Gateway on port 8080
+    # during port-forwarding.
+    httpPort: 18080
+    serviceName: "c8-golden-stable-89-rdbms-pooler"
+
+  additionalOptions:
+    - name: http-relative-path
+      value: /auth
+    - name: log-console-output
+      value: json
+    - name: log-level
+      value: info
+
+  ingress:
+    enabled: false
+
+  hostname:
+    # The hostname as exposed to UI clients when redirecting after authentication.
+    # Since the assumption is to port-forward to Keycloak and open it through
+    # localhost:18080, the hostname should be localhost here.
+    hostname: localhost
+    strict: false
+
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  scheduling:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                    - "benchmark-n2-standard-4"
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - "europe-west1-d"
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
@@ -1,0 +1,51 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# The Secret is used by:
+#
+#   1. The Keycloak deployment, to fetch the username/password to use when connecting to PostgreSQL
+#   2. The CNPG Operator to configure the password for the "keycloak" PostgreSQL role
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "postgresql-keycloak-user"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster.
+      Keycloak itself uses a Secret with duplicated values in
+      "keycloak-operator/c8-golden-stable-89-rdbms-pooler-postgresql".
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "WmlkYTckTmFjb1NlZGI="
+
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: "keycloak-operator"
+  name: "c8-golden-stable-89-rdbms-pooler-postgresql"
+  annotations:
+    description: |
+      Contains the username/password for the Keycloak user in PostgreSQL.
+      This is used by the Keycloak instance to connect into PostgreSQL.
+      This Secret is a duplicate of the Secret used to initialize the PostgreSQL cluster by the CNPG Operator in
+      "c8-golden-stable-89-rdbms-pooler/postgresql-keycloak-user".
+  labels:
+    # Same convention as the Keycloak CR's labels, so this Secret can be found
+    # and cleaned up alongside it (it lives in the shared keycloak-operator
+    # namespace, not the load test's own namespace).
+    camunda.io/load-test-namespace: "c8-golden-stable-89-rdbms-pooler"
+    deadline-date: TEST_DATE
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+type: kubernetes.io/basic-auth
+data:
+  username: "a2V5Y2xvYWs="
+  password: "WmlkYTckTmFjb1NlZGI="
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak-user.yaml
+# Configure the PostgreSQL credentials for the Keycloak application itself.

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/keycloak/postgresql-keycloak.yaml
@@ -1,0 +1,85 @@
+---
+# Source: load-test-setup/templates/keycloak/postgresql-keycloak.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Keycloak itself.
+#
+# This is **NOT** the PostgreSQL cluster used by Camunda if it's configured to
+# use PostgreSQL as a secondary storage database!
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-keycloak
+spec:
+  description: PostgreSQL cluster for Keycloak and Camunda Identity
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/ghcrio/cloudnative-pg/postgresql:18.4
+
+  resources:
+    limits:
+      cpu: 150m
+      memory: 192Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  storage:
+    size: 1Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    # The PostgreSQL configuration flags.
+    parameters:
+      lock_timeout: 30s
+      statement_timeout: "0"
+      #log_statement: all
+      #log_connections: "on"
+      #log_disconnections: "on"
+
+  # Initialize the Keycloak PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Keycloak to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: postgresql-keycloak-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "PofpPurc8[Gaxu"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://c8-golden-stable-89-rdbms-pooler.keycloak-operator.svc.cluster.local:18080/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-89-rdbms-pooler"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-pooler.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-pooler.yaml
@@ -1,0 +1,27 @@
+---
+# Source: load-test-setup/templates/postgresql-pooler.yaml
+# Configure a CNPG Pooler (PgBouncer, transaction-pooling mode) in front of the
+# PostgreSQL cluster above, so many mostly-idle client connections (one pool per
+# broker pod x physical tenant) multiplex onto a handful of real PostgreSQL
+# server connections instead of exhausting `max_connections`. See
+# `postgresql.pooler` in values.yaml for background.
+#
+# The CNPG Operator names the generated Kubernetes Service after this
+# resource's `metadata.name`; the JDBC URL in the platform values must be kept
+# in sync with it (same convention as `postgresql.clusterName` and the `-rw`
+# Service today).
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/connection_pooling
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgresql-pooler
+spec:
+  cluster:
+    name: postgresql
+  instances: 1
+  type: rw
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-user.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql-user.yaml
@@ -1,0 +1,22 @@
+---
+# Source: load-test-setup/templates/postgresql-user.yaml
+# Configure the PostgreSQL credentials for the Camunda application (secondary storage).
+# The Secret is used by:
+#
+#   1. The CNPG Operator to configure the password for the "camunda" PostgreSQL role
+#   2. Camunda itself, to connect into the PostgreSQL cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-camunda-user
+  annotations:
+    description: |
+      Contains the username/password for the Camunda user in PostgreSQL.
+      This is used by the CNPG Operator to initialize the PostgreSQL cluster
+      used for Camunda's secondary storage.
+  labels:
+    cnpg.io/reload: "true"
+type: kubernetes.io/basic-auth
+data:
+  username: "Y2FtdW5kYQ=="
+  password: "Y2FtdW5kYQ=="

--- a/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-pooler/load-test-setup/templates/postgresql.yaml
@@ -1,0 +1,106 @@
+---
+# Source: load-test-setup/templates/postgresql.yaml
+# Configure a CNPG-managed PostgreSQL cluster for Camunda secondary storage.
+#
+# Reference: https://cloudnative-pg.io/docs/1.30/cloudnative-pg.v1
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql
+spec:
+  description: PostgreSQL cluster for Camunda secondary storage
+
+  instances: 1
+  imageName: europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/postgres:18.4
+
+  resources:
+    limits:
+      cpu: 3000m
+      memory: 12Gi
+    requests:
+      cpu: 3000m
+      memory: 8Gi
+
+  storage:
+    size: 256Gi
+    storageClass: benchmark-ssd-zonal-v1
+
+  affinity:
+    nodeSelector:
+      topology.kubernetes.io/zone: "europe-west1-d"
+      component: benchmark-n2-standard-4
+
+    tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+
+  postgresql:
+    shared_preload_libraries:
+      - pg_stat_statements
+
+    # The PostgreSQL configuration flags.
+    parameters:
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_max_workers: "6"
+      autovacuum_naptime: 15s
+      autovacuum_vacuum_cost_limit: "5000"
+      autovacuum_vacuum_scale_factor: "0.03"
+      checkpoint_completion_target: "0.9"
+      checkpoint_timeout: 20min
+      effective_cache_size: 7GB
+      log_connections: "off"
+      log_disconnections: "off"
+      log_statement: none
+      maintenance_work_mem: 1GB
+      max_wal_size: 4GB
+      min_wal_size: 1GB
+      pg_stat_statements.max: "10000"
+      pg_stat_statements.track: all
+      shared_buffers: 2GB
+      track_functions: all
+      track_io_timing: "on"
+      wal_buffers: 128MB
+      wal_writer_delay: 200ms
+      wal_writer_flush_after: 1MB
+      work_mem: 32MB
+
+  postgresUID: 999
+  postgresGID: 999
+
+  # Initialize the Camunda PostgreSQL cluster with:
+  #
+  # 1. A dedicated user
+  # 2. A dedicated database, owned by the user created in 1.
+  # 3. The password comes from the specified Kubernetes Secret
+  #
+  # The dedicated user will also be used by Camunda to connect into this
+  # PostgreSQL cluster.
+  #
+  # In this cluster, this "bootstrap/initdb" method is preferred over the
+  # dedicated `Database`/`DatabaseRole` custom resources, as:
+  #
+  # 1. We only create a single database role + database ; we don't need to
+  #    manage multiple databases.
+  # 2. It's faster to provision the PostgreSQL cluster: this bootstrap method is
+  #    done very early during the cluster creation, whereas the custom resource
+  #    requires the CNPG Operator to trigger reconciliations.
+  #
+  # Reference: https://cloudnative-pg.io/docs/1.30/bootstrap#bootstrap-an-empty-cluster-initdb
+  bootstrap:
+    initdb:
+      database: camunda
+      owner: camunda
+      secret:
+        name: postgresql-camunda-user
+
+  managed:
+    services:
+      # Only deploy the (mandatory) read-write `rw` Kubernetes service. We
+      # don't have a fancy enough PostgreSQL usage to need the other services,
+      # and it simplifies the deployed resources.
+      # Cf. https://cloudnative-pg.io/docs/1.30/service_management
+      disabledDefaultServices:
+        - ro # replica nodes, only for reading
+        - r  # any PostgreSQL node, only for reading

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -58,6 +58,7 @@ type scenario struct {
 	PhysicalTenantCount int
 	PlatformOnly        bool
 	PathFilter          []string
+	UsePgbouncer        bool // scaffold with newLoadTest.sh --use-pgbouncer
 }
 
 // versionedScenario defines a scenario with a specific version
@@ -103,9 +104,11 @@ var defaultScenarios = []scenario{
 	// Makefile target, verifying opt-in chart features without duplicating the
 	// full storage matrix.
 	{Name: "chaos-killer", Storage: "elasticsearch", Optimize: false, SetupTarget: "template-load-test-setup-chaos"},
-	// The CNPG Pooler (PgBouncer) only applies to postgresql, unlike chaos-killer
-	// above, so this scaffolds with postgresql storage rather than an arbitrary one.
-	{Name: "rdbms-pooler", Storage: "postgresql", Optimize: false, SetupTarget: "template-load-test-setup-pooler"},
+	// The CNPG Pooler (PgBouncer) is baked in at scaffold time via
+	// newLoadTest.sh --use-pgbouncer (see UsePgbouncer below), and only applies
+	// to postgresql, unlike chaos-killer above, so this scaffolds with
+	// postgresql storage rather than an arbitrary one.
+	{Name: "rdbms-pooler", Storage: "postgresql", Optimize: false, SetupTarget: "template-load-test-setup", UsePgbouncer: true},
 	// physical_tenant_count=1 deploys a pt1 tenant alongside the default one, sharing the
 	// default tenant's secondary storage (table prefix for rdbms, index prefix for ES/OS,
 	// REST-routing/authorization only for none). One scenario per storage type; N>1 is
@@ -188,7 +191,11 @@ func TestGoldenFiles(t *testing.T) {
 		t.Run(namespace, func(t *testing.T) {
 			t.Parallel()
 
-			ns := Scaffold(t, s.Version, namespace, s.Storage, strconv.FormatBool(s.Optimize))
+			var extraArgs []string
+			if s.UsePgbouncer {
+				extraArgs = append(extraArgs, "--use-pgbouncer")
+			}
+			ns := Scaffold(t, s.Version, namespace, s.Storage, strconv.FormatBool(s.Optimize), extraArgs...)
 			defer ns.Cleanup()
 
 			if s.Workload != "" {

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -103,6 +103,9 @@ var defaultScenarios = []scenario{
 	// Makefile target, verifying opt-in chart features without duplicating the
 	// full storage matrix.
 	{Name: "chaos-killer", Storage: "elasticsearch", Optimize: false, SetupTarget: "template-load-test-setup-chaos"},
+	// The CNPG Pooler (PgBouncer) only applies to postgresql, unlike chaos-killer
+	// above, so this scaffolds with postgresql storage rather than an arbitrary one.
+	{Name: "rdbms-pooler", Storage: "postgresql", Optimize: false, SetupTarget: "template-load-test-setup-pooler"},
 	// physical_tenant_count=1 deploys a pt1 tenant alongside the default one, sharing the
 	// default tenant's secondary storage (table prefix for rdbms, index prefix for ES/OS,
 	// REST-routing/authorization only for none). One scenario per storage type; N>1 is

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -58,7 +58,7 @@ type scenario struct {
 	PhysicalTenantCount int
 	PlatformOnly        bool
 	PathFilter          []string
-	UsePgbouncer        bool // scaffold with newLoadTest.sh --use-pgbouncer
+	ExtraArgs           []string // extra newLoadTest.sh flags, e.g. "--use-pgbouncer"
 }
 
 // versionedScenario defines a scenario with a specific version
@@ -105,10 +105,10 @@ var defaultScenarios = []scenario{
 	// full storage matrix.
 	{Name: "chaos-killer", Storage: "elasticsearch", Optimize: false, SetupTarget: "template-load-test-setup-chaos"},
 	// The CNPG Pooler (PgBouncer) is baked in at scaffold time via
-	// newLoadTest.sh --use-pgbouncer (see UsePgbouncer below), and only applies
+	// newLoadTest.sh --use-pgbouncer (see ExtraArgs below), and only applies
 	// to postgresql, unlike chaos-killer above, so this scaffolds with
 	// postgresql storage rather than an arbitrary one.
-	{Name: "rdbms-pooler", Storage: "postgresql", Optimize: false, SetupTarget: "template-load-test-setup", UsePgbouncer: true},
+	{Name: "rdbms-pooler", Storage: "postgresql", Optimize: false, SetupTarget: "template-load-test-setup", ExtraArgs: []string{"--use-pgbouncer"}},
 	// physical_tenant_count=1 deploys a pt1 tenant alongside the default one, sharing the
 	// default tenant's secondary storage (table prefix for rdbms, index prefix for ES/OS,
 	// REST-routing/authorization only for none). One scenario per storage type; N>1 is
@@ -191,11 +191,7 @@ func TestGoldenFiles(t *testing.T) {
 		t.Run(namespace, func(t *testing.T) {
 			t.Parallel()
 
-			var extraArgs []string
-			if s.UsePgbouncer {
-				extraArgs = append(extraArgs, "--use-pgbouncer")
-			}
-			ns := Scaffold(t, s.Version, namespace, s.Storage, strconv.FormatBool(s.Optimize), extraArgs...)
+			ns := Scaffold(t, s.Version, namespace, s.Storage, strconv.FormatBool(s.Optimize), s.ExtraArgs...)
 			defer ns.Cleanup()
 
 			if s.Workload != "" {

--- a/load-tests/setup/test/scaffold.go
+++ b/load-tests/setup/test/scaffold.go
@@ -25,7 +25,7 @@ func (ns *ScaffoldedNamespace) Cleanup() {
 	_ = os.RemoveAll(ns.Dir)
 }
 
-// Scaffold runs newLoadTest.sh -t <version> <namespace> <storage> 1 <optimize>
+// Scaffold runs newLoadTest.sh -t <version> <namespace> <storage> 1 <optimize> [extraArgs...]
 // with GIT_AUTHOR=golden-test in the environment and returns a ScaffoldedNamespace.
 //
 // newLoadTest.sh reads the author label from the GIT_AUTHOR env var
@@ -38,7 +38,9 @@ func (ns *ScaffoldedNamespace) Cleanup() {
 // namespace must be unique per (version, scenario) pair to allow parallel execution.
 // storage is one of: elasticsearch, opensearch, postgresql, none.
 // optimize is "true" or "false".
-func Scaffold(t *testing.T, setupDirName, namespace, storage, optimize string) *ScaffoldedNamespace {
+// extraArgs are additional newLoadTest.sh flags (e.g. "--use-pgbouncer") for
+// scaffold-time opt-in features baked into the generated values files.
+func Scaffold(t *testing.T, setupDirName, namespace, storage, optimize string, extraArgs ...string) *ScaffoldedNamespace {
 	t.Helper()
 
 	scriptDir := filepath.Join(repoRoot(t), "load-tests", "setup")
@@ -51,7 +53,8 @@ func Scaffold(t *testing.T, setupDirName, namespace, storage, optimize string) *
 	// Clean up any leftover from a previous interrupted run.
 	_ = os.RemoveAll(namespaceDir)
 
-	cmd := exec.Command(script, "-t", setupDirName, namespace, storage, "1", optimize)
+	args := append([]string{"-t", setupDirName, namespace, storage, "1", optimize}, extraArgs...)
+	cmd := exec.Command(script, args...)
 	// newLoadTest.sh copies sibling files (Makefile, values/) with relative
 	// paths, so it must run from its own directory.
 	cmd.Dir = scriptDir


### PR DESCRIPTION
## Summary
Workaround for #61935: add opt-in PgBouncer connection pooling (via a CNPG `Pooler`) for the RDBMS/PostgreSQL load-test setup, so load tests can scale to more physical tenants and more broker nodes without hitting Postgres's connection limit.

Off by default: scaffold with `./newLoadTest.sh <namespace> postgresql 1 true --use-pgbouncer`, then `make install`.
