### PR TITLE
ci: keep a raced TestRail close from failing an otherwise green run

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -280,6 +280,7 @@ jobs:
 
       - name: Publish test results to TestRail
         if: always()
+        shell: bash
         env:
           TESTRAIL_HOST: "https://camunda.testrail.com/"
           TESTRAIL_USERNAME: ${{ steps.secrets.outputs.TESTRAIL_QA_EMAIL }}
@@ -287,15 +288,30 @@ jobs:
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
           pip install trcli==1.14.1
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             --batch-size 500 \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster API Test Run Results - ${{ github.event.inputs.branch }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -272,14 +272,29 @@ jobs:
           CAMUNDA_MODE: ${{ matrix.camunda_mode }}
         run: |
           pip install trcli
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster API Test Run Results - $BRANCH (Mode $CAMUNDA_MODE) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
@@ -778,14 +793,29 @@ jobs:
           TASKLIST_MODE: ${{ matrix.tasklist_mode }}
         run: |
           pip install trcli
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster Test Run Results - $BRANCH (Mode $CAMUNDA_MODE, Tasklist $TASKLIST_MODE) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -373,15 +373,30 @@ jobs:
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
           pip install trcli==1.14.1
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             --batch-size 500 \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "Release C8 Orchestration Cluster API Test Run Results - v${{ needs.validate-release.outputs.release_version }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
@@ -1094,15 +1109,30 @@ jobs:
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
           pip install trcli==1.14.1
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             --batch-size 500 \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "Release C8 Orchestration Cluster Test Run Results - v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -298,15 +298,30 @@ jobs:
           BRANCH_NAME: ${{ inputs.branch }}
         run: |
           pip install trcli==1.14.1
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             --batch-size 500 \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME (Mode ${{ inputs.camunda_mode }}) - API tests - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - name: Sanitize branch name for artifact names
         id: sanitize

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -385,15 +385,30 @@ jobs:
           BRANCH_NAME: ${{ inputs.branch }}
         run: |
           pip install trcli==1.14.1
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             --batch-size 500 \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME (Tasklist ${{ inputs.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - name: Sanitize branch name for artifact names
         id: sanitize

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -420,15 +420,30 @@ jobs:
           DATABASE_NAME: ${{ matrix.database.database-name }}
         run: |
           pip install trcli==1.14.1
+          log=$(mktemp)
+          set +e
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
             --batch-size 500 \
+            --timeout 180 \
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME - $DATABASE_NAME (Mode ${{ inputs.camunda_mode }}) - API tests - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            -f "$JUNIT_RESULTS_FILE"
+            -f "$JUNIT_RESULTS_FILE" 2>&1 | tee "$log"
+          status=${PIPESTATUS[0]}
+          set -e
+          # trcli's --close-run is not idempotent: past its client timeout it retries
+          # silently and TestRail rejects the retry because the first close landed.
+          # Requiring the Done line means a mid-upload rejection still fails the step.
+          if [ "$status" -ne 0 ] &&
+            grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
+            grep -qF 'The test run is already completed' "$log"; then
+            echo "::warning::TestRail close raced its own retry; all results were uploaded"
+            exit 0
+          fi
+          exit "$status"
 
       - name: Upload json report to GitHub Actions Artifacts
         if: always()


### PR DESCRIPTION
## Description

Run [33350627410](https://github.com/camunda/camunda/actions/runs/33350627410) (C8 Orchestration Cluster Nightly 8.10 - API Tests (RDBMS)) went red on `Publish test results to TestRail` in two of thirty matrix cells. Every test passed and all 1198 results reached TestRail. Only the close call failed:

```
Adding results: 1198/1198, Done.
No attachments found to upload.
                                  <- 61 seconds of silence
This operation is not allowed. The test run is already completed.
##[error]Process completed with exit code 1.
```

TestRail runs [158239](https://camunda.testrail.com/index.php?/runs/view/158239) and [158236](https://camunda.testrail.com/index.php?/runs/view/158236) were created and fully populated.

### Root cause

`trcli --close-run` is not idempotent. The 61-second gap is trcli's 60s default per-call timeout (`DEFAULT_API_CALL_TIMEOUT` in [trcli/settings.py](https://github.com/gurock/trcli/blob/main/trcli/settings.py)): the `close_run` POST exceeded it, the retry loop in `trcli/api/api_client.py` caught the `Timeout` and silently `continue`d (no log line, hence the blank gap), and TestRail rejected the retry with a 400 because the first close had already landed server-side. trcli treats that 400 as fatal.

TestRail is slow enough for this to happen because the whole matrix publishes at once. In this run, `Creating test run` alone took 114 seconds, well past the 60s the client was willing to wait.

Intermittent, not new: run 32923232738 (2026-08-26) hit the same step in one cell.

### Change

Each of the eight `trcli` call sites gains `--timeout 180` and a guard:

```bash
if [ "$status" -ne 0 ] &&
  grep -qE 'Adding results: [0-9]+/[0-9]+, Done\.' "$log" &&
  grep -qF 'The test run is already completed' "$log"; then
  echo "::warning::TestRail close raced its own retry; all results were uploaded"
  exit 0
fi
exit "$status"
```

**Both greps must match, and that is the whole safety property.** The second alone would be dangerous: an `already completed` seen while results were still uploading means those results never landed, and the step must stay red. Requiring the `Done.` line narrows the forgiven case to a close that raced after a complete upload. Everything else falls through to `exit "$status"` unchanged. No `continue-on-error`, no disabled assertions, no weakened checks.

`tee` keeps trcli's progress live in the job log, and `${PIPESTATUS[0]}` recovers trcli's own exit code past the pipe.

### Why the guard is repeated inline

An earlier revision of this PR extracted the invocation into `.github/scripts/publish-testrail-results.sh` with bats coverage. That failed with exit 127 in [an on-demand run](https://github.com/camunda/camunda/actions/runs/33395370584/job/99498972450), because **these workflows check out a ref that is not their own**:

| Workflow | Checks out |
|---|---|
| the three `reusable-*` workflows | `${{ inputs.branch }}` (`stable/8.10` for the 8.10 nightly) |
| the two on-demand workflows | a user-supplied branch |
| `e2e-tests-release` | an already-cut tag |

GitHub reads the workflow YAML from the dispatched ref, but the working tree comes from the checkout, so anything addressed by repo-relative path resolves only if it exists on the *target* ref. `JUNIT_RESULTS_FILE` works because `qa/...` exists there; a new script does not. Merging that revision would have taken the 8.10 nightly from intermittently red on 2 of 30 cells to red on all 30 cells nightly. A local composite action (`uses: ./.github/actions/...`) resolves from `$GITHUB_WORKSPACE` and would fail identically.

The workflow YAML is the only place read from the workflow's own ref, which is why the existing code inlines trcli and why this change stays inline.

**Reviewer note:** inlining means the guard has no automated test. The two-grep condition above is the thing to read carefully, particularly that dropping the `Done.` check would turn this into failure masking.

### Verification

- All eight rewritten `run:` blocks pass `bash -n` and are `shellcheck` clean (GHA expressions substituted with a placeholder).
- Each of the eight blocks replayed against a stubbed `trcli` across four scenarios, all correct:
  - the real Postgres 15 output from run 33350627410 (upload complete, close raced) → exit 0 with the warning
  - `already completed` with no `Done.` line (mid-upload) → exit 1
  - an unrelated auth failure after a complete upload → exit 1
  - plain success → exit 0
- `actionlint` over the six changed workflows: 4 findings before, 4 after, none introduced (all pre-existing).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Nightly run: https://github.com/camunda/camunda/actions/runs/33350627410

On demand after improvement [here](https://github.com/camunda/camunda/actions/runs/33398699026/job/99509935993)

Nightly after fix [here](https://github.com/camunda/camunda/actions/runs/33400858071)
