### PR TITLE
revert: upgrade micrometer to 1.16.7 to remediate CVE-2026-59295 and CVE-2026-59296 (stable/optimize-8.7)

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -340,7 +340,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>${micrometer.version}</version>
+      <version>1.13.4</version>
     </dependency>
 
     <!--Lucene dependencies-->

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -63,11 +63,6 @@
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
     <netty.version>4.1.137.Final</netty.version>
     <log4j2.version>2.25.4</log4j2.version>
-    <!-- Override Spring Boot's micrometer version to address CVE-2026-59295.
-         The 1.15.x fix (1.15.13) is Spring Enterprise-only, so we move to the 1.16.x OSS line. -->
-    <micrometer.version>1.16.7</micrometer.version>
-    <!-- Must match what micrometer-registry-prometheus 1.16.x requires -->
-    <prometheus-metrics.version>1.4.3</prometheus-metrics.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.37</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
@@ -155,21 +150,6 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
         <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Must be declared before spring-boot-dependencies so this version wins -->
-      <dependency>
-        <groupId>io.prometheus</groupId>
-        <artifactId>prometheus-metrics-bom</artifactId>
-        <version>${prometheus-metrics.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${micrometer.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -84,7 +84,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.5</version.protobuf>
     <version.protobuf-common>2.45.0</version.protobuf-common>
-    <version.micrometer>1.16.7</version.micrometer>
+    <version.micrometer>1.13.4</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.1</version.sbe>
     <version.scala>2.13.15</version.scala>
@@ -1021,19 +1021,6 @@
         <scope>import</scope>
       </dependency>
 
-      <!--
-        Override Spring Boot's micrometer version to address CVE-2026-59295.
-        The 1.15.x fix (1.15.13) is Spring Enterprise-only, so we move to the 1.16.x OSS line.
-        Must be declared before spring-boot-dependencies so this version wins.
-      -->
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${version.micrometer}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
@@ -1317,6 +1304,14 @@
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
         <version>${version.reactor-netty}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Reverts #61317.

This reverts the micrometer 1.16.7 upgrade merged into `stable/optimize-8.7`.