### PR TITLE
feat: limit the number of buffered side efffects

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Processing.java
+++ b/configuration/src/main/java/io/camunda/configuration/Processing.java
@@ -30,6 +30,7 @@ public class Processing {
       true;
 
   private static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
+  private static final int DEFAULT_MAX_PENDING_SIDE_EFFECTS = 1000;
 
   private static final Set<String> LEGACY_MAX_COMMANDS_IN_BATCH_PROPERTIES =
       Set.of("zeebe.broker.processingCfg.maxCommandsInBatch");
@@ -173,6 +174,18 @@ public class Processing {
    * Default is 1000.
    */
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
+
+  /**
+   * Sets how many processed records may wait for their side effects to be committed before
+   * processing stops reading new records. Processing reads records as soon as they are appended,
+   * while a record's side effects, such as command responses, only run once its results are
+   * committed. This limit bounds the memory those waiting side effects retain when commits are
+   * slow. It is a safety valve rather than a tuning knob: the default sits far above the number of
+   * records processed within one commit round trip, so it should not be reached in normal
+   * operation. Raise it only to trade memory for throughput on a partition whose commit latency is
+   * genuinely high. Must be a positive integer. Default is 1000.
+   */
+  private int maxPendingSideEffects = DEFAULT_MAX_PENDING_SIDE_EFFECTS;
 
   public Integer getMaxCommandsInBatch() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
@@ -334,6 +347,14 @@ public class Processing {
 
   public void setMaxRecoverableRetries(final int maxRecoverableRetries) {
     this.maxRecoverableRetries = maxRecoverableRetries;
+  }
+
+  public int getMaxPendingSideEffects() {
+    return maxPendingSideEffects;
+  }
+
+  public void setMaxPendingSideEffects(final int maxPendingSideEffects) {
+    this.maxPendingSideEffects = maxPendingSideEffects;
   }
 
   public FlowControl getFlowControl() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -218,6 +218,7 @@ public class BrokerBasedPropertiesOverride {
     // processing
     override.getProcessing().setMaxCommandsInBatch(processing.getMaxCommandsInBatch());
     override.getProcessing().setMaxRecoverableRetries(processing.getMaxRecoverableRetries());
+    override.getProcessing().setMaxPendingSideEffects(processing.getMaxPendingSideEffects());
     override
         .getProcessing()
         .setScheduledTaskCheckInterval(processing.getScheduledTasksCheckInterval());

--- a/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
@@ -46,6 +46,7 @@ public class ProcessingPropertiesTest {
   private static final boolean
       EXPECTED_CONFIGURED_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE = false;
   private static final int EXPECTED_MAX_RECOVERABLE_RETRIES = 50;
+  private static final int EXPECTED_MAX_PENDING_SIDE_EFFECTS = 250;
 
   @Nested
   @TestPropertySource(
@@ -67,7 +68,8 @@ public class ProcessingPropertiesTest {
             + EXPECTED_ENABLE_MESSAGE_BODY_ON_EXPIRED,
         "camunda.processing.evaluate-boundary-event-correlation-key-in-activity-scope="
             + EXPECTED_CONFIGURED_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
-        "camunda.processing.max-recoverable-retries=" + EXPECTED_MAX_RECOVERABLE_RETRIES
+        "camunda.processing.max-recoverable-retries=" + EXPECTED_MAX_RECOVERABLE_RETRIES,
+        "camunda.processing.max-pending-side-effects=" + EXPECTED_MAX_PENDING_SIDE_EFFECTS
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerBasedProperties;
@@ -83,7 +85,8 @@ public class ProcessingPropertiesTest {
           .returns(
               EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
           .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions)
-          .returns(EXPECTED_MAX_RECOVERABLE_RETRIES, ProcessingCfg::getMaxRecoverableRetries);
+          .returns(EXPECTED_MAX_RECOVERABLE_RETRIES, ProcessingCfg::getMaxRecoverableRetries)
+          .returns(EXPECTED_MAX_PENDING_SIDE_EFFECTS, ProcessingCfg::getMaxPendingSideEffects);
 
       assertThat(brokerBasedProperties.getExperimental().getConsistencyChecks())
           .returns(EXPECTED_ENABLE_PRECONDITIONS_CHECK, ConsistencyCheckCfg::isEnablePreconditions)
@@ -199,6 +202,7 @@ public class ProcessingPropertiesTest {
         "camunda.processing.evaluate-boundary-event-correlation-key-in-activity-scope="
             + EXPECTED_DEFAULT_EVALUATE_BOUNDARY_EVENT_CORRELATION_KEY_IN_ACTIVITY_SCOPE,
         "camunda.processing.max-recoverable-retries=" + EXPECTED_MAX_RECOVERABLE_RETRIES,
+        "camunda.processing.max-pending-side-effects=" + EXPECTED_MAX_PENDING_SIDE_EFFECTS,
 
         // legacy
         "zeebe.broker.processingCfg.maxCommandsInBatch=1",
@@ -228,7 +232,8 @@ public class ProcessingPropertiesTest {
           .returns(
               EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
           .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions)
-          .returns(EXPECTED_MAX_RECOVERABLE_RETRIES, ProcessingCfg::getMaxRecoverableRetries);
+          .returns(EXPECTED_MAX_RECOVERABLE_RETRIES, ProcessingCfg::getMaxRecoverableRetries)
+          .returns(EXPECTED_MAX_PENDING_SIDE_EFFECTS, ProcessingCfg::getMaxPendingSideEffects);
 
       assertThat(brokerBasedProperties.getExperimental().getConsistencyChecks())
           .returns(EXPECTED_ENABLE_PRECONDITIONS_CHECK, ConsistencyCheckCfg::isEnablePreconditions)

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -349,6 +349,7 @@ processing.flow-control.write.throttle.enabled
 processing.flow-control.write.throttle.minimum-limit
 processing.flow-control.write.throttle.resolution
 processing.max-commands-in-batch
+processing.max-pending-side-effects
 processing.max-recoverable-retries
 processing.scheduled-tasks-check-interval
 processing.skip-positions

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1430,6 +1430,14 @@ camunda: # Type: io.camunda.configuration.Camunda
     # (see maxMessageSize), processing will be rolled back and retried with a smaller maximum batch size.
     # Lowering the command limit can reduce the frequency of rollback and retry.
     max-commands-in-batch: 100 # Type: Integer, Env: CAMUNDA_PROCESSING_MAXCOMMANDSINBATCH
+    # Sets how many processed records may wait for their side effects to be committed before processing
+    # stops reading new records. Processing reads records as soon as they are appended, while a record's
+    # side effects, such as command responses, only run once its results are committed. This limit bounds
+    # the memory those waiting side effects retain when commits are slow. It is a safety valve rather than
+    # a tuning knob: the default sits far above the number of records processed within one commit round
+    # trip, so it should not be reached in normal operation. Raise it only to trade memory for throughput
+    # on a partition whose commit latency is genuinely high. Must be a positive integer. Default is 1000.
+    max-pending-side-effects: 1000 # Type: Integer, Env: CAMUNDA_PROCESSING_MAXPENDINGSIDEEFFECTS
     # Sets the maximum number of recoverable retries for state update and replay operations. When the
     # limit is reached, the operation fails and the partition restarts. Must be a positive integer.
     # Default is 1000.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -14,8 +14,10 @@ public final class ProcessingCfg implements ConfigurationEntry {
 
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
   private static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
+  private static final int DEFAULT_MAX_PENDING_SIDE_EFFECTS = 1000;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
+  private int maxPendingSideEffects = DEFAULT_MAX_PENDING_SIDE_EFFECTS;
   private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
   private Set<Long> skipPositions;
 
@@ -28,6 +30,10 @@ public final class ProcessingCfg implements ConfigurationEntry {
     if (maxRecoverableRetries < 1) {
       throw new IllegalArgumentException(
           "maxRecoverableRetries must be >= 1 but was %s".formatted(maxRecoverableRetries));
+    }
+    if (maxPendingSideEffects < 1) {
+      throw new IllegalArgumentException(
+          "maxPendingSideEffects must be >= 1 but was %s".formatted(maxPendingSideEffects));
     }
     if (!scheduledTaskCheckInterval.isPositive()) {
       throw new IllegalArgumentException(
@@ -42,6 +48,20 @@ public final class ProcessingCfg implements ConfigurationEntry {
 
   public void setMaxCommandsInBatch(final int maxCommandsInBatch) {
     this.maxCommandsInBatch = maxCommandsInBatch;
+  }
+
+  /**
+   * How many processing results may wait for their records to be committed before processing stops
+   * reading new records. Bounds the memory held by queued responses and post-commit tasks when
+   * commits are slow. Raise it only to trade memory for throughput on a partition whose commit
+   * latency is high.
+   */
+  public int getMaxPendingSideEffects() {
+    return maxPendingSideEffects;
+  }
+
+  public void setMaxPendingSideEffects(final int maxPendingSideEffects) {
+    this.maxPendingSideEffects = maxPendingSideEffects;
   }
 
   public int getMaxRecoverableRetries() {
@@ -67,6 +87,8 @@ public final class ProcessingCfg implements ConfigurationEntry {
         + maxCommandsInBatch
         + ", maxRecoverableRetries="
         + maxRecoverableRetries
+        + ", maxPendingSideEffects="
+        + maxPendingSideEffects
         + ", scheduledTaskCheckInterval="
         + scheduledTaskCheckInterval
         + '}';

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -172,6 +172,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .commandResponseWriter(context.getCommandApiService().newCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
         .maxRecoverableRetries(context.getBrokerCfg().getProcessing().getMaxRecoverableRetries())
+        .maxPendingSideEffects(context.getBrokerCfg().getProcessing().getMaxPendingSideEffects())
         .setScheduledTaskCheckInterval(
             context.getBrokerCfg().getProcessing().getScheduledTaskCheckInterval())
         .processingFilter(processingFilter)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -145,6 +145,70 @@ final class ProcessingCfgTest {
   }
 
   @Test
+  void shouldUseDefaultMaxPendingSideEffects() {
+    // given
+    final var cfg = new ProcessingCfg();
+
+    // when
+    final int limit = cfg.getMaxPendingSideEffects();
+
+    // then
+    assertThat(limit).isEqualTo(1000);
+  }
+
+  @Test
+  void shouldSetMaxPendingSideEffects() {
+    // given
+    final var cfg = new ProcessingCfg();
+    cfg.setMaxPendingSideEffects(50);
+
+    // when
+    final int limit = cfg.getMaxPendingSideEffects();
+
+    // then
+    assertThat(limit).isEqualTo(50);
+  }
+
+  @Test
+  void shouldSetMaxPendingSideEffectsFromConfig() {
+    // given
+    final var cfg =
+        TestConfigReader.readConfig("processing-cfg", Collections.emptyMap()).getProcessing();
+
+    // when
+    final int limit = cfg.getMaxPendingSideEffects();
+
+    // then
+    assertThat(limit).isEqualTo(250);
+  }
+
+  @Test
+  void shouldSetMaxPendingSideEffectsFromEnvironment() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.processing.maxPendingSideEffects", "75");
+    final var cfg = TestConfigReader.readConfig("processing-cfg", environment).getProcessing();
+
+    // when
+    final var limit = cfg.getMaxPendingSideEffects();
+
+    // then
+    assertThat(limit).isEqualTo(75);
+  }
+
+  @Test
+  void shouldRejectInvalidMaxPendingSideEffects() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.processing.maxPendingSideEffects", "0");
+
+    // then
+    assertThatThrownBy(() -> TestConfigReader.readConfig("processing-cfg", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxPendingSideEffects must be >= 1");
+  }
+
+  @Test
   void shouldSetSkipPositions() {
     // given
     final var cfg = new ProcessingCfg();

--- a/zeebe/broker/src/test/resources/system/processing-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/processing-cfg.yaml
@@ -3,4 +3,5 @@ zeebe:
     processing:
       maxCommandsInBatch: 125
       maxRecoverableRetries: 200
+      maxPendingSideEffects: 250
       skipPositions: 1, 2, 3

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -168,6 +168,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
   private final LogStreamWriter logStreamWriter;
   private boolean inProcessing;
   private final int maxCommandsInBatch;
+  private final int maxPendingSideEffects;
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
   private final SideEffectRunner sideEffectRunner;
@@ -192,6 +193,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
     abortCondition = context.getAbortCondition();
     lastProcessedPositionState = context.getLastProcessedPositionState();
     maxCommandsInBatch = context.getMaxCommandsInBatch();
+    maxPendingSideEffects = context.getMaxPendingSideEffects();
 
     // Waiting between write attempts is safe: processing of the next record is guarded by
     // `inProcessing`, and no other job on this actor touches the open transaction or writes to
@@ -214,7 +216,12 @@ public final class ProcessingStateMachine implements CloseableSilently {
     processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
     sideEffectRunner =
         new SideEffectRunner(
-            context.getPartitionId(), actor, processingMetrics, context.getCommandResponseWriter());
+            context.getPartitionId(),
+            actor,
+            processingMetrics,
+            context.getCommandResponseWriter(),
+            maxPendingSideEffects,
+            () -> actor.submit(this::tryToReadNextRecord));
     context.getLogStream().registerCommittedPositionListener(sideEffectRunner);
     final EventFilter commandFilter =
         event -> {
@@ -275,6 +282,12 @@ public final class ProcessingStateMachine implements CloseableSilently {
     }
 
     if (shouldProcessNext.getAsBoolean() && hasNext) {
+      if (!sideEffectRunner.hasCapacity()) {
+        // Stop before consuming the record, so no seek is needed once capacity frees up. The
+        // runner wakes us again when it drains an entry.
+        return;
+      }
+
       final var currentRecord = logStreamReader.next();
       this.currentRecord = currentRecord;
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -799,6 +799,16 @@ public final class ProcessingStateMachine implements CloseableSilently {
     return errorHandlingPhase != ErrorHandlingPhase.ENDLESS_ERROR_LOOP;
   }
 
+  /**
+   * How long processing has been continuously stopped because pending side effects filled the
+   * queue, or {@link Duration#ZERO} if it currently has room to read more. Lets the stream
+   * processor tell a stall that has outlasted a normal commit round trip from the brief, expected
+   * waits of healthy operation.
+   */
+  public Duration getPendingSideEffectsBlockedDuration() {
+    return sideEffectRunner.capacityExhaustedDuration();
+  }
+
   public void startProcessing(final LastProcessingPositions lastProcessingPositions) {
     // Replay ends at the end of the log and returns the lastSourceRecordPosition
     // which is equal to the last processed position

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -27,6 +27,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Must run on the Processing State Machine's actor because side effects are not necessarily
  * thread-safe.
+ *
+ * <p>The queue is bounded. Processing reads uncommitted records, so it can run arbitrarily far
+ * ahead of the commit index while commits are slow, and every queued entry retains its responses
+ * and post-commit task closures until it runs. {@link #hasCapacity()} lets the processing state
+ * machine stop reading new records once the queue is full, which bounds that memory. Capacity frees
+ * up on commit, which never depends on further processing, so this cannot deadlock.
  */
 final class SideEffectRunner implements CommittedPositionListener {
   private static final Logger LOG = LoggerFactory.getLogger(SideEffectRunner.class);
@@ -35,6 +41,8 @@ final class SideEffectRunner implements CommittedPositionListener {
   private final ActorControl actor;
   private final ProcessingMetrics processingMetrics;
   private final CommandResponseWriter responseWriter;
+  private final int maxPendingSideEffects;
+  private final Runnable onCapacityAvailable;
   private final Queue<SideEffects> sideEffects;
   private long highestCommittedPosition = StreamProcessor.UNSET_POSITION;
   private boolean executingSideEffects;
@@ -43,12 +51,26 @@ final class SideEffectRunner implements CommittedPositionListener {
       final int partitionId,
       final ActorControl actor,
       final ProcessingMetrics processingMetrics,
-      final CommandResponseWriter responseWriter) {
+      final CommandResponseWriter responseWriter,
+      final int maxPendingSideEffects,
+      final Runnable onCapacityAvailable) {
     this.actor = actor;
     this.processingMetrics = processingMetrics;
     this.responseWriter = responseWriter;
     this.partitionId = partitionId;
+    this.maxPendingSideEffects = maxPendingSideEffects;
+    this.onCapacityAvailable = onCapacityAvailable;
     sideEffects = new ArrayDeque<>();
+  }
+
+  /**
+   * Whether another processing result's side effects fit in the queue.
+   *
+   * <p>Must be called on {@link #actor}'s thread. The processing state machine checks this before
+   * it reads the next record, so the queue never grows beyond {@code maxPendingSideEffects}.
+   */
+  boolean hasCapacity() {
+    return sideEffects.size() < maxPendingSideEffects;
   }
 
   /**
@@ -120,11 +142,19 @@ final class SideEffectRunner implements CommittedPositionListener {
   }
 
   private void completeSideEffects(final SideEffects completedSideEffects) {
+    final var wasFull = !hasCapacity();
     sideEffects.remove();
     processingMetrics.setPendingSideEffects(sideEffects.size());
     executingSideEffects = false;
     completedSideEffects.completionCallback().run();
     executeNextSideEffects();
+    if (wasFull) {
+      // Processing stopped reading records because the queue was full. Nothing else will wake it:
+      // the records it stopped on are already appended, so no append notification is coming.
+      // Signalling only on the full -> not-full transition keeps this to one job per stall
+      // instead of one per side effect.
+      onCapacityAvailable.run();
+    }
   }
 
   private void sendResponses(final Collection<ProcessingResponse> responses) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommittedPositionListener;
 import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.PostCommitTask;
 import io.camunda.zeebe.stream.api.ProcessingResponse;
 import io.camunda.zeebe.stream.impl.metrics.ProcessingMetrics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.List;
@@ -46,6 +48,8 @@ final class SideEffectRunner implements CommittedPositionListener {
   private final Queue<SideEffects> sideEffects;
   private long highestCommittedPosition = StreamProcessor.UNSET_POSITION;
   private boolean executingSideEffects;
+  private volatile boolean capacityExhausted;
+  private volatile long capacityExhaustedSinceMillis;
 
   SideEffectRunner(
       final int partitionId,
@@ -71,6 +75,22 @@ final class SideEffectRunner implements CommittedPositionListener {
    */
   boolean hasCapacity() {
     return sideEffects.size() < maxPendingSideEffects;
+  }
+
+  /**
+   * How long the queue has been continuously at {@code maxPendingSideEffects}, or {@link
+   * Duration#ZERO} if it currently has room. Distinguishes a stall that has outlasted a normal
+   * commit round trip from the brief, expected waits that happen under healthy operation.
+   *
+   * <p>Must be called on {@link #actor}'s thread to read a value consistent with {@link
+   * #hasCapacity()}; the stream processor's health report calls it from other threads too, where it
+   * still returns a safe, if possibly stale, answer.
+   */
+  Duration capacityExhaustedDuration() {
+    return capacityExhausted
+        ? Duration.ofMillis(
+            Math.max(0, ActorClock.currentTimeMillis() - capacityExhaustedSinceMillis))
+        : Duration.ZERO;
   }
 
   /**
@@ -106,6 +126,12 @@ final class SideEffectRunner implements CommittedPositionListener {
             new AggregatePostCommitTask(partitionId, position, postCommitTasks),
             completionCallback));
     processingMetrics.setPendingSideEffects(sideEffects.size());
+    if (!capacityExhausted && !hasCapacity()) {
+      // Ordered before the flag write below: a reader that observes capacityExhausted == true is
+      // then guaranteed to observe this timestamp too.
+      capacityExhaustedSinceMillis = ActorClock.currentTimeMillis();
+      capacityExhausted = true;
+    }
     executeNextSideEffects();
   }
 
@@ -149,6 +175,7 @@ final class SideEffectRunner implements CommittedPositionListener {
     completedSideEffects.completionCallback().run();
     executeNextSideEffects();
     if (wasFull) {
+      capacityExhausted = false;
       // Processing stopped reading records because the queue was full. Nothing else will wake it:
       // the records it stopped on are already appended, so no append notification is coming.
       // Signalling only on the full -> not-full transition keeps this to one job per stall

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -86,6 +87,13 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   public static final long UNSET_POSITION = -1L;
   public static final Duration HEALTH_CHECK_TICK_DURATION = Duration.ofSeconds(5);
 
+  /**
+   * How long processing may sit at the pending-side-effects limit before it counts as a stall
+   * rather than a normal, brief wait for the next commit. Well above a commit round trip under
+   * healthy operation (milliseconds), so ordinary operation never crosses it.
+   */
+  public static final Duration PENDING_SIDE_EFFECTS_STALL_THRESHOLD = Duration.ofSeconds(30);
+
   private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
       "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
@@ -95,6 +103,11 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final StreamProcessorMetrics metrics;
   private final StageableScheduledCommandCache scheduledCommandCache;
+  // Reused across ticks so the warning repeats at most once per
+  // PENDING_SIDE_EFFECTS_STALL_THRESHOLD
+  // for as long as the stall lasts, instead of once per health-check tick.
+  private final Logger pendingSideEffectsStallLogger =
+      new ThrottledLogger(LOG, PENDING_SIDE_EFFECTS_STALL_THRESHOLD);
 
   // log stream
   private final LogStream logStream;
@@ -305,6 +318,23 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void healthCheckTick() {
     lastTickTime = ActorClock.currentTimeMillis();
     actor.schedule(HEALTH_CHECK_TICK_DURATION, this::healthCheckTick);
+    warnIfStalledOnPendingSideEffects();
+  }
+
+  private void warnIfStalledOnPendingSideEffects() {
+    if (processingStateMachine == null) {
+      return;
+    }
+
+    final var stalledFor = processingStateMachine.getPendingSideEffectsBlockedDuration();
+    if (stalledFor.compareTo(PENDING_SIDE_EFFECTS_STALL_THRESHOLD) >= 0) {
+      pendingSideEffectsStallLogger.warn(
+          "Processing on partition {} has been stalled for {} waiting for pending side effects to "
+              + "commit. This can mean replication is lagging, or that maxPendingSideEffects is too "
+              + "low for this partition's commit latency.",
+          partitionId,
+          stalledFor);
+    }
   }
 
   private void startProcessing(final LastProcessingPositions lastProcessingPositions) {
@@ -502,6 +532,20 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     if (processingStateMachine != null && !processingStateMachine.isMakingProgress()) {
       return HealthReport.unhealthy(this)
           .withMessage("Processing not making progress. It is in an error handling loop.", instant);
+    }
+
+    // A processor stalled here keeps ticking normally: it is not blocked in a runUntilDone loop,
+    // it is simply choosing not to read further records, so the check below would not catch it.
+    if (processingStateMachine != null) {
+      final var stalledFor = processingStateMachine.getPendingSideEffectsBlockedDuration();
+      if (stalledFor.compareTo(PENDING_SIDE_EFFECTS_STALL_THRESHOLD) >= 0) {
+        return HealthReport.unhealthy(this)
+            .withMessage(
+                "Processing has been stalled for "
+                    + stalledFor
+                    + " waiting for pending side effects to commit",
+                instant);
+      }
     }
 
     // If healthCheckTick was not invoked it indicates the actor is blocked in a runUntilDone loop.

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -146,6 +146,11 @@ public final class StreamProcessorBuilder {
           "Batch processing limit must be >= 1 but was %s"
               .formatted(streamProcessorContext.getMaxCommandsInBatch()));
     }
+    if (streamProcessorContext.getMaxPendingSideEffects() < 1) {
+      throw new IllegalArgumentException(
+          "maxPendingSideEffects must be >= 1 but was %s"
+              .formatted(streamProcessorContext.getMaxPendingSideEffects()));
+    }
     if (streamProcessorContext.getMaxRecoverableRetries() < 1) {
       throw new IllegalArgumentException(
           "maxRecoverableRetries must be >= 1 but was %s"
@@ -155,6 +160,11 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder maxCommandsInBatch(final int maxCommandsInBatch) {
     streamProcessorContext.maxCommandsInBatch(maxCommandsInBatch);
+    return this;
+  }
+
+  public StreamProcessorBuilder maxPendingSideEffects(final int maxPendingSideEffects) {
+    streamProcessorContext.maxPendingSideEffects(maxPendingSideEffects);
     return this;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -34,6 +34,14 @@ import org.jspecify.annotations.Nullable;
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
 
   public static final int DEFAULT_MAX_COMMANDS_IN_BATCH = 100;
+
+  /**
+   * Bounds how far processing runs ahead of the commit index. In healthy operation the queue holds
+   * roughly the records processed within one commit round trip, which is orders of magnitude below
+   * this. It is a safety valve against unbounded memory when commits are slow, not a tuning knob.
+   */
+  public static final int DEFAULT_MAX_PENDING_SIDE_EFFECTS = 1000;
+
   public static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
   private @Nullable ActorControl actor;
@@ -59,6 +67,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private @Nullable KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
+  private int maxPendingSideEffects = DEFAULT_MAX_PENDING_SIDE_EFFECTS;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
   private EventFilter processingFilter = e -> true;
   private @Nullable ControllableStreamClock clock;
@@ -268,6 +277,15 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public int getMaxCommandsInBatch() {
     return maxCommandsInBatch;
+  }
+
+  public StreamProcessorContext maxPendingSideEffects(final int maxPendingSideEffects) {
+    this.maxPendingSideEffects = maxPendingSideEffects;
+    return this;
+  }
+
+  public int getMaxPendingSideEffects() {
+    return maxPendingSideEffects;
   }
 
   public StreamProcessorContext maxRecoverableRetries(final int maxRecoverableRetries) {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorHealthTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorHealthTest.java
@@ -14,8 +14,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
+import io.camunda.zeebe.stream.api.PostCommitTask;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.util.health.FailureListener;
@@ -257,6 +259,77 @@ public class StreamProcessorHealthTest {
 
       // then - should recover and become healthy again
       Awaitility.await("wait for recovery after blocking operation completes")
+          .atMost(Duration.ofSeconds(15))
+          .untilAsserted(() -> assertThat(streamProcessor.getHealthReport().isHealthy()).isTrue());
+    }
+  }
+
+  @Nested
+  final class PendingSideEffectsStallDetectionTest {
+
+    @BeforeEach
+    void setup() {
+      // Ensure the clock is behind real time, so that once the queue fills, the stall immediately
+      // looks older than PENDING_SIDE_EFFECTS_STALL_THRESHOLD without waiting the real threshold
+      // out.
+      actorClock.setCurrentTime(Instant.ofEpochMilli(1765200166956L));
+    }
+
+    private StreamProcessor startProcessorBlockedOnPendingSideEffects(
+        final ListLogStorage logStorage) {
+      streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+      final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+      resultBuilder.appendPostCommitTask(Mockito.mock(PostCommitTask.class));
+      final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+      when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+      logStorage.deferCommits();
+
+      final var processor =
+          streamPlatform.buildStreamProcessor(
+              streamPlatform.getLogStream(), true, cfg -> cfg.maxPendingSideEffects(1));
+      streamPlatform.writeBatch(
+          RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+      return processor;
+    }
+
+    @Test
+    void shouldMarkUnhealthyWhenProcessingStallsOnPendingSideEffects() {
+      // given - the single allowed side effect fills the queue and is never committed
+      streamProcessor = startProcessorBlockedOnPendingSideEffects(new ListLogStorage());
+
+      // then - the stall is reported as unhealthy
+      Awaitility.await("wait for the pending side effects stall to be detected")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> {
+                final var healthReport = streamProcessor.getHealthReport();
+                assertThat(healthReport.isUnhealthy()).isTrue();
+                assertThat(healthReport.getIssue().message())
+                    .contains("stalled")
+                    .contains("pending side effects");
+              });
+    }
+
+    @Test
+    void shouldRecoverAfterPendingSideEffectsDrain() {
+      // given
+      final var logStorage = new ListLogStorage();
+      streamProcessor = startProcessorBlockedOnPendingSideEffects(logStorage);
+
+      Awaitility.await("wait for the pending side effects stall to be detected")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> assertThat(streamProcessor.getHealthReport().isUnhealthy()).isTrue());
+
+      // when - the results are committed, which drains the queue. The clock is reset first so that
+      // the next health-check tick recomputes lastTickTime from real time; otherwise the unrelated
+      // blocked-actor check below would keep reporting unhealthy against the still-pinned past
+      // value.
+      actorClock.reset();
+      logStorage.commitPendingEntries();
+
+      // then - processing resumes and the processor recovers
+      Awaitility.await("wait for recovery after the pending side effects drain")
           .atMost(Duration.ofSeconds(15))
           .untilAsserted(() -> assertThat(streamProcessor.getHealthReport().isHealthy()).isTrue());
     }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -788,6 +788,64 @@ public final class StreamProcessorTest {
         .untilAsserted(() -> assertThat(pendingSideEffects()).isZero());
   }
 
+  @Test
+  public void shouldStopProcessingWhenTooManySideEffectsArePending() {
+    // given - a processor that allows only one processing result to wait for commit
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    final var postCommitTask = mock(PostCommitTask.class);
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder.appendPostCommitTask(postCommitTask);
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+    logStorage.deferCommits();
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(), true, cfg -> cfg.maxPendingSideEffects(1));
+
+    // when - two commands are written but nothing is committed
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+
+    // then - only the first command is processed, because its side effects fill the queue
+    await("only the first command is processed")
+        .during(Duration.ofMillis(200))
+        .atMost(Duration.ofMillis(TIMEOUT_MILLIS))
+        .untilAsserted(
+            () -> {
+              verify(defaultMockedRecordProcessor, Mockito.times(1)).process(any(), any());
+              assertThat(pendingSideEffects()).isEqualTo(1);
+            });
+  }
+
+  @Test
+  public void shouldResumeProcessingWhenPendingSideEffectsDrain() {
+    // given - processing stopped because the single allowed side effect is waiting for commit
+    final var logStorage = new ListLogStorage();
+    streamPlatform.setLogContext(streamPlatform.createLogContext(logStorage, 1));
+    final var postCommitTask = mock(PostCommitTask.class);
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder.appendPostCommitTask(postCommitTask);
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
+    logStorage.deferCommits();
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(), true, cfg -> cfg.maxPendingSideEffects(1));
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+    await("processing stopped on the full side effect queue")
+        .untilAsserted(
+            () -> verify(defaultMockedRecordProcessor, Mockito.times(1)).process(any(), any()));
+
+    // when - the results are committed, which drains the queue
+    logStorage.commitPendingEntries();
+
+    // then - the blocked command is processed and both side effects run
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+    verify(postCommitTask, TIMEOUT.times(2)).flush();
+  }
+
   private double pendingSideEffects() {
     return streamPlatform
         .getProcessorMeterRegistry()


### PR DESCRIPTION
## Why

Since #59206, side effects run only after their records are committed. Every processing result therefore keeps its responses and post-commit task closures on the heap until the commit arrives, and processing reads uncommitted records, so it can run arbitrarily far ahead of the commit index.
The side effect queue is bounded only by the request limiter, with no direct control over memory usage, commands that bypass the limiter (e.g. job completion) or internal follow-up commands.

This left an opening for unexpected OOMs caused by too many buffered side effects.

## What

The side effect queue is now bounded, and the bound is configurable as `camunda.processing.max-pending-side-effects` (default 1000).

Before it reads the next record, the processing state machine checks that another result's side effects still fit:

https://github.com/camunda/camunda/blob/763524ad5fcb93f4cbd8587a0132b6cfac7c567a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java#L285-L289

It stops *before* consuming the record, so no seek is needed to resume. The runner wakes it again once a commit drains an entry, signalling only on the full → not-full transition so that a stall costs one actor job rather than one per side effect:

https://github.com/camunda/camunda/blob/763524ad5fcb93f4cbd8587a0132b6cfac7c567a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java#L144-L158

**The limit becomes client backpressure.** A blocked processor stops signalling `onProcessed`, so the request limiter shrinks and clients are throttled, instead of the broker running out of memory.

## Observability

Nicolas pointed out that the pending-side-effects gauge was the only signal for this, and that a genuine stall would not even trip the existing blocked-actor detection: that check relies on the health-check tick going silent, but a processor stopped on this limit keeps ticking normally — it isn't stuck in a `runUntilDone` loop, it's choosing not to read further records.

Added:
- `SideEffectRunner` tracks how long the queue has been continuously at its limit.
- `StreamProcessor#getHealthReport()` reports unhealthy once that duration reaches a new `PENDING_SIDE_EFFECTS_STALL_THRESHOLD` (30s).
- The health-check tick logs a throttled warning while stalled, via the `ThrottledLogger` already used elsewhere in this class.

A single slow commit never crosses 30s, so ordinary operation never logs or reports unhealthy.

Related to #59177.
