### PR TITLE
fix: resolve tenant authorizations for stateless bearer API callers

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
@@ -360,7 +360,13 @@ public class CCSMTokenService {
         .or(this::cslBearerAccessToken);
   }
 
+  // Only under CSL: the legacy public API path (api.jwtAuthForApiEnabled) also authenticates as a
+  // JwtAuthenticationToken, which must keep resolving no token here to avoid per-tenant Identity
+  // calls for API requests that previously resolved none.
   private Optional<String> cslBearerAccessToken() {
+    if (!isCslActive()) {
+      return Optional.empty();
+    }
     if (SecurityContextHolder.getContext().getAuthentication()
         instanceof final JwtAuthenticationToken jwtToken) {
       return Optional.ofNullable(jwtToken.getToken())
@@ -368,6 +374,11 @@ public class CCSMTokenService {
           .filter(StringUtils::isNotBlank);
     }
     return Optional.empty();
+  }
+
+  private boolean isCslActive() {
+    return camundaAuthenticationProviderProvider != null
+        && camundaAuthenticationProviderProvider.getIfAvailable() != null;
   }
 
   private Optional<HttpServletRequest> currentRequest() {
@@ -397,15 +408,12 @@ public class CCSMTokenService {
         .map(token -> token.getTokenValue());
   }
 
+  // Propagates Identity failures so callers can distinguish a failed lookup (worth retrying) from a
+  // user who genuinely has no tenants (a valid, cacheable result).
   public List<TenantDto> getAuthorizedTenantsFromToken(final String accessToken) {
-    try {
-      return identity.tenants().forToken(accessToken).stream()
-          .map(tenant -> new TenantDto(tenant.getTenantId(), tenant.getName(), ZEEBE_DATA_SOURCE))
-          .toList();
-    } catch (final Exception e) {
-      LOG.error("Could not retrieve authorized tenants from identity.", e);
-      return Collections.emptyList();
-    }
+    return identity.tenants().forToken(accessToken).stream()
+        .map(tenant -> new TenantDto(tenant.getTenantId(), tenant.getName(), ZEEBE_DATA_SOURCE))
+        .toList();
   }
 
   private String extractTokenFromAuthorizationValue(final String cookieValue) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
@@ -333,18 +333,11 @@ public class CCSMTokenService {
     if (provider == null) {
       return Optional.empty();
     }
-    if (!isCslAuthenticatedRequest()) {
+    if (!CslAuthentication.isCslAuthenticatedRequest()) {
       return Optional.empty();
     }
     return Optional.ofNullable(provider.getCamundaAuthentication())
         .map(CamundaAuthentication::authenticatedUsername);
-  }
-
-  // CSL authenticates both the webapp (OAuth2) and bearer API (JWT) chains.
-  private static boolean isCslAuthenticatedRequest() {
-    final var authentication = SecurityContextHolder.getContext().getAuthentication();
-    return authentication instanceof OAuth2AuthenticationToken
-        || authentication instanceof JwtAuthenticationToken;
   }
 
   public Optional<String> getCurrentUserAuthToken() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
@@ -333,12 +333,18 @@ public class CCSMTokenService {
     if (provider == null) {
       return Optional.empty();
     }
-    if (!(SecurityContextHolder.getContext().getAuthentication()
-        instanceof OAuth2AuthenticationToken)) {
+    if (!isCslAuthenticatedRequest()) {
       return Optional.empty();
     }
     return Optional.ofNullable(provider.getCamundaAuthentication())
         .map(CamundaAuthentication::authenticatedUsername);
+  }
+
+  // CSL authenticates both the webapp (OAuth2) and bearer API (JWT) chains.
+  private static boolean isCslAuthenticatedRequest() {
+    final var authentication = SecurityContextHolder.getContext().getAuthentication();
+    return authentication instanceof OAuth2AuthenticationToken
+        || authentication instanceof JwtAuthenticationToken;
   }
 
   public Optional<String> getCurrentUserAuthToken() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
@@ -50,6 +50,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -345,8 +347,21 @@ public class CCSMTokenService {
       return Optional.empty();
     }
     // Under CSL the token lives in the OIDC session's authorized client; fall back to the auth
-    // cookie for the legacy CCSM setup.
-    return cslSessionAccessToken(request).or(() -> AuthCookieService.getAuthCookieToken(request));
+    // cookie for the legacy CCSM setup, then to the validated bearer token for stateless API
+    // callers (e.g. the Web Modeler cluster proxy) that carry neither a session nor an auth cookie.
+    return cslSessionAccessToken(request)
+        .or(() -> AuthCookieService.getAuthCookieToken(request))
+        .or(this::cslBearerAccessToken);
+  }
+
+  private Optional<String> cslBearerAccessToken() {
+    if (SecurityContextHolder.getContext().getAuthentication()
+        instanceof final JwtAuthenticationToken jwtToken) {
+      return Optional.ofNullable(jwtToken.getToken())
+          .map(Jwt::getTokenValue)
+          .filter(StringUtils::isNotBlank);
+    }
+    return Optional.empty();
   }
 
   private Optional<HttpServletRequest> currentRequest() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CslAuthentication.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CslAuthentication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Shared CSL request detection for the security package. {@link SessionService} and {@link
+ * CCSMTokenService} both decide the same thing — is the current request CSL authenticated — and the
+ * bug this guards against came from those two answers drifting apart, so they resolve it here.
+ */
+final class CslAuthentication {
+
+  private CslAuthentication() {}
+
+  /**
+   * True when CSL authenticated the current request: an {@link OAuth2AuthenticationToken} from the
+   * {@code oauth2Login} webapp chain, or a {@link JwtAuthenticationToken} from the bearer API
+   * chain. CSL supplies a converter for both, so its authenticated username is authoritative for
+   * either and the legacy cookie/sub branches are not consulted.
+   */
+  static boolean isCslAuthenticatedRequest() {
+    final var authentication = SecurityContextHolder.getContext().getAuthentication();
+    return authentication instanceof OAuth2AuthenticationToken
+        || authentication instanceof JwtAuthenticationToken;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/SessionService.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 
@@ -119,7 +118,7 @@ public class SessionService implements ConfigurationReloadable {
    */
   public String getRequestUserOrFailNotAuthorized(final HttpServletRequest request) {
     final CamundaAuthenticationProvider cslProvider = cslAuthenticationProvider();
-    if (cslProvider != null && isCslAuthenticatedRequest()) {
+    if (cslProvider != null && CslAuthentication.isCslAuthenticatedRequest()) {
       return cslAuthenticatedUsername(cslProvider)
           .orElseThrow(
               () ->
@@ -139,18 +138,6 @@ public class SessionService implements ConfigurationReloadable {
     return camundaAuthenticationProviderProvider == null
         ? null
         : camundaAuthenticationProviderProvider.getIfAvailable();
-  }
-
-  /**
-   * True when CSL authenticated the current request: an {@link OAuth2AuthenticationToken} from the
-   * {@code oauth2Login} webapp chain, or a {@link JwtAuthenticationToken} from the bearer API
-   * chain. CSL supplies a converter for both, so its authenticated username is authoritative for
-   * either and the legacy branches below are not consulted.
-   */
-  private static boolean isCslAuthenticatedRequest() {
-    final var authentication = SecurityContextHolder.getContext().getAuthentication();
-    return authentication instanceof OAuth2AuthenticationToken
-        || authentication instanceof JwtAuthenticationToken;
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/util/tenant/CamundaCCSMTenantAuthorizationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/util/tenant/CamundaCCSMTenantAuthorizationService.java
@@ -122,7 +122,15 @@ public class CamundaCCSMTenantAuthorizationService implements DataSourceTenantAu
 
   private void repopulateCacheWithCurrentUserTenantAuthorization() {
     getCurrentUserId()
-        .ifPresent(id -> userTenantAuthorizations.put(id, fetchCurrentUserAuthorizedTenants()));
+        .ifPresent(
+            id -> {
+              final List<TenantDto> tenants = fetchCurrentUserAuthorizedTenants();
+              // Never cache an empty result. Caching it would hide the user's tenants for the whole
+              // expireAfterWrite TTL.
+              if (!tenants.isEmpty()) {
+                userTenantAuthorizations.put(id, tenants);
+              }
+            });
   }
 
   private List<TenantDto> fetchCurrentUserAuthorizedTenants() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/util/tenant/CamundaCCSMTenantAuthorizationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/util/tenant/CamundaCCSMTenantAuthorizationService.java
@@ -120,24 +120,27 @@ public class CamundaCCSMTenantAuthorizationService implements DataSourceTenantAu
         .anyMatch(tenant -> Objects.equals(tenantId, tenant.getId()));
   }
 
+  // Caches a successful Identity response (even an empty one); a failed or absent lookup returns
+  // Optional.empty() and stays uncached so the next request retries instead of masking tenants.
   private void repopulateCacheWithCurrentUserTenantAuthorization() {
     getCurrentUserId()
         .ifPresent(
-            id -> {
-              final List<TenantDto> tenants = fetchCurrentUserAuthorizedTenants();
-              // Never cache an empty result. Caching it would hide the user's tenants for the whole
-              // expireAfterWrite TTL.
-              if (!tenants.isEmpty()) {
-                userTenantAuthorizations.put(id, tenants);
-              }
-            });
+            id ->
+                fetchCurrentUserAuthorizedTenants()
+                    .ifPresent(tenants -> userTenantAuthorizations.put(id, tenants)));
   }
 
-  private List<TenantDto> fetchCurrentUserAuthorizedTenants() {
-    return ccsmTokenService
-        .getCurrentUserAuthToken()
-        .map(ccsmTokenService::getAuthorizedTenantsFromToken)
-        .orElse(Collections.emptyList());
+  private Optional<List<TenantDto>> fetchCurrentUserAuthorizedTenants() {
+    final Optional<String> authToken = ccsmTokenService.getCurrentUserAuthToken();
+    if (authToken.isEmpty()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(ccsmTokenService.getAuthorizedTenantsFromToken(authToken.get()));
+    } catch (final Exception e) {
+      LOG.error("Could not retrieve authorized tenants from Identity.", e);
+      return Optional.empty();
+    }
   }
 
   private Optional<String> getCurrentUserId() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -395,6 +395,23 @@ public class CCSMTokenServiceTest {
   }
 
   @Test
+  void shouldResolveCurrentUserIdFromCslPrincipalForBearerRequests() {
+    // given — CSL authenticates a bearer request as a JWT; the id must still come from the
+    // configured username-claim, not the raw sub claim
+    SecurityContextHolder.getContext().setAuthentication(jwtAuthentication("bearer-token"));
+    when(camundaAuthenticationProviderProvider.getIfAvailable())
+        .thenReturn(camundaAuthenticationProvider);
+    when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenReturn(CamundaAuthentication.of(b -> b.user("preferred-username")));
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserIdFromAuthToken();
+
+    // then — id comes from the CSL principal, without decoding the bearer token
+    assertThat(result).contains("preferred-username");
+  }
+
+  @Test
   void shouldFallBackToSubClaimForCurrentUserIdWhenNotUnderCsl() {
     // given — legacy CCSM: no CSL principal provider, id derived from the token's sub claim
     setCurrentRequestWithAuthCookie(ACCESS_TOKEN_VALUE);

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -48,6 +48,8 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -348,6 +350,32 @@ public class CCSMTokenServiceTest {
     assertThat(result).contains("cookie-token");
   }
 
+  @Test
+  void shouldFallBackToValidatedBearerTokenWhenNoSessionOrCookie() {
+    // given — stateless API caller (e.g. the Web Modeler cluster proxy): no OIDC session and no
+    // auth cookie, only a validated bearer token in the security context
+    setCurrentRequestWithoutAuthCookie();
+    SecurityContextHolder.getContext().setAuthentication(jwtAuthentication("bearer-token"));
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
+
+    // then
+    assertThat(result).contains("bearer-token");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoSessionCookieOrBearerToken() {
+    // given — an authenticated request that carries none of the supported token sources
+    setCurrentRequestWithoutAuthCookie();
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
   // --- getCurrentUserIdFromAuthToken: principal source (CSL claim vs legacy sub) ---
 
   @Test
@@ -393,6 +421,17 @@ public class CCSMTokenServiceTest {
     when(request.getAttributeNames()).thenReturn(Collections.emptyEnumeration());
     when(request.getCookies()).thenReturn(new Cookie[] {cookie});
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  private void setCurrentRequestWithoutAuthCookie() {
+    when(request.getAttributeNames()).thenReturn(Collections.emptyEnumeration());
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  private JwtAuthenticationToken jwtAuthentication(final String tokenValue) {
+    final Jwt jwt =
+        Jwt.withTokenValue(tokenValue).header("alg", "none").claim("sub", "user").build();
+    return new JwtAuthenticationToken(jwt);
   }
 
   private OAuth2AuthenticationToken oauthToken() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -386,6 +386,11 @@ public class CCSMTokenServiceTest {
     // cookie must win so a lingering context token can never override the request's own credential
     setCurrentRequestWithAuthCookie("cookie-token");
     SecurityContextHolder.getContext().setAuthentication(jwtAuthentication("bearer-token"));
+    // CSL active, so the bearer token is a live alternative: only the cookie-before-bearer ordering
+    // keeps it from winning. Lenient because that ordering short-circuits before the bearer branch.
+    lenient()
+        .when(camundaAuthenticationProviderProvider.getIfAvailable())
+        .thenReturn(camundaAuthenticationProvider);
 
     // when
     final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -352,16 +352,46 @@ public class CCSMTokenServiceTest {
 
   @Test
   void shouldFallBackToValidatedBearerTokenWhenNoSessionOrCookie() {
-    // given — stateless API caller (e.g. the Web Modeler cluster proxy): no OIDC session and no
+    // given — stateless CSL API caller (e.g. the Web Modeler cluster proxy): no OIDC session and no
     // auth cookie, only a validated bearer token in the security context
     setCurrentRequestWithoutAuthCookie();
     SecurityContextHolder.getContext().setAuthentication(jwtAuthentication("bearer-token"));
+    when(camundaAuthenticationProviderProvider.getIfAvailable())
+        .thenReturn(camundaAuthenticationProvider);
 
     // when
     final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
 
     // then
     assertThat(result).contains("bearer-token");
+  }
+
+  @Test
+  void shouldNotFallBackToBearerTokenWhenCslInactive() {
+    // given — the legacy public API path also authenticates as a JwtAuthenticationToken, but CSL is
+    // not active; the bearer token must not flow into tenant resolution as it did not before
+    setCurrentRequestWithoutAuthCookie();
+    SecurityContextHolder.getContext().setAuthentication(jwtAuthentication("api-token"));
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldPreferAuthCookieOverBearerTokenWhenBothPresent() {
+    // given — a request carrying both a stale auth cookie and a security-context bearer token; the
+    // cookie must win so a lingering context token can never override the request's own credential
+    setCurrentRequestWithAuthCookie("cookie-token");
+    SecurityContextHolder.getContext().setAuthentication(jwtAuthentication("bearer-token"));
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
+
+    // then
+    assertThat(result).contains("cookie-token");
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/tenant/CCSMTenantAuthorizationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/tenant/CCSMTenantAuthorizationServiceTest.java
@@ -126,28 +126,44 @@ public class CCSMTenantAuthorizationServiceTest {
   }
 
   @Test
-  public void shouldNotCacheEmptyTenantAuthorizationsAndRetry() {
-    // given — Identity resolves no tenants on the first attempt (e.g. a transient hiccup), then the
-    // real tenants once it recovers
+  public void shouldNotCacheFailedTenantLookupAndRetry() {
+    // given — Identity fails on the first attempt (e.g. a transient outage), then resolves the real
+    // tenants once it recovers
     final List<TenantDto> authorizedTenants =
         List.of(new TenantDto("tenant1Id", "tenant1", ZEEBE_DATA_SOURCE));
     when(ccsmTokenService.getAuthorizedTenantsFromToken(TEST_TOKEN))
-        .thenReturn(List.of())
+        .thenThrow(new RuntimeException("identity unavailable"))
         .thenReturn(authorizedTenants);
 
-    // when — the first resolution yields nothing
+    // when — the first resolution fails
     final List<TenantDto> firstResult = underTest.getCurrentUserAuthorizedTenants();
 
-    // then — the empty result is not cached
+    // then — the failed lookup is not cached
     assertThat(firstResult).isEmpty();
 
     // when — a subsequent call is made before the cache TTL would have expired
     final List<TenantDto> secondResult = underTest.getCurrentUserAuthorizedTenants();
 
-    // then — Identity is queried again (the empty result was never cached) and the resolved tenants
-    // are returned instead of a stale empty list
+    // then — Identity is queried again (the failure was never cached) and the resolved tenants are
+    // returned instead of a stale empty list
     Mockito.verify(ccsmTokenService, times(2)).getAuthorizedTenantsFromToken(TEST_TOKEN);
     assertThat(secondResult).containsExactlyInAnyOrderElementsOf(authorizedTenants);
+  }
+
+  @Test
+  public void shouldCacheSuccessfulEmptyTenantAuthorizations() {
+    // given — Identity successfully resolves that the user genuinely has no tenants (e.g. right
+    // after multi-tenancy is enabled, before any mapping rule exists)
+    when(ccsmTokenService.getAuthorizedTenantsFromToken(TEST_TOKEN)).thenReturn(List.of());
+
+    // when — the tenants are resolved twice before the cache TTL would have expired
+    final List<TenantDto> firstResult = underTest.getCurrentUserAuthorizedTenants();
+    final List<TenantDto> secondResult = underTest.getCurrentUserAuthorizedTenants();
+
+    // then — the empty result is cached, so Identity is queried only once rather than per request
+    Mockito.verify(ccsmTokenService, times(1)).getAuthorizedTenantsFromToken(TEST_TOKEN);
+    assertThat(firstResult).isEmpty();
+    assertThat(secondResult).isEmpty();
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/tenant/CCSMTenantAuthorizationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/tenant/CCSMTenantAuthorizationServiceTest.java
@@ -126,7 +126,7 @@ public class CCSMTenantAuthorizationServiceTest {
   }
 
   @Test
-  public void emptyTenantAuthorizationsAreNotCachedAndAreRetried() {
+  public void shouldNotCacheEmptyTenantAuthorizationsAndRetry() {
     // given — Identity resolves no tenants on the first attempt (e.g. a transient hiccup), then the
     // real tenants once it recovers
     final List<TenantDto> authorizedTenants =

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/tenant/CCSMTenantAuthorizationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/tenant/CCSMTenantAuthorizationServiceTest.java
@@ -126,6 +126,31 @@ public class CCSMTenantAuthorizationServiceTest {
   }
 
   @Test
+  public void emptyTenantAuthorizationsAreNotCachedAndAreRetried() {
+    // given — Identity resolves no tenants on the first attempt (e.g. a transient hiccup), then the
+    // real tenants once it recovers
+    final List<TenantDto> authorizedTenants =
+        List.of(new TenantDto("tenant1Id", "tenant1", ZEEBE_DATA_SOURCE));
+    when(ccsmTokenService.getAuthorizedTenantsFromToken(TEST_TOKEN))
+        .thenReturn(List.of())
+        .thenReturn(authorizedTenants);
+
+    // when — the first resolution yields nothing
+    final List<TenantDto> firstResult = underTest.getCurrentUserAuthorizedTenants();
+
+    // then — the empty result is not cached
+    assertThat(firstResult).isEmpty();
+
+    // when — a subsequent call is made before the cache TTL would have expired
+    final List<TenantDto> secondResult = underTest.getCurrentUserAuthorizedTenants();
+
+    // then — Identity is queried again (the empty result was never cached) and the resolved tenants
+    // are returned instead of a stale empty list
+    Mockito.verify(ccsmTokenService, times(2)).getAuthorizedTenantsFromToken(TEST_TOKEN);
+    assertThat(secondResult).containsExactlyInAnyOrderElementsOf(authorizedTenants);
+  }
+
+  @Test
   public void noTenantAuthorizationsReturnedIfNoUserTokenPresent() {
     // given
     when(ccsmTokenService.getCurrentUserIdFromAuthToken()).thenReturn(Optional.empty());


### PR DESCRIPTION
## Description

Under CSL, a stateless API caller (e.g. the Web Modeler cluster proxy) authenticates with a validated bearer token but carries neither an OIDC session nor an auth cookie. This PR fixes two related multi-tenancy defects that left such callers with no authorized tenants:

- **`CCSMTokenService`** — `getCurrentUserAuthToken()` only read the token from the OIDC session's authorized client or the legacy auth cookie. Add a third fallback that reads the validated bearer token from the `JwtAuthenticationToken` in the security context, so `identity.tenants().forToken(...)` can resolve tenants for stateless callers.
- **`CamundaCCSMTenantAuthorizationService`** — `repopulateCacheWithCurrentUserTenantAuthorization()` cached an empty tenant list on a transient empty fetch, hiding a user's tenants for the whole `expireAfterWrite` TTL. Only cache non-empty results so an empty fetch is retried on the next call.

Both paths are covered by new unit tests (`CCSMTokenServiceTest`, `CCSMTenantAuthorizationServiceTest`).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to https://github.com/camunda/camunda-hub/issues/27685