### PR TITLE
fix: stop physical-tenant load-test workers from leaking job streams into the default tenant

### DIFF
--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -389,14 +389,16 @@ When `physical_tenant_count > 0`, the Makefile:
   the default tenant has: `CREATE` on `RESOURCE`, `CREATE_PROCESS_INSTANCE`/`UPDATE_PROCESS_INSTANCE`/
   `READ_PROCESS_INSTANCE`/`READ_PROCESS_DEFINITION` on `PROCESS_DEFINITION`, `CREATE` on `MESSAGE`) and
   OIDC provider assignment — and layers it on top of the plain storage values.
-- Clones the generated `load-test-credentials` secret into `load-test-credentials-pt<i>` per tenant,
-  overriding only the REST address to that tenant's path `http://camunda:8080/physical-tenants/pt<i>`.
 - Renders the `starter`/`worker` from the same chart, values, scenario and **image** as the default
   tester, renames them to `starter-pt<i>`/`worker-pt<i>`, and applies them — looped over `pt1..ptN`.
-  These testers are pinned to REST (`--set global.preferRest.enabled=true`), independent of the
-  namespace default: per-tenant isolation relies on the tenant's REST base address, and the load
-  tester does not send the `Camunda-Physical-Tenant` gRPC header, so gRPC would route to the
-  default tenant.
+  Each tester shares the default tenant's `load-test-credentials` secret and gets a
+  `CAMUNDA_CLIENT_PHYSICAL_TENANT_ID=pt<i>` env var: the camunda-spring-boot-starter client turns
+  that into the `Camunda-Physical-Tenant` gRPC header (so job streams register into the tenant's
+  own partition group) and, via `prefixPhysicalTenantPath` (default `true`), the
+  `/physical-tenants/pt<i>` REST path prefix — so both gRPC and REST route correctly with no
+  per-tenant secret or address override needed. These testers still pin
+  `--set global.preferRest.enabled=true` regardless of the namespace `prefer_rest` default;
+  dropping that now-redundant override is tracked in #61463.
 
 A second Helm release per tenant is not used because the `camunda-load-tests` subchart hardcodes the
 `starter`/`worker` resource names, which would collide in the same namespace. This also means each

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -391,13 +391,8 @@ When `physical_tenant_count > 0`, the Makefile:
   OIDC provider assignment — and layers it on top of the plain storage values.
 - Renders the `starter`/`worker` from the same chart, values, scenario and **image** as the default
   tester, renames them to `starter-pt<i>`/`worker-pt<i>`, and applies them — looped over `pt1..ptN`.
-  Each tester shares the default tenant's `load-test-credentials` secret and gets a
-  `CAMUNDA_CLIENT_PHYSICAL_TENANT_ID=pt<i>` env var: the camunda-spring-boot-starter client turns
-  that into the `Camunda-Physical-Tenant` gRPC header (so job streams register into the tenant's
-  own partition group) and, via `prefixPhysicalTenantPath` (default `true`), the
-  `/physical-tenants/pt<i>` REST path prefix — so both gRPC and REST route correctly with no
-  per-tenant secret or address override needed. They honor the namespace's `prefer_rest`
-  default like every other tester, with no separate REST/gRPC pin.
+  Each tester gets a `CAMUNDA_CLIENT_PHYSICAL_TENANT_ID=pt<i>` env var, which routes both gRPC and
+  REST traffic to that tenant, so no per-tenant secret or address override is needed.
 
 A second Helm release per tenant is not used because the `camunda-load-tests` subchart hardcodes the
 `starter`/`worker` resource names, which would collide in the same namespace. This also means each

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -396,9 +396,8 @@ When `physical_tenant_count > 0`, the Makefile:
   that into the `Camunda-Physical-Tenant` gRPC header (so job streams register into the tenant's
   own partition group) and, via `prefixPhysicalTenantPath` (default `true`), the
   `/physical-tenants/pt<i>` REST path prefix — so both gRPC and REST route correctly with no
-  per-tenant secret or address override needed. These testers still pin
-  `--set global.preferRest.enabled=true` regardless of the namespace `prefer_rest` default;
-  dropping that now-redundant override is tracked in #61463.
+  per-tenant secret or address override needed. They honor the namespace's `prefer_rest`
+  default like every other tester, with no separate REST/gRPC pin.
 
 A second Helm release per tenant is not used because the `camunda-load-tests` subchart hardcodes the
 `starter`/`worker` resource names, which would collide in the same namespace. This also means each

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -273,24 +273,32 @@ ifeq ($(physical_tenants_supported),true)
 generate-physical-tenant-values:
 	../generate-physical-tenant-values.sh "$(secondary_storage)" "$(physical_tenant_count)" "$(rdbms_storages)"
 
-# Deploy pt1..ptN's own load testers, sharing the default tenant's secondary storage.
-# The camunda-load-tests subchart hardcodes the starter/worker resource names, so a second
-# Helm release per tenant would collide. Instead we render only those two templates from the
-# same chart, values, scenario and image as the default tester, rename them to *-pt<i>, and
-# apply — looped over pt1..ptN. These testers are pinned to REST
-# (--set global.preferRest.enabled=true) regardless of the namespace default: per-tenant
-# isolation is wired solely through the tenant's REST base address (the credentials clone
-# below), and the load tester never sets a physical tenant id, so it emits no
-# Camunda-Physical-Tenant gRPC header — over gRPC the requests would fall back to the
-# default tenant.
+# Deploy pt1..ptN's own load testers, sharing the default tenant's secondary storage and its
+# load-test-credentials secret. The camunda-load-tests subchart hardcodes the starter/worker
+# resource names, so a second Helm release per tenant would collide. Instead we render only
+# those two templates from the same chart, values, scenario and image as the default tester,
+# rename them to *-pt<i>, and apply — looped over pt1..ptN. Each tenant gets its own
+# CAMUNDA_CLIENT_PHYSICAL_TENANT_ID env var: the load-tester's camunda-spring-boot-starter client
+# turns that into both the `Camunda-Physical-Tenant` gRPC metadata header (so its job stream
+# registers into the tenant's own partition group instead of leaking into "default") and, via
+# prefixPhysicalTenantPath (default true), the `/physical-tenants/<tenant>` REST path prefix —
+# so both gRPC and REST route correctly without a per-tenant secret or address override.
+#
+# Still pins --set global.preferRest.enabled=true regardless of the namespace prefer_rest
+# default (see prefer_rest above) — dropping that now-redundant override is tracked in #61463.
+#
+# The extraEnvVars index below (4) is appended after the 4 entries already set in
+# global.extraEnvVars by scenarios/load-tester-values-defaults.yaml — currently
+# LOAD_TESTER_LOG_APPENDER (0), LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME (1),
+# LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION (2), OPTIMIZE_LOADTEST_CLIENT_SECRET (3).
+# Helm merges --set on a list index positionally, not by appending, so reusing an
+# already-used index (0-3) would silently overwrite one of those defaults instead of
+# adding a new entry. Bump this index if that file's global.extraEnvVars list grows.
 .PHONY: install-load-test-physical-tenants
 install-load-test-physical-tenants:
 	@for i in $$(seq 1 $(physical_tenant_count)); do \
 	  tenant="pt$$i"; \
 	  echo "Deploying the $$tenant physical-tenant load tester for namespace $(namespace)..."; \
-	  kubectl get secret load-test-credentials -n $(namespace) -o json \
-	    | jq --arg tenant "$$tenant" '.data.zeebeRestAddress = ("http://camunda:8080/physical-tenants/" + $$tenant | @base64) | .metadata.name = ("load-test-credentials-" + $$tenant) | del(.metadata.uid,.metadata.resourceVersion,.metadata.creationTimestamp,.metadata.ownerReferences,.metadata.managedFields)' \
-	    | kubectl apply -n $(namespace) -f - ; \
 	  helm template load-test-setup $(helm_chart_load_test_setup) \
 	      --namespace $(namespace) \
 	      -s charts/load-tester/templates/starter.yaml \
@@ -298,7 +306,8 @@ install-load-test-physical-tenants:
 	      $(load_test_setup_flags) \
 	      --set load-tester.enabled=true \
 	      --set global.preferRest.enabled=true \
-	      --set load-tester.saas.credentials.existingSecret=load-test-credentials-$$tenant \
+	      --set global.extraEnvVars[4].name=CAMUNDA_CLIENT_PHYSICAL_TENANT_ID \
+	      --set global.extraEnvVars[4].value=$$tenant \
 	    | sed -E "s/: starter$$/: starter-$$tenant/; s/: worker$$/: worker-$$tenant/" \
 	    | kubectl apply -n $(namespace) -f - ; \
 	done

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -293,8 +293,8 @@ install-load-test-physical-tenants:
 	      -s charts/load-tester/templates/workers.yaml \
 	      $(load_test_setup_flags) \
 	      --set load-tester.enabled=true \
-	      --set global.extraEnvVars[4].name=CAMUNDA_CLIENT_PHYSICAL_TENANT_ID \
-	      --set global.extraEnvVars[4].value=$$tenant \
+	      --set-string 'global.extraEnvVars[4].name=CAMUNDA_CLIENT_PHYSICAL_TENANT_ID' \
+	      --set-string "global.extraEnvVars[4].value=$$tenant" \
 	    | sed -E "s/: starter$$/: starter-$$tenant/; s/: worker$$/: worker-$$tenant/" \
 	    | kubectl apply -n $(namespace) -f - ; \
 	done

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -283,9 +283,8 @@ generate-physical-tenant-values:
 # registers into the tenant's own partition group instead of leaking into "default") and, via
 # prefixPhysicalTenantPath (default true), the `/physical-tenants/<tenant>` REST path prefix —
 # so both gRPC and REST route correctly without a per-tenant secret or address override.
-#
-# Still pins --set global.preferRest.enabled=true regardless of the namespace prefer_rest
-# default (see prefer_rest above) — dropping that now-redundant override is tracked in #61463.
+# Honors the namespace's prefer_rest default via $(load_test_setup_flags) like every other
+# target — no separate preferRest override needed here.
 #
 # The extraEnvVars index below (4) is appended after the 4 entries already set in
 # global.extraEnvVars by scenarios/load-tester-values-defaults.yaml — currently
@@ -305,7 +304,6 @@ install-load-test-physical-tenants:
 	      -s charts/load-tester/templates/workers.yaml \
 	      $(load_test_setup_flags) \
 	      --set load-tester.enabled=true \
-	      --set global.preferRest.enabled=true \
 	      --set global.extraEnvVars[4].name=CAMUNDA_CLIENT_PHYSICAL_TENANT_ID \
 	      --set global.extraEnvVars[4].value=$$tenant \
 	    | sed -E "s/: starter$$/: starter-$$tenant/; s/: worker$$/: worker-$$tenant/" \

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -273,26 +273,15 @@ ifeq ($(physical_tenants_supported),true)
 generate-physical-tenant-values:
 	../generate-physical-tenant-values.sh "$(secondary_storage)" "$(physical_tenant_count)" "$(rdbms_storages)"
 
-# Deploy pt1..ptN's own load testers, sharing the default tenant's secondary storage and its
-# load-test-credentials secret. The camunda-load-tests subchart hardcodes the starter/worker
-# resource names, so a second Helm release per tenant would collide. Instead we render only
-# those two templates from the same chart, values, scenario and image as the default tester,
-# rename them to *-pt<i>, and apply — looped over pt1..ptN. Each tenant gets its own
-# CAMUNDA_CLIENT_PHYSICAL_TENANT_ID env var: the load-tester's camunda-spring-boot-starter client
-# turns that into both the `Camunda-Physical-Tenant` gRPC metadata header (so its job stream
-# registers into the tenant's own partition group instead of leaking into "default") and, via
-# prefixPhysicalTenantPath (default true), the `/physical-tenants/<tenant>` REST path prefix —
-# so both gRPC and REST route correctly without a per-tenant secret or address override.
-# Honors the namespace's prefer_rest default via $(load_test_setup_flags) like every other
-# target — no separate preferRest override needed here.
+# Deploy pt1..ptN's own load testers, sharing the default tenant's secondary storage. The
+# camunda-load-tests subchart hardcodes the starter/worker resource names, so a second Helm
+# release per tenant would collide — instead render only those two templates, rename to
+# *-pt<i>, and apply, looped over pt1..ptN. Each tenant gets its own
+# CAMUNDA_CLIENT_PHYSICAL_TENANT_ID env var, which routes both gRPC and REST to that tenant.
 #
-# The extraEnvVars index below (4) is appended after the 4 entries already set in
-# global.extraEnvVars by scenarios/load-tester-values-defaults.yaml — currently
-# LOAD_TESTER_LOG_APPENDER (0), LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME (1),
-# LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION (2), OPTIMIZE_LOADTEST_CLIENT_SECRET (3).
-# Helm merges --set on a list index positionally, not by appending, so reusing an
-# already-used index (0-3) would silently overwrite one of those defaults instead of
-# adding a new entry. Bump this index if that file's global.extraEnvVars list grows.
+# extraEnvVars[4]: index 4 because scenarios/load-tester-values-defaults.yaml already sets
+# indices 0-3. Helm merges --set list indices positionally, so reusing one would silently
+# overwrite it instead of adding a new entry — bump this index if that file's list grows.
 .PHONY: install-load-test-physical-tenants
 install-load-test-physical-tenants:
 	@for i in $$(seq 1 $(physical_tenant_count)); do \


### PR DESCRIPTION
## Problem

- `install-load-test-physical-tenants` isolated each tenant only via a REST address override — it never set a physical tenant id.
- The load tester streams jobs over gRPC regardless of the REST/gRPC preference, so with no `Camunda-Physical-Tenant` header, `worker-pt<i>`'s job stream registered into the **default** partition group instead of its own.
- Result: PT job activation silently split across REST long-poll and a leaking default-tenant gRPC stream — an asymmetry that corrupts per-tenant throughput/overhead measurements.
- `install-load-test-physical-tenants` also hardcoded `--set global.preferRest.enabled=true`, ignoring the namespace's `prefer_rest` default added in #61457 — now redundant once gRPC routes correctly (tracked as follow-up #61463).

## What we did

- Set `CAMUNDA_CLIENT_PHYSICAL_TENANT_ID=pt<i>` per tenant instead of the REST-address override. The camunda-spring-boot-starter client turns this into both the `Camunda-Physical-Tenant` gRPC header and, via `prefixPhysicalTenantPath` (default `true`), the `/physical-tenants/pt<i>` REST path prefix — so the per-tenant secret clone is no longer needed.
- Dropped the hardcoded `--set global.preferRest.enabled=true` pin so PT testers honor the namespace's `prefer_rest` default like every other tester.
- Quoted the `helm --set` index args (`global.extraEnvVars[4]...`) and switched to `--set-string`, so `[`/`]` can't be misread as shell globs and the tenant id can't be coerced by Helm's YAML type inference.
- Trimmed the README/Makefile docs to match.

## Verification

- Rendered `starter-pt1`/`worker-pt1` manifests directly (no live cluster) — confirms the env var is set and no secret/address override is baked in.
- `make test PATTERN='/.*physical-tenants'` — all 8 `main`/`stable-810` physical-tenant golden scenarios pass unchanged.

## Related issues

closes #61463
