### PR TITLE
revert: upgrade micrometer to 1.16.7 to remediate CVE-2026-59296 (stable/8.8)

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -65,10 +65,6 @@
       <artifactId>micrometer-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -38,15 +38,7 @@
   <dependencyManagement>
     <dependencies>
       <!-- Re-import these BOMs (first-import-wins) ahead of spring-boot-dependencies so its
-      vulnerable netty/jackson/log4j/plexus-utils/micrometer pins don't leak into the flattened
-      clients. -->
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${version.micrometer}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+      vulnerable netty/jackson/log4j/plexus-utils pins don't leak into the flattened clients. -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,9 +83,9 @@
     <version.opensearch-java>2.19.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>4.33.6</version.protobuf>
+    <version.protobuf>4.31.1</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.16.7</version.micrometer>
+    <version.micrometer>1.15.12</version.micrometer>
     <version.rocksdbjni>10.2.1</version.rocksdbjni>
     <version.sbe>1.35.6</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
Reverts #61198.

This reverts the micrometer 1.16.7 upgrade merged into `stable/8.8`.