### PR TITLE
refactor: add jspecify annotations to zeebe-broker-client

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -470,7 +470,7 @@ public final class ResponseMapper {
   public static MessagePublicationResult toMessagePublicationResponse(
       final BrokerResponse<MessageRecord> brokerResponse) {
     return MessagePublicationResult.Builder.create()
-        .tenantId(brokerResponse.getResponse().getTenantId())
+        .tenantId(brokerResponse.getResponseOrThrow().getTenantId())
         .messageKey(keyToString(brokerResponse.getKey()))
         .build();
   }
@@ -652,14 +652,14 @@ public final class ResponseMapper {
   public static SignalBroadcastResult toSignalBroadcastResponse(
       final BrokerResponse<SignalRecord> brokerResponse) {
     return SignalBroadcastResult.Builder.create()
-        .tenantId(brokerResponse.getResponse().getTenantId())
+        .tenantId(brokerResponse.getResponseOrThrow().getTenantId())
         .signalKey(keyToString(brokerResponse.getKey()))
         .build();
   }
 
   public static EvaluateConditionalResult toConditionalEvaluationResponse(
       final BrokerResponse<ConditionalEvaluationRecord> brokerResponse) {
-    final var response = brokerResponse.getResponse();
+    final var response = brokerResponse.getResponseOrThrow();
     final var processInstances =
         response.getStartedProcessInstances().stream()
             .map(
@@ -807,7 +807,7 @@ public final class ResponseMapper {
 
   public static EvaluateDecisionResult toEvaluateDecisionResponse(
       final BrokerResponse<DecisionEvaluationRecord> brokerResponse) {
-    final var decisionEvaluationRecord = brokerResponse.getResponse();
+    final var decisionEvaluationRecord = brokerResponse.getResponseOrThrow();
     final var evaluatedDecisions = buildEvaluatedDecisions(decisionEvaluationRecord);
     return EvaluateDecisionResult.Builder.create()
         .decisionDefinitionId(decisionEvaluationRecord.getDecisionId())

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientException.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientException.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents exceptional errors that occur in the gateway-broker client on the broker side, e.g.
  * error responses, command rejections, etc.
@@ -20,7 +22,7 @@ public class BrokerClientException extends RuntimeException {
     super(message);
   }
 
-  public BrokerClientException(final String message, final Throwable cause) {
+  public BrokerClientException(final String message, final @Nullable Throwable cause) {
     super(message, cause);
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientRequestMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientRequestMetrics.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.api;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.FAILED_REQUESTS;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.REQUEST_LATENCY;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.TOTAL_REQUESTS;
+import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.RequestKeyNames;
 import io.camunda.zeebe.util.collection.Map3D;
@@ -18,7 +19,6 @@ import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -33,7 +33,7 @@ public final class BrokerClientRequestMetrics {
   private final Map3D<Integer, String, Enum<?>, Counter> failedRequests;
 
   public BrokerClientRequestMetrics(final MeterRegistry registry) {
-    this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
+    this.registry = requireNonNull(registry, "must specify a meter registry");
 
     requestLatency = Table.simple();
     totalRequests = Table.simple();

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.api;
 
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PARTITION_ROLE;
+import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.cluster.PartitionId;
@@ -17,7 +18,6 @@ import io.camunda.zeebe.util.collection.Table;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -30,7 +30,7 @@ public final class BrokerClientTopologyMetrics {
   private final Table<PartitionId, BrokerMemberId, AtomicInteger> brokerTopologyRole;
 
   public BrokerClientTopologyMetrics(final MeterRegistry registry) {
-    this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
+    this.registry = requireNonNull(registry, "must specify a meter registry");
     brokerTopologyRole = Table.simple();
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -12,10 +12,8 @@ import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
 import java.util.Set;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public interface BrokerClusterState {
 
   int PARTITION_ID_NULL = -3;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerErrorException.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerErrorException.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.api;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
+import org.jspecify.annotations.Nullable;
 
 public class BrokerErrorException extends BrokerClientException {
   private static final String ERROR_MESSAGE_FORMAT = "Received error from broker (%s): %s";
@@ -18,7 +19,7 @@ public class BrokerErrorException extends BrokerClientException {
     this(brokerError, null);
   }
 
-  public BrokerErrorException(final BrokerError error, final Throwable cause) {
+  public BrokerErrorException(final BrokerError error, final @Nullable Throwable cause) {
     super(String.format(ERROR_MESSAGE_FORMAT, error.getCode(), error.getMessage()), cause);
     this.error = error;
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerRejectionException.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerRejectionException.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.api;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import org.jspecify.annotations.Nullable;
 
 /** A client command was rejected by the broker. */
 public class BrokerRejectionException extends BrokerClientException {
@@ -19,7 +20,8 @@ public class BrokerRejectionException extends BrokerClientException {
     this(rejection, null);
   }
 
-  public BrokerRejectionException(final BrokerRejection rejection, final Throwable cause) {
+  public BrokerRejectionException(
+      final BrokerRejection rejection, final @Nullable Throwable cause) {
     super(
         String.format(
             ERROR_MESSAGE_FORMAT,

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -12,7 +12,6 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
-import org.jspecify.annotations.NonNull;
 
 public interface BrokerTopologyManager extends ClusterConfigurationUpdateListener {
 
@@ -21,13 +20,12 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
    * null}: a group that is not (yet) known is represented by an uninitialized {@link
    * BrokerClusterState}.
    */
-  @NonNull BrokerClusterState getTopology(@NonNull String physicalTenantId);
+  BrokerClusterState getTopology(String physicalTenantId);
 
   /**
    * Returns live topology for the default partition group. Equivalent to {@code
    * getTopology("default")}.
    */
-  @NonNull
   default BrokerClusterState getTopology() {
     return getTopology(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
@@ -52,7 +50,7 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
    * there either, so callers gating work on this method hold off and retry rather than act on a
    * tenant whose state they cannot see.
    */
-  default boolean isRecovering(@NonNull final String physicalTenantId) {
+  default boolean isRecovering(final String physicalTenantId) {
     final var partitionGroup = getClusterConfiguration().partitionGroup(physicalTenantId);
     return partitionGroup == null
         || partitionGroup.members().isEmpty()

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
   protected final int schemaId;
   protected final int templateId;
 
-  private String partitionGroup;
+  private @Nullable String partitionGroup;
 
   public BrokerRequest(final int schemaId, final int templateId) {
     this.schemaId = schemaId;
@@ -44,7 +45,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
   }
 
   @Override
-  public String getPartitionGroup() {
+  public @Nullable String getPartitionGroup() {
     return partitionGroup;
   }
 
@@ -88,7 +89,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
   }
 
   // public so we can do assertions in tests
-  public abstract BufferWriter getRequestWriter();
+  public abstract @Nullable BufferWriter getRequestWriter();
 
   public void serializeValue() {
     final BufferWriter valueWriter = getRequestWriter();

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.client.api.dto;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.broker.client.api.UnsupportedBrokerResponseException;
@@ -18,7 +20,6 @@ import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -57,7 +58,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
    * {@link io.camunda.cluster.PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID}.
    */
   public void setPartitionGroup(final String partitionGroup) {
-    Objects.requireNonNull(partitionGroup, "partitionGroup must not be null");
+    requireNonNull(partitionGroup, "partitionGroup must not be null");
     if (partitionGroup.isBlank()) {
       throw new IllegalArgumentException("partitionGroup must not be blank");
     }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerResponse.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerResponse.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.zeebe.broker.client.api.dto;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.broker.client.api.BrokerClientException;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
+import org.jspecify.annotations.Nullable;
 
 public class BrokerResponse<T> {
   private static final String ILLEGAL_SUCCESS_RESPONSE_MESSAGE =
@@ -19,7 +22,7 @@ public class BrokerResponse<T> {
       "Expected broker response to be either response, rejection, or error, but is neither of them";
 
   private final boolean isResponse;
-  private final T response;
+  private final @Nullable T response;
   private final int partitionId;
   private final long key;
 
@@ -45,7 +48,7 @@ public class BrokerResponse<T> {
     return false;
   }
 
-  public BrokerError getError() {
+  public @Nullable BrokerError getError() {
     return null;
   }
 
@@ -53,7 +56,7 @@ public class BrokerResponse<T> {
     return false;
   }
 
-  public BrokerRejection getRejection() {
+  public @Nullable BrokerRejection getRejection() {
     return null;
   }
 
@@ -61,13 +64,13 @@ public class BrokerResponse<T> {
     return isResponse;
   }
 
-  public T getResponse() {
+  public @Nullable T getResponse() {
     return response;
   }
 
   public T getResponseOrThrow() {
     if (isResponse()) {
-      return response;
+      return requireNonNull(response, "response is null");
     }
 
     throw toException();
@@ -77,9 +80,9 @@ public class BrokerResponse<T> {
     if (isResponse()) {
       return new IllegalBrokerResponseException(ILLEGAL_SUCCESS_RESPONSE_MESSAGE);
     } else if (isError()) {
-      return new BrokerErrorException(getError());
+      return new BrokerErrorException(requireNonNull(getError(), "error is null"));
     } else if (isRejection()) {
-      return new BrokerRejectionException(getRejection());
+      return new BrokerRejectionException(requireNonNull(getRejection(), "rejection is null"));
     }
 
     return new IllegalBrokerResponseException(ILLEGAL_RESPONSE_MESSAGE);

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/package-info.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.broker.client.api.dto;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/package-info.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.broker.client.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProvider.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerAddressProvider.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -22,7 +21,6 @@ import org.jspecify.annotations.Nullable;
  * route to a node that has no elected leader but is in recovery mode — every other mode requires an
  * elected leader or picks a random broker.
  */
-@NullMarked
 final class BrokerAddressProvider implements Supplier<@Nullable String> {
 
   private final BrokerTopologyManager topologyManager;

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.Subscription;
@@ -150,7 +152,7 @@ public final class BrokerClientImpl implements BrokerClient {
                     topic,
                     msg -> {
                       handler.accept((String) msg);
-                      return CompletableFuture.completedFuture(null);
+                      return CompletableFuture.completedFuture(unit());
                     })
                 .join());
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -129,7 +129,7 @@ public final class BrokerClientImpl implements BrokerClient {
               if (error != null) {
                 throwableConsumer.accept(error);
               } else if (response.isResponse()) {
-                responseConsumer.accept(response.getKey(), response.getResponse());
+                responseConsumer.accept(response.getKey(), response.getResponseOrThrow());
               } else {
                 throwableConsumer.accept(response.toException());
               }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.agrona.collections.Int2ObjectHashMap;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,7 +32,6 @@ import org.jspecify.annotations.Nullable;
  * The configured cluster state is updated from the global {@link
  * io.camunda.zeebe.dynamic.config.state.ClusterConfiguration}.
  */
-@NullMarked
 public record BrokerClientTopologyImpl(
     LiveClusterState liveClusterState, ConfiguredClusterState configuredClusterState)
     implements BrokerClusterState {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -33,11 +35,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 final class BrokerRequestManager extends Actor {
 
   private static final TransportRequestSender SENDER_WITH_RETRY =
-      (c, s, r, t) -> c.sendRequestWithRetry(s, BrokerRequestManager::responseValidation, r, t);
+      // annotations required: `@Nullable` is not inferred implicitly from lambda
+      (ClientTransport transport,
+          Supplier<@Nullable String> nodeAddressSupplier,
+          ClientRequest request,
+          Duration timeout) ->
+          transport.sendRequestWithRetry(
+              nodeAddressSupplier, BrokerRequestManager::responseValidation, request, timeout);
   private static final TransportRequestSender SENDER_WITHOUT_RETRY = ClientTransport::sendRequest;
   private final ClientTransport clientTransport;
   private final RequestDispatchStrategy dispatchStrategy;
@@ -148,7 +157,8 @@ final class BrokerRequestManager extends Actor {
           RequestResult result = null;
           try {
             if (error == null) {
-              final BrokerResponse<T> response = request.getResponse(clientResponse);
+              final BrokerResponse<T> response =
+                  request.getResponse(requireNonNull(clientResponse));
 
               result = handleResponse(response, returnFuture);
               if (result.wasProcessed()) {
@@ -169,7 +179,9 @@ final class BrokerRequestManager extends Actor {
   }
 
   private <T> void registerFailure(
-      final BrokerRequest<T> request, final RequestResult result, final Throwable error) {
+      final BrokerRequest<T> request,
+      final @Nullable RequestResult result,
+      final @Nullable Throwable error) {
     if (result != null && result.getErrorCode() == ErrorCode.RESOURCE_EXHAUSTED) {
       return;
     }
@@ -288,9 +300,9 @@ final class BrokerRequestManager extends Actor {
 
   private static class RequestResult {
     private final boolean processed;
-    private final ErrorCode errorCode;
+    private final @Nullable ErrorCode errorCode;
 
-    RequestResult(final boolean processed, final ErrorCode errorCode) {
+    RequestResult(final boolean processed, final @Nullable ErrorCode errorCode) {
       this.processed = processed;
       this.errorCode = errorCode;
     }
@@ -299,7 +311,7 @@ final class BrokerRequestManager extends Actor {
       return processed;
     }
 
-    public ErrorCode getErrorCode() {
+    public @Nullable ErrorCode getErrorCode() {
       return errorCode;
     }
 
@@ -316,7 +328,7 @@ final class BrokerRequestManager extends Actor {
 
     ActorFuture<DirectBuffer> send(
         ClientTransport transport,
-        Supplier<String> nodeAddressSupplier,
+        Supplier<@Nullable String> nodeAddressSupplier,
         ClientRequest clientRequest,
         Duration timeout);
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
-import static java.util.Objects.requireNonNull;
-
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.AdditionalErrorCodes;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -111,9 +109,7 @@ final class BrokerRequestManager extends Actor {
       final TransportRequestSender sender,
       final Duration requestTimeout) {
     if (!request.hasPartitionGroup()) {
-      throw new IllegalStateException(
-          "Cannot send request '%s': no partition group (physical tenant) was set. Requests are not implicitly routed to the default tenant; call setPartitionGroup explicitly, even when targeting the default tenant."
-              .formatted(request.getType()));
+      throw missingPartitionGroupException(request);
     }
     final CompletableFuture<BrokerResponse<T>> responseFuture = new CompletableFuture<>();
     request.serializeValue();
@@ -127,9 +123,15 @@ final class BrokerRequestManager extends Actor {
       final TransportRequestSender sender,
       final Duration requestTimeout) {
 
+    final var partitionGroup = request.getPartitionGroup();
+    if (partitionGroup == null) {
+      returnFuture.completeExceptionally(missingPartitionGroupException(request));
+      return;
+    }
+
     final BrokerAddressProvider nodeIdProvider;
     try {
-      nodeIdProvider = determineBrokerNodeIdProvider(request);
+      nodeIdProvider = determineBrokerNodeIdProvider(request, partitionGroup);
     } catch (final PartitionNotFoundException e) {
       returnFuture.completeExceptionally(e);
       metrics.registerFailedRequest(
@@ -153,12 +155,11 @@ final class BrokerRequestManager extends Actor {
 
     actor.runOnCompletion(
         responseFuture,
-        (clientResponse, error) -> {
+        (final DirectBuffer clientResponse, final @Nullable Throwable error) -> {
           RequestResult result = null;
           try {
             if (error == null) {
-              final BrokerResponse<T> response =
-                  request.getResponse(requireNonNull(clientResponse));
+              final BrokerResponse<T> response = request.getResponse(clientResponse);
 
               result = handleResponse(response, returnFuture);
               if (result.wasProcessed()) {
@@ -215,7 +216,8 @@ final class BrokerRequestManager extends Actor {
         return RequestResult.processed();
       } else if (response.isError()) {
         responseFuture.complete(response);
-        return RequestResult.failed(response.getError().getCode());
+        final var error = response.getError();
+        return RequestResult.failed(error == null ? ErrorCode.NULL_VAL : error.getCode());
       } else {
         responseFuture.completeExceptionally(response.toException());
       }
@@ -226,8 +228,8 @@ final class BrokerRequestManager extends Actor {
     return RequestResult.failed(ErrorCode.NULL_VAL);
   }
 
-  private BrokerAddressProvider determineBrokerNodeIdProvider(final BrokerRequest<?> request) {
-    final var partitionGroup = request.getPartitionGroup();
+  private BrokerAddressProvider determineBrokerNodeIdProvider(
+      final BrokerRequest<?> request, final String partitionGroup) {
     if (request.getBrokerId().isPresent()) {
       return BrokerAddressProvider.fixed(
           topologyManager, partitionGroup, clusterState -> request.getBrokerId().orElseThrow());
@@ -264,6 +266,13 @@ final class BrokerRequestManager extends Actor {
       // random broker of the request's partition group
       return BrokerAddressProvider.randomBroker(topologyManager, partitionGroup);
     }
+  }
+
+  private static IllegalStateException missingPartitionGroupException(
+      final BrokerRequest<?> request) {
+    return new IllegalStateException(
+        "Cannot send request '%s': no partition group (physical tenant) was set. Requests are not implicitly routed to the default tenant; call setPartitionGroup explicitly, even when targeting the default tenant."
+            .formatted(request.getType()));
   }
 
   private void throwIfPartitionInactive(final String partitionGroup, final int partitionId) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +69,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   @Override
-  public @NonNull BrokerClusterState getTopology(final @NonNull String physicalTenantId) {
+  public BrokerClusterState getTopology(final String physicalTenantId) {
     return topologyPerGroup.getOrDefault(
         physicalTenantId, BrokerClientTopologyImpl.uninitialized());
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/ErrorResponseHandler.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/ErrorResponseHandler.java
@@ -12,11 +12,12 @@ import io.camunda.zeebe.protocol.record.ErrorResponseDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class ErrorResponseHandler {
   private final ErrorResponseDecoder decoder = new ErrorResponseDecoder();
 
-  private DirectBuffer errorMessage;
+  private @Nullable DirectBuffer errorMessage;
 
   public boolean handlesResponse(final MessageHeaderDecoder responseHeader) {
     return ErrorResponseDecoder.SCHEMA_ID == responseHeader.schemaId()
@@ -36,7 +37,7 @@ public final class ErrorResponseHandler {
     return decoder.errorCode();
   }
 
-  public DirectBuffer getErrorMessage() {
+  public @Nullable DirectBuffer getErrorMessage() {
     return errorMessage;
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
@@ -19,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Return the next partition using a round-robin strategy, but skips the partitions where there is
@@ -90,7 +93,7 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
 
     var currentValue = state.partitionRing().get();
     if (currentValue.version() >= expectedVersion) {
-      return currentValue.partitions();
+      return requireNonNull(currentValue.partitions());
     }
 
     final var newPartitionRing =
@@ -113,7 +116,7 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
     return newPartitionRing;
   }
 
-  record VersionedPartitionRing(long version, PartitionRing partitions) {
+  record VersionedPartitionRing(long version, @Nullable PartitionRing partitions) {
     static final long NOT_INITIALIZED = -2;
     static final long NO_ROUTING_STATE = -1;
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/package-info.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.broker.client.impl;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotBrokerRequest.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotBrokerRequest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class SnapshotBrokerRequest extends BrokerRequest<SnapshotResponse> {
 
@@ -81,7 +82,7 @@ public class SnapshotBrokerRequest extends BrokerRequest<SnapshotResponse> {
   }
 
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.queryapi;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.messaging.MessagingConfig;
@@ -218,6 +219,11 @@ public final class QueryApiIT {
     @Override
     public RequestType getRequestType() {
       return RequestType.QUERY;
+    }
+
+    @Override
+    public String getPartitionGroup() {
+      return DEFAULT_PHYSICAL_TENANT_ID;
     }
 
     @Override

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -141,6 +141,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/BrokerExecuteQuery.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/query/impl/BrokerExecuteQuery.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class BrokerExecuteQuery extends BrokerRequest<String> {
   private final ExecuteQueryRequest request = new ExecuteQueryRequest();
@@ -58,7 +59,7 @@ public final class BrokerExecuteQuery extends BrokerRequest<String> {
    * @return null to avoid writing any serialized value
    */
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.jspecify.annotations.Nullable;
 
 public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
   private final AdminRequest request = new AdminRequest();
@@ -103,7 +104,7 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
    * @return null to avoid writing any serialized value
    */
   @Override
-  public BufferWriter getRequestWriter() {
+  public @Nullable BufferWriter getRequestWriter() {
     return null;
   }
 

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.test.broker.protocol.commandapi;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.keyNullValue;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.partitionIdNullValue;
 
@@ -119,6 +120,11 @@ public final class ExecuteCommandRequest implements ClientRequest {
   @Override
   public RequestType getRequestType() {
     return RequestType.COMMAND;
+  }
+
+  @Override
+  public String getPartitionGroup() {
+    return DEFAULT_PHYSICAL_TENANT_ID;
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.transport;
 
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.jspecify.annotations.Nullable;
 
 public interface ClientRequest extends BufferWriter {
 
@@ -23,10 +23,8 @@ public interface ClientRequest extends BufferWriter {
   RequestType getRequestType();
 
   /**
-   * @return the partition group (physical tenant) this request targets; defaults to {@code
-   *     "default"} for backward compatibility
+   * @return the partition group (physical tenant) this request targets, or {@code null} when none
+   *     has been configured
    */
-  default String getPartitionGroup() {
-    return PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-  }
+  @Nullable String getPartitionGroup();
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -62,6 +62,14 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
       final boolean shouldRetry,
       final Duration timeout) {
 
+    final var requestFuture = new CompletableActorFuture<DirectBuffer>();
+    final var partitionGroup = clientRequest.getPartitionGroup();
+    if (partitionGroup == null) {
+      requestFuture.completeExceptionally(
+          new IllegalStateException("Cannot send a request without a partition group"));
+      return requestFuture;
+    }
+
     // copy once
     final var length = clientRequest.getLength();
     final var requestBytes = new byte[length];
@@ -70,11 +78,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
 
     final var partitionId = clientRequest.getPartitionId();
     final var requestType = clientRequest.getRequestType();
-    final var topicName =
-        AtomixServerTransport.topicName(
-            clientRequest.getPartitionGroup(), partitionId, requestType);
-
-    final var requestFuture = new CompletableActorFuture<DirectBuffer>();
+    final var topicName = AtomixServerTransport.topicName(partitionGroup, partitionId, requestType);
     final var requestContext =
         new RequestContext(
             requestFuture,

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapterTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.transport.impl;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.messaging.MessagingService;
+import io.camunda.zeebe.transport.ClientRequest;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class AtomixClientTransportAdapterTest {
+
+  @Test
+  void shouldFailBeforeSerializingRequestWithoutPartitionGroup() {
+    // given
+    final var request = mock(ClientRequest.class);
+    when(request.getPartitionGroup()).thenReturn(null);
+    final var transport = new AtomixClientTransportAdapter(mock(MessagingService.class));
+
+    // when
+    final var responseFuture =
+        transport.sendRequest(() -> "localhost:26500", request, Duration.ofSeconds(1));
+
+    // then
+    assertThatThrownBy(responseFuture::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot send a request without a partition group");
+    verify(request, never()).getLength();
+    verify(request, never()).write(any(), anyInt());
+  }
+}


### PR DESCRIPTION
## Summary

- mark all Zeebe broker-client packages with `@NullMarked` and describe existing nullable contracts
- make `ClientRequest#getPartitionGroup()` explicit and nullable, preserving default routing in test utilities
- align downstream request writers and response consumers with the corrected contracts
- reject missing partition groups through the transport future before request serialization

Removing the default `ClientRequest#getPartitionGroup()` implementation is intentional. Each implementation now declares its routing behavior explicitly instead of inheriting a default that did not match `BrokerRequest`.


closes #53250
