### PR TITLE
fix: scope business-value report definitions to requested tenants

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
@@ -187,7 +187,10 @@ public abstract class ReportEvaluationHandler {
                                   scopedDef.getKey(),
                                   reportEvaluationInfo.getUserId())
                               .stream()
-                              .map(def -> toReportDataDefinitionDto(def, scopedDef.getVersions())))
+                              .map(
+                                  def ->
+                                      toReportDataDefinitionDto(
+                                          def, scopedDef.getVersions(), scopedDef.getTenantIds())))
                   .toList();
           processReportData.setDefinitions(validatedDefs);
           // Heatmap tiles render on top of the BPMN diagram, so the frontend needs the definition
@@ -253,14 +256,29 @@ public abstract class ReportEvaluationHandler {
   private ReportDataDefinitionDto toReportDataDefinitionDto(
       final io.camunda.optimize.dto.optimize.query.definition.DefinitionResponseDto def,
       final List<String> versions) {
+    return toReportDataDefinitionDto(def, versions, null);
+  }
+
+  private ReportDataDefinitionDto toReportDataDefinitionDto(
+      final io.camunda.optimize.dto.optimize.query.definition.DefinitionResponseDto def,
+      final List<String> versions,
+      final List<String> requestedTenantIds) {
     final List<String> resolvedVersions =
         versions == null || versions.isEmpty() ? List.of(ALL_VERSIONS) : versions;
+    final List<String> availableTenantIds =
+        def.getTenants().stream().map(TenantDto::getId).toList();
+    // An unscoped definition deserializes tenantIds to DEFAULT_TENANT_IDS ([null]); treat that (and
+    // any all-null list) as "no scope" so unscoped/agentic reports keep all available tenants.
+    final List<String> scopedTenantIds =
+        requestedTenantIds == null
+            ? List.of()
+            : requestedTenantIds.stream().filter(Objects::nonNull).toList();
+    final List<String> resolvedTenantIds =
+        scopedTenantIds.isEmpty()
+            ? availableTenantIds
+            : availableTenantIds.stream().filter(scopedTenantIds::contains).toList();
     return new ReportDataDefinitionDto(
-        def.getKey(),
-        def.getName(),
-        resolvedVersions,
-        def.getTenants().stream().map(TenantDto::getId).toList(),
-        def.getName());
+        def.getKey(), def.getName(), resolvedVersions, resolvedTenantIds, def.getName());
   }
 
   private CombinedReportEvaluationResult evaluateCombinedReport(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
@@ -269,10 +269,10 @@ public abstract class ReportEvaluationHandler {
         def.getTenants().stream().map(TenantDto::getId).toList();
     // An unscoped definition deserializes tenantIds to DEFAULT_TENANT_IDS ([null]); treat that (and
     // any all-null list) as "no scope" so unscoped/agentic reports keep all available tenants.
-    final List<String> scopedTenantIds =
+    final Set<String> scopedTenantIds =
         requestedTenantIds == null
-            ? List.of()
-            : requestedTenantIds.stream().filter(Objects::nonNull).toList();
+            ? Set.of()
+            : requestedTenantIds.stream().filter(Objects::nonNull).collect(Collectors.toSet());
     final List<String> resolvedTenantIds =
         scopedTenantIds.isEmpty()
             ? availableTenantIds


### PR DESCRIPTION
## Description

When a business-value tile was scoped to one or more processes, the L1 branch of `ReportEvaluationHandler.setDataSourcesForSystemGeneratedReports` rebuilt each definition from its key and versions and attached **every** tenant the definition was available on, ignoring the tenant IDs requested by the caller. As a result, selecting a tenant did not filter the tile's data.

This change intersects the definition's available tenants with the requested tenant IDs. A `null`/all-`null` request — the unscoped default, which deserializes to `[null]` — keeps all available tenants, preserving the existing behavior for unscoped and agentic reports.

> Note: `toReportDataDefinitionDto` is private and there is no existing test harness that constructs a `ReportEvaluationHandler` (the business-value tests only mock it), so no unit test is added here. Happy to add a small package-private seam + test if reviewers prefer explicit coverage of the intersection logic.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

_No linked issue._