### PR TITLE
ci: harden Windows e2e job against runner flakiness

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -309,6 +309,7 @@ jobs:
         working-directory: .\c8run
 
       - name: make a package
+        timeout-minutes: 5
         run: .\packager.exe package
         working-directory: .\c8run
         env:
@@ -320,12 +321,16 @@ jobs:
         working-directory: .\c8run
 
       - name: Run c8run
+        timeout-minutes: 3
         run: bash -c './c8run.exe start --config e2e_tests/prefix-config.yaml'
         working-directory: ./c8run
         shell: bash
 
       - name: Install jq
-        run: choco install jq
+        uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
+        with:
+          version: 1.8.2
+          force: 'true'
 
       - name: Run test
         shell: bash

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -29,7 +29,7 @@ env:
   TEST_OWNER: '@camunda/distribution'
 
 permissions:
-  actions: write
+  actions: none
   attestations: none
   checks: write
   contents: read

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -31,7 +31,7 @@ env:
 permissions:
   actions: none
   attestations: none
-  checks: write
+  checks: none
   contents: read
   deployments: none
   id-token: none
@@ -42,7 +42,7 @@ permissions:
   pull-requests: none
   repository-projects: none
   security-events: none
-  statuses: write
+  statuses: none
 
 jobs:
   linting:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -330,7 +330,6 @@ jobs:
         uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
         with:
           version: 1.8.2
-          force: 'true'
 
       - name: Run test
         shell: bash


### PR DESCRIPTION
## Summary
- Replace `choco install jq` with `dcarbone/install-jq-action` (already used in `ci.yml`) to cut network-dependent, variable-time install on Windows.
- Add `timeout-minutes` to `make a package` (5m) and `Run c8run` (3m) so a slow step surfaces by name instead of the whole job hitting the 15-minute job cap silently.

Job has almost no headroom against its 15-minute cap (normal runs 13-16min), so a slow runner alone trips a false timeout (INC-7567) with no code actually broken.

Closes #61468

## Test plan
- [x] Triggered `workflow_dispatch` on this branch: https://github.com/camunda/camunda/actions/runs/33394622066
- [x] `C8Run Test Windows` job passed, ~9min total (well under 15min cap)
- [x] `make a package` 1m18s (cap 5m), `Run c8run` 58s (cap 3m), `Install jq` (new action) 20s — all green