### PR TITLE
refactor: add jspecify nullness annotations to zeebe-db

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a column family, where it is possible to store keys of type {@link KeyType} and
@@ -45,7 +46,7 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
    * @param key the key
    * @return if the key was found in the column family then the value, otherwise null
    */
-  ValueType get(KeyType key);
+  @Nullable ValueType get(KeyType key);
 
   /**
    * Returns the corresponding stored value in the column family to the given key. Returns null if
@@ -55,7 +56,7 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
    *
    * <p>Use this method if you would otherwise immediately copy the returned value.
    */
-  ValueType get(KeyType key, Supplier<ValueType> valueSupplier);
+  @Nullable ValueType get(KeyType key, Supplier<ValueType> valueSupplier);
 
   /**
    * Visits the values, which are stored in the column family. The ordering depends on the key.

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -93,7 +93,7 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
    * @param startAtKey indicates on which key the iteration should start
    * @param visitor the visitor which visits the key-value pairs
    */
-  void whileTrue(KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
+  void whileTrue(@Nullable KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
 
   /**
    * Visits the key-value pairs, which are stored in the column family. The ordering depends on the
@@ -149,7 +149,9 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
    * @param visitor the visitor which visits the key-value pairs
    */
   void whileEqualPrefix(
-      DbKey keyPrefix, KeyType startAtKey, KeyValuePairVisitor<KeyType, ValueType> visitor);
+      DbKey keyPrefix,
+      @Nullable KeyType startAtKey,
+      KeyValuePairVisitor<KeyType, ValueType> visitor);
 
   /**
    * Visits the key-value pairs in reverse order, which are stored in the column family. The visitor

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.db.impl;
 
 import static io.camunda.zeebe.db.ColumnFamilyMetricsDoc.*;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.db.ColumnFamilyMetrics;
 import io.camunda.zeebe.protocol.EnumValue;
@@ -15,7 +16,6 @@ import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.util.Objects;
 
 public final class FineGrainedColumnFamilyMetrics implements ColumnFamilyMetrics {
 
@@ -28,7 +28,7 @@ public final class FineGrainedColumnFamilyMetrics implements ColumnFamilyMetrics
   public <ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue>
       FineGrainedColumnFamilyMetrics(
           final ColumnFamilyNames columnFamily, final MeterRegistry registry) {
-    this.registry = Objects.requireNonNull(registry, "registry cannot be null");
+    this.registry = requireNonNull(registry, "registry cannot be null");
     final var columnFamilyLabel = columnFamily.name();
     get = createTimer(columnFamilyLabel, OperationType.GET);
     put = createTimer(columnFamilyLabel, OperationType.PUT);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/package-info.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.db.impl;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbOptionsFormatter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDbOptionsFormatter.java
@@ -14,6 +14,7 @@ import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import jnr.ffi.annotations.In;
 import jnr.ffi.annotations.Out;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,8 +92,8 @@ final class RocksDbOptionsFormatter {
    * class would throw {@link NoClassDefFoundError}.
    */
   private static final class Holder {
-    private static final LibC LIB_C;
-    private static final Runtime RUNTIME;
+    private static final @Nullable LibC LIB_C;
+    private static final @Nullable Runtime RUNTIME;
 
     static {
       LibC libC = null;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.db.impl.rocksdb;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -25,7 +27,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Supplier;
 import org.agrona.CloseHelper;
@@ -73,11 +74,11 @@ public final class ZeebeRocksDbFactory<
       final AccessMetricsConfiguration metricsConfiguration,
       final Supplier<MeterRegistry> meterRegistryFactory,
       final RocksDbResources rocksDbResources) {
-    this.rocksDbConfiguration = Objects.requireNonNull(rocksDbConfiguration);
-    this.consistencyChecksSettings = Objects.requireNonNull(consistencyChecksSettings);
+    this.rocksDbConfiguration = requireNonNull(rocksDbConfiguration);
+    this.consistencyChecksSettings = requireNonNull(consistencyChecksSettings);
     metrics = metricsConfiguration;
-    this.meterRegistryFactory = Objects.requireNonNull(meterRegistryFactory);
-    this.rocksDbResources = Objects.requireNonNull(rocksDbResources);
+    this.meterRegistryFactory = requireNonNull(meterRegistryFactory);
+    this.rocksDbResources = requireNonNull(rocksDbResources);
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/package-info.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/metrics/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.db.impl.rocksdb.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/package-info.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
@@ -17,6 +17,7 @@ import java.util.function.ObjIntConsumer;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class ColumnFamilyContext {
 
@@ -64,7 +65,7 @@ public class ColumnFamilyContext {
     return valueBuffer.byteArray();
   }
 
-  public void wrapKeyView(final byte[] key) {
+  public void wrapKeyView(final byte @Nullable [] key) {
     if (key != null) {
       // wrap without the column family key
       keyViewBuffer.wrap(key, Long.BYTES, key.length - Long.BYTES);
@@ -73,7 +74,7 @@ public class ColumnFamilyContext {
     }
   }
 
-  public DirectBuffer getKeyView() {
+  public @Nullable DirectBuffer getKeyView() {
     return isKeyViewEmpty() ? null : keyViewBuffer;
   }
 
@@ -81,7 +82,7 @@ public class ColumnFamilyContext {
     return keyViewBuffer.capacity() == ZERO_SIZE_ARRAY.length;
   }
 
-  public void wrapValueView(final byte[] value) {
+  public void wrapValueView(final byte @Nullable [] value) {
     if (value != null) {
       valueViewBuffer.wrap(value);
     } else {
@@ -89,7 +90,7 @@ public class ColumnFamilyContext {
     }
   }
 
-  public DirectBuffer getValueView() {
+  public @Nullable DirectBuffer getValueView() {
     return isValueViewEmpty() ? null : valueViewBuffer;
   }
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.impl.DbBytes;
 import io.camunda.zeebe.db.impl.rocksdb.DbNullKey;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksIterator;
 import org.slf4j.Logger;
@@ -97,8 +98,8 @@ public class RawTransactionalColumnFamily {
         });
   }
 
-  public byte[] get(final ZeebeTransaction transaction, final byte[] key, final int keyLen)
-      throws Exception {
+  public byte @Nullable [] get(
+      final ZeebeTransaction transaction, final byte[] key, final int keyLen) throws Exception {
     return transaction.get(
         transactionDb.getDefaultNativeHandle(),
         transactionDb.getReadOptionsNativeHandle(),

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RocksDbInternal.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RocksDbInternal.java
@@ -32,24 +32,28 @@ public final class RocksDbInternal {
   static final EnumSet<Code> RECOVERABLE_ERROR_CODES =
       EnumSet.of(Ok, Aborted, Expired, IOError, Busy, TimedOut, TryAgain, MergeInProgress);
 
+  @SuppressWarnings("NullAway.Init")
   static Field nativeHandle;
 
   /**
    * WriteBatchWithIndex.put(long handle, byte[] key, int keyLength, byte[] value, int valueLength,
    * long cfHandle) — package-private final method, no offset params.
    */
+  @SuppressWarnings("NullAway.Init")
   static MethodHandle putWithHandle;
 
   /**
    * WriteBatchWithIndex.getFromBatchAndDB(long handle, long dbHandle, long readOptionsHandle,
    * byte[] key, int keyLength, long cfHandle) — private static native, no offset param.
    */
+  @SuppressWarnings("NullAway.Init")
   static MethodHandle getWithHandle;
 
   /**
    * WriteBatchWithIndex.delete(long handle, byte[] key, int keyLength, long cfHandle) —
    * package-private final method, no offset param.
    */
+  @SuppressWarnings("NullAway.Init")
   static MethodHandle removeWithHandle;
 
   static {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.db.impl.rocksdb.transaction;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.startsWith;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.ColumnFamilyMetrics;
@@ -467,8 +468,8 @@ class TransactionalColumnFamily<
       final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     try (final var timer = metrics.measureIterateLatency()) {
       final var seekTarget = Objects.requireNonNullElse(startAt, prefix);
-      Objects.requireNonNull(prefix);
-      Objects.requireNonNull(visitor);
+      requireNonNull(prefix);
+      requireNonNull(visitor);
 
       /*
        * NOTE: it doesn't seem possible in Java RocksDB to set a flexible prefix extractor on
@@ -516,9 +517,9 @@ class TransactionalColumnFamily<
       final DbKey prefix,
       final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     try (final var timer = metrics.measureIterateLatency()) {
-      Objects.requireNonNull(startAt);
-      Objects.requireNonNull(prefix);
-      Objects.requireNonNull(visitor);
+      requireNonNull(startAt);
+      requireNonNull(prefix);
+      requireNonNull(visitor);
 
       columnFamilyContext.withPrefixKey(
           prefix,
@@ -556,7 +557,7 @@ class TransactionalColumnFamily<
    *     the given startAt.
    */
   private long countEachInPrefix(final DbKey prefix) {
-    final var seekTarget = Objects.requireNonNull(prefix);
+    final var seekTarget = requireNonNull(prefix);
 
     final var count = new MutableLong(0);
 
@@ -617,8 +618,8 @@ class TransactionalColumnFamily<
       final DbKey startAt, final DbKey prefix, final KeyVisitor<KeyType> visitor) {
     try (final var timer = metrics.measureIterateLatency()) {
       final var seekTarget = Objects.requireNonNullElse(startAt, prefix);
-      Objects.requireNonNull(prefix);
-      Objects.requireNonNull(visitor);
+      requireNonNull(prefix);
+      requireNonNull(visitor);
 
       columnFamilyContext.withPrefixKey(
           prefix,
@@ -655,9 +656,9 @@ class TransactionalColumnFamily<
   private void forEachKeyInPrefixReverse(
       final DbKey startAt, final DbKey prefix, final KeyVisitor<KeyType> visitor) {
     try (final var timer = metrics.measureIterateLatency()) {
-      Objects.requireNonNull(startAt);
-      Objects.requireNonNull(prefix);
-      Objects.requireNonNull(visitor);
+      requireNonNull(startAt);
+      requireNonNull(prefix);
+      requireNonNull(visitor);
 
       columnFamilyContext.withPrefixKey(
           prefix,

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -29,10 +29,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableLong;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksIterator;
 
@@ -142,12 +142,12 @@ class TransactionalColumnFamily<
   }
 
   @Override
-  public ValueType get(final KeyType key) {
+  public @Nullable ValueType get(final KeyType key) {
     try (final var timer = metrics.measureGetLatency()) {
       ensureInOpenTransaction(
           transaction -> {
             columnFamilyContext.writeKey(key);
-            final byte[] value =
+            final var value =
                 transaction.get(
                     transactionDb.getDefaultNativeHandle(),
                     transactionDb.getReadOptionsNativeHandle(),
@@ -165,13 +165,13 @@ class TransactionalColumnFamily<
   }
 
   @Override
-  public ValueType get(final KeyType key, final Supplier<ValueType> valueSupplier) {
+  public @Nullable ValueType get(final KeyType key, final Supplier<ValueType> valueSupplier) {
     final var result = new MutableReference<ValueType>();
     try (final var timer = metrics.measureGetLatency()) {
       ensureInOpenTransaction(
           transaction -> {
             columnFamilyContext.writeKey(key);
-            final byte[] valueBytes =
+            final var valueBytes =
                 transaction.get(
                     transactionDb.getDefaultNativeHandle(),
                     transactionDb.getReadOptionsNativeHandle(),
@@ -345,7 +345,7 @@ class TransactionalColumnFamily<
       ensureInOpenTransaction(
           transaction -> {
             columnFamilyContext.writeKey(key);
-            final byte[] value =
+            final var value =
                 transaction.get(
                     transactionDb.getDefaultNativeHandle(),
                     transactionDb.getReadOptionsNativeHandle(),
@@ -689,7 +689,7 @@ class TransactionalColumnFamily<
       final KeyType keyInstance, final KeyVisitor<KeyType> visitor, final byte[] keyBytes) {
     columnFamilyContext.wrapKeyView(keyBytes);
 
-    final DirectBuffer keyViewBuffer = columnFamilyContext.getKeyView();
+    final var keyViewBuffer = requireNonNull(columnFamilyContext.getKeyView());
     keyInstance.wrap(keyViewBuffer, 0, keyViewBuffer.capacity());
 
     return visitor.visit(keyInstance);
@@ -705,9 +705,9 @@ class TransactionalColumnFamily<
     columnFamilyContext.wrapKeyView(keyBytes);
     columnFamilyContext.wrapValueView(iterator.value());
 
-    final DirectBuffer keyViewBuffer = columnFamilyContext.getKeyView();
+    final var keyViewBuffer = requireNonNull(columnFamilyContext.getKeyView());
     keyInstance.wrap(keyViewBuffer, 0, keyViewBuffer.capacity());
-    final DirectBuffer valueViewBuffer = columnFamilyContext.getValueView();
+    final var valueViewBuffer = requireNonNull(columnFamilyContext.getValueView());
     valueInstance.wrap(valueViewBuffer, 0, valueViewBuffer.capacity());
 
     return iteratorConsumer.visit(keyInstance, valueInstance);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -213,7 +213,7 @@ class TransactionalColumnFamily<
 
   @Override
   public void whileTrue(
-      final KeyType startAtKey, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
+      final @Nullable KeyType startAtKey, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     ensureInOpenTransaction(transaction -> forEachInPrefix(startAtKey, new DbNullKey(), visitor));
   }
 
@@ -244,7 +244,7 @@ class TransactionalColumnFamily<
   @Override
   public void whileEqualPrefix(
       final DbKey keyPrefix,
-      final KeyType startAtKey,
+      final @Nullable KeyType startAtKey,
       final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     ensureInOpenTransaction(transaction -> forEachInPrefix(startAtKey, keyPrefix, visitor));
   }
@@ -463,7 +463,7 @@ class TransactionalColumnFamily<
    *     indicate whether iteration should continue or not, see {@link KeyValuePairVisitor}.
    */
   private void forEachInPrefix(
-      final DbKey startAt,
+      final @Nullable DbKey startAt,
       final DbKey prefix,
       final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     try (final var timer = metrics.measureIterateLatency()) {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.TransactionOperation;
 import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import org.agrona.LangUtil;
+import org.jspecify.annotations.Nullable;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
@@ -66,7 +67,7 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
     }
   }
 
-  public byte[] get(
+  public byte @Nullable [] get(
       final long columnFamilyHandle,
       final long readOptionsHandle,
       final byte[] key,

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/package-info.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.db.impl.rocksdb.transaction;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/package-info.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.db;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Description
Marks zeebe-db's packages are `@NullMarked` and adds `@Nullable` annotatiosn where required

Note: RocksDB library is not null marked, so we have no nullness annotation coming from it. 
For how it's set up nullaway right now, it treats everything as non null. 
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53269
