### PR TITLE
docs: rename incident type

### DIFF
--- a/docs/monorepo-docs/release/release-monorepo.md
+++ b/docs/monorepo-docs/release/release-monorepo.md
@@ -590,8 +590,9 @@ Consider opening an incident for serious issues (see below).
 # Incident Process
 
 If you discover serious issues during the Monorepo Release process (while working on any of its subtasks), you can start the incident (per usual process with `/inc` command in Slack).
+The incident type is shared among the C8 Release Train (not just Monorepo) and can be used for any blocker encountered during it.
 
-Please select incident type: `C8 Monorepo Release incident`.
+Please select incident type: `C8 Release incident`.
 
 Who can start the incident:
 - Anyone participating in the current release process (Release Manager, QA Engineers, etc.)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Align docs with the new incident name.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to https://github.com/camunda/team-eng-ops/issues/306
