### PR TITLE
fix: move optimize 8.7 off Spring Framework 6.2.19 to clear CVE-2026-47884

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -54,7 +54,9 @@
     <spring.boot.version>3.5.15</spring.boot.version>
     <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
     <opentelemetry.version>1.62.0</opentelemetry.version>
-    <spring.version>6.2.19</spring.version>
+    <!-- 6.2.20+ (fixing CVE-2026-47884) ships only on the Spring Enterprise line, as OSS 6.2 is
+         capped at 6.2.19. This overrides Spring Boot's managed version for the Optimize build. -->
+    <spring.version>6.2.19-spring-framework-6.2.21</spring.version>
     <spring.security.version>6.5.11</spring.security.version>
     <version.tomcat>10.1.56</version.tomcat>
     <httpclient.version>4.5.14</httpclient.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,9 @@
     <version.feel-scala>1.18.0</version.feel-scala>
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>
-    <version.spring>6.2.19</version.spring>
+    <!--  OSS Spring Framework 6.2 is capped at 6.2.19; 6.2.20+ (fixing CVE-2026-47884) ships
+          only via the Spring Enterprise line, mirroring stable/8.7.  -->
+    <version.spring>6.2.19-spring-framework-6.2.21</version.spring>
     <version.spring-security>6.5.11</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>


### PR DESCRIPTION
## What

Bumps `<version.spring>` on `stable/optimize-8.7` from OSS `6.2.19` to the Spring Enterprise coordinate `6.2.19-spring-framework-6.2.21`, matching what `stable/8.7` already ships (#61410).

## Why

**CVE-2026-47884** (Critical) affects Spring Framework `6.2.0 – 6.2.19`. `stable/optimize-8.7` was pinned to OSS `6.2.19`, inside that range, so version-string scanners flag it.

### Reachability — `not_affected` (`vulnerable_code_not_in_execute_path`)

The CVE is an SSRF/RCE via `XsltView`, triggered only when a Spring MVC app has a `/**` mapping that renders a view whose name is **not** explicitly specified. Optimize does not meet those preconditions:

- No `XsltView` / `XsltViewResolver`, no `ContentNegotiatingViewResolver`, no `RequestToViewNameTranslator`.
- All `/**` occurrences are Spring **Security** authorization matchers, not MVC view-rendering mappings.
- Static content is written directly to the servlet response; the welcome page uses an explicit `forward:index.html`.

So this is scanner-noise remediation (dependency hygiene), not an exploitable-path fix.

### Version choice

OSS Spring Framework 6.2 is capped at `6.2.19`; `6.2.20+` (which fixes this CVE) ships only on the Spring Enterprise line, resolved from Camunda's private CPM Artifactory. This mirrors `stable/8.7` (#61410).

## Validation

⚠️ The enterprise BOM cannot be resolved without CPM credentials locally (`spring-framework-bom:6.2.19-spring-framework-6.2.21` returns `401` against `camunda-cpm`). CI has those credentials and is the validation gate for this change.
