### PR TITLE
ci: load-test: save profiling into a single artifact per test/pod

### DIFF
--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -144,6 +144,7 @@ jobs:
       # Give enough time for a preempted pod to come back, if any.
       PROFILE_RETRY_WAIT_SECONDS: 120
       PROFILE_RETRY_TIMEOUT_MINUTES: 15
+      OUTPUT_DIR: profiling/${{ matrix.pod }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -174,6 +175,7 @@ jobs:
       - name: Compute run date
         id: run-date
         run: echo "date=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
       # Profiling is best-effort: continue-on-error keeps a permanently-failing event from
       # failing this job, so a single flaky/preempted pod doesn't spuriously fail the whole
       # load test run -- the remaining "Profile ..." steps below still run regardless, and
@@ -205,27 +207,22 @@ jobs:
           retry_wait_seconds: ${{ env.PROFILE_RETRY_WAIT_SECONDS }}
           timeout_minutes: ${{ env.PROFILE_RETRY_TIMEOUT_MINUTES }}
           command: ./load-tests/docs/scripts/executeProfiling.sh "${POD}" alloc "${PROFILER_OPTIONS}" "${TEST_TYPE}"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        id: upload-artifact
         with:
-          name: flamegraph-${{ inputs.test-type }}-cpu-${{ matrix.pod }}-${{ steps.run-date.outputs.date }}
-          path: ${{ matrix.pod }}-flamegraph*-cpu-*.html
+          name: flamegraph-${{ inputs.test-type }}-${{ matrix.pod }}-${{ steps.run-date.outputs.date }}
+          # The name of the directory in which the profiling output has been written.
+          # This is set in executeProfiling.sh.
+          path: ${{ env.OUTPUT_DIR }}
           if-no-files-found: warn
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: flamegraph-${{ inputs.test-type }}-wall-${{ matrix.pod }}-${{ steps.run-date.outputs.date }}
-          path: ${{ matrix.pod }}-flamegraph*-wall-*.html
-          if-no-files-found: warn
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: flamegraph-${{ inputs.test-type }}-alloc-${{ matrix.pod }}-${{ steps.run-date.outputs.date }}
-          path: ${{ matrix.pod }}-flamegraph*-alloc-*.html
-          if-no-files-found: warn
+
       - name: Summarize profiling
         if: success()
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-            ## Profiling \`${NAME}\` on ${POD}
-            Async profiling (cpu, wall, alloc) has been executed sequentially on ${NAME}-${POD}. Please download the artifacts.
+            ## Profiling \`${NAME}\` on \`${POD}\`
+            Async profiling (\`cpu\`, \`wall\`, \`alloc\`) has been executed sequentially on \`${NAME}\`/\`${POD}\`. Please download [the artifacts](${{ steps.upload-artifact.outputs.artifact-url }}).
           EOF
       - name: Observe build status
         if: always()

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -22,11 +22,14 @@ if [ -z "$1" ]; then
   echo "Usage: ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS] [TEST-TYPE]"
   exit 1
 fi
-node=$1
+pod_name=$1
 
 profiler_event="${2:-cpu}"
 additional_options="${3:-}"
 test_type="${4:-}"
+
+OUTPUT_DIR="${OUTPUT_DIR:-"profiling"}"
+echo "Profiling reports will be saved to $OUTPUT_DIR"
 
 if [[ $profiler_event == "wall" ]]; then
   # Add -t flag for wall profiling to split threads (recommended for wall-clock profiling)
@@ -35,7 +38,7 @@ fi
 
 # Determine right container path
 containerPath=/usr/local/camunda/data
-if ! kubectl exec "$node" -- ls -la "$containerPath";
+if ! kubectl exec "$pod_name" -- ls -la "$containerPath";
 then
   # Old container path
   containerPath=/usr/local/zeebe/data
@@ -49,12 +52,12 @@ then
   tar -xzvf profiler.tar.gz
 fi
 
-if ! kubectl exec "$node" -- test -f data/libasyncProfiler.so;
+if ! kubectl exec "$pod_name" -- test -f data/libasyncProfiler.so;
 then
   # Copy async profiler to pod
-  kubectl cp async-profiler-4.0-linux-x64/bin/asprof "$node":"$containerPath/asprof"
-  kubectl cp async-profiler-4.0-linux-x64/lib/libasyncProfiler.so "$node":"$containerPath/libasyncProfiler.so"
-  kubectl exec "$node" -- chmod +x "$containerPath/asprof"
+  kubectl cp async-profiler-4.0-linux-x64/bin/asprof "$pod_name":"$containerPath/asprof"
+  kubectl cp async-profiler-4.0-linux-x64/lib/libasyncProfiler.so "$pod_name":"$containerPath/libasyncProfiler.so"
+  kubectl exec "$pod_name" -- chmod +x "$containerPath/asprof"
 fi
 
 # Run profiling
@@ -75,19 +78,20 @@ filename="$filename-$profiler_event-$(date +%Y%m%d).html"
 #   As we want to find the PID of the Java process we can use awk
 #   to check the fifth input whether it contains "/java/"
 #   If so we return the first input, which is the PID
-PID=$(kubectl exec "$node" -- ps -ax | awk '$5 ~ /java/ {print $1}')
+PID=$(kubectl exec "$pod_name" -- ps -ax | awk '$5 ~ /java/ {print $1}')
 
 # Run profiling
-kubectl exec "$node" -- ./data/asprof -e "$profiler_event" -d "${PROFILING_DURATION:-100}" -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" $additional_options "$PID"
+kubectl exec "$pod_name" -- ./data/asprof -e "$profiler_event" -d "${PROFILING_DURATION:-100}" -f "$containerPath/$filename" --libpath "$containerPath/libasyncProfiler.so" $additional_options "$PID"
 
-# Copy result
-kubectl cp "$node:$containerPath/$filename" "$node-$filename"
+# Copy result into specified output directory.
+mkdir -p "$OUTPUT_DIR"
+kubectl cp "$pod_name:$containerPath/$filename" "$OUTPUT_DIR/$filename"
 
 # Clean up
 # Comment out the following lines to make exeuction faster next time
 # These are best-effort: a cleanup failure (e.g. a file already removed,
 # a permission hiccup, or a transient exec error) must not fail the whole
 # profiling run, so failures here are swallowed rather than propagated.
-kubectl exec "$node" -- rm -f "$containerPath/asprof" "$containerPath/libasyncProfiler.so" "$containerPath/$filename" || true
+kubectl exec "$pod_name" -- rm -f "$containerPath/asprof" "$containerPath/libasyncProfiler.so" "$containerPath/$filename" || true
 rm -f profiler.tar.gz
 rm -rf async-profiler-4.0-linux-x64/


### PR DESCRIPTION
## Description

Instead of one GitHub Actions artifact per test/pod/profiling event, this groups all the profiling events for the same test/pod into a single artifact.

This reduces the list of artifacts generated and simplifies fetching all the profiling information for a single pod.

* Before: https://github.com/camunda/camunda/actions/runs/33403714535
  <img width="1279" height="1131" alt="image" src="https://github.com/user-attachments/assets/b78608e2-942c-425e-aed1-edcebb8d45f1" />
* After: https://github.com/camunda/camunda/actions/runs/33404163007
  <img width="1279" height="853" alt="image" src="https://github.com/user-attachments/assets/885cdf4e-eeb6-4c4b-9e64-c17d709bc5a6" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://app.incident.io/camunda/incidents/7574
