### PR TITLE
feat: add metrics for process instance suspend/resume

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -137,12 +137,14 @@ public class Engine implements RecordProcessor {
             recordProcessorContext, writers, config, securityConfig);
     processingState = typedProcessorContext.getProcessingState();
     writers.setKeyValidator(processingState.getKeyGenerator());
-    bufferingBehavior = new CommandBufferingBehavior(processingState.getKeyGenerator(), writers);
     suspensionCheck = new SuspensionCheck(processingState);
+    final var suspensionMetrics = typedProcessorContext.getSuspensionMetrics();
 
     ((EventAppliers) eventApplier).registerEventAppliers(processingState);
     final TypedRecordProcessors typedRecordProcessors =
         typedRecordProcessorFactory.createProcessors(typedProcessorContext);
+    bufferingBehavior =
+        new CommandBufferingBehavior(processingState.getKeyGenerator(), writers, suspensionMetrics);
 
     recordProcessorContext.addLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SuspensionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SuspensionMetrics.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.engine.metrics.SuspensionMetricsDoc.BufferedCommandAction;
+import io.camunda.zeebe.engine.metrics.SuspensionMetricsDoc.SuspensionAction;
+import io.camunda.zeebe.engine.metrics.SuspensionMetricsDoc.SuspensionKeyNames;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.HashMap;
+
+public final class SuspensionMetrics implements StreamProcessorLifecycleAware {
+  private final MeterRegistry registry;
+
+  private final Counter suspendedCounter;
+  private final Counter resumedCounter;
+  private final Counter jobSuspendedCounter;
+  private final Counter jobResumedCounter;
+  private final Counter commandBufferedCounter;
+  private final Counter commandDrainedCounter;
+  private final Counter commandDroppedCounter;
+
+  /**
+   * In-flight resume timers keyed by process instance key. All calls happen on the stream processor
+   * actor thread, so a plain {@link HashMap} is safe here; see {@link MessageCorrelationMetrics}
+   * for the same reasoning applied to its per-key samples.
+   */
+  private final HashMap<Long, Timer.ResourceSample> resumeDurationSamples = new HashMap<>();
+
+  public SuspensionMetrics(final MeterRegistry meterRegistry) {
+    registry = meterRegistry;
+
+    suspendedCounter =
+        registerCounter(
+            meterRegistry, SuspensionMetricsDoc.SUSPENSION_EVENTS, SuspensionAction.SUSPENDED);
+    resumedCounter =
+        registerCounter(
+            meterRegistry, SuspensionMetricsDoc.SUSPENSION_EVENTS, SuspensionAction.RESUMED);
+    jobSuspendedCounter =
+        registerCounter(
+            meterRegistry, SuspensionMetricsDoc.JOB_SUSPENSION_EVENTS, SuspensionAction.SUSPENDED);
+    jobResumedCounter =
+        registerCounter(
+            meterRegistry, SuspensionMetricsDoc.JOB_SUSPENSION_EVENTS, SuspensionAction.RESUMED);
+    commandBufferedCounter =
+        registerCounter(
+            meterRegistry,
+            SuspensionMetricsDoc.BUFFERED_COMMAND_EVENTS,
+            BufferedCommandAction.BUFFERED);
+    commandDrainedCounter =
+        registerCounter(
+            meterRegistry,
+            SuspensionMetricsDoc.BUFFERED_COMMAND_EVENTS,
+            BufferedCommandAction.DRAINED);
+    commandDroppedCounter =
+        registerCounter(
+            meterRegistry,
+            SuspensionMetricsDoc.BUFFERED_COMMAND_EVENTS,
+            BufferedCommandAction.DROPPED);
+
+    MicrometerUtil.buildTimer(SuspensionMetricsDoc.RESUME_DURATION)
+        .minimumExpectedValue(Duration.ofMillis(10))
+        .register(meterRegistry);
+  }
+
+  public void instanceSuspended() {
+    suspendedCounter.increment();
+  }
+
+  public void instanceResumed() {
+    resumedCounter.increment();
+  }
+
+  public void jobSuspended() {
+    jobSuspendedCounter.increment();
+  }
+
+  public void jobsSuspended(final int count) {
+    jobSuspendedCounter.increment(count);
+  }
+
+  public void jobResumed() {
+    jobResumedCounter.increment();
+  }
+
+  public void commandBuffered() {
+    commandBufferedCounter.increment();
+  }
+
+  public void commandDrained() {
+    commandDrainedCounter.increment();
+  }
+
+  public void commandsDropped(final int count) {
+    commandDroppedCounter.increment(count);
+  }
+
+  public void startResumeDuration(final long processInstanceKey) {
+    resumeDurationSamples.computeIfAbsent(
+        processInstanceKey,
+        key -> Timer.resource(registry, SuspensionMetricsDoc.RESUME_DURATION.getName()));
+  }
+
+  public void stopResumeDuration(final long processInstanceKey) {
+    final var sample = resumeDurationSamples.remove(processInstanceKey);
+    if (sample != null) {
+      sample.close();
+    }
+  }
+
+  /**
+   * Discards the in-flight resume-duration sample for the given key without recording it. Called
+   * when a resuming instance terminates before the resume completes, so the sample does not leak.
+   */
+  public void cancelResumeDuration(final long processInstanceKey) {
+    resumeDurationSamples.remove(processInstanceKey);
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    resumeDurationSamples.clear();
+  }
+
+  private static Counter registerCounter(
+      final MeterRegistry meterRegistry,
+      final ExtendedMeterDocumentation meterDoc,
+      final Enum<?> action) {
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(SuspensionKeyNames.ACTION.asString(), action.toString())
+        .register(meterRegistry);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SuspensionMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/SuspensionMetricsDoc.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+/** {@link SuspensionMetricsDoc} documents process instance and job suspension metrics. */
+@SuppressWarnings("NullableProblems")
+public enum SuspensionMetricsDoc implements ExtendedMeterDocumentation {
+  /** Number of process instance suspension lifecycle events */
+  SUSPENSION_EVENTS {
+    @Override
+    public String getName() {
+      return "zeebe.process.instance.suspension.events.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of process instance suspension lifecycle events";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return ACTION_KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Number of job suspension lifecycle events */
+  JOB_SUSPENSION_EVENTS {
+    @Override
+    public String getName() {
+      return "zeebe.job.suspension.events.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of job suspension lifecycle events";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return ACTION_KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Number of buffered command lifecycle events */
+  BUFFERED_COMMAND_EVENTS {
+    @Override
+    public String getName() {
+      return "zeebe.buffered.commands.events.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of buffered command lifecycle events";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return ACTION_KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Wall-clock time from RESUME command to RESUMED event per process instance */
+  RESUME_DURATION {
+    private static final Duration[] BUCKETS =
+        new Duration[] {
+          Duration.ofMillis(10),
+          Duration.ofMillis(100),
+          Duration.ofMillis(500),
+          Duration.ofSeconds(1),
+          Duration.ofSeconds(5),
+          Duration.ofSeconds(10),
+          Duration.ofSeconds(30),
+          Duration.ofMinutes(1),
+          Duration.ofMinutes(5)
+        };
+
+    @Override
+    public String getName() {
+      return "zeebe.process.instance.resume.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Wall-clock time from RESUME command to RESUMED event per process instance";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  };
+
+  private static final KeyName[] ACTION_KEY_NAMES = new KeyName[] {SuspensionKeyNames.ACTION};
+
+  /** Tags/label values used by the suspension metrics. */
+  public enum SuspensionKeyNames implements KeyName {
+    /**
+     * The suspension lifecycle action; see {@link SuspensionAction} and {@link
+     * BufferedCommandAction} for possible values.
+     */
+    ACTION {
+      @Override
+      public String asString() {
+        return "action";
+      }
+    }
+  }
+
+  public enum SuspensionAction {
+    SUSPENDED,
+    RESUMED;
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+
+  public enum BufferedCommandAction {
+    BUFFERED,
+    DRAINED,
+    DROPPED;
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionActivateProcessor;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessInstructionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
@@ -88,7 +89,8 @@ public final class BpmnProcessors {
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final SuspensionMetrics suspensionMetrics) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         processingState.getProcessMessageSubscriptionState();
     final var keyGenerator = processingState.getKeyGenerator();
@@ -103,12 +105,19 @@ public final class BpmnProcessors {
         bpmnBehaviors.jobActivationBehavior(),
         subscriptionCommandSender,
         transientProcessMessageSubscriptionState,
-        clock);
-    addBufferedCommandProcessor(writers, typedRecordProcessors, processingState);
+        clock,
+        suspensionMetrics);
+    addBufferedCommandProcessor(writers, typedRecordProcessors, processingState, suspensionMetrics);
 
     final var bpmnStreamProcessor =
         new BpmnStreamProcessor(
-            bpmnBehaviors, processingState, writers, processEngineMetrics, config);
+            bpmnBehaviors,
+            processingState,
+            writers,
+            processEngineMetrics,
+            config,
+            processingState.getSuspensionState(),
+            suspensionMetrics);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(
@@ -120,7 +129,8 @@ public final class BpmnProcessors {
         scheduledTaskState,
         writers,
         clock,
-        transientProcessMessageSubscriptionState);
+        transientProcessMessageSubscriptionState,
+        suspensionMetrics);
     addTimerStreamProcessors(
         typedRecordProcessors, timerChecker, processingState, bpmnBehaviors, writers);
     addConditionalStreamProcessors(typedRecordProcessors, processingState, bpmnBehaviors, writers);
@@ -183,7 +193,8 @@ public final class BpmnProcessors {
       final BpmnJobActivationBehavior jobActivationBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final SuspensionMetrics suspensionMetrics) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
@@ -192,11 +203,12 @@ public final class BpmnProcessors {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.RESUME,
-        new ProcessInstanceResumeProcessor(processingState, writers, cslCheck));
+        new ProcessInstanceResumeProcessor(processingState, writers, cslCheck, suspensionMetrics));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.RESUME_JOBS,
-        new ProcessInstanceResumeJobsProcessor(processingState, writers, jobActivationBehavior));
+        new ProcessInstanceResumeJobsProcessor(
+            processingState, writers, jobActivationBehavior, suspensionMetrics));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.COMPLETE_RESUMING,
@@ -204,7 +216,8 @@ public final class BpmnProcessors {
             processingState.getElementInstanceState(),
             processingState.getSuspensionState(),
             writers,
-            timerChecker));
+            timerChecker,
+            suspensionMetrics));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.SUSPEND,
@@ -214,17 +227,19 @@ public final class BpmnProcessors {
             cslCheck,
             subscriptionCommandSender,
             transientProcessMessageSubscriptionState,
-            clock));
+            clock,
+            suspensionMetrics));
   }
 
   private static void addBufferedCommandProcessor(
       final Writers writers,
       final TypedRecordProcessors typedRecordProcessors,
-      final ProcessingState processingState) {
+      final ProcessingState processingState,
+      final SuspensionMetrics suspensionMetrics) {
     typedRecordProcessors.onCommand(
         ValueType.BUFFERED_COMMAND,
         BufferedCommandIntent.DRAIN,
-        new BufferedCommandDrainProcessor(processingState, writers));
+        new BufferedCommandDrainProcessor(processingState, writers, suspensionMetrics));
   }
 
   private static void addBpmnStepProcessor(
@@ -248,7 +263,8 @@ public final class BpmnProcessors {
       final Supplier<ScheduledTaskState> scheduledTaskState,
       final Writers writers,
       final InstantSource clock,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final SuspensionMetrics suspensionMetrics) {
     // One CreateProcessor instance handles both CREATE (the create acknowledgement) and REOPEN (a
     // manifest re-subscribe drained from the suspend/resume buffer); it branches on the intent.
     final var createProcessor =
@@ -286,7 +302,8 @@ public final class BpmnProcessors {
                 processingState.getSuspensionState(),
                 writers,
                 transientProcessMessageSubscriptionState,
-                processingState.getKeyGenerator()))
+                processingState.getKeyGenerator(),
+                suspensionMetrics))
         .withListener(
             new PendingProcessMessageSubscriptionCheckScheduler(
                 subscriptionCommandSender,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.metrics.MessageCorrelationMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.metrics.SecretResolutionMetrics;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.metrics.TenantMetrics;
 import io.camunda.zeebe.engine.processing.agenthistory.AgentHistoryProcessors;
 import io.camunda.zeebe.engine.processing.agentinstance.AgentInstanceProcessors;
@@ -174,6 +175,7 @@ public final class EngineProcessors {
     final var tenantMetrics = new TenantMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var messageCorrelationMetrics =
         new MessageCorrelationMetrics(typedRecordProcessorContext.getMeterRegistry());
+    final var suspensionMetrics = typedRecordProcessorContext.getSuspensionMetrics();
     final var secretResolutionMetrics =
         new SecretResolutionMetrics(typedRecordProcessorContext.getMeterRegistry());
     // built here rather than with the other secret reference processors because the job activation
@@ -361,7 +363,9 @@ public final class EngineProcessors {
             asyncRequestBehavior,
             cslCheck,
             transientProcessMessageSubscriptionState,
-            processEngineMetrics);
+            processEngineMetrics,
+            suspensionMetrics);
+    typedRecordProcessors.withListener(suspensionMetrics);
 
     addDecisionProcessors(
         typedRecordProcessors, decisionBehavior, writers, processingState, cslCheck);
@@ -379,7 +383,8 @@ public final class EngineProcessors {
         tenantCheck,
         incidentMetrics,
         secretStoreRegistry,
-        secretResolutionScheduler);
+        secretResolutionScheduler,
+        suspensionMetrics);
 
     final var userTaskProcessor =
         createUserTaskProcessor(
@@ -686,7 +691,8 @@ public final class EngineProcessors {
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final SuspensionMetrics suspensionMetrics) {
     return BpmnProcessors.addBpmnStreamProcessor(
         processingState,
         scheduledTaskState,
@@ -703,7 +709,8 @@ public final class EngineProcessors {
         asyncRequestBehavior,
         cslCheck,
         transientProcessMessageSubscriptionState,
-        processEngineMetrics);
+        processEngineMetrics,
+        suspensionMetrics);
   }
 
   private static void addDeploymentRelatedProcessorAndServices(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.container.AdHocSubProcessInnerInstanceProcessor;
@@ -36,6 +37,7 @@ import io.camunda.zeebe.engine.processing.bpmn.task.UndefinedTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.UserTaskProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.EnumMap;
 import java.util.Map;
@@ -49,7 +51,9 @@ public final class BpmnElementProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final BpmnStateTransitionBehavior stateTransitionBehavior,
       final AsyncRequestState asyncRequestState,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final SuspensionState suspensionState,
+      final SuspensionMetrics suspensionMetrics) {
     // tasks
     processors.put(
         BpmnElementType.SERVICE_TASK,
@@ -90,7 +94,12 @@ public final class BpmnElementProcessors {
     // containers
     processors.put(
         BpmnElementType.PROCESS,
-        new ProcessProcessor(bpmnBehaviors, stateTransitionBehavior, asyncRequestState));
+        new ProcessProcessor(
+            bpmnBehaviors,
+            stateTransitionBehavior,
+            asyncRequestState,
+            suspensionState,
+            suspensionMetrics));
     processors.put(
         BpmnElementType.SUB_PROCESS,
         new SubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor.TransitionOutcome;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -72,7 +74,9 @@ public final class BpmnStreamProcessor
       final MutableProcessingState processingState,
       final Writers writers,
       final ProcessEngineMetrics processEngineMetrics,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final SuspensionState suspensionState,
+      final SuspensionMetrics suspensionMetrics) {
     processState = processingState.getProcessState();
 
     rejectionWriter = writers.rejection();
@@ -91,7 +95,12 @@ public final class BpmnStreamProcessor
             writers);
     processors =
         new BpmnElementProcessors(
-            bpmnBehaviors, stateTransitionBehavior, processingState.getAsyncRequestState(), config);
+            bpmnBehaviors,
+            stateTransitionBehavior,
+            processingState.getAsyncRequestState(),
+            config,
+            suspensionState,
+            suspensionMetrics);
     stateBehavior = bpmnBehaviors.stateBehavior();
     jobBehavior = bpmnBehaviors.jobBehavior();
     eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.container;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
@@ -25,6 +26,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
 import io.camunda.zeebe.engine.state.immutable.AsyncRequestState.AsyncRequest;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.util.Either;
@@ -44,11 +46,15 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
   private final AgentInstanceBehavior agentInstanceBehavior;
   private final BpmnProcessDeletionBehavior processDeletionBehavior;
   private final AsyncRequestState asyncRequestState;
+  private final SuspensionState suspensionState;
+  private final SuspensionMetrics suspensionMetrics;
 
   public ProcessProcessor(
       final BpmnBehaviors bpmnBehaviors,
       final BpmnStateTransitionBehavior stateTransitionBehavior,
-      final AsyncRequestState asyncRequestState) {
+      final AsyncRequestState asyncRequestState,
+      final SuspensionState suspensionState,
+      final SuspensionMetrics suspensionMetrics) {
     stateBehavior = bpmnBehaviors.stateBehavior();
     this.stateTransitionBehavior = stateTransitionBehavior;
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
@@ -60,6 +66,8 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
     agentInstanceBehavior = bpmnBehaviors.agentInstanceBehavior();
     processDeletionBehavior = bpmnBehaviors.processDeletionBehavior();
     this.asyncRequestState = asyncRequestState;
+    this.suspensionState = suspensionState;
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   @Override
@@ -94,10 +102,18 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
     // event applier will delete the element instance
     processResultSenderBehavior.sendResult(context);
 
-    return transitionTo(
-        element,
-        context,
-        completing -> stateTransitionBehavior.transitionToCompleted(element, completing));
+    final var result =
+        transitionTo(
+            element,
+            context,
+            completing -> stateTransitionBehavior.transitionToCompleted(element, completing));
+
+    // a completing instance may have been RESUMING (a buffered command drained straight to
+    // completion, superseding the RESUME_JOBS/COMPLETE_RESUMING chain — see those processors'
+    // lifecycle-ending rejection) without ever reaching the normal resume finish line; discard the
+    // sample so it doesn't stay in the map forever
+    suspensionMetrics.cancelResumeDuration(context.getElementInstanceKey());
+    return result;
   }
 
   @Override
@@ -118,6 +134,12 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
   @Override
   public void finalizeTermination(
       final ExecutableProcess element, final BpmnElementContext terminationContext) {
+    final long piKey = terminationContext.getElementInstanceKey();
+
+    // capture suspension state before finalization — the applier clears it
+    final boolean wasSuspended = suspensionState.getSuspensionState(piKey) != null;
+    final int droppedCommands = wasSuspended ? suspensionState.countBufferedCommands(piKey) : 0;
+
     agentInstanceBehavior.completeAgentInstancesOfProcessInstance(element, terminationContext);
     transitionTo(
         element,
@@ -126,6 +148,12 @@ public final class ProcessProcessor implements BpmnElementContainerProcessor<Exe
             Either.right(
                 stateTransitionBehavior.transitionToTerminated(
                     context, element.getEventType(), getAsyncRequest(context))));
+
+    // metrics after all writes
+    if (droppedCommands > 0) {
+      suspensionMetrics.commandsDropped(droppedCommands);
+    }
+    suspensionMetrics.cancelResumeDuration(piKey);
   }
 
   private AsyncRequest getAsyncRequest(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -41,7 +42,8 @@ public final class JobEventProcessors {
       final CslTenantCheck tenantCheck,
       final IncidentMetrics incidentMetrics,
       final SecretStoreRegistry secretStoreRegistry,
-      final SecretResolutionScheduler secretResolutionScheduler) {
+      final SecretResolutionScheduler secretResolutionScheduler,
+      final SuspensionMetrics suspensionMetrics) {
 
     final var keyGenerator = processingState.getKeyGenerator();
 
@@ -106,7 +108,12 @@ public final class JobEventProcessors {
             ValueType.JOB,
             JobIntent.TIME_OUT,
             new JobTimeOutProcessor(
-                processingState, writers, jobMetrics, bpmnBehaviors.jobActivationBehavior(), clock))
+                processingState,
+                writers,
+                jobMetrics,
+                bpmnBehaviors.jobActivationBehavior(),
+                suspensionMetrics,
+                clock))
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE_RETRIES,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -38,6 +39,7 @@ public final class JobTimeOutProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final JobProcessingMetrics jobMetrics;
   private final BpmnJobActivationBehavior jobActivationBehavior;
+  private final SuspensionMetrics suspensionMetrics;
   private final InstantSource clock;
 
   public JobTimeOutProcessor(
@@ -45,6 +47,7 @@ public final class JobTimeOutProcessor
       final Writers writers,
       final JobProcessingMetrics jobMetrics,
       final BpmnJobActivationBehavior jobActivationBehavior,
+      final SuspensionMetrics suspensionMetrics,
       final InstantSource clock) {
     jobState = state.getJobState();
     suspensionState = state.getSuspensionState();
@@ -52,6 +55,7 @@ public final class JobTimeOutProcessor
     rejectionWriter = writers.rejection();
     this.jobMetrics = jobMetrics;
     this.jobActivationBehavior = jobActivationBehavior;
+    this.suspensionMetrics = suspensionMetrics;
     this.clock = clock;
   }
 
@@ -71,6 +75,7 @@ public final class JobTimeOutProcessor
       if (suspensionState.getSuspensionState(job.getProcessInstanceKey())
           == SuspensionState.State.SUSPENDED) {
         stateWriter.appendFollowUpEvent(jobKey, JobIntent.SUSPENDED, job);
+        suspensionMetrics.jobSuspended();
       } else {
         jobActivationBehavior.notifyJobAvailableAsSideEffect(job);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -47,6 +48,7 @@ public final class ProcessMessageSubscriptionDeleteProcessor
   private final SuspensionState suspensionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
   private final KeyGenerator keyGenerator;
+  private final SuspensionMetrics suspensionMetrics;
 
   // Scratch copy of the manifest, taken before CREATED (whose applier re-reads the shared record),
   // so the REOPEN command we buffer keeps the right field values.
@@ -58,11 +60,13 @@ public final class ProcessMessageSubscriptionDeleteProcessor
       final SuspensionState suspensionState,
       final Writers writers,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final SuspensionMetrics suspensionMetrics) {
     this.subscriptionState = subscriptionState;
     this.suspensionState = suspensionState;
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
     this.keyGenerator = keyGenerator;
+    this.suspensionMetrics = suspensionMetrics;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
@@ -94,6 +98,7 @@ public final class ProcessMessageSubscriptionDeleteProcessor
     }
 
     final long processInstanceKey = subscription.getRecord().getProcessInstanceKey();
+    final boolean bufferedReopen;
     if (subscription.getRecord().isClosedForSuspend()) {
       // Restore the PI-side row to OPENED as the durable resume manifest and buffer a REOPEN so the
       // drain re-subscribes it one row per batch on resume. Snapshot before CREATED, whose applier
@@ -105,6 +110,7 @@ public final class ProcessMessageSubscriptionDeleteProcessor
           subscription.getRecord());
       bufferReopenCommand(subscription.getKey(), reopenScratch);
       retriggerDrainIfResuming(processInstanceKey, reopenScratch);
+      bufferedReopen = true;
     } else {
       stateWriter.appendFollowUpEvent(
           subscription.getKey(),
@@ -115,6 +121,7 @@ public final class ProcessMessageSubscriptionDeleteProcessor
       // Re-wake the drain here too, otherwise the instance stays RESUMING forever. Self-gates on
       // RESUMING, so it is a no-op for the common unsuspended close.
       retriggerDrainIfResuming(processInstanceKey, subscription.getRecord());
+      bufferedReopen = false;
     }
 
     // update transient state in a side-effect to ensure that these changes only take effect after
@@ -124,6 +131,11 @@ public final class ProcessMessageSubscriptionDeleteProcessor
           transientProcessMessageSubscriptionState.remove(
               new PendingSubscription(elementInstanceKey, messageName, tenantId));
         });
+
+    // metrics after all writes
+    if (bufferedReopen) {
+      suspensionMetrics.commandBuffered();
+    }
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
@@ -61,15 +62,19 @@ public final class BufferedCommandDrainProcessor
   private final SuspensionState suspensionState;
   private final ElementInstanceState elementInstanceState;
   private final ProcessMessageSubscriptionState processMessageSubscriptionState;
+  private final SuspensionMetrics suspensionMetrics;
 
   public BufferedCommandDrainProcessor(
-      final ProcessingState processingState, final Writers writers) {
+      final ProcessingState processingState,
+      final Writers writers,
+      final SuspensionMetrics suspensionMetrics) {
     stateWriter = writers.state();
     commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     suspensionState = processingState.getSuspensionState();
     elementInstanceState = processingState.getElementInstanceState();
     processMessageSubscriptionState = processingState.getProcessMessageSubscriptionState();
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   @Override
@@ -93,6 +98,7 @@ public final class BufferedCommandDrainProcessor
     } else {
       appendNextDrainCommand(drainValue);
     }
+    suspensionMetrics.commandDrained();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CommandBufferingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CommandBufferingBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.BufferedCommandRecord;
@@ -31,10 +32,15 @@ public final class CommandBufferingBehavior {
 
   private final KeyGenerator keyGenerator;
   private final Writers writers;
+  private final SuspensionMetrics suspensionMetrics;
 
-  public CommandBufferingBehavior(final KeyGenerator keyGenerator, final Writers writers) {
+  public CommandBufferingBehavior(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final SuspensionMetrics suspensionMetrics) {
     this.keyGenerator = keyGenerator;
     this.writers = writers;
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   /**
@@ -69,5 +75,6 @@ public final class CommandBufferingBehavior {
         .state()
         .appendFollowUpEvent(
             bufferedCommandKey, BufferedCommandIntent.BUFFERED, bufferedCommandRecord);
+    suspensionMetrics.commandBuffered();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
@@ -58,18 +59,21 @@ public final class ProcessInstanceCompleteResumingProcessor
   private final ElementInstanceState elementInstanceState;
   private final SuspensionState suspensionState;
   private final DueDateTimerCheckScheduler timerChecker;
+  private final SuspensionMetrics suspensionMetrics;
 
   public ProcessInstanceCompleteResumingProcessor(
       final ElementInstanceState elementInstanceState,
       final SuspensionState suspensionState,
       final Writers writers,
-      final DueDateTimerCheckScheduler timerChecker) {
+      final DueDateTimerCheckScheduler timerChecker,
+      final SuspensionMetrics suspensionMetrics) {
     stateWriter = writers.state();
     sideEffectWriter = writers.sideEffect();
     rejectionWriter = writers.rejection();
     this.elementInstanceState = elementInstanceState;
     this.suspensionState = suspensionState;
     this.timerChecker = timerChecker;
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   @Override
@@ -102,6 +106,8 @@ public final class ProcessInstanceCompleteResumingProcessor
         () -> {
           timerChecker.scheduleTimer(-1);
         });
+    suspensionMetrics.stopResumeDuration(processInstanceKey);
+    suspensionMetrics.instanceResumed();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -87,11 +88,13 @@ public final class ProcessInstanceResumeJobsProcessor
   private final SuspensionState suspensionState;
   private final ProcessInstanceSuspensionJobBehavior suspensionJobBehavior;
   private final BpmnJobActivationBehavior jobActivationBehavior;
+  private final SuspensionMetrics suspensionMetrics;
 
   public ProcessInstanceResumeJobsProcessor(
       final ProcessingState processingState,
       final Writers writers,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final SuspensionMetrics suspensionMetrics) {
     stateWriter = writers.state();
     commandWriter = writers.command();
     rejectionWriter = writers.rejection();
@@ -101,6 +104,7 @@ public final class ProcessInstanceResumeJobsProcessor
         new ProcessInstanceSuspensionJobBehavior(
             elementInstanceState, processingState.getJobState(), stateWriter);
     this.jobActivationBehavior = jobActivationBehavior;
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   @Override
@@ -132,6 +136,9 @@ public final class ProcessInstanceResumeJobsProcessor
       nextIntent = ProcessInstanceIntent.COMPLETE_RESUMING;
     }
     commandWriter.appendFollowUpCommand(processInstanceKey, nextIntent, followUpValue);
+    if (resumedJobKey >= 0) {
+      suspensionMetrics.jobResumed();
+    }
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -56,11 +57,13 @@ public final class ProcessInstanceResumeProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final CslAuthorizationCheck cslCheck;
   private final SuspensionState suspensionState;
+  private final SuspensionMetrics suspensionMetrics;
 
   public ProcessInstanceResumeProcessor(
       final ProcessingState processingState,
       final Writers writers,
-      final CslAuthorizationCheck cslCheck) {
+      final CslAuthorizationCheck cslCheck,
+      final SuspensionMetrics suspensionMetrics) {
     elementInstanceState = processingState.getElementInstanceState();
     responseWriter = writers.response();
     stateWriter = writers.state();
@@ -68,6 +71,7 @@ public final class ProcessInstanceResumeProcessor
     rejectionWriter = writers.rejection();
     this.cslCheck = cslCheck;
     suspensionState = processingState.getSuspensionState();
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   @Override
@@ -174,6 +178,9 @@ public final class ProcessInstanceResumeProcessor
     // buffer spans several command batches, and RESUMED is written only once it is empty
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.RESUMING, value, command);
+    if (!isRestart) {
+      suspensionMetrics.startResumeDuration(command.getKey());
+    }
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
@@ -57,6 +58,7 @@ public final class ProcessInstanceSuspendProcessor
   private final SuspensionState suspensionState;
   private final ProcessInstanceSuspensionJobBehavior suspensionJobBehavior;
   private final ProcessInstanceSuspensionMessageSubscriptionBehavior suspensionSubscriptionBehavior;
+  private final SuspensionMetrics suspensionMetrics;
 
   public ProcessInstanceSuspendProcessor(
       final ProcessingState processingState,
@@ -64,7 +66,8 @@ public final class ProcessInstanceSuspendProcessor
       final CslAuthorizationCheck cslCheck,
       final SubscriptionCommandSender subscriptionCommandSender,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final SuspensionMetrics suspensionMetrics) {
     elementInstanceState = processingState.getElementInstanceState();
     responseWriter = writers.response();
     stateWriter = writers.state();
@@ -84,6 +87,7 @@ public final class ProcessInstanceSuspendProcessor
             subscriptionCommandSender,
             transientProcessMessageSubscriptionState,
             clock);
+    this.suspensionMetrics = suspensionMetrics;
   }
 
   @Override
@@ -97,11 +101,15 @@ public final class ProcessInstanceSuspendProcessor
     final ProcessInstanceRecord value = elementInstance.getValue();
     // Park jobs before the instance-level SUSPENDED event so suspension is complete when the
     // marker is written. A later SUSPENDING intermediate state can chunk this work first.
-    suspensionJobBehavior.suspendJobs(command.getKey());
+    final int suspendedJobCount = suspensionJobBehavior.suspendJobs(command.getKey());
     suspensionSubscriptionBehavior.closeSubscriptions(command.getKey());
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.SUSPENDED, value);
     responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.SUSPENDED, value, command);
+    suspensionMetrics.instanceSuspended();
+    if (suspendedJobCount > 0) {
+      suspensionMetrics.jobsSuspended(suspendedJobCount);
+    }
   }
 
   private boolean validateCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspensionJobBehavior.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import java.util.ArrayDeque;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import org.jspecify.annotations.NullMarked;
 
@@ -55,12 +56,17 @@ public final class ProcessInstanceSuspensionJobBehavior {
     this.stateWriter = stateWriter;
   }
 
-  /** Appends {@link JobIntent#SUSPENDED} for every job in {@link #SUSPENDABLE_STATES}. */
-  public void suspendJobs(final long processInstanceKey) {
+  /**
+   * Appends {@link JobIntent#SUSPENDED} for every job in {@link #SUSPENDABLE_STATES}.
+   *
+   * @return the number of jobs suspended; the caller records the metric after all writes complete
+   */
+  public int suspendJobs(final long processInstanceKey) {
     final var processInstance = elementInstanceState.getInstance(processInstanceKey);
     if (processInstance == null) {
-      return;
+      return 0;
     }
+    final var count = new AtomicInteger();
     walk(
         processInstance,
         elementInstance ->
@@ -69,8 +75,10 @@ public final class ProcessInstanceSuspensionJobBehavior {
                 SUSPENDABLE_STATES,
                 (jobKey, job) -> {
                   stateWriter.appendFollowUpEvent(jobKey, JobIntent.SUSPENDED, job);
+                  count.incrementAndGet();
                   return true;
                 }));
+    return count.get();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
@@ -43,4 +44,6 @@ public interface TypedRecordProcessorContext {
   TransientPendingSubscriptionState getTransientProcessMessageSubscriptionState();
 
   MeterRegistry getMeterRegistry();
+
+  SuspensionMetrics getSuspensionMetrics();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -11,6 +11,7 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.el.impl.ExpressionLanguageMetricsImpl;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.ScheduledTaskDbState;
@@ -41,6 +42,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final ControllableStreamClock clock;
   private final EngineSecurityConfig securityConfig;
   private final MeterRegistry meterRegistry;
+  private final SuspensionMetrics suspensionMetrics;
 
   public TypedRecordProcessorContextImpl(
       final RecordProcessorContext context,
@@ -55,6 +57,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
     transientAskState = new TransientPendingMessageStartProcessInstanceAskState();
     clock = Objects.requireNonNull(context.getClock());
     meterRegistry = context.getMeterRegistry();
+    suspensionMetrics = new SuspensionMetrics(meterRegistry);
     processingState =
         new ProcessingDbState(
             partitionId,
@@ -134,5 +137,10 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public MeterRegistry getMeterRegistry() {
     return meterRegistry;
+  }
+
+  @Override
+  public SuspensionMetrics getSuspensionMetrics() {
+    return suspensionMetrics;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -56,6 +56,13 @@ public interface SuspensionState {
    */
   Optional<BufferedCommand> getOldestBufferedCommand(long processInstanceKey);
 
+  /**
+   * Counts the buffered commands for the given process instance without reading their values,
+   * unlike {@link #visitBufferedCommands} which deserializes every record. Use this when only the
+   * count is needed, e.g. for a dropped-commands metric on termination.
+   */
+  int countBufferedCommands(long processInstanceKey);
+
   @FunctionalInterface
   interface BufferedCommandVisitor {
     void visit(long bufferedCommandKey, BufferedCommandRecordValue command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.BufferedComma
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 
 public final class DbSuspensionState implements MutableSuspensionState {
@@ -108,6 +109,18 @@ public final class DbSuspensionState implements MutableSuspensionState {
           }
           visitor.visit(bufferedKey, stored.getRecord());
         });
+  }
+
+  @Override
+  public int countBufferedCommands(final long key) {
+    processInstanceKey.wrapLong(key);
+    final var count = new AtomicInteger();
+    bufferedCommandByProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        (compositeKey, nil) -> {
+          count.incrementAndGet();
+        });
+    return count.get();
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SuspensionMetricsIntegrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SuspensionMetricsIntegrationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class SuspensionMetricsIntegrationTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRecordSuspendAndResumeMetrics() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId).startEvent().userTask().endEvent().done())
+        .deploy();
+    final long piKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // when — suspend
+    engine.processInstance().withInstanceKey(piKey).suspend();
+
+    // then
+    assertThat(suspensionCounter("suspended")).isOne();
+
+    // when — resume
+    engine.processInstance().withInstanceKey(piKey).resume();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+        .withProcessInstanceKey(piKey)
+        .await();
+
+    // then
+    assertThat(suspensionCounter("resumed")).isOne();
+  }
+
+  @Test
+  public void shouldRecordJobSuspensionMetrics() {
+    // given — a process with a service task that has an active job
+    final String processId = Strings.newRandomValidBpmnId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long piKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED).withProcessInstanceKey(piKey).await();
+
+    // when — suspend (parks the job)
+    engine.processInstance().withInstanceKey(piKey).suspend();
+
+    // then
+    RecordingExporter.jobRecords(JobIntent.SUSPENDED).withProcessInstanceKey(piKey).await();
+    assertThat(jobSuspensionCounter("suspended"))
+        .describedAs("job suspended count")
+        .isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldRecordCommandBufferingMetrics() {
+    // given — a process waiting on a message catch event (has an open message subscription)
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(
+                    "msg",
+                    e ->
+                        e.message(
+                            m ->
+                                m.name(messageName)
+                                    .zeebeCorrelationKey("=\"%s\"".formatted(correlationKey))))
+                .endEvent()
+                .done())
+        .deploy();
+    final long piKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(piKey)
+        .await();
+
+    // when — suspend tears down the message subscription; the DELETE ack buffers a REOPEN
+    engine.processInstance().withInstanceKey(piKey).suspend();
+    RecordingExporter.records().withIntent(BufferedCommandIntent.BUFFERED).await();
+
+    // then
+    assertThat(bufferedCommandCounter("buffered"))
+        .describedAs("buffered command count")
+        .isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldRecordDroppedCommandsOnTerminationWhileSuspended() {
+    // given — a suspended instance with a buffered REOPEN command
+    final String processId = Strings.newRandomValidBpmnId();
+    final String messageName = Strings.newRandomValidBpmnId();
+    final String correlationKey = Strings.newRandomValidBpmnId();
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .intermediateCatchEvent(
+                    "msg",
+                    e ->
+                        e.message(
+                            m ->
+                                m.name(messageName)
+                                    .zeebeCorrelationKey("=\"%s\"".formatted(correlationKey))))
+                .endEvent()
+                .done())
+        .deploy();
+    final long piKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(piKey)
+        .await();
+    engine.processInstance().withInstanceKey(piKey).suspend();
+    RecordingExporter.records().withIntent(BufferedCommandIntent.BUFFERED).await();
+
+    // when — cancel while suspended, dropping the buffered command
+    engine.processInstance().withInstanceKey(piKey).cancel();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(piKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThat(bufferedCommandCounter("dropped"))
+        .describedAs("dropped command count")
+        .isGreaterThanOrEqualTo(1);
+  }
+
+  private MeterRegistry registry() {
+    return engine.getMeterRegistry();
+  }
+
+  private double suspensionCounter(final String action) {
+    return registry()
+        .get("zeebe.process.instance.suspension.events.total")
+        .tag("action", action)
+        .counter()
+        .count();
+  }
+
+  private double jobSuspensionCounter(final String action) {
+    return registry()
+        .get("zeebe.job.suspension.events.total")
+        .tag("action", action)
+        .counter()
+        .count();
+  }
+
+  private double bufferedCommandCounter(final String action) {
+    return registry()
+        .get("zeebe.buffered.commands.events.total")
+        .tag("action", action)
+        .counter()
+        .count();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SuspensionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/SuspensionMetricsTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Recorder-level unit tests: verifies that every recording method on {@link SuspensionMetrics}
+ * registers the documented meter under the expected name and tags and increments/records it.
+ */
+final class SuspensionMetricsTest {
+
+  private static final String SUSPENSION_EVENTS_METRIC =
+      "zeebe.process.instance.suspension.events.total";
+  private static final String JOB_SUSPENSION_EVENTS_METRIC = "zeebe.job.suspension.events.total";
+  private static final String BUFFERED_COMMAND_EVENTS_METRIC =
+      "zeebe.buffered.commands.events.total";
+  private static final String RESUME_DURATION_METRIC = "zeebe.process.instance.resume.duration";
+
+  private final AtomicLong monotonicNanos = new AtomicLong();
+  private SimpleMeterRegistry registry;
+  private SuspensionMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    final Clock clock =
+        new Clock() {
+          @Override
+          public long wallTime() {
+            return System.currentTimeMillis();
+          }
+
+          @Override
+          public long monotonicTime() {
+            return monotonicNanos.get();
+          }
+        };
+    registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+    metrics = new SuspensionMetrics(registry);
+  }
+
+  @Test
+  void shouldIncrementSuspensionEventCounterOnSuspend() {
+    // when
+    metrics.instanceSuspended();
+    metrics.instanceSuspended();
+
+    // then
+    assertThat(suspensionEventCount("suspended")).isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldIncrementSuspensionEventCounterOnResume() {
+    // when
+    metrics.instanceResumed();
+
+    // then
+    assertThat(suspensionEventCount("resumed")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldIncrementJobSuspensionCounters() {
+    // when
+    metrics.jobSuspended();
+    metrics.jobSuspended();
+    metrics.jobResumed();
+
+    // then
+    assertThat(jobSuspensionEventCount("suspended")).isEqualTo(2.0);
+    assertThat(jobSuspensionEventCount("resumed")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldTrackBufferedCommandCounters() {
+    // given
+    for (int i = 0; i < 5; i++) {
+      metrics.commandBuffered();
+    }
+
+    // when
+    metrics.commandDrained();
+    metrics.commandDrained();
+    metrics.commandsDropped(1);
+
+    // then
+    assertThat(bufferedCommandEventCount("buffered")).isEqualTo(5.0);
+    assertThat(bufferedCommandEventCount("drained")).isEqualTo(2.0);
+    assertThat(bufferedCommandEventCount("dropped")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldCountDroppedCommandsByAmount() {
+    // when
+    metrics.commandsDropped(10);
+
+    // then
+    assertThat(bufferedCommandEventCount("dropped")).isEqualTo(10.0);
+  }
+
+  @Test
+  void shouldRecordResumeDuration() {
+    // given
+    metrics.startResumeDuration(1234L);
+
+    // when
+    advanceClock(Duration.ofMillis(50));
+    metrics.stopResumeDuration(1234L);
+
+    // then
+    final var timer = registry.find(RESUME_DURATION_METRIC).timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldIgnoreDuplicateStartForSameKey() {
+    // given
+    metrics.startResumeDuration(1234L);
+    advanceClock(Duration.ofMillis(50));
+
+    // when — second start for the same key is ignored (computeIfAbsent guard)
+    metrics.startResumeDuration(1234L);
+    metrics.stopResumeDuration(1234L);
+
+    // then — the timer recorded the original sample's duration, not a near-zero one
+    final var timer = registry.find(RESUME_DURATION_METRIC).timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(50.0);
+  }
+
+  @Test
+  void shouldTrackMultipleKeysIndependently() {
+    // given
+    metrics.startResumeDuration(1L);
+    advanceClock(Duration.ofMillis(100));
+    metrics.startResumeDuration(2L);
+
+    // when
+    advanceClock(Duration.ofMillis(50));
+    metrics.stopResumeDuration(1L);
+    metrics.stopResumeDuration(2L);
+
+    // then
+    final var timer = registry.find(RESUME_DURATION_METRIC).timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(2L);
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(200.0);
+  }
+
+  @Test
+  void shouldNotFailWhenStoppingNonExistentTimer() {
+    // when / then - no start was ever called for this key
+    assertThatCode(() -> metrics.stopResumeDuration(9999L)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldClearTimerSamplesOnRecovery() {
+    // given
+    metrics.startResumeDuration(1234L);
+
+    // when - recovery clears the in-flight sample, so the later stop has nothing to record
+    metrics.onRecovered(null);
+    metrics.stopResumeDuration(1234L);
+
+    // then
+    final var timer = registry.find(RESUME_DURATION_METRIC).timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isZero();
+  }
+
+  @Test
+  void shouldDiscardResumeDurationSampleOnCancel() {
+    // given
+    metrics.startResumeDuration(42L);
+    advanceClock(Duration.ofMillis(100));
+
+    // when — instance terminates mid-resume; sample discarded without recording
+    metrics.cancelResumeDuration(42L);
+
+    // then — timer exists (eager registration) but has no recordings
+    final var timer = registry.find(RESUME_DURATION_METRIC).timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isZero();
+  }
+
+  @Test
+  void shouldIncrementJobSuspendedCounterByBatch() {
+    // when
+    metrics.jobsSuspended(7);
+
+    // then
+    assertThat(jobSuspensionEventCount("suspended")).isEqualTo(7.0);
+  }
+
+  private void advanceClock(final Duration duration) {
+    monotonicNanos.addAndGet(duration.toNanos());
+  }
+
+  private double suspensionEventCount(final String action) {
+    return taggedCounter(SUSPENSION_EVENTS_METRIC, action);
+  }
+
+  private double jobSuspensionEventCount(final String action) {
+    return taggedCounter(JOB_SUSPENSION_EVENTS_METRIC, action);
+  }
+
+  private double bufferedCommandEventCount(final String action) {
+    return taggedCounter(BUFFERED_COMMAND_EVENTS_METRIC, action);
+  }
+
+  private double taggedCounter(final String name, final String action) {
+    final var counter = registry.get(name).tag("action", action).counter();
+    return counter.count();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.container;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBufferedMessageStartEventBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessDeletionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessResultSenderBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.util.Either;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class ProcessProcessorTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 42L;
+
+  private BpmnStateTransitionBehavior stateTransitionBehavior;
+  private SuspensionMetrics suspensionMetrics;
+  private BpmnElementContext context;
+  private ExecutableProcess element;
+  private ProcessProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    final var bpmnBehaviors = mock(BpmnBehaviors.class);
+    when(bpmnBehaviors.processResultSenderBehavior())
+        .thenReturn(mock(BpmnProcessResultSenderBehavior.class));
+    when(bpmnBehaviors.bufferedMessageStartEventBehavior())
+        .thenReturn(mock(BpmnBufferedMessageStartEventBehavior.class));
+    when(bpmnBehaviors.processDeletionBehavior())
+        .thenReturn(mock(BpmnProcessDeletionBehavior.class));
+
+    stateTransitionBehavior = mock(BpmnStateTransitionBehavior.class);
+    suspensionMetrics = mock(SuspensionMetrics.class);
+    final var asyncRequestState = mock(AsyncRequestState.class);
+    final var suspensionState = mock(SuspensionState.class);
+
+    processor =
+        new ProcessProcessor(
+            bpmnBehaviors,
+            stateTransitionBehavior,
+            asyncRequestState,
+            suspensionState,
+            suspensionMetrics);
+
+    element = mock(ExecutableProcess.class);
+    context = mock(BpmnElementContext.class);
+    when(context.getElementInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(context.getParentProcessInstanceKey()).thenReturn(0L);
+    when(stateTransitionBehavior.transitionToCompleted(any(), any()))
+        .thenReturn(Either.right(context));
+  }
+
+  @Test
+  void shouldCancelResumeDurationSampleOnCompletion() {
+    // given — a process instance completing normally (whether or not it was ever resuming: a
+    // buffered command can drain straight to completion, superseding the RESUME_JOBS/
+    // COMPLETE_RESUMING chain before it reaches the normal resume finish line)
+
+    // when
+    processor.finalizeCompletion(element, context);
+
+    // then — the in-flight resume-duration sample, if any, is discarded rather than left dangling
+    verify(suspensionMetrics).cancelResumeDuration(PROCESS_INSTANCE_KEY);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionHandoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionHandoutTest.java
@@ -231,6 +231,15 @@ public final class JobSuspensionHandoutTest {
         .isTrue();
     final Record<JobBatchRecordValue> reactivated = ENGINE.jobs().withType(jobType).activate();
     assertThat(reactivated.getValue().getJobKeys()).isEmpty();
+    assertThat(
+            ENGINE
+                .getMeterRegistry()
+                .get("zeebe.job.suspension.events.total")
+                .tag("action", "suspended")
+                .counter()
+                .count())
+        .describedAs("job suspended count for the timeout-while-suspended path")
+        .isGreaterThanOrEqualTo(1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -42,18 +43,20 @@ public final class BufferedCommandDrainProcessorTest {
 
   private StateWriter stateWriter;
   private TypedCommandWriter commandWriter;
+  private SuspensionMetrics suspensionMetrics;
   private BufferedCommandDrainProcessor processor;
 
   @BeforeEach
   void setUp() {
     stateWriter = mock(StateWriter.class);
     commandWriter = mock(TypedCommandWriter.class);
+    suspensionMetrics = mock(SuspensionMetrics.class);
 
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
     when(writers.command()).thenReturn(commandWriter);
 
-    processor = new BufferedCommandDrainProcessor(processingState, writers);
+    processor = new BufferedCommandDrainProcessor(processingState, writers, suspensionMetrics);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -44,6 +45,7 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
   private SideEffectWriter sideEffectWriter;
   private TypedRejectionWriter rejectionWriter;
   private DueDateTimerCheckScheduler timerChecker;
+  private SuspensionMetrics suspensionMetrics;
   private ProcessInstanceCompleteResumingProcessor processor;
 
   @BeforeEach
@@ -54,6 +56,7 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
     sideEffectWriter = mock(SideEffectWriter.class);
     rejectionWriter = mock(TypedRejectionWriter.class);
     timerChecker = mock(DueDateTimerCheckScheduler.class);
+    suspensionMetrics = mock(SuspensionMetrics.class);
 
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
@@ -62,7 +65,7 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
 
     processor =
         new ProcessInstanceCompleteResumingProcessor(
-            elementInstanceState, suspensionState, writers, timerChecker);
+            elementInstanceState, suspensionState, writers, timerChecker, suspensionMetrics);
 
     // default: the common case of an active instance still marked RESUMING
     when(suspensionState.getSuspensionState(PROCESS_INSTANCE_KEY))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -66,6 +67,7 @@ public final class ProcessInstanceResumeJobsProcessorTest {
   private TypedCommandWriter commandWriter;
   private TypedRejectionWriter rejectionWriter;
   private BpmnJobActivationBehavior jobActivationBehavior;
+  private SuspensionMetrics suspensionMetrics;
   private ProcessInstanceResumeJobsProcessor processor;
 
   @BeforeEach
@@ -77,6 +79,7 @@ public final class ProcessInstanceResumeJobsProcessorTest {
     commandWriter = mock(TypedCommandWriter.class);
     rejectionWriter = mock(TypedRejectionWriter.class);
     jobActivationBehavior = mock(BpmnJobActivationBehavior.class);
+    suspensionMetrics = mock(SuspensionMetrics.class);
     // a hand-out that takes the job, unless a test overrides it to prove the chain still advances
     // when it doesn't
     when(jobActivationBehavior.publishWork(anyLong(), any(), any())).thenReturn(true);
@@ -87,7 +90,8 @@ public final class ProcessInstanceResumeJobsProcessorTest {
     when(writers.rejection()).thenReturn(rejectionWriter);
 
     processor =
-        new ProcessInstanceResumeJobsProcessor(processingState, writers, jobActivationBehavior);
+        new ProcessInstanceResumeJobsProcessor(
+            processingState, writers, jobActivationBehavior, suspensionMetrics);
 
     // the cycle owns the resume by default: marker still RESUMING, as it is throughout a resume
     // that nothing else interferes with

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
@@ -308,6 +308,29 @@ public final class SuspensionStateTest {
   }
 
   @Test
+  public void shouldCountBufferedCommandsForProcessInstanceOnly() {
+    // given
+    final long processInstanceKeyA = 1L;
+    final long processInstanceKeyB = 2L;
+    assertThat(suspensionState.countBufferedCommands(processInstanceKeyA)).isZero();
+
+    // when
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKeyA, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKeyA, 2L));
+    suspensionState.bufferCommand(30L, bufferedCommandRecord(processInstanceKeyB, 3L));
+
+    // then
+    assertThat(suspensionState.countBufferedCommands(processInstanceKeyA)).isEqualTo(2);
+    assertThat(suspensionState.countBufferedCommands(processInstanceKeyB)).isEqualTo(1);
+
+    // when — removing one of A's commands
+    suspensionState.removeBufferedCommand(10L);
+
+    // then
+    assertThat(suspensionState.countBufferedCommands(processInstanceKeyA)).isEqualTo(1);
+  }
+
+  @Test
   public void shouldNotFailWhenRemovingOrClearingBufferedCommandsWithNothingBuffered() {
     // given
     final long processInstanceKey = 1L;


### PR DESCRIPTION
## Description

Add metric definitions, recorder class, and processor wiring for process instance suspend/resume observability.

**SuspensionMetricsDoc** defines four metrics following the `EngineMetricsDoc` pattern:

| Metric | Type | Labels | Purpose |
|--------|------|--------|---------|
| `zeebe.process.instance.suspension.events.total` | Counter | `action` (suspended/resumed) | Lifecycle events |
| `zeebe.job.suspension.events.total` | Counter | `action` (suspended/resumed) | Job parking/unparking |
| `zeebe.buffered.commands.events.total` | Counter | `action` (buffered/drained/dropped) | Command buffer lifecycle |
| `zeebe.process.instance.resume.duration` | Timer | SLO buckets 10ms–5min | Wall-clock resume duration |

No gauge for "currently suspended instances" or "currently buffered commands": an accurate gauge needs rebuilding from persisted state on every leader change, and that rebuild is an unbounded full column-family scan (`ColumnFamily.count()` — "This is an expensive operation... should be used with care"). The cost scales with however many instances/commands are suspended at the time, which is exactly the pathological case (a large suspended backlog) where you'd most want the failover to stay fast. Counters don't have this problem — they simply restart at zero and dashboards use `increase()`/`rate()` over a window, which is the idiomatic way Prometheus handles a counter reset. The suspended/resumed and buffered/drained/dropped counters already give a "rate of change" view; the exact instantaneous count is available via the v2 API (secondary storage) without touching the engine's failover path.

**SuspensionMetrics** is the runtime recorder:
- Counters eagerly registered at construction (IncidentMetrics pattern)
- Timer.resource()/ResourceSample for resume duration (BatchOperationMetrics pattern)
- `computeIfAbsent` guard on timer samples to prevent leaked samples on duplicate starts
- Implements `StreamProcessorLifecycleAware`; its own `onRecovered()` clears stale in-flight timer samples so a resuming instance from a previous leadership term doesn't record a meaningless duration

**Processor wiring** — metrics are recorded at every write site:
- `ProcessInstanceSuspendProcessor` (suspend lifecycle, batch job-suspend count)
- `ProcessInstanceResumeProcessor` / `ProcessInstanceCompleteResumingProcessor` (starts/stops the resume-duration timer, resume lifecycle)
- `ProcessInstanceResumeJobsProcessor` (per-job resume)
- `ProcessInstanceSuspensionJobBehavior` (job suspend, called from `ProcessInstanceSuspendProcessor`)
- `JobTimeOutProcessor` (job suspended on timeout while instance suspended)
- `CommandBufferingBehavior` / `BufferedCommandDrainProcessor` (buffer/drain via the suspension gate)
- `ProcessMessageSubscriptionDeleteProcessor.processRecord()` (buffered REOPEN on suspend-triggered subscription close, recorded after all writes complete)
- `ProcessProcessor.finalizeTermination()` (dropped-command count and resume-timer cancellation on termination — covers both execution-listener and direct bypass paths)

`SuspensionMetrics` is constructed in `Engine.init()` (before the processor factory runs, so it's always available to processors regardless of factory) and registered as a lifecycle listener via `typedRecordProcessors.withListener(suspensionMetrics)` in `EngineProcessors`.

Added `SuspensionMetricsIntegrationTest` (full `EngineRule` coverage of the wiring above, including the dropped-commands counter on termination-while-suspended).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #57793




