### PR TITLE
fix: honor legacy camunda.database connection pool limits in the exporter

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -67,6 +67,10 @@ camunda.data.secondary-storage.elasticsearch.max-connections-per-route=<int>
 * `max-connections-per-route` — maximum number of connections allowed per route. For Camunda this
   is typically set to the same value as `max-connections`.
 
+Both fall back to the legacy `camunda.database.max-connections[-per-route]` keys when the unified
+keys are unset. The exporter's own `zeebe.broker.exporters.camundaexporter.args.connect.*` keys are
+not part of that fallback, so a limit set there sizes only the exporter's client.
+
 Both default to unset, in which case the underlying Apache HttpClient defaults apply. They are
 useful when a component consumes many connections (e.g. running the archiver with a high thread
 count), which can otherwise exhaust the pool and throttle other operations such as health checks.

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -375,11 +375,24 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   /**
+   * Resolved with {@link BackwardsCompatibilityMode#SUPPORTED} rather than the {@code
+   * SUPPORTED_ONLY_IF_VALUES_MATCH} its neighbours use. The neighbours all have a non-null default,
+   * so a legacy value has something to be compared against; this property is unset by default.
+   * Under {@code SUPPORTED_ONLY_IF_VALUES_MATCH} every deployment that configures only the legacy
+   * property would compare it against the unset unified value and fail to start.
+   *
    * @throws IllegalArgumentException if configured with a non-positive value
    */
   public Integer getMaxConnections() {
-    validatePositive(".max-connections", maxConnections);
-    return maxConnections;
+    final Integer resolved =
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+            prefix() + ".max-connections",
+            maxConnections,
+            Integer.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            legacyMaxConnectionsProperties());
+    validatePositive(".max-connections", resolved);
+    return resolved;
   }
 
   public void setMaxConnections(final Integer maxConnections) {
@@ -387,11 +400,20 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   /**
+   * See {@link #getMaxConnections()} for why this is resolved as {@code SUPPORTED}.
+   *
    * @throws IllegalArgumentException if configured with a non-positive value
    */
   public Integer getMaxConnectionsPerRoute() {
-    validatePositive(".max-connections-per-route", maxConnectionsPerRoute);
-    return maxConnectionsPerRoute;
+    final Integer resolved =
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+            prefix() + ".max-connections-per-route",
+            maxConnectionsPerRoute,
+            Integer.class,
+            BackwardsCompatibilityMode.SUPPORTED,
+            legacyMaxConnectionsPerRouteProperties());
+    validatePositive(".max-connections-per-route", resolved);
+    return resolved;
   }
 
   public void setMaxConnectionsPerRoute(final Integer maxConnectionsPerRoute) {
@@ -597,6 +619,22 @@ public abstract class DocumentBasedSecondaryStorageDatabase
         "camunda.operate." + dbName + ".connectionTimeout",
         "camunda.tasklist." + dbName + ".connectionTimeout",
         "zeebe.broker.exporters.camundaexporter.args.connect.connectionTimeout");
+  }
+
+  /**
+   * Only 'camunda.database', where the properties around it also list 'camunda.operate.*',
+   * 'camunda.tasklist.*' and the exporter args. The connection pool was never exposed on the
+   * operate and tasklist prefixes. The exporter args are deliberately left out too: those resolve
+   * under SUPPORTED, so listing them would let a limit meant for the exporter's client silently
+   * size the webapps' client as well.
+   */
+  private Set<String> legacyMaxConnectionsProperties() {
+    return Set.of("camunda.database.maxConnections");
+  }
+
+  /** See {@link #legacyMaxConnectionsProperties()} for why only 'camunda.database' is listed. */
+  private Set<String> legacyMaxConnectionsPerRouteProperties() {
+    return Set.of("camunda.database.maxConnectionsPerRoute");
   }
 
   private Set<String> legacyNumberOfReplicasProperties() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -70,10 +70,9 @@ public final class CamundaExporterConfigurationApplier {
         source.getConnectionTimeout() != null
             ? Math.toIntExact(source.getConnectionTimeout().toMillis())
             : null);
-    // Unlike the fields above, these two register no legacy property on their source getter:
-    // they were born with the unified property, so there is no pre-unified path to migrate from.
-    // 'zeebe.broker.exporters.camundaexporter.args.connect.maxConnections[PerRoute]' still binds
-    // onto this same target, so copy only when set — an unset unified value must not wipe it.
+    // Unlike the fields above, these two do not list the exporter args among their legacy
+    // properties: 'zeebe.broker.exporters.camundaexporter.args.connect.maxConnections[PerRoute]'
+    // binds onto this same target, so copy only when set — an unset unified value must not wipe it.
     final var maxConnections = source.getMaxConnections();
     if (maxConnections != null) {
       target.setMaxConnections(maxConnections);

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -760,10 +760,13 @@ public class SecondaryStorageElasticsearchTest {
       })
   class WithOnlyLegacyExporterConnectionPoolSet {
     final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
 
     WithOnlyLegacyExporterConnectionPoolSet(
-        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
       this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
     }
 
     @Test
@@ -783,6 +786,63 @@ public class SecondaryStorageElasticsearchTest {
           .isEqualTo(EXPECTED_MAX_CONNECTIONS);
       assertThat(exporterConfiguration.getConnect().getMaxConnectionsPerRoute())
           .isEqualTo(EXPECTED_MAX_CONNECTIONS_PER_ROUTE);
+    }
+
+    @Test
+    void shouldLeaveTheSearchEngineConnectPropertiesUnsized() {
+      // then an exporter-scoped limit must not size the webapps' client
+      assertThat(searchEngineConnectProperties)
+          .returns(null, SearchEngineConnectProperties::getMaxConnections)
+          .returns(null, SearchEngineConnectProperties::getMaxConnectionsPerRoute);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
+        "camunda.database.max-connections=" + EXPECTED_MAX_CONNECTIONS,
+        "camunda.database.max-connections-per-route=" + EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
+      })
+  class WithConnectionPoolOnLegacyDatabase {
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithConnectionPoolOnLegacyDatabase(
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void shouldFallBackToTheLegacyPropertyForTheCamundaExporter() {
+      // given
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      // when
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+
+      // then
+      assertThat(exporterConfiguration.getConnect())
+          .returns(EXPECTED_MAX_CONNECTIONS, ConnectConfiguration::getMaxConnections)
+          .returns(
+              EXPECTED_MAX_CONNECTIONS_PER_ROUTE, ConnectConfiguration::getMaxConnectionsPerRoute);
+    }
+
+    @Test
+    void shouldFallBackToTheLegacyPropertyForTheSearchEngineConnectProperties() {
+      // then
+      assertThat(searchEngineConnectProperties)
+          .returns(EXPECTED_MAX_CONNECTIONS, SearchEngineConnectProperties::getMaxConnections)
+          .returns(
+              EXPECTED_MAX_CONNECTIONS_PER_ROUTE,
+              SearchEngineConnectProperties::getMaxConnectionsPerRoute);
     }
   }
 


### PR DESCRIPTION
## Description

The unified `camunda.data.secondary-storage.<db>.max-connections` and `.max-connections-per-route` getters registered no legacy property, so `camunda.database.max-connections[-per-route]` only ever reached the webapps' client, through the plain bean copy in
SearchEngineConnectPropertiesOverride, and never reached the camunda exporter's client. A deployment that had tuned the pool on the legacy key silently kept the Apache HttpClient defaults for the exporter.

The same two properties on stable/8.8 do resolve that legacy key, which left the branches disagreeing on what it means — raised in review of the 8.8 backport (#61103). Both getters now resolve it through UnifiedConfigurationHelper, listing `camunda.database.maxConnections` and `camunda.database.maxConnectionsPerRoute`, so the legacy key feeds both consumers of the unified source and the branches behave alike. Only the camelCase spelling is listed: the helper on this branch already falls back to the kebab-case key.

The mode is SUPPORTED rather than the SUPPORTED_ONLY_IF_VALUES_MATCH the neighbouring properties use. Those all have a non-null default, so a legacy value has something to be compared against, while these are unset by default: under SUPPORTED_ONLY_IF_VALUES_MATCH every deployment that configures only the legacy key would compare it against the unset unified value and fail to start.

The exporter's own `...args.connect.maxConnections[PerRoute]` args are deliberately left out of the legacy sets. They resolve under SUPPORTED, so listing them would let a limit meant for the exporter's client silently size the webapps' client as well. The null guard in CamundaExporterConfigurationApplier still keeps an unset unified value from wiping a limit bound through those args.

The positive-value validation now runs on the resolved value, so a non-positive legacy value is rejected the same way as a unified one instead of reaching Apache HttpClient.

## Related issues

related to https://github.com/camunda/camunda/pull/61103#discussion_r3893469856
