### PR TITLE
Feat/async replication time delay itest

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
@@ -26,7 +26,7 @@ import java.time.Duration;
 import java.util.Objects;
 import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
@@ -39,10 +39,10 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
   protected static final Duration DEFAULT_MAX_LAG = Duration.ofSeconds(3);
 
   /** The replication cluster; created by {@link #createCluster()} in {@link #beforeAll()}. */
-  protected @AutoClose R cluster;
+  protected R cluster;
 
-  protected @AutoClose TestCamundaApplication testInstance;
-  protected @AutoClose CamundaClient camundaClient;
+  protected TestCamundaApplication testInstance;
+  protected CamundaClient camundaClient;
   protected MeterRegistry meterRegistry;
 
   /**
@@ -155,6 +155,14 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
     waitForProcessesToBeDeployed(camundaClient, 1);
 
     exporterAcknowledgedAll();
+  }
+
+  @AfterAll
+  void afterAll() {
+    // preserve order, first shutdown Camunda, then the database
+    camundaClient.close();
+    testInstance.close();
+    cluster.close();
   }
 
   protected void startProcessInstances(final int count) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/TimeBasedReplicationLagIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/TimeBasedReplicationLagIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration.ReplicationType;
+import io.camunda.exporter.rdbms.replication.DefaultReplicationController;
+import io.camunda.it.rdbms.db.util.PostgresReplicationClusterContainer;
+import io.camunda.it.rdbms.db.util.ReplicationClusterContainer;
+import io.camunda.zeebe.test.util.logging.LogCapturer;
+import java.time.Duration;
+import org.apache.logging.log4j.Level;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class TimeBasedReplicationLagIT<R extends ReplicationClusterContainer>
+    extends AbstractAsyncReplicationIT<R> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TimeBasedReplicationLagIT.class);
+
+  private static final Duration MAX_LAG = Duration.ofSeconds(20);
+  private static final Duration REPLICA_DELAY_ABOVE_MAX_LAG = Duration.ofSeconds(30);
+  private static final Duration REPLICA_DELAY_BELOW_MAX_LAG = Duration.ofSeconds(15);
+  private static final int LAG_TRIGGERING_PROCESS_INSTANCES = 1;
+  private static final int BLOCKED_PROCESS_INSTANCES = 5;
+
+  private LogCapturer pauseLog;
+
+  @BeforeAll
+  void before() {
+    pauseLog = LogCapturer.capturing(DefaultReplicationController.class, Level.WARN);
+  }
+
+  @AfterAll
+  void after() {
+    pauseLog.close();
+  }
+
+  @Override
+  protected Duration getMaxLag() {
+    return MAX_LAG;
+  }
+
+  @Override
+  protected ReplicationType getReplicationType() {
+    return ReplicationType.TIME_LAG;
+  }
+
+  protected abstract void setReplicaApplyDelay(Duration delay);
+
+  protected abstract void resetReplicaApplyDelay();
+
+  @Test
+  void shouldPauseAndResumeExportingWhenReplicaLagCrossesMaxLag() {
+    // given - the time-based replication monitor allows up to 30s lag
+    exporterAcknowledgedAll();
+    LOG.info("Setting replica apply delay to {} to trigger lag", REPLICA_DELAY_ABOVE_MAX_LAG);
+    setReplicaApplyDelay(REPLICA_DELAY_ABOVE_MAX_LAG);
+
+    try {
+      final long exportedPositionBeforeLag = getCurrentExporterPosition();
+      LOG.info("Exported position before lag: {}", exportedPositionBeforeLag);
+
+      // when - a committed export is held back on the still-connected replica
+      LOG.info("Starting {} process instances to trigger lag", LAG_TRIGGERING_PROCESS_INSTANCES);
+      startProcessInstances(LAG_TRIGGERING_PROCESS_INSTANCES);
+      waitForProcessInstancesToStart(camundaClient, LAG_TRIGGERING_PROCESS_INSTANCES);
+      awaitExporterPositionAdvances(exportedPositionBeforeLag);
+      waitUntilExporterPausesOnMaxLag();
+
+      // then - once lag is above maxLag, new broker records are not exported to the DB
+      final long exportedPositionBeforeBlockedTraffic = getCurrentExporterPosition();
+      LOG.info(
+          "Exported position before blocked traffic: {}", exportedPositionBeforeBlockedTraffic);
+      LOG.info(
+          "Starting {} process instances to run against stopped exporter lag",
+          BLOCKED_PROCESS_INSTANCES);
+      startProcessInstances(BLOCKED_PROCESS_INSTANCES);
+      awaitExporterPositionStable(Duration.ofSeconds(2), Duration.ofSeconds(4));
+      assertThat(getCurrentExporterPosition()).isEqualTo(exportedPositionBeforeBlockedTraffic);
+
+      // when - the replica is still connected, but its apply delay is reduced below maxLag again
+      setReplicaApplyDelay(REPLICA_DELAY_BELOW_MAX_LAG);
+
+      // then - exporting resumes and the blocked process instances become readable from RDBMS
+      awaitExporterPositionAdvances(exportedPositionBeforeBlockedTraffic);
+      waitForProcessInstancesToStart(
+          camundaClient, LAG_TRIGGERING_PROCESS_INSTANCES + BLOCKED_PROCESS_INSTANCES);
+      exporterAcknowledgedAll();
+    } finally {
+      resetReplicaApplyDelay();
+    }
+  }
+
+  private void waitUntilExporterPausesOnMaxLag() {
+    Awaitility.await("RDBMS exporter pauses because replica lag exceeded maxLag")
+        .atMost(REPLICA_DELAY_ABOVE_MAX_LAG.plusSeconds(10))
+        .untilAsserted(
+            () -> assertThat(pauseLog.contains("[RDBMS Exporter P1] Pausing exporter")).isTrue());
+  }
+}
+
+class PostgresTimeBasedReplicationLagIT
+    extends TimeBasedReplicationLagIT<PostgresReplicationClusterContainer> {
+
+  @Override
+  protected PostgresReplicationClusterContainer createCluster() {
+    return new PostgresReplicationClusterContainer();
+  }
+
+  @Override
+  protected void setReplicaApplyDelay(final Duration delay) {
+    cluster.setReplicaApplyDelay(delay);
+  }
+
+  @Override
+  protected void resetReplicaApplyDelay() {
+    cluster.resetReplicaApplyDelay();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/PostgresReplicationClusterContainer.java
@@ -202,11 +202,44 @@ public final class PostgresReplicationClusterContainer
     LOG.info("PostgreSQL replica promoted to primary");
   }
 
+  /**
+   * Dynamically changes how long the standby waits before applying WAL commits from the primary.
+   */
+  public void setReplicaApplyDelay(final Duration delay) {
+    if (delay.isNegative()) {
+      throw new IllegalArgumentException("Replica apply delay must not be negative");
+    }
+
+    final var delayInMillis = delay.toMillis();
+    LOG.info("Setting PostgreSQL replica apply delay to {} ms", delayInMillis);
+    executeOnReplica("ALTER SYSTEM SET recovery_min_apply_delay = '%dms'".formatted(delayInMillis));
+    reloadReplicaConfiguration();
+  }
+
+  public void resetReplicaApplyDelay() {
+    LOG.info("Resetting PostgreSQL replica apply delay");
+    executeOnReplica("ALTER SYSTEM RESET recovery_min_apply_delay");
+    reloadReplicaConfiguration();
+  }
+
   private Connection replicaConnection() throws Exception {
     return DriverManager.getConnection(
         "jdbc:postgresql://%s:%d/%s".formatted(getReplicaHost(), getReplicaPort(), DATABASE_NAME),
         USERNAME,
         PASSWORD);
+  }
+
+  private void reloadReplicaConfiguration() {
+    executeOnReplica("SELECT pg_reload_conf()");
+  }
+
+  private void executeOnReplica(final String sql) {
+    try (final Connection conn = replicaConnection();
+        final Statement stmt = conn.createStatement()) {
+      stmt.execute(sql);
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to execute SQL on PostgreSQL replica: " + sql, e);
+    }
   }
 
   private void waitForReplication() {


### PR DESCRIPTION
This pull request introduces support for testing time-based replication lag handling in the RDBMS exporter, specifically for PostgreSQL. It does so by adding a new abstract test class for time-based lag, implementing control over the replica's apply delay, and ensuring proper resource cleanup in the test lifecycle.

**Time-based replication lag test support:**

* Added a new abstract test class `TimeBasedReplicationLagIT` (and concrete implementation `PostgresTimeBasedReplicationLagIT`) to verify exporter behavior when replica lag exceeds and then drops below the configured maximum lag. This includes simulating delays and checking exporter pause/resume logic.

**PostgreSQL replica control enhancements:**

* Added `setReplicaApplyDelay` and `resetReplicaApplyDelay` methods to `PostgresReplicationClusterContainer` to dynamically control and reset the replica's WAL apply delay, enabling simulation of lag scenarios.
* Introduced helper methods to execute SQL commands on the replica and reload its configuration (`executeOnReplica`, `reloadReplicaConfiguration`).

**Test resource management improvements:**

* Replaced the use of `@AutoClose` with explicit resource management and added an `@AfterAll` method in `AbstractAsyncReplicationIT` to ensure resources (`cluster`, `testInstance`, `camundaClient`) are closed in the correct order after tests. [[1]](diffhunk://#diff-bbea209f70247a6ec1a7c95657a98162bf70717cc46e31e028969d0394f0c165L42-R45) [[2]](diffhunk://#diff-bbea209f70247a6ec1a7c95657a98162bf70717cc46e31e028969d0394f0c165R160-R167) [[3]](diffhunk://#diff-bbea209f70247a6ec1a7c95657a98162bf70717cc46e31e028969d0394f0c165L29-R29)
