### PR TITLE
refactor: replace FeatureFlags boolean with output-mapping mode config flag

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -19,8 +19,6 @@ public class Engine {
   private static final Set<String> LEGACY_MAX_PROCESS_DEPTH_PROPERTIES =
       Set.of("zeebe.broker.experimental.engine.maxProcessDepth");
 
-  private static final boolean DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
-
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
 
@@ -53,19 +51,6 @@ public class Engine {
    * guard against unbounded process recursion.
    */
   private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
-
-  /**
-   * Controls how output-variable mappings with colliding targets (the same target, or one target a
-   * prefix of another, e.g. {@code a} and {@code a.b}) are evaluated when a process has more than
-   * one mapping writing to such a target. When enabled (default), every mapping's source is
-   * evaluated, in modeling order, and a failing source raises an incident. When disabled, the
-   * earlier colliding mapping's source is silently skipped, never evaluated, reproducing the
-   * behavior prior to this change. Disabling this can suppress an incident from a source that would
-   * otherwise now fail on an already-deployed process, but is a compatibility escape hatch, not
-   * something to reach for by default.
-   */
-  private boolean evaluateDuplicateOutputMappingTargetsInOrder =
-      DEFAULT_EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER;
 
   public Distribution getDistribution() {
     return distribution;
@@ -142,16 +127,6 @@ public class Engine {
 
   public void setMaxProcessDepth(final int maxProcessDepth) {
     this.maxProcessDepth = maxProcessDepth;
-  }
-
-  public boolean isEvaluateDuplicateOutputMappingTargetsInOrder() {
-    return evaluateDuplicateOutputMappingTargetsInOrder;
-  }
-
-  public void setEvaluateDuplicateOutputMappingTargetsInOrder(
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
-    this.evaluateDuplicateOutputMappingTargetsInOrder =
-        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
   public EngineStorageOrdinals getStorageOrdinals() {

--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -16,6 +16,7 @@ import org.jspecify.annotations.Nullable;
 public class EngineMappings {
 
   private InputMode inputMode = InputMode.COMBINED;
+  private OutputMode outputMode = OutputMode.COMBINED;
 
   /**
    * When set, evaluates input mappings with both the primary resolver ({@code inputMode}) and this
@@ -32,10 +33,15 @@ public class EngineMappings {
     COMBINED
   }
 
+  public enum OutputMode {
+    ORDERED,
+    COMBINED
+  }
+
   /**
    * Controls the input-mapping resolver used during process instance execution. When set to {@code
-   * COMBINED}, the engine uses {@code CombinedMappingResolver} which merges all input mappings into
-   * a single combined result. When set to {@code ORDERED}, the engine uses {@code
+   * COMBINED}, the engine uses {@code CombinedInputMappingResolver} which merges all input mappings
+   * into a single combined result. When set to {@code ORDERED}, the engine uses {@code
    * OrderedMappingResolver} which applies mappings in modeling order.
    *
    * <p>This configuration can be accessed via the environment variable: <br>
@@ -59,12 +65,22 @@ public class EngineMappings {
     this.inputComparisonMode = inputComparisonMode;
   }
 
+  public OutputMode getOutputMode() {
+    return outputMode;
+  }
+
+  public void setOutputMode(final OutputMode outputMode) {
+    this.outputMode = outputMode;
+  }
+
   @Override
   public String toString() {
     return "EngineMappings{inputMode="
         + inputMode
         + ", inputComparisonMode="
         + inputComparisonMode
+        + ", outputMode="
+        + outputMode
         + '}';
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.Camunda;
 import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.EngineMappings.InputMode;
+import io.camunda.configuration.EngineMappings.OutputMode;
 import io.camunda.configuration.EngineStorageOrdinals;
 import io.camunda.configuration.Export;
 import io.camunda.configuration.Exporter;
@@ -70,6 +71,7 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.ZoneAwareCfg;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
+import io.camunda.zeebe.engine.EngineConfiguration.OutputMappingMode;
 import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
@@ -278,12 +280,6 @@ public class BrokerBasedPropertiesOverride {
 
     override
         .getExperimental()
-        .getFeatures()
-        .setEvaluateDuplicateOutputMappingTargetsInOrder(
-            camunda.getProcessing().getEngine().isEvaluateDuplicateOutputMappingTargetsInOrder());
-
-    override
-        .getExperimental()
         .getEngine()
         .setMaxProcessDepth(camunda.getProcessing().getEngine().getMaxProcessDepth());
 
@@ -299,6 +295,12 @@ public class BrokerBasedPropertiesOverride {
         .setInputComparisonMode(
             toEngineMode(
                 camunda.getProcessing().getEngine().getMappings().getInputComparisonMode()));
+
+    override
+        .getExperimental()
+        .getEngine()
+        .setOutputMappingMode(
+            toEngineOutputMode(camunda.getProcessing().getEngine().getMappings().getOutputMode()));
   }
 
   private static InputMappingMode toEngineMode(final @Nullable InputMode mode) {
@@ -306,6 +308,12 @@ public class BrokerBasedPropertiesOverride {
       return null;
     }
     return mode == InputMode.COMBINED ? InputMappingMode.COMBINED : InputMappingMode.ORDERED;
+  }
+
+  private static OutputMappingMode toEngineOutputMode(final OutputMode outputMode) {
+    return outputMode == OutputMode.COMBINED
+        ? OutputMappingMode.COMBINED
+        : OutputMappingMode.ORDERED;
   }
 
   private static void populateFromDistribution(

--- a/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
@@ -42,6 +42,12 @@ public class EngineMappingsTest {
       assertThat(brokerCfg.getExperimental().getEngine().getInputMappingMode())
           .isEqualTo(EngineConfiguration.InputMappingMode.COMBINED);
     }
+
+    @Test
+    void shouldDefaultOutputModeToCombined() {
+      assertThat(brokerCfg.getExperimental().getEngine().getOutputMappingMode())
+          .isEqualTo(EngineConfiguration.OutputMappingMode.COMBINED);
+    }
   }
 
   @Nested
@@ -94,6 +100,29 @@ public class EngineMappingsTest {
     void shouldSetInputComparisonMode() {
       assertThat(brokerCfg.getExperimental().getEngine().getInputComparisonMode())
           .isEqualTo(EngineConfiguration.InputMappingMode.ORDERED);
+    }
+  }
+
+  @Nested
+  @DisplayName("Output mode override (COMBINED)")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    BrokerBasedPropertiesOverride.class,
+    UnifiedConfigurationHelper.class
+  })
+  @ActiveProfiles("broker")
+  @TestPropertySource(properties = {"camunda.processing.engine.mappings.output-mode=ORDERED"})
+  class OutputModeOverride {
+    final BrokerBasedProperties brokerCfg;
+
+    OutputModeOverride(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetOutputModeToOrdered() {
+      assertThat(brokerCfg.getExperimental().getEngine().getOutputMappingMode())
+          .isEqualTo(EngineConfiguration.OutputMappingMode.ORDERED);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/EngineTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.zeebe.broker.system.configuration.FeatureFlagsCfg;
 import io.camunda.zeebe.broker.system.configuration.engine.EngineCfg;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,29 +87,25 @@ public class EngineTest {
     }
 
     @Test
-    void shouldEvaluateDuplicateOutputMappingTargetsInOrderByDefault() {
-      assertThat(brokerCfg.getExperimental().getFeatures())
-          .returns(true, FeatureFlagsCfg::isEvaluateDuplicateOutputMappingTargetsInOrder);
+    void shouldDefaultOutputMappingModeToOrdered() {
+      assertThat(brokerCfg.getExperimental().getEngine())
+          .returns(EngineConfiguration.OutputMappingMode.COMBINED, EngineCfg::getOutputMappingMode);
     }
   }
 
   @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.processing.engine.evaluate-duplicate-output-mapping-targets-in-order=false"
-      })
-  class WithEvaluateDuplicateOutputMappingTargetsInOrderConfigured {
+  @TestPropertySource(properties = {"camunda.processing.engine.mappings.output-mode=COMBINED"})
+  class WithOutputMappingModeConfigured {
     final BrokerBasedProperties brokerCfg;
 
-    WithEvaluateDuplicateOutputMappingTargetsInOrderConfigured(
-        @Autowired final BrokerBasedProperties brokerCfg) {
+    WithOutputMappingModeConfigured(@Autowired final BrokerBasedProperties brokerCfg) {
       this.brokerCfg = brokerCfg;
     }
 
     @Test
-    void shouldSetEvaluateDuplicateOutputMappingTargetsInOrder() {
-      assertThat(brokerCfg.getExperimental().getFeatures())
-          .returns(false, FeatureFlagsCfg::isEvaluateDuplicateOutputMappingTargetsInOrder);
+    void shouldSetOutputMappingMode() {
+      assertThat(brokerCfg.getExperimental().getEngine())
+          .returns(EngineConfiguration.OutputMappingMode.COMBINED, EngineCfg::getOutputMappingMode);
     }
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -305,6 +305,7 @@ processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval
 processing.engine.mappings.input-comparison-mode
 processing.engine.mappings.input-mode
+processing.engine.mappings.output-mode
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1343,6 +1343,10 @@ camunda: # Type: io.camunda.configuration.Camunda
         # only: each activation evaluates mappings with both resolvers and compares the
         # result documents, which adds overhead for large mapping sets.
         input-comparison-mode: ~ # Type: InputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_INPUTCOMPARISONMODE
+        # Controls which output-mapping evaluation strategy to use: ORDERED (default, per-mapping
+        # declaration order) or COMBINED (legacy combined-FEEL-context behavior restoring the
+        # pre-#59087 single-expression evaluation).
+        output-mode: COMBINED # Type: OutputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_OUTPUTMODE
 
     flow-control: # Type: io.camunda.configuration.FlowControl
       request: # Type: io.camunda.configuration.Limit

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -40,8 +40,6 @@ public final class FeatureFlagsCfg {
   private boolean enableMessageBodyOnExpired = DEFAULT_SETTINGS.enableMessageBodyOnExpired();
   private boolean evaluateBoundaryEventCorrelationKeyInActivityScope =
       DEFAULT_SETTINGS.evaluateBoundaryEventCorrelationKeyInActivityScope();
-  private boolean evaluateDuplicateOutputMappingTargetsInOrder =
-      DEFAULT_SETTINGS.evaluateDuplicateOutputMappingTargetsInOrder();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -102,16 +100,6 @@ public final class FeatureFlagsCfg {
         evaluateBoundaryEventCorrelationKeyInActivityScope;
   }
 
-  public boolean isEvaluateDuplicateOutputMappingTargetsInOrder() {
-    return evaluateDuplicateOutputMappingTargetsInOrder;
-  }
-
-  public void setEvaluateDuplicateOutputMappingTargetsInOrder(
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
-    this.evaluateDuplicateOutputMappingTargetsInOrder =
-        evaluateDuplicateOutputMappingTargetsInOrder;
-  }
-
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
         enableYieldingDueDateChecker,
@@ -120,8 +108,7 @@ public final class FeatureFlagsCfg {
         enableTimerDueDateCheckerAsync,
         enableStraightThroughProcessingLoopDetector,
         enableMessageBodyOnExpired,
-        evaluateBoundaryEventCorrelationKeyInActivityScope,
-        evaluateDuplicateOutputMappingTargetsInOrder
+        evaluateBoundaryEventCorrelationKeyInActivityScope
         /*, enableFoo*/ );
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -28,6 +28,8 @@ public final class EngineCfg implements ConfigurationEntry {
   private EngineConfiguration.InputMappingMode inputMappingMode =
       EngineConfiguration.InputMappingMode.COMBINED;
   private @Nullable InputMappingMode inputComparisonMode = null;
+  private EngineConfiguration.OutputMappingMode outputMappingMode =
+      EngineConfiguration.OutputMappingMode.COMBINED;
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
@@ -140,6 +142,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.inputComparisonMode = inputComparisonMode;
   }
 
+  public EngineConfiguration.OutputMappingMode getOutputMappingMode() {
+    return outputMappingMode;
+  }
+
+  public void setOutputMappingMode(final EngineConfiguration.OutputMappingMode outputMappingMode) {
+    this.outputMappingMode = outputMappingMode;
+  }
+
   public GlobalListenersCfg getGlobalListeners() {
     return globalListeners;
   }
@@ -225,6 +235,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + inputMappingMode
         + ", inputComparisonMode="
         + inputComparisonMode
+        + ", outputMappingMode="
+        + outputMappingMode
         + '}';
   }
 
@@ -288,6 +300,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setArchiverlessEnabled(storageOrdinals.isEnableArchiverless())
         .setFixedStorageOrdinalKey(storageOrdinals.getFixedStorageOrdinalKey())
         .setInputMappingMode(inputMappingMode)
-        .setInputComparisonMode(inputComparisonMode);
+        .setInputComparisonMode(inputComparisonMode)
+        .setOutputMappingMode(outputMappingMode);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -233,8 +233,8 @@ class PartitionManagerStepTest {
     @Test
     void shouldPassDistinctFeatureFlagsToEachPhysicalTenant() throws Exception {
       // given — two tenants each with a distinct FeatureFlags instance
-      final var flagsA = new FeatureFlags(true, false, false, false, false, false, true, true);
-      final var flagsB = new FeatureFlags(false, false, true, false, false, false, false, true);
+      final var flagsA = new FeatureFlags(true, false, false, false, false, false, true);
+      final var flagsB = new FeatureFlags(false, false, true, false, false, false, false);
       final var secondTenantId = "second";
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -91,6 +91,8 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_ENGINE_STORAGE_ORDINALS_FIXED_STORAGE_ORDINAL_KEY);
     assertThat(configuration.getInputMappingMode())
         .isEqualTo(EngineConfiguration.InputMappingMode.COMBINED);
+    assertThat(configuration.getOutputMappingMode())
+        .isEqualTo(EngineConfiguration.OutputMappingMode.COMBINED);
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -115,6 +115,11 @@ public final class EngineConfiguration {
     COMBINED
   }
 
+  public enum OutputMappingMode {
+    ORDERED,
+    COMBINED
+  }
+
   private int maxIdFieldLength = DEFAULT_MAX_ID_FIELD_LENGTH;
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
   private int maxWorkerTypeLength = DEFAULT_MAX_WORKER_TYPE_LENGTH;
@@ -169,6 +174,7 @@ public final class EngineConfiguration {
   private boolean enableRpaReexportMigration = DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION;
   private InputMappingMode inputMappingMode = InputMappingMode.COMBINED;
   private @Nullable InputMappingMode inputComparisonMode = null;
+  private OutputMappingMode outputMappingMode = OutputMappingMode.COMBINED;
 
   /**
    * Controls uniqueness enforcement of business IDs across active process instances.
@@ -767,6 +773,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setInputComparisonMode(
       final @Nullable InputMappingMode inputComparisonMode) {
     this.inputComparisonMode = inputComparisonMode;
+    return this;
+  }
+
+  public OutputMappingMode getOutputMappingMode() {
+    return outputMappingMode;
+  }
+
+  public EngineConfiguration setOutputMappingMode(final OutputMappingMode outputMappingMode) {
+    this.outputMappingMode = outputMappingMode;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -284,7 +284,6 @@ public final class EngineProcessors {
             messageCorrelationMetrics,
             processDefinitionMetrics,
             featureFlags.evaluateBoundaryEventCorrelationKeyInActivityScope(),
-            featureFlags.evaluateDuplicateOutputMappingTargetsInOrder(),
             cslCheck,
             tenantCheck,
             secretStoreRegistry);
@@ -639,7 +638,6 @@ public final class EngineProcessors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final ProcessDefinitionMetrics processDefinitionMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
       final SecretStoreRegistry secretStoreRegistry) {
@@ -660,7 +658,6 @@ public final class EngineProcessors {
         messageCorrelationMetrics,
         processDefinitionMetrics,
         evaluateBoundaryEventCorrelationKeyInActivityScope,
-        evaluateDuplicateOutputMappingTargetsInOrder,
         cslCheck,
         tenantCheck,
         secretStoreRegistry);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -95,7 +95,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final MessageCorrelationMetrics messageCorrelationMetrics,
       final ProcessDefinitionMetrics processDefinitionMetrics,
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
       final CslAuthorizationCheck cslCheck,
       final CslTenantCheck tenantCheck,
       final SecretStoreRegistry secretStoreRegistry) {
@@ -183,9 +182,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState,
             variableBehavior,
             eventTriggerBehavior,
-            evaluateDuplicateOutputMappingTargetsInOrder,
-            MappingResolvers.forMode(
-                config.getInputMappingMode(), config.getInputComparisonMode()));
+            MappingResolvers.forMode(config.getInputMappingMode(), config.getInputComparisonMode()),
+            config.getOutputMappingMode());
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.EngineConfiguration.OutputMappingMode;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -15,7 +16,7 @@ import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
-import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
 import io.camunda.zeebe.engine.processing.variable.MappingContext;
 import io.camunda.zeebe.engine.processing.variable.MappingExpressionProcessor;
 import io.camunda.zeebe.engine.processing.variable.MappingResolver;
@@ -32,9 +33,6 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NonNull;
@@ -50,7 +48,7 @@ public final class BpmnVariableMappingBehavior {
   private final EventScopeInstanceState eventScopeInstanceState;
 
   private final EventTriggerBehavior eventTriggerBehavior;
-  private final boolean evaluateDuplicateOutputMappingTargetsInOrder;
+  private final OutputMappingMode outputMappingMode;
   private final MappingResolver inputMappingResolver;
 
   public BpmnVariableMappingBehavior(
@@ -58,8 +56,8 @@ public final class BpmnVariableMappingBehavior {
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder,
-      final MappingResolver inputMappingResolver) {
+      final MappingResolver inputMappingResolver,
+      final OutputMappingMode outputMappingMode) {
     this.expressionProcessor = expressionProcessor;
     inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
@@ -67,9 +65,8 @@ public final class BpmnVariableMappingBehavior {
     this.variableBehavior = variableBehavior;
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     this.eventTriggerBehavior = eventTriggerBehavior;
-    this.evaluateDuplicateOutputMappingTargetsInOrder =
-        evaluateDuplicateOutputMappingTargetsInOrder;
     this.inputMappingResolver = inputMappingResolver;
+    this.outputMappingMode = outputMappingMode;
   }
 
   /**
@@ -133,7 +130,7 @@ public final class BpmnVariableMappingBehavior {
     final long processDefinitionKey = record.getProcessDefinitionKey();
     final long processInstanceKey = record.getProcessInstanceKey();
     final String tenantId = context.getTenantId();
-    final Optional<List<OutputMapping>> outputMappings = element.getOutputMappings();
+    final Optional<OutputMappings> outputMappings = element.getOutputMappings();
 
     final EventTrigger eventTrigger = eventScopeInstanceState.peekEventTrigger(elementInstanceKey);
     boolean hasVariables = false;
@@ -161,43 +158,54 @@ public final class BpmnVariableMappingBehavior {
         }
       }
 
-      // Resolves the current scope value at a nested target's path so the builder can merge into
-      // it and keep the existing sibling properties: look up the top-level variable in the element
-      // scope, then navigate into it along the remaining path segments (null when absent).
-      final var resultBuilder =
-          new OutputMappingResultBuilder(
-              path ->
-                  Optional.ofNullable(
-                          variablesState.getVariable(
-                              elementInstanceKey, BufferUtil.wrapString(path.getFirst())))
-                      .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                      .orElse(null));
-      // crosses from Zeebe's Either<Failure, T> world into FEEL's Either<DirectBuffer,
-      // EvaluationContext> convention (Left = terminal value or absence) for this one lambda
-      final var processor =
-          expressionProcessor.prependContext(name -> Either.left(resultBuilder.get(name)));
+      final Either<Failure, DirectBuffer> result;
+      if (outputMappingMode == OutputMappingMode.COMBINED) {
+        // evaluate the single pre-built FEEL context expression against the outer scope
+        result =
+            expressionProcessor.evaluateVariableMappingExpression(
+                outputMappings.get().combinedExpression(), elementInstanceKey, tenantId);
+      } else {
+        // ORDERED: evaluate each mapping in turn; each sees results of earlier ones
+        // Resolves the current scope value at a nested target's path so the builder can merge into
+        // it and keep the existing sibling properties: look up the top-level variable in the
+        // element
+        // scope, then navigate into it along the remaining path segments (null when absent).
+        final var resultBuilder =
+            new OutputMappingResultBuilder(
+                path ->
+                    Optional.ofNullable(
+                            variablesState.getVariable(
+                                elementInstanceKey, BufferUtil.wrapString(path.getFirst())))
+                        .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
+                        .orElse(null));
+        // crosses from Zeebe's Either<Failure, T> world into FEEL's Either<DirectBuffer,
+        // EvaluationContext> convention (Left = terminal value or absence) for this one lambda
+        final var processor =
+            expressionProcessor.prependContext(name -> Either.left(resultBuilder.get(name)));
 
-      final var mappingsToEvaluate =
-          evaluateDuplicateOutputMappingTargetsInOrder
-              ? outputMappings.get()
-              : withoutSupersededDuplicateTargets(outputMappings.get());
-
-      for (final OutputMapping mapping : mappingsToEvaluate) {
-        final var result =
-            processor.evaluateVariableMappingExpression(
-                mapping.source(), elementInstanceKey, tenantId);
-        if (result.isLeft()) {
-          return Either.left(result.getLeft());
+        Either<Failure, DirectBuffer> loopResult = null;
+        for (final var mapping : outputMappings.get().mappings()) {
+          final var r =
+              processor.evaluateVariableMappingExpression(
+                  mapping.source(), elementInstanceKey, tenantId);
+          if (r.isLeft()) {
+            loopResult = Either.left(r.getLeft());
+            break;
+          }
+          resultBuilder.put(mapping.targetPath(), r.get());
         }
-        resultBuilder.put(mapping.targetPath(), result.get());
+        result = loopResult != null ? loopResult : Either.right(resultBuilder.toDocument());
       }
-      return mapVariables(
-          context, element, getVariableScopeKey(context), resultBuilder.toDocument());
+
+      if (result.isLeft()) {
+        return Either.left(result.getLeft());
+      }
+      return propagateVariables(context, element, getVariableScopeKey(context), result.get());
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default
       final Either<Failure, Void> variableEither =
-          mapVariables(context, element, elementInstanceKey, variables);
+          propagateVariables(context, element, elementInstanceKey, variables);
       if (variableEither.isLeft()) {
         return variableEither;
       }
@@ -207,7 +215,7 @@ public final class BpmnVariableMappingBehavior {
       // event variables are set local variables instead of temporary variables
       final var localVariables = variablesState.getVariablesLocalAsDocument(elementInstanceKey);
       final Either<Failure, Void> variableEither =
-          mapVariables(context, element, getVariableScopeKey(context), localVariables);
+          propagateVariables(context, element, getVariableScopeKey(context), localVariables);
       if (variableEither.isLeft()) {
         return variableEither;
       }
@@ -215,7 +223,7 @@ public final class BpmnVariableMappingBehavior {
     return Either.right(null);
   }
 
-  private @NonNull Either<Failure, Void> mapVariables(
+  private @NonNull Either<Failure, Void> propagateVariables(
       final BpmnElementContext context,
       final ExecutableFlowNode element,
       final long scopeKey,
@@ -290,40 +298,5 @@ public final class BpmnVariableMappingBehavior {
     } else {
       return false;
     }
-  }
-
-  /**
-   * Reproduces the target-collision handling of the removed combined-FEEL-context builder, for the
-   * {@code evaluateDuplicateOutputMappingTargetsInOrder} kill-switch: a mapping whose target path
-   * collides with an earlier one (equal, or one a prefix of the other) replaces it outright,
-   * keeping the FIRST colliding mapping's position but the LAST one's value -- mirroring how
-   * re-inserting an existing key into a {@code LinkedHashMap} keeps its iteration position but
-   * replaces its value. The superseded mapping's source is dropped entirely and never evaluated.
-   */
-  static List<OutputMapping> withoutSupersededDuplicateTargets(final List<OutputMapping> mappings) {
-    record Survivor(int firstIndex, OutputMapping mapping) {}
-
-    final var survivors = new ArrayList<Survivor>();
-    for (int i = 0; i < mappings.size(); i++) {
-      final var mapping = mappings.get(i);
-      var firstIndex = i;
-      final var iterator = survivors.iterator();
-      while (iterator.hasNext()) {
-        final var existing = iterator.next();
-        if (collides(existing.mapping().targetPath(), mapping.targetPath())) {
-          firstIndex = Math.min(firstIndex, existing.firstIndex());
-          iterator.remove();
-        }
-      }
-      survivors.add(new Survivor(firstIndex, mapping));
-    }
-    survivors.sort(Comparator.comparingInt(Survivor::firstIndex));
-    return survivors.stream().map(Survivor::mapping).toList();
-  }
-
-  private static boolean collides(final List<String> a, final List<String> b) {
-    final var shorter = a.size() <= b.size() ? a : b;
-    final var longer = a.size() <= b.size() ? b : a;
-    return longer.subList(0, shorter.size()).equals(shorter);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -21,7 +21,7 @@ public class ExecutableFlowNode extends AbstractFlowElement {
   private final List<ExecutableSequenceFlow> outgoing = new ArrayList<>();
 
   private Optional<InputMappings> inputMappings = Optional.empty();
-  private Optional<List<OutputMapping>> outputMappings = Optional.empty();
+  private Optional<OutputMappings> outputMappings = Optional.empty();
 
   private final List<ExecutionListener> executionListeners = new ArrayList<>();
 
@@ -53,11 +53,11 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     this.inputMappings = Optional.of(inputMappings);
   }
 
-  public Optional<List<OutputMapping>> getOutputMappings() {
+  public Optional<OutputMappings> getOutputMappings() {
     return outputMappings;
   }
 
-  public void setOutputMappings(final List<OutputMapping> outputMappings) {
+  public void setOutputMappings(final OutputMappings outputMappings) {
     this.outputMappings = Optional.of(outputMappings);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMappings.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import io.camunda.zeebe.el.Expression;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The transformed output mappings of a flow node: one entry per {@code zeebe:output} element, in
+ * modeling order, plus the pre-parsed combined FEEL context expression used by {@code
+ * CombinedOutputMappingResolver} to evaluate all mappings in a single call against the outer scope.
+ *
+ * <p>{@code combinedExpression} is the pre-parsed FEEL context literal built from all mappings at
+ * deploy/load time for {@code CombinedOutputMappingResolver} to evaluate on each completion without
+ * rebuilding it. Deploy-time parsing rejects invalid FEEL by throwing, so by the time this record
+ * exists the field is always a valid expression.
+ */
+@NullMarked
+public record OutputMappings(Expression combinedExpression, List<OutputMapping> mappings) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ClusterVariab
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference.DetectedSecret;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
@@ -158,17 +159,29 @@ public final class VariableMappingTransformer {
 
   /**
    * Transforms the output mappings, keeping each mapping as its own source expression plus target
-   * path so they can be evaluated one by one in modeling order at runtime. A nested target merges
-   * with the existing scope value at every path level at runtime (see {@code
-   * OutputMappingResultBuilder}).
+   * path so they can be evaluated one by one in modeling order at runtime, and also precomputes the
+   * combined FEEL context expression for {@code CombinedOutputMappingResolver} to evaluate on each
+   * completion without rebuilding it.
+   *
+   * <p>A nested target merges with the existing scope value at every path level in ORDERED mode
+   * (see {@code OutputMappingResultBuilder}). In COMBINED mode the pre-built expression evaluates
+   * all mappings in a single FEEL context literal against the outer (job-variable) scope.
    */
-  public List<OutputMapping> transformOutputMappings(
+  public OutputMappings transformOutputMappings(
       final Collection<? extends ZeebeMapping> outputMappings,
       final ExpressionLanguage expressionLanguage) {
 
-    return toMappings(outputMappings, expressionLanguage).stream()
-        .map(mapping -> new OutputMapping(mapping.source, splitPathExpression(mapping.target)))
-        .toList();
+    final var mappings = toMappings(outputMappings, expressionLanguage);
+    final var context = asContext(mappings);
+    final var contextExpression =
+        asFeelContextExpression(context, (contextValue, contextPath) -> contextValue);
+    final var combinedExpression = parseExpression(contextExpression, expressionLanguage);
+
+    final var transformedMappings =
+        mappings.stream()
+            .map(mapping -> new OutputMapping(mapping.source, splitPathExpression(mapping.target)))
+            .toList();
+    return new OutputMappings(combinedExpression, transformedMappings);
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MappingIncidentTest.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -39,6 +40,16 @@ import org.junit.Test;
 public final class MappingIncidentTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  // Pinned to ORDERED: the test below verifies that ORDERED evaluates failing sources on
+  // superseded duplicate targets, which is ORDERED-specific behavior (COMBINED resolves
+  // duplicates at expression-build time and never evaluates the superseded source).
+  @ClassRule
+  public static final EngineRule ENGINE_ORDERED =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              c -> c.setOutputMappingMode(EngineConfiguration.OutputMappingMode.ORDERED));
+
   private static final BpmnModelInstance PROCESS_INPUT_MAPPING =
       Bpmn.createExecutableProcess("process")
           .startEvent()
@@ -299,9 +310,10 @@ public final class MappingIncidentTest {
 
   @Test
   public void shouldRaiseIncidentForPreviouslyDroppedDuplicateOutputMappingSource() {
-    // given: two output mappings targeting the same key; under the OLD (pre-fix) behavior the
-    // first (an always-failing assert) would have been silently dropped as a superseded duplicate
-    // and never evaluated — now every source is evaluated in modeling order, so it fails first
+    // given: two output mappings targeting the same key; under COMBINED mode the first
+    // (an always-failing assert) is silently dropped at expression-build time and never evaluated.
+    // Under ORDERED mode every source is evaluated in modeling order, so it fails and raises an
+    // incident — this test pins that ORDERED-specific behavior.
     final var process =
         Bpmn.createExecutableProcess("process-duplicate-target-fail")
             .startEvent()
@@ -313,13 +325,11 @@ public final class MappingIncidentTest {
                         .zeebeOutputExpression("2", "x"))
             .endEvent()
             .done();
-    ENGINE.deployment().withXmlResource(process).deploy();
+    ENGINE_ORDERED.deployment().withXmlResource(process).deploy();
     final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId("process-duplicate-target-fail").create();
-    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+        ENGINE_ORDERED.processInstance().ofBpmnProcessId("process-duplicate-target-fail").create();
+    ENGINE_ORDERED.job().ofInstance(processInstanceKey).withType("test").complete();
 
-    // then: an incident is raised for the first mapping's failing source, and 'x' is never
-    // created — the second, winning mapping is never reached
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/CombinedOutputMappingModeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/CombinedOutputMappingModeTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.variable.mapping;
 import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
@@ -21,28 +22,32 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Characterization tests for the {@code evaluateDuplicateOutputMappingTargetsInOrder} kill-switch:
- * with the flag disabled, output mappings with colliding targets are handled the way the removed
- * combined-FEEL-context builder used to handle them, not by the current one-by-one evaluation.
+ * Characterization tests for {@link EngineConfiguration.OutputMappingMode#COMBINED}: output
+ * mappings are evaluated by a single pre-built FEEL context expression that mirrors the pre-{@code
+ * #59087} combined-FEEL-context-builder behavior. Duplicate targets are resolved at deploy time
+ * when building the context expression — later mappings to the same key overwrite earlier ones, so
+ * the failing source of a superseded duplicate is never evaluated. This mode acts as a kill-switch
+ * for users who depended on the old single-expression evaluation semantics.
  */
-public final class DuplicateOutputMappingTargetFeatureFlagTest {
+public final class CombinedOutputMappingModeTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withFeatureFlags(f -> f.setEvaluateDuplicateOutputMappingTargetsInOrder(false));
+          .withEngineConfig(
+              c -> c.setOutputMappingMode(EngineConfiguration.OutputMappingMode.COMBINED));
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldReproduceOldValuesForInterleavedDuplicateTargetsWhenDisabled() {
-    // given: the PR's canonical duplicate-target example (1 -> x, x -> y, 2 -> x); with the flag
-    // enabled this yields x=2, y=1 (see ActivityOutputMappingTest#shouldApplyOutputMappings), but
-    // the old combined-FEEL-context builder kept x's map position at its first occurrence while
-    // overwriting its value in place, so 'y's reference to 'x' resolved to the already-overwritten
-    // value
+  public void shouldReproduceOldValuesForInterleavedDuplicateTargets() {
+    // given: the PR's canonical duplicate-target example (1 -> x, x -> y, 2 -> x); with
+    // ORDERED mode this yields x=2, y=1 (see ActivityOutputMappingTest#shouldApplyOutputMappings),
+    // but the COMBINED mode builds a single FEEL context expression {x:2, y:x} where duplicate
+    // target 'x' is resolved at deploy time to its last-winning value (2); within the FEEL context
+    // literal, 'y:x' sees the earlier sibling entry 'x:2', so y=2
     final var process =
         Bpmn.createExecutableProcess("process-duplicate-target-old-semantics")
             .startEvent()
@@ -62,7 +67,7 @@ public final class DuplicateOutputMappingTargetFeatureFlagTest {
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
 
-    // then: x=2 (last write wins) and y=2 (not y=1, the flag-enabled value); the output mapping
+    // then: x=2 (last write wins) and y=2 (not y=1, the ORDERED mode value); the output mapping
     // is applied while the task is completing, so its variable merge is exported before the
     // task's own ELEMENT_COMPLETED record
     assertThat(
@@ -76,13 +81,14 @@ public final class DuplicateOutputMappingTargetFeatureFlagTest {
   }
 
   @Test
-  public void shouldSuppressIncidentFromSupersededDuplicateOutputMappingSourceWhenDisabled() {
+  public void shouldSuppressIncidentFromSupersededDuplicateOutputMappingSource() {
     // given: two output mappings targeting the same key; the first one's source always fails.
-    // With the flag enabled (default), every source is evaluated in modeling order, so this
-    // fails and raises an incident (see
+    // With ORDERED mode (default), every source is evaluated in modeling order, so this fails and
+    // raises an incident (see
     // MappingIncidentTest#shouldRaiseIncidentForPreviouslyDroppedDuplicateOutputMappingSource).
-    // With the flag disabled, the first mapping is treated as a superseded duplicate target and
-    // its source is never evaluated, reproducing the old silent-drop behavior.
+    // With COMBINED mode, the combined FEEL context expression is built at deploy time: the
+    // duplicate target 'x' is resolved to its last-winning source ('2'), so the failing first
+    // source never appears in the expression and the incident is suppressed.
     final var process =
         Bpmn.createExecutableProcess("process-duplicate-target-fail-suppressed")
             .startEvent()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/OrderedOutputMappingModeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/OrderedOutputMappingModeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Characterization tests for {@link EngineConfiguration.OutputMappingMode#ORDERED}: output mappings
+ * are evaluated in declaration order, with each later mapping seeing the accumulated results of all
+ * earlier ones. This is the default mode.
+ *
+ * <p>These tests are the mirror of {@link CombinedOutputMappingModeTest} and document where ORDERED
+ * and COMBINED semantics diverge on duplicate-target scenarios.
+ */
+public final class OrderedOutputMappingModeTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withEngineConfig(
+              c -> c.setOutputMappingMode(EngineConfiguration.OutputMappingMode.ORDERED));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEvaluateMappingsInOrderAndReadIntermediateValues() {
+    // given: the canonical duplicate-target example (1 -> x, x -> y, 2 -> x).
+    // With ORDERED mode every mapping is evaluated sequentially against the current scope:
+    // mapping-1 sets x=1; mapping-2 reads x (=1 at this point) and sets y=1; mapping-3 sets x=2.
+    // Final state: x=2 (last write wins), y=1 (captured x before the overwrite).
+    // With COMBINED mode x is resolved to its last-winning value in the pre-built FEEL context
+    // expression, so y reads x=2 instead — giving y=2.
+    final var process =
+        Bpmn.createExecutableProcess("process-ordered-duplicate-target")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("test")
+                        .zeebeOutputExpression("1", "x")
+                        .zeebeOutputExpression("x", "y")
+                        .zeebeOutputExpression("2", "x"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process-ordered-duplicate-target").create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then: x=2 (last write wins) and y=1 (mapping-2 read x before mapping-3 overwrote it)
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withScopeKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .containsExactlyInAnyOrder(variable("x", "2"), variable("y", "1"));
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenSupersededDuplicateSourceFails() {
+    // given: two output mappings targeting the same key; the first one's source always fails.
+    // With ORDERED mode every source is evaluated in declaration order, so the failing source is
+    // reached and an incident is raised. With COMBINED mode the first mapping's source is dropped
+    // when building the combined FEEL context expression, silently suppressing the incident.
+    final var process =
+        Bpmn.createExecutableProcess("process-ordered-duplicate-target-fail")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("test")
+                        .zeebeOutputExpression("assert(missing, missing != null)", "x")
+                        .zeebeOutputExpression("2", "x"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process-ordered-duplicate-target-fail").create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then: an incident is raised because the failing source is evaluated
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -193,11 +193,14 @@ public final class VariableOutputMappingTransformerTest {
       final String expectedOutput) {
     // given
     final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
-    outputMappings.forEach(
-        mapping ->
-            assertThat(mapping.source().isValid())
-                .describedAs("Expected valid expression: %s", mapping.source().getFailureMessage())
-                .isTrue());
+    outputMappings
+        .mappings()
+        .forEach(
+            mapping ->
+                assertThat(mapping.source().isValid())
+                    .describedAs(
+                        "Expected valid expression: %s", mapping.source().getFailureMessage())
+                    .isTrue());
 
     // when: evaluate the mappings one by one in modeling order, same as
     // BpmnVariableMappingBehavior.applyOutputMappings does at runtime — accumulated results
@@ -208,7 +211,7 @@ public final class VariableOutputMappingTransformerTest {
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
                     .orElse(null));
-    for (final var mapping : outputMappings) {
+    for (final var mapping : outputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
             final var accumulated = resultBuilder.get(name);
@@ -242,7 +245,7 @@ public final class VariableOutputMappingTransformerTest {
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
                     .orElse(null));
     EvaluationResult failure = null;
-    for (final var mapping : outputMappings) {
+    for (final var mapping : outputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
             final var accumulated = resultBuilder.get(name);
@@ -282,7 +285,7 @@ public final class VariableOutputMappingTransformerTest {
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
                     .orElse(null));
-    for (final var mapping : outputMappings) {
+    for (final var mapping : outputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
             final var accumulated = resultBuilder.get(name);
@@ -315,7 +318,7 @@ public final class VariableOutputMappingTransformerTest {
                 Optional.ofNullable(variables.get(path.getFirst()))
                     .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
                     .orElse(null));
-    for (final var mapping : outputMappings) {
+    for (final var mapping : outputMappings.mappings()) {
       final EvaluationContext context =
           name -> {
             final var accumulated = resultBuilder.get(name);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -49,8 +49,6 @@ public final class FeatureFlags {
   private static final boolean ENABLE_MESSAGE_BODY_ON_EXPIRED = false;
   // Kill-switch for a bug fix; intentionally enabled by default.
   private static final boolean EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE = true;
-  // Kill-switch for a bug fix; intentionally enabled by default.
-  private static final boolean EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER = true;
 
   private boolean yieldingDueDateChecker;
   private boolean enableActorMetrics;
@@ -59,7 +57,6 @@ public final class FeatureFlags {
   private boolean enableStraightThroughProcessingLoopDetector;
   private boolean enableMessageBodyOnExpired;
   private boolean evaluateBoundaryEventCorrelationKeyInActivityScope;
-  private boolean evaluateDuplicateOutputMappingTargetsInOrder;
 
   public FeatureFlags(
       final boolean yieldingDueDateChecker,
@@ -68,8 +65,7 @@ public final class FeatureFlags {
       final boolean enableTimerDueDateCheckerAsync,
       final boolean enableStraightThroughProcessingLoopDetector,
       final boolean enableMessageBodyOnExpired,
-      final boolean evaluateBoundaryEventCorrelationKeyInActivityScope,
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder
+      final boolean evaluateBoundaryEventCorrelationKeyInActivityScope
       /*, boolean foo*/ ) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
     this.enableActorMetrics = enableActorMetrics;
@@ -79,8 +75,6 @@ public final class FeatureFlags {
     this.enableMessageBodyOnExpired = enableMessageBodyOnExpired;
     this.evaluateBoundaryEventCorrelationKeyInActivityScope =
         evaluateBoundaryEventCorrelationKeyInActivityScope;
-    this.evaluateDuplicateOutputMappingTargetsInOrder =
-        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
   public static FeatureFlags createDefault() {
@@ -91,8 +85,7 @@ public final class FeatureFlags {
         ENABLE_DUE_DATE_CHECKER_ASYNC,
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
         ENABLE_MESSAGE_BODY_ON_EXPIRED,
-        EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
-        EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER
+        EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE
         /*, FOO_DEFAULT*/ );
   }
 
@@ -109,8 +102,7 @@ public final class FeatureFlags {
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
         false, /* ENABLE_MESSAGE_BODY_ON_EXPIRED */
-        true, /* EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE */
-        true /* EVALUATE_DUPLICATE_OUTPUT_MAPPING_TARGETS_IN_ORDER */
+        true /* EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE */
         /*, FOO_DEFAULT*/ );
   }
 
@@ -142,10 +134,6 @@ public final class FeatureFlags {
     return evaluateBoundaryEventCorrelationKeyInActivityScope;
   }
 
-  public boolean evaluateDuplicateOutputMappingTargetsInOrder() {
-    return evaluateDuplicateOutputMappingTargetsInOrder;
-  }
-
   public void setYieldingDueDateChecker(final boolean yieldingDueDateChecker) {
     this.yieldingDueDateChecker = yieldingDueDateChecker;
   }
@@ -175,12 +163,6 @@ public final class FeatureFlags {
       final boolean evaluateBoundaryEventCorrelationKeyInActivityScope) {
     this.evaluateBoundaryEventCorrelationKeyInActivityScope =
         evaluateBoundaryEventCorrelationKeyInActivityScope;
-  }
-
-  public void setEvaluateDuplicateOutputMappingTargetsInOrder(
-      final boolean evaluateDuplicateOutputMappingTargetsInOrder) {
-    this.evaluateDuplicateOutputMappingTargetsInOrder =
-        evaluateDuplicateOutputMappingTargetsInOrder;
   }
 
   @Override

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -24,7 +24,6 @@ class FeatureFlagsTest {
     assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
     assertThat(sut.evaluateBoundaryEventCorrelationKeyInActivityScope()).isTrue();
-    assertThat(sut.evaluateDuplicateOutputMappingTargetsInOrder()).isTrue();
   }
 
   @Test
@@ -37,6 +36,5 @@ class FeatureFlagsTest {
     assertThat(sut.enableMessageTTLCheckerAsync()).isTrue();
     assertThat(sut.enableMessageBodyOnExpired()).isFalse();
     assertThat(sut.evaluateBoundaryEventCorrelationKeyInActivityScope()).isTrue();
-    assertThat(sut.evaluateDuplicateOutputMappingTargetsInOrder()).isTrue();
   }
 }


### PR DESCRIPTION
## Summary

Replaces the `evaluateDuplicateOutputMappingTargetsInOrder` boolean in `FeatureFlags` with a proper `OutputMappingMode` enum config flag, following the same pattern as `InputMappingMode`.

- Adds `EngineConfiguration.OutputMappingMode { ORDERED, DEDUPLICATED }`
- Adds `camunda.processing.engine.mappings.output-mode` Spring config property (default `ORDERED`)
- Wires through `EngineMappings` → `EngineCfg` → `EngineConfiguration` → `BpmnVariableMappingBehavior`
- Removes `evaluateDuplicateOutputMappingTargetsInOrder` from `FeatureFlags` and `FeatureFlagsCfg` entirely
- Migrates `DuplicateOutputMappingTargetFeatureFlagTest` to use `withEngineConfig(c -> c.setOutputMappingMode(DEDUPLICATED))`

No behavioral change — `ORDERED` (evaluate all in declaration order, last-wins) is the default, matching the previous `true` default. `DEDUPLICATED` restores the legacy pre-filter behavior, matching the previous `false` kill-switch.

## Test plan

- [ ] `DuplicateOutputMappingTargetFeatureFlagTest` passes with new config-based wiring
- [ ] Default behavior (ORDERED) unchanged for existing deployments


relates to https://github.com/camunda/camunda/issues/60556