### PR TITLE
ci: retry transient errors in load-test docker image tag validation

### DIFF
--- a/.github/scripts/load-test-validate-docker-image-tags.sh
+++ b/.github/scripts/load-test-validate-docker-image-tags.sh
@@ -4,7 +4,7 @@
 # Validates that the Docker Hub image tags requested for a load test (orchestration,
 # optimize, identity, connectors) actually exist before the deploy job wastes time on
 # a namespace that can never come up. Retries transient registry errors, but fails fast
-# on a genuinely missing manifest.
+# on a genuinely missing image.
 #
 # Usage: load-test-validate-docker-image-tags.sh <orchestration-tag> <optimize-tag> <identity-tag> <connectors-tag> [enable-optimize]
 #   orchestration-tag   Docker Hub tag for camunda/camunda (empty to skip)
@@ -26,18 +26,22 @@ validate_image() {
   local max_retries=3
   local retry_delay=5
   local attempt=1
+  local manifest_output
 
   while true; do
     echo "Validating Docker image ${image} (attempt ${attempt}/${max_retries})"
-    manifest_output=$(docker manifest inspect "${image}" 2>&1 >/dev/null)
-    status=$?
 
-    if [ "${status}" -eq 0 ]; then
+    # Use the `if`-form so a non-zero `docker manifest inspect` does NOT abort the script under
+    # `set -e`: a bare `manifest_output=$(docker manifest inspect ...)` assignment inherits the
+    # command's failure status, which `set -e` treats as fatal — skipping the retry/classification
+    # below and turning every transient registry error (e.g. Docker Hub rate limiting) into a
+    # hard failure.
+    if manifest_output=$(docker manifest inspect "${image}" 2>&1 >/dev/null); then
       echo "Docker image ${image} exists"
       return 0
     fi
 
-    # Distinguish missing tag from transient errors
+    # Distinguish a genuinely missing image from transient errors, retrying only the latter.
     if echo "${manifest_output}" | grep -qiE "manifest unknown|no such manifest|not found"; then
       echo "::error::Docker image ${image} does not exist on Docker Hub"
       return 1
@@ -45,10 +49,10 @@ validate_image() {
 
     if [ "${attempt}" -ge "${max_retries}" ]; then
       echo "::error::Failed to validate Docker image ${image} after ${max_retries} attempts: ${manifest_output}"
-      return "${status}"
+      return 1
     fi
 
-    echo "Transient error (attempt ${attempt}/${max_retries}), retrying in ${retry_delay}s..."
+    echo "Transient error (attempt ${attempt}/${max_retries}), retrying in ${retry_delay}s: ${manifest_output}"
     sleep "${retry_delay}"
     attempt=$((attempt + 1))
   done


### PR DESCRIPTION
## Description

The load-test image-tag validation (`.github/scripts/load-test-validate-docker-image-tags.sh`) false-failed on `camunda/camunda:8.10-SNAPSHOT` — a tag that **does** exist — reddening the `Calculate Image Tag` step of smoke/load-test runs (e.g. https://github.com/camunda/camunda/actions/runs/33389848295/job/99481311526).

Root cause: with `set -euo pipefail`, the bare assignment `manifest_output=$(docker manifest inspect "${image}" …)` inherits the command's non-zero status, which `set -e` treats as fatal — so the script aborted on the *first* inspect failure and the code that retries transient errors / distinguishes "genuinely missing" from "transient" was dead code. Every transient registry blip (e.g. anonymous Docker Hub rate limiting on this login-less job) became a hard failure. The CI log shows exactly this: `Validating … (attempt 1/3)` then a bare `exit 1`, with no retry and no `::error::…does not exist`.

## Change

- Use the `if`-form (`if manifest_output=$(…); then`) so a non-zero inspect no longer aborts under `set -e`; transient errors now actually retry (3×) and only a genuinely missing image fast-fails.

`docker manifest inspect` is kept: no digest is passed (just a tag) and the images are Docker manifest lists (`application/vnd.docker.distribution.manifest.list.v2+json`), so the `tag@digest` drift (#58977) and OCI-index media-type issues that motivated `docker buildx imagetools inspect` elsewhere don't apply here.

## Verification

```
$ ./load-test-validate-docker-image-tags.sh 8.10-SNAPSHOT "" "" "" false
Validating Docker image camunda/camunda:8.10-SNAPSHOT (attempt 1/3)
Docker image camunda/camunda:8.10-SNAPSHOT exists            # exit 0

$ ./load-test-validate-docker-image-tags.sh definitely-no-such-tag-xyz "" "" "" false
::error::Docker image camunda/camunda:definitely-no-such-tag-xyz does not exist on Docker Hub   # exit 1, fast-fail
```

## Checklist

- [ ] ~Enable backports~ — this is a CI script fix; backport to active stable branches if their load-test/smoke workflows use the same script.

