### PR TITLE
revert: upgrade micrometer to 1.16.7 to remediate CVE-2026-59296 (stable/8.7)

### DIFF
--- a/.github/dependency-review-config.json
+++ b/.github/dependency-review-config.json
@@ -1,7 +1,8 @@
 {
   "_comment": "Vulnerability gate exceptions — governs the pr-vuln-check job in ci.yml. Gate rules (in check.py): block if fixable (any severity) or high/critical (any fix status). Dev-scoped deps excluded. Add GHSA IDs below with reason, tracking issue, and review-by date. File is CODEOWNERS-protected.",
   "_example": "GHSA-xxxx-xxxx-xxxx: Vetted: no exploit path in our usage; INC-XYZ; review by 2026-12-01",
+  "_reason_GHSA-g3pr-3p32-fp23": "io.micrometer:micrometer-core@1.14.14 — Vetted: no exploit path in our usage; INC-7443; review by 2026-31-08; no patch release available as OSS ended",
   "allow-ghsas": [
-    "GHSA-g3pr-3p32-fp23: Vetted: no exploit path in our usage; INC-7443; review by 2026-31-08; no patch release available as OSS ended"
+    "GHSA-g3pr-3p32-fp23"
   ]
 }

--- a/.github/dependency-review-config.json
+++ b/.github/dependency-review-config.json
@@ -1,5 +1,7 @@
 {
   "_comment": "Vulnerability gate exceptions — governs the pr-vuln-check job in ci.yml. Gate rules (in check.py): block if fixable (any severity) or high/critical (any fix status). Dev-scoped deps excluded. Add GHSA IDs below with reason, tracking issue, and review-by date. File is CODEOWNERS-protected.",
   "_example": "GHSA-xxxx-xxxx-xxxx: Vetted: no exploit path in our usage; INC-XYZ; review by 2026-12-01",
-  "allow-ghsas": []
+  "allow-ghsas": [
+    "GHSA-g3pr-3p32-fp23: Vetted: no exploit path in our usage; INC-7443; review by 2026-31-08; no patch release available as OSS ended"
+  ]
 }

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -38,15 +38,7 @@
   <dependencyManagement>
     <dependencies>
       <!-- Re-import these BOMs (first-import-wins) ahead of spring-boot-dependencies so its
-      vulnerable netty/jackson/log4j/plexus-utils/micrometer pins don't leak into the flattened
-      clients. -->
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${version.micrometer}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+      vulnerable netty/jackson/log4j/plexus-utils pins don't leak into the flattened clients. -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,9 +83,9 @@
     <version.opensearch-java>2.9.1</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>4.33.6</version.protobuf>
+    <version.protobuf>4.31.1</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.16.7</version.micrometer>
+    <version.micrometer>1.15.12</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
Reverts #61194.

This reverts the micrometer 1.16.7 upgrade merged into `stable/8.7`.