### PR TITLE
ci: route Tasklist webapp and frontend to the post-reorg owner

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -460,3 +460,9 @@ optimize.Dockerfile         @camunda/core-features
 # Optimize frontend: overrides the broad /optimize/ rule above, which predates the
 # optimize-frontend/optimize-backend team split.
 /optimize/client/           @camunda/optimize-frontend
+
+# Tasklist webapp + frontend: overrides the broad /tasklist/ rule above, which
+# predates the 2026-07-01 reorg moving Tasklist ownership out of Core Features.
+# Mirrors the /operate/client/ and /optimize/client/ overrides above.
+/tasklist/client/           @camunda/human-task-orchestration
+/tasklist/webapp/           @camunda/human-task-orchestration


### PR DESCRIPTION
**Draft — needs a decision on the right team handle before it's ready.**

## What

Adds two late overrides so Tasklist's webapp and frontend paths point at the team that owns Tasklist post-reorg:

- `/tasklist/client/` → `@camunda/human-task-orchestration`
- `/tasklist/webapp/` → `@camunda/human-task-orchestration`

Importer and archiver paths under `/tasklist/` stay with `@camunda/data-layer` — untouched.

## Why

The broad `/tasklist/` rule assigns Tasklist to `@camunda/core-features`. That predates the 2026-07-01 reorg, which moved Tasklist to the Employee Engagement & Tasklist Pod. This mirrors the two overrides already at the bottom of the file for the same reason:

> `# Operate frontend: overrides the broad /operate/ rule above, which predates the operate-frontend/operate-backend team split.`

Found while auditing how an automated routing assistant picks teams for incoming engineering questions. `.codeowners` is one of its strongest signals when a question carries a file path, so a stale attribution here pulls Tasklist questions toward Core Features. In the audited sample the assistant only got those right by preferring its own team-ownership memory over this file — which is the wrong way round for a file that's meant to be authoritative.

## The open question

Which handle should these paths use? Candidates, both real:

- `@camunda/human-task-orchestration` — 7 members, includes the engineers currently fixing Tasklist webapp issues, plus PM/design
- `@camunda/human-task-orchestration-dev` — 3 members, engineering-only

I picked the broader one so review requests reach the pod rather than a subset, but the pod should decide. Happy to switch it, split it per path, or close this if the intended owner is something else entirely.

cc @camunda/core-features (current owner of the broad rule), @camunda/human-task-orchestration

🤖 Generated with [Claude Code](https://claude.com/claude-code)