### PR TITLE
feat: warm secret resolution at job creation for the long-poll path

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -39,6 +39,8 @@ on:
           - typical
           - max
           - archiver
+          - secrets
+          - secrets-control
         default: max
       secondary-storage-type:
         description: 'Secondary database backend for Camunda Platform'
@@ -158,7 +160,7 @@ on:
         default: ""
         required: false
       scenario:
-        description: 'Workload scenario to run. Options: latency, realistic, typical, max, archiver.'
+        description: 'Workload scenario to run. Options: latency, realistic, typical, max, archiver, secrets, secrets-control.'
         type: string
         required: false
         default: ""

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
@@ -18,6 +18,7 @@ public class StarterProperties {
   private Duration rateDuration = Duration.ofSeconds(1);
   private int threads = 2;
   private String bpmnXmlPath = "bpmn/one_task.bpmn";
+  private int secretVariants = 0;
   private List<String> extraBpmnModels = List.of();
   private String businessKey = "businessKey";
   private String payloadPath = "bpmn/big_payload.json";
@@ -69,6 +70,18 @@ public class StarterProperties {
 
   public void setBpmnXmlPath(final String bpmnXmlPath) {
     this.bpmnXmlPath = bpmnXmlPath;
+  }
+
+  /**
+   * How many variants of {@link #getBpmnXmlPath()} the starter deploys, each with its own process
+   * id and its own secret name. {@code 0} disables the mode and deploys the model as it is.
+   */
+  public int getSecretVariants() {
+    return secretVariants;
+  }
+
+  public void setSecretVariants(final int secretVariants) {
+    this.secretVariants = secretVariants;
   }
 
   public List<String> getExtraBpmnModels() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
+import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -51,6 +52,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -74,6 +76,12 @@ public class Starter implements CommandLineRunner {
   private static final long NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos();
   private static final TypeReference<HashMap<String, Object>> VARIABLES_TYPE_REF =
       new TypeReference<>() {};
+  private static final String PROCESS_ID_PLACEHOLDER = "__PROCESS_ID__";
+  private static final String SECRET_PLACEHOLDER = "__SECRET__";
+
+  /** Keeps one deployment well below the gateway's maximum message size. */
+  private static final int VARIANT_DEPLOY_BATCH_SIZE = 50;
+
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final CamundaClient client;
@@ -282,13 +290,14 @@ public class Starter implements CommandLineRunner {
             processInstancesStartedCounter.increment();
 
             final var startTime = System.nanoTime();
+            final var processId = nextProcessId();
             final CompletionStage<?> requestFuture;
             if (starterCfg.isStartViaMessage()) {
               requestFuture = startInstanceByMessagePublishing(vars);
             } else if (starterCfg.isWithResults()) {
-              requestFuture = startInstanceWithAwaitingResult(starterCfg.getProcessId(), vars);
+              requestFuture = startInstanceWithAwaitingResult(processId, vars);
             } else {
-              requestFuture = startInstance(startTime, starterCfg.getProcessId(), vars);
+              requestFuture = startInstance(startTime, processId, vars);
             }
             requestFuture.whenComplete(
                 (noop, error) -> {
@@ -377,21 +386,70 @@ public class Starter implements CommandLineRunner {
   }
 
   private void deployProcess() {
-    final var deployCmd = constructDeploymentCommand();
+    if (starterCfg.getSecretVariants() > 0) {
+      deployVariants();
+      return;
+    }
 
+    final var result = sendWithRetry(constructDeploymentCommand());
+    final var benchmarkProcessDefinitionKey =
+        result.getProcesses().stream()
+            .filter(p -> p.getBpmnProcessId().equals(starterCfg.getProcessId()))
+            .findFirst()
+            .map(Process::getProcessDefinitionKey)
+            .orElse(0L);
+    if (properties.isPerformReadBenchmarks()) {
+      dataReadMeter.setContextProcessDefinitionKey(benchmarkProcessDefinitionKey);
+    }
+  }
+
+  /**
+   * Deploys one variant of the configured model per secret, each with its own process id and its
+   * own secret name, so the variants together hold as many distinct static secret references as
+   * configured. No process definition key is handed to the read benchmarks here, and {@code
+   * extra-bpmn-models} are not deployed: neither has a meaning when no single definition represents
+   * the workload.
+   */
+  private void deployVariants() {
+    final int variants = starterCfg.getSecretVariants();
+    final String template = payloadReader.readPayload(starterCfg.getBpmnXmlPath());
+    if (!template.contains(PROCESS_ID_PLACEHOLDER)) {
+      // every variant would deploy under the same process id, which reads as a working run of a
+      // single definition rather than the configured number of them
+      throw new IllegalStateException(
+          "Model '%s' holds no %s placeholder, so it cannot be deployed as %d variants"
+              .formatted(starterCfg.getBpmnXmlPath(), PROCESS_ID_PLACEHOLDER, variants));
+    }
+    LOG.info(
+        "Deploying {} variants of template {} in batches of {}",
+        variants,
+        starterCfg.getBpmnXmlPath(),
+        VARIANT_DEPLOY_BATCH_SIZE);
+
+    for (int first = 0; first < variants; first += VARIANT_DEPLOY_BATCH_SIZE) {
+      final int last = Math.min(first + VARIANT_DEPLOY_BATCH_SIZE, variants);
+      DeployResourceCommandStep2 deployCmd = null;
+      for (int variant = first; variant < last; variant++) {
+        final String processId = variantProcessId(variant);
+        final String resource =
+            template
+                .replace(PROCESS_ID_PLACEHOLDER, processId)
+                .replace(SECRET_PLACEHOLDER, variantSecretName(variant));
+        final String resourceName = processId + ".bpmn";
+        deployCmd =
+            deployCmd == null
+                ? client.newDeployResourceCommand().addResourceStringUtf8(resource, resourceName)
+                : deployCmd.addResourceStringUtf8(resource, resourceName);
+      }
+      sendWithRetry(deployCmd);
+      LOG.info("Deployed variants {}..{} of {}", first, last - 1, variants);
+    }
+  }
+
+  private DeploymentEvent sendWithRetry(final DeployResourceCommandStep2 deployCmd) {
     while (true) {
       try {
-        final var result = deployCmd.send().join();
-        final var benchmarkProcessDefinitionKey =
-            result.getProcesses().stream()
-                .filter(p -> p.getBpmnProcessId().equals(starterCfg.getProcessId()))
-                .findFirst()
-                .map(Process::getProcessDefinitionKey)
-                .orElse(0L);
-        if (properties.isPerformReadBenchmarks()) {
-          dataReadMeter.setContextProcessDefinitionKey(benchmarkProcessDefinitionKey);
-        }
-        break;
+        return deployCmd.send().join();
       } catch (final Exception e) {
         THROTTLED_LOGGER.warn("Failed to deploy process, retrying", e);
         try {
@@ -401,6 +459,22 @@ public class Starter implements CommandLineRunner {
         }
       }
     }
+  }
+
+  /** The process the next instance is started on: a random variant, or the configured process. */
+  private String nextProcessId() {
+    final int variants = starterCfg.getSecretVariants();
+    return variants > 0
+        ? variantProcessId(ThreadLocalRandom.current().nextInt(variants))
+        : starterCfg.getProcessId();
+  }
+
+  private String variantProcessId(final int variant) {
+    return starterCfg.getProcessId() + "-" + variant;
+  }
+
+  private static String variantSecretName(final int variant) {
+    return "s" + variant;
   }
 
   private DeployResourceCommandStep2 constructDeploymentCommand() {

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -81,6 +81,13 @@ load-tester:
     rate-duration: ${LOAD_TESTER_STARTER_RATE_DURATION:1s}
     threads: ${LOAD_TESTER_STARTER_THREADS:2}
     bpmn-xml-path: ${LOAD_TESTER_STARTER_BPMN_XML_PATH:bpmn/one_task.bpmn}
+    # Secret benchmark mode. When > 0, bpmn-xml-path is read as a template with
+    # __PROCESS_ID__ and __SECRET__ placeholders, and that many variants are deployed
+    # as `<process-id>-<i>` referencing secret `s<i>`. Each instance is then started on
+    # a uniformly random variant, so the share of secret cache misses follows the ratio
+    # of variants to camunda.secrets.cache.max-size. The backing secret store must hold
+    # s0..s<n-1>; see load-tests/setup/main/values/camunda-platform-values-secrets.yaml.
+    secret-variants: ${LOAD_TESTER_STARTER_SECRET_VARIANTS:0}
     # Extra BPMN models: set via indexed env vars, e.g.
     # LOAD_TESTER_STARTER_EXTRA_BPMN_MODELS_0_=bpmn/realistic/refundingProcess.bpmn
     extra-bpmn-models: []

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -60,7 +60,7 @@ camunda:
         # @JobWorker picks up the correct values per deployment.
         name: ${LOAD_TESTER_WORKER_WORKER_NAME:benchmark-worker}
         type: ${LOAD_TESTER_WORKER_JOB_TYPE:benchmark-task}
-        stream-enabled: true
+        stream-enabled: ${LOAD_TESTER_WORKER_STREAM_ENABLED:true}
         max-jobs-active: ${LOAD_TESTER_WORKER_CAPACITY:30}
         # Default: completionDelay(300ms) * 6 = 1800ms. The old HOCON app computed
         # this dynamically; here it's static. Update if completionDelay changes.

--- a/load-tests/load-tester/src/main/resources/bpmn/deep_payload_30kb.json
+++ b/load-tests/load-tester/src/main/resources/bpmn/deep_payload_30kb.json
@@ -1,0 +1,2823 @@
+{
+  "orderReference": "ORD-2026-0000042",
+  "channel": "web",
+  "requestedAt": "2026-08-28T09:15:00Z",
+  "priority": "standard",
+  "customer": {
+    "profile": {
+      "contact": {
+        "address": {
+          "geo": {
+            "region": {
+              "district": {
+                "block": {
+                  "unit": {
+                    "code": "UNIT-0042-B",
+                    "floor": 3,
+                    "verified": true,
+                    "notes": "delivery to the rear entrance"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "items": [
+    {
+      "sku": "SKU-00000",
+      "name": "alpha-delta-component",
+      "quantity": 1,
+      "unitPrice": 10.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 100,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            10,
+            20,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00001",
+      "name": "bravo-echo-component",
+      "quantity": 2,
+      "unitPrice": 11.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 101,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            11,
+            21,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00002",
+      "name": "charlie-foxtrot-component",
+      "quantity": 3,
+      "unitPrice": 13.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 102,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            12,
+            22,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00003",
+      "name": "delta-golf-component",
+      "quantity": 4,
+      "unitPrice": 14.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 103,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            13,
+            23,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00004",
+      "name": "echo-hotel-component",
+      "quantity": 5,
+      "unitPrice": 15.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 104,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            14,
+            24,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00005",
+      "name": "foxtrot-india-component",
+      "quantity": 6,
+      "unitPrice": 16.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 105,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            15,
+            25,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00006",
+      "name": "golf-juliet-component",
+      "quantity": 7,
+      "unitPrice": 18.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 106,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            16,
+            26,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00007",
+      "name": "hotel-alpha-component",
+      "quantity": 1,
+      "unitPrice": 19.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 107,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            17,
+            27,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00008",
+      "name": "india-bravo-component",
+      "quantity": 2,
+      "unitPrice": 20.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 108,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            18,
+            28,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00009",
+      "name": "juliet-charlie-component",
+      "quantity": 3,
+      "unitPrice": 21.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 109,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            19,
+            29,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00010",
+      "name": "alpha-delta-component",
+      "quantity": 4,
+      "unitPrice": 23.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 110,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            20,
+            30,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00011",
+      "name": "bravo-echo-component",
+      "quantity": 5,
+      "unitPrice": 24.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 111,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            21,
+            31,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00012",
+      "name": "charlie-foxtrot-component",
+      "quantity": 6,
+      "unitPrice": 25.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 112,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            22,
+            32,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00013",
+      "name": "delta-golf-component",
+      "quantity": 7,
+      "unitPrice": 26.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 113,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            23,
+            33,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00014",
+      "name": "echo-hotel-component",
+      "quantity": 1,
+      "unitPrice": 28.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 114,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            24,
+            34,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00015",
+      "name": "foxtrot-india-component",
+      "quantity": 2,
+      "unitPrice": 29.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 115,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            25,
+            35,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00016",
+      "name": "golf-juliet-component",
+      "quantity": 3,
+      "unitPrice": 30.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 116,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            26,
+            36,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00017",
+      "name": "hotel-alpha-component",
+      "quantity": 4,
+      "unitPrice": 31.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 117,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            27,
+            37,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00018",
+      "name": "india-bravo-component",
+      "quantity": 5,
+      "unitPrice": 33.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 118,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            28,
+            38,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00019",
+      "name": "juliet-charlie-component",
+      "quantity": 6,
+      "unitPrice": 34.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 119,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            29,
+            39,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00020",
+      "name": "alpha-delta-component",
+      "quantity": 7,
+      "unitPrice": 35.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 120,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            30,
+            40,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00021",
+      "name": "bravo-echo-component",
+      "quantity": 1,
+      "unitPrice": 36.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 121,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            31,
+            41,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00022",
+      "name": "charlie-foxtrot-component",
+      "quantity": 2,
+      "unitPrice": 38.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 122,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            32,
+            42,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00023",
+      "name": "delta-golf-component",
+      "quantity": 3,
+      "unitPrice": 39.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 123,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            33,
+            43,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00024",
+      "name": "echo-hotel-component",
+      "quantity": 4,
+      "unitPrice": 40.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 124,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            34,
+            44,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00025",
+      "name": "foxtrot-india-component",
+      "quantity": 5,
+      "unitPrice": 41.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 125,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            35,
+            45,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00026",
+      "name": "golf-juliet-component",
+      "quantity": 6,
+      "unitPrice": 43.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 126,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            36,
+            46,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00027",
+      "name": "hotel-alpha-component",
+      "quantity": 7,
+      "unitPrice": 44.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 127,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            37,
+            47,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00028",
+      "name": "india-bravo-component",
+      "quantity": 1,
+      "unitPrice": 45.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 128,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            38,
+            48,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00029",
+      "name": "juliet-charlie-component",
+      "quantity": 2,
+      "unitPrice": 46.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 129,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            39,
+            49,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00030",
+      "name": "alpha-delta-component",
+      "quantity": 3,
+      "unitPrice": 48.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 130,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            40,
+            20,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00031",
+      "name": "bravo-echo-component",
+      "quantity": 4,
+      "unitPrice": 49.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 131,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            41,
+            21,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00032",
+      "name": "charlie-foxtrot-component",
+      "quantity": 5,
+      "unitPrice": 50.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 132,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            42,
+            22,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00033",
+      "name": "delta-golf-component",
+      "quantity": 6,
+      "unitPrice": 51.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 133,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            43,
+            23,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00034",
+      "name": "echo-hotel-component",
+      "quantity": 7,
+      "unitPrice": 53.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 134,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            44,
+            24,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00035",
+      "name": "foxtrot-india-component",
+      "quantity": 1,
+      "unitPrice": 54.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 135,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            45,
+            25,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00036",
+      "name": "golf-juliet-component",
+      "quantity": 2,
+      "unitPrice": 55.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 136,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            46,
+            26,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00037",
+      "name": "hotel-alpha-component",
+      "quantity": 3,
+      "unitPrice": 56.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 137,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            47,
+            27,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00038",
+      "name": "india-bravo-component",
+      "quantity": 4,
+      "unitPrice": 58.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 138,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            48,
+            28,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00039",
+      "name": "juliet-charlie-component",
+      "quantity": 5,
+      "unitPrice": 59.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 139,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            49,
+            29,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00040",
+      "name": "alpha-delta-component",
+      "quantity": 6,
+      "unitPrice": 10.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 140,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            50,
+            30,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00041",
+      "name": "bravo-echo-component",
+      "quantity": 7,
+      "unitPrice": 11.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 141,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            51,
+            31,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00042",
+      "name": "charlie-foxtrot-component",
+      "quantity": 1,
+      "unitPrice": 13.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 142,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            52,
+            32,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00043",
+      "name": "delta-golf-component",
+      "quantity": 2,
+      "unitPrice": 14.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 143,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            53,
+            33,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00044",
+      "name": "echo-hotel-component",
+      "quantity": 3,
+      "unitPrice": 15.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 144,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            54,
+            34,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00045",
+      "name": "foxtrot-india-component",
+      "quantity": 4,
+      "unitPrice": 16.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 145,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            55,
+            35,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00046",
+      "name": "golf-juliet-component",
+      "quantity": 5,
+      "unitPrice": 18.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 146,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            56,
+            36,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00047",
+      "name": "hotel-alpha-component",
+      "quantity": 6,
+      "unitPrice": 19.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 147,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            57,
+            37,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00048",
+      "name": "india-bravo-component",
+      "quantity": 7,
+      "unitPrice": 20.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 148,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            58,
+            38,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00049",
+      "name": "juliet-charlie-component",
+      "quantity": 1,
+      "unitPrice": 21.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 149,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            59,
+            39,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00050",
+      "name": "alpha-delta-component",
+      "quantity": 2,
+      "unitPrice": 23.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 150,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            10,
+            40,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00051",
+      "name": "bravo-echo-component",
+      "quantity": 3,
+      "unitPrice": 24.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 151,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            11,
+            41,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00052",
+      "name": "charlie-foxtrot-component",
+      "quantity": 4,
+      "unitPrice": 25.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 152,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            12,
+            42,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00053",
+      "name": "delta-golf-component",
+      "quantity": 5,
+      "unitPrice": 26.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 153,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            13,
+            43,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00054",
+      "name": "echo-hotel-component",
+      "quantity": 6,
+      "unitPrice": 28.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 154,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            14,
+            44,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00055",
+      "name": "foxtrot-india-component",
+      "quantity": 7,
+      "unitPrice": 29.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 155,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            15,
+            45,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00056",
+      "name": "golf-juliet-component",
+      "quantity": 1,
+      "unitPrice": 30.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 156,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            16,
+            46,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00057",
+      "name": "hotel-alpha-component",
+      "quantity": 2,
+      "unitPrice": 31.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 157,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            17,
+            47,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00058",
+      "name": "india-bravo-component",
+      "quantity": 3,
+      "unitPrice": 33.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 158,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            18,
+            48,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00059",
+      "name": "juliet-charlie-component",
+      "quantity": 4,
+      "unitPrice": 34.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 159,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            19,
+            49,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00060",
+      "name": "alpha-delta-component",
+      "quantity": 5,
+      "unitPrice": 35.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 160,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            20,
+            20,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00061",
+      "name": "bravo-echo-component",
+      "quantity": 6,
+      "unitPrice": 36.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 161,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            21,
+            21,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00062",
+      "name": "charlie-foxtrot-component",
+      "quantity": 7,
+      "unitPrice": 38.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 162,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            22,
+            22,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00063",
+      "name": "delta-golf-component",
+      "quantity": 1,
+      "unitPrice": 39.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 163,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            23,
+            23,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00064",
+      "name": "echo-hotel-component",
+      "quantity": 2,
+      "unitPrice": 40.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 164,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            24,
+            24,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00065",
+      "name": "foxtrot-india-component",
+      "quantity": 3,
+      "unitPrice": 41.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 165,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            25,
+            25,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00066",
+      "name": "golf-juliet-component",
+      "quantity": 4,
+      "unitPrice": 43.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 166,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            26,
+            26,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00067",
+      "name": "hotel-alpha-component",
+      "quantity": 5,
+      "unitPrice": 44.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 167,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            27,
+            27,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00068",
+      "name": "india-bravo-component",
+      "quantity": 6,
+      "unitPrice": 45.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 168,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            28,
+            28,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00069",
+      "name": "juliet-charlie-component",
+      "quantity": 7,
+      "unitPrice": 46.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 169,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            29,
+            29,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00070",
+      "name": "alpha-delta-component",
+      "quantity": 1,
+      "unitPrice": 48.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 170,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            30,
+            30,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00071",
+      "name": "bravo-echo-component",
+      "quantity": 2,
+      "unitPrice": 49.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 171,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            31,
+            31,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00072",
+      "name": "charlie-foxtrot-component",
+      "quantity": 3,
+      "unitPrice": 50.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 172,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            32,
+            32,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00073",
+      "name": "delta-golf-component",
+      "quantity": 4,
+      "unitPrice": 51.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 173,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            33,
+            33,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00074",
+      "name": "echo-hotel-component",
+      "quantity": 5,
+      "unitPrice": 53.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 174,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            34,
+            34,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00075",
+      "name": "foxtrot-india-component",
+      "quantity": 6,
+      "unitPrice": 54.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 175,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            35,
+            35,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00076",
+      "name": "golf-juliet-component",
+      "quantity": 7,
+      "unitPrice": 55.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 176,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            36,
+            36,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00077",
+      "name": "hotel-alpha-component",
+      "quantity": 1,
+      "unitPrice": 56.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 177,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            37,
+            37,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00078",
+      "name": "india-bravo-component",
+      "quantity": 2,
+      "unitPrice": 58.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 178,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            38,
+            38,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00079",
+      "name": "juliet-charlie-component",
+      "quantity": 3,
+      "unitPrice": 59.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 179,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            39,
+            39,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00080",
+      "name": "alpha-delta-component",
+      "quantity": 4,
+      "unitPrice": 10.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 180,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            40,
+            40,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00081",
+      "name": "bravo-echo-component",
+      "quantity": 5,
+      "unitPrice": 11.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 181,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            41,
+            41,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00082",
+      "name": "charlie-foxtrot-component",
+      "quantity": 6,
+      "unitPrice": 13.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 182,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            42,
+            42,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00083",
+      "name": "delta-golf-component",
+      "quantity": 7,
+      "unitPrice": 14.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 183,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            43,
+            43,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00084",
+      "name": "echo-hotel-component",
+      "quantity": 1,
+      "unitPrice": 15.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 184,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            44,
+            44,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00085",
+      "name": "foxtrot-india-component",
+      "quantity": 2,
+      "unitPrice": 16.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 185,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            45,
+            45,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00086",
+      "name": "golf-juliet-component",
+      "quantity": 3,
+      "unitPrice": 18.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 186,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            46,
+            46,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00087",
+      "name": "hotel-alpha-component",
+      "quantity": 4,
+      "unitPrice": 19.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 187,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            47,
+            47,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00088",
+      "name": "india-bravo-component",
+      "quantity": 5,
+      "unitPrice": 20.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 188,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            48,
+            48,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00089",
+      "name": "juliet-charlie-component",
+      "quantity": 6,
+      "unitPrice": 21.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 189,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            49,
+            49,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00090",
+      "name": "alpha-delta-component",
+      "quantity": 7,
+      "unitPrice": 23.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 190,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            50,
+            20,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00091",
+      "name": "bravo-echo-component",
+      "quantity": 1,
+      "unitPrice": 24.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 191,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            51,
+            21,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00092",
+      "name": "charlie-foxtrot-component",
+      "quantity": 2,
+      "unitPrice": 25.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 192,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            52,
+            22,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00093",
+      "name": "delta-golf-component",
+      "quantity": 3,
+      "unitPrice": 26.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 193,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            53,
+            23,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00094",
+      "name": "echo-hotel-component",
+      "quantity": 4,
+      "unitPrice": 28.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 194,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            54,
+            24,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00095",
+      "name": "foxtrot-india-component",
+      "quantity": 5,
+      "unitPrice": 29.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 195,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            55,
+            25,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00096",
+      "name": "golf-juliet-component",
+      "quantity": 6,
+      "unitPrice": 30.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 196,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            56,
+            26,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00097",
+      "name": "hotel-alpha-component",
+      "quantity": 7,
+      "unitPrice": 31.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 197,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            57,
+            27,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00098",
+      "name": "india-bravo-component",
+      "quantity": 1,
+      "unitPrice": 33.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 198,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            58,
+            28,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00099",
+      "name": "juliet-charlie-component",
+      "quantity": 2,
+      "unitPrice": 34.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 199,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            59,
+            29,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00100",
+      "name": "alpha-delta-component",
+      "quantity": 3,
+      "unitPrice": 35.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 200,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            10,
+            30,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00101",
+      "name": "bravo-echo-component",
+      "quantity": 4,
+      "unitPrice": 36.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 201,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            11,
+            31,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00102",
+      "name": "charlie-foxtrot-component",
+      "quantity": 5,
+      "unitPrice": 38.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 202,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            12,
+            32,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00103",
+      "name": "delta-golf-component",
+      "quantity": 6,
+      "unitPrice": 39.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 203,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            13,
+            33,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00104",
+      "name": "echo-hotel-component",
+      "quantity": 7,
+      "unitPrice": 40.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 204,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            14,
+            34,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00105",
+      "name": "foxtrot-india-component",
+      "quantity": 1,
+      "unitPrice": 41.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 205,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            15,
+            35,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00106",
+      "name": "golf-juliet-component",
+      "quantity": 2,
+      "unitPrice": 43.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 206,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            16,
+            36,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00107",
+      "name": "hotel-alpha-component",
+      "quantity": 3,
+      "unitPrice": 44.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 207,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            17,
+            37,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00108",
+      "name": "india-bravo-component",
+      "quantity": 4,
+      "unitPrice": 45.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 208,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            18,
+            38,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00109",
+      "name": "juliet-charlie-component",
+      "quantity": 5,
+      "unitPrice": 46.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 209,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            19,
+            39,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00110",
+      "name": "alpha-delta-component",
+      "quantity": 6,
+      "unitPrice": 48.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 210,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            20,
+            40,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00111",
+      "name": "bravo-echo-component",
+      "quantity": 7,
+      "unitPrice": 49.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 211,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            21,
+            41,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00112",
+      "name": "charlie-foxtrot-component",
+      "quantity": 1,
+      "unitPrice": 50.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 212,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            22,
+            42,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00113",
+      "name": "delta-golf-component",
+      "quantity": 2,
+      "unitPrice": 51.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 213,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            23,
+            43,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00114",
+      "name": "echo-hotel-component",
+      "quantity": 3,
+      "unitPrice": 53.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 214,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            24,
+            44,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00115",
+      "name": "foxtrot-india-component",
+      "quantity": 4,
+      "unitPrice": 54.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 215,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            25,
+            45,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00116",
+      "name": "golf-juliet-component",
+      "quantity": 5,
+      "unitPrice": 55.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 216,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            26,
+            46,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00117",
+      "name": "hotel-alpha-component",
+      "quantity": 6,
+      "unitPrice": 56.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 217,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            27,
+            47,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00118",
+      "name": "india-bravo-component",
+      "quantity": 7,
+      "unitPrice": 58.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 218,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            28,
+            48,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00119",
+      "name": "juliet-charlie-component",
+      "quantity": 1,
+      "unitPrice": 59.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 219,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            29,
+            49,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00120",
+      "name": "alpha-delta-component",
+      "quantity": 2,
+      "unitPrice": 10.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 220,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            30,
+            20,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00121",
+      "name": "bravo-echo-component",
+      "quantity": 3,
+      "unitPrice": 11.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 221,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            31,
+            21,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00122",
+      "name": "charlie-foxtrot-component",
+      "quantity": 4,
+      "unitPrice": 13.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 222,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            32,
+            22,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00123",
+      "name": "delta-golf-component",
+      "quantity": 5,
+      "unitPrice": 14.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 223,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            33,
+            23,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00124",
+      "name": "echo-hotel-component",
+      "quantity": 6,
+      "unitPrice": 15.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 224,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            34,
+            24,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00125",
+      "name": "foxtrot-india-component",
+      "quantity": 7,
+      "unitPrice": 16.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 225,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            35,
+            25,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00126",
+      "name": "golf-juliet-component",
+      "quantity": 1,
+      "unitPrice": 18.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 226,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            36,
+            26,
+            36
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00127",
+      "name": "hotel-alpha-component",
+      "quantity": 2,
+      "unitPrice": 19.25,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 227,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            37,
+            27,
+            37
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00128",
+      "name": "india-bravo-component",
+      "quantity": 3,
+      "unitPrice": 20.5,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 228,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            38,
+            28,
+            38
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00129",
+      "name": "juliet-charlie-component",
+      "quantity": 4,
+      "unitPrice": 21.75,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 229,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            39,
+            29,
+            39
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00130",
+      "name": "alpha-delta-component",
+      "quantity": 5,
+      "unitPrice": 23.0,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 230,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            40,
+            30,
+            40
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00131",
+      "name": "bravo-echo-component",
+      "quantity": 6,
+      "unitPrice": 24.25,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 231,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            41,
+            31,
+            41
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00132",
+      "name": "charlie-foxtrot-component",
+      "quantity": 7,
+      "unitPrice": 25.5,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 232,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            42,
+            32,
+            42
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00133",
+      "name": "delta-golf-component",
+      "quantity": 1,
+      "unitPrice": 26.75,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 233,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            43,
+            33,
+            43
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00134",
+      "name": "echo-hotel-component",
+      "quantity": 2,
+      "unitPrice": 28.0,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 234,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            44,
+            34,
+            44
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00135",
+      "name": "foxtrot-india-component",
+      "quantity": 3,
+      "unitPrice": 29.25,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 235,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            45,
+            35,
+            45
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00136",
+      "name": "golf-juliet-component",
+      "quantity": 4,
+      "unitPrice": 30.5,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 236,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            46,
+            36,
+            46
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00137",
+      "name": "hotel-alpha-component",
+      "quantity": 5,
+      "unitPrice": 31.75,
+      "attributes": {
+        "colour": "india",
+        "weightGrams": 237,
+        "packaging": {
+          "kind": "charlie",
+          "recyclable": false,
+          "dimensionsMm": [
+            47,
+            37,
+            47
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00138",
+      "name": "india-bravo-component",
+      "quantity": 6,
+      "unitPrice": 33.0,
+      "attributes": {
+        "colour": "juliet",
+        "weightGrams": 238,
+        "packaging": {
+          "kind": "delta",
+          "recyclable": true,
+          "dimensionsMm": [
+            48,
+            38,
+            48
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00139",
+      "name": "juliet-charlie-component",
+      "quantity": 7,
+      "unitPrice": 34.25,
+      "attributes": {
+        "colour": "alpha",
+        "weightGrams": 239,
+        "packaging": {
+          "kind": "echo",
+          "recyclable": false,
+          "dimensionsMm": [
+            49,
+            39,
+            49
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00140",
+      "name": "alpha-delta-component",
+      "quantity": 1,
+      "unitPrice": 35.5,
+      "attributes": {
+        "colour": "bravo",
+        "weightGrams": 240,
+        "packaging": {
+          "kind": "foxtrot",
+          "recyclable": true,
+          "dimensionsMm": [
+            50,
+            40,
+            30
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00141",
+      "name": "bravo-echo-component",
+      "quantity": 2,
+      "unitPrice": 36.75,
+      "attributes": {
+        "colour": "charlie",
+        "weightGrams": 241,
+        "packaging": {
+          "kind": "golf",
+          "recyclable": false,
+          "dimensionsMm": [
+            51,
+            41,
+            31
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00142",
+      "name": "charlie-foxtrot-component",
+      "quantity": 3,
+      "unitPrice": 38.0,
+      "attributes": {
+        "colour": "delta",
+        "weightGrams": 242,
+        "packaging": {
+          "kind": "hotel",
+          "recyclable": true,
+          "dimensionsMm": [
+            52,
+            42,
+            32
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00143",
+      "name": "delta-golf-component",
+      "quantity": 4,
+      "unitPrice": 39.25,
+      "attributes": {
+        "colour": "echo",
+        "weightGrams": 243,
+        "packaging": {
+          "kind": "india",
+          "recyclable": false,
+          "dimensionsMm": [
+            53,
+            43,
+            33
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00144",
+      "name": "echo-hotel-component",
+      "quantity": 5,
+      "unitPrice": 40.5,
+      "attributes": {
+        "colour": "foxtrot",
+        "weightGrams": 244,
+        "packaging": {
+          "kind": "juliet",
+          "recyclable": true,
+          "dimensionsMm": [
+            54,
+            44,
+            34
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00145",
+      "name": "foxtrot-india-component",
+      "quantity": 6,
+      "unitPrice": 41.75,
+      "attributes": {
+        "colour": "golf",
+        "weightGrams": 245,
+        "packaging": {
+          "kind": "alpha",
+          "recyclable": false,
+          "dimensionsMm": [
+            55,
+            45,
+            35
+          ]
+        }
+      }
+    },
+    {
+      "sku": "SKU-00146",
+      "name": "golf-juliet-component",
+      "quantity": 7,
+      "unitPrice": 43.0,
+      "attributes": {
+        "colour": "hotel",
+        "weightGrams": 246,
+        "packaging": {
+          "kind": "bravo",
+          "recyclable": true,
+          "dimensionsMm": [
+            56,
+            46,
+            36
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/load-tests/load-tester/src/main/resources/bpmn/secret_task.bpmn
+++ b/load-tests/load-tester/src/main/resources/bpmn/secret_task.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template for the `secrets` load test scenario. The starter substitutes
+  __PROCESS_ID__ and __SECRET__ once per variant it deploys, so every variant
+  carries a distinct static secret reference on its service task. See
+  LOAD_TESTER_STARTER_SECRET_VARIANTS in the load tester's application.yaml.
+-->
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_secret_task" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="__PROCESS_ID__" name="One task process with one secret reference" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>flow_start_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="task" name="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=camunda.secrets.__SECRET__" target="token" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_start_task</bpmn:incoming>
+      <bpmn:outgoing>flow_task_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>flow_task_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_task" sourceRef="start" targetRef="task" />
+    <bpmn:sequenceFlow id="flow_task_end" sourceRef="task" targetRef="end" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/load-tests/load-tester/src/main/resources/bpmn/secret_task_control.bpmn
+++ b/load-tests/load-tester/src/main/resources/bpmn/secret_task_control.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Control template for the `secrets-control` load test scenario: identical to
+  secret_task.bpmn, except the input mapping reads a plain process variable
+  instead of a secret. Deployed as the same number of variants, so the only
+  difference against the `secrets` run is the secret resolution itself.
+-->
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_secret_task_control" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="__PROCESS_ID__" name="One task process without a secret reference" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>flow_start_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="task" name="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=orderReference" target="token" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_start_task</bpmn:incoming>
+      <bpmn:outgoing>flow_task_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>flow_task_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_task" sourceRef="start" targetRef="task" />
+    <bpmn:sequenceFlow id="flow_task_end" sourceRef="task" targetRef="end" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -429,6 +429,8 @@ make typical   # 50 instances/s, 6 workers, typical_process BPMN
 make realistic # Realistic multi-instance benchmark (values from camunda-load-tests-helm)
 make max       # 300 instances/s — maximum stress, also disables consistency check overhead
 make archiver  # Multi-instance archiver scenario (no workers)
+make secrets   # 100 jobs/s, each referencing one of 1500 secrets — see below
+make secrets-control # the same run without secret references, for attribution
 ```
 
 You can also pass `scenario=` directly to combine with additional overrides:
@@ -455,6 +457,49 @@ To render Helm templates for inspection:
 make template scenario=max          # renders platform manifests
 make template-load-test scenario=max  # renders load test manifests
 ```
+
+#### The `secrets` scenario
+
+Measures secret resolution on the job activation path (`main` only). It puts the engine in
+the state that path is most sensitive to: many distinct references, a cache that cannot hold
+them all, and job variables large enough that injecting into them costs something.
+
+| Parameter | Value | Where |
+|---|---|---|
+| Process instances (and jobs) | 100/s | `--set load-tester.starter.rate=100` |
+| Distinct secret references | 1500 | `LOAD_TESTER_STARTER_SECRET_VARIANTS`, `load-tester-values-secret-benchmark.yaml` |
+| Secret cache | 1000 entries, 20m ttl (product defaults) | `camunda-platform-override-values-secrets.yaml` |
+| Resulting cache miss rate | ~1/3 of jobs | consequence of the two rows above |
+| Job variables | ~30KB, 10 levels deep | `bpmn/deep_payload_30kb.json` |
+| Secret store | file-based, `/etc/camunda/secrets` | `camunda-platform-values-secrets.yaml` |
+
+The starter deploys 1500 variants of `bpmn/secret_task.bpmn`, one per secret, because a job's
+secret references are extracted from its element's input mappings at deploy time and are
+therefore static. Each instance is started on a uniformly random variant, which is what makes
+the misses independent rather than a scan over the whole key space (a cyclic pattern would
+evict every entry before its reuse and miss ~always). An init container seeds the store with
+`s0`..`s1499`; that count must match the variant count, or the surplus references fail
+resolution and raise incidents.
+
+The engine's process definition cache is raised to 2000 for the same reason it exists: 1500
+definitions against its default of 1000 would add a definition cache miss to the same
+activation path, and afterwards the two are indistinguishable.
+
+What to read, per namespace, in [the benchmark dashboards](https://dashboard.benchmark.camunda.cloud/):
+
+- `zeebe_job_activation_time` — created to activated; carries the park and reactivation of a miss
+- `zeebe_job_life_time` — created to completed
+- `camunda_secret_cache_result{result="HIT"|"MISS"}` — expect a hit ratio near 0.67
+- `camunda_secret_cache_size` / `camunda_secret_cache_evictions{cause="SIZE"}` — expect ~1000 and a steady rise
+- `camunda_secret_resolution_duration` / `_outcome` — the background resolution itself
+
+Before trusting any of it, check that the run is actually at its operating point: starter rate
+~100/s, completion ratio ~1, no incidents, no write backpressure. A hit ratio far from 0.67 means
+the workload is not what this table describes.
+
+Note that `helm upgrade` runs with `--reset-then-reuse-values`, so switching an existing
+namespace between `secrets` and `secrets-control` leaves the previous scenario's `--set` values
+in place. Use a separate namespace per scenario.
 
 ### Accessing Services
 

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -18,8 +18,9 @@
 #   camunda-platform-values-optimize-elasticsearch.yaml fallback file.
 #
 # - scenario_max_override_key
-#   Helm --set-file key, including the trailing '=', used by the `max` scenario
-#   to override platform configuration. This differs by chart version.
+#   Helm --set-file key, including the trailing '=', used by the `max`, `secrets`
+#   and `secrets-control` scenarios to override platform configuration. This
+#   differs by chart version.
 #
 # - install_storage_target
 #   Set to `install-storage` for versions that deploy their own secondary
@@ -59,7 +60,7 @@ additional_load_test_configuration ?=
 helm_chart_platform = charts/camunda-platform
 
 # Scenario: controls the workload profile for the load test.
-# Options: latency, realistic, typical, max, archiver
+# Options: latency, realistic, typical, max, archiver, secrets, secrets-control
 # Use named targets (make max) or pass directly: make install scenario=max
 scenario ?=
 
@@ -78,6 +79,25 @@ $(error scenario=max requires scenario_max_override_key to be declared by the ve
 endif
 _scenario_load_test_flags = --set load-tester.starter.rate=300
 _scenario_platform_flags = --set-file '$(scenario_max_override_key)./camunda-platform-override-values.yaml'
+else ifeq ($(scenario),secrets)
+ifeq ($(scenario_max_override_key),)
+$(error scenario=secrets requires scenario_max_override_key to be declared by the version Makefile)
+endif
+# Secret resolution at job activation: 100 jobs/s, each on one of 1500 process definition
+# variants carrying a distinct static secret reference, over a ~30KB / 10-level-deep
+# payload. Against the 1000-entry secret cache, ~1/3 of the jobs take the cache miss path
+# (park, background resolution, reactivation). See load-tests/setup/README.md.
+_scenario_load_test_flags = -f load-tester-values-secret-benchmark.yaml --set load-tester.starter.rate=100 --set load-tester.starter.processId=secret-bench --set load-tester.starter.bpmnXmlPath=bpmn/secret_task.bpmn --set load-tester.starter.payloadPath=bpmn/deep_payload_30kb.json --set load-tester.workers.worker.replicas=6 --set load-tester.workers.worker.payloadPath=bpmn/emptyPayload.json
+_scenario_platform_flags = --set-file '$(scenario_max_override_key)./camunda-platform-override-values-secrets.yaml' -f camunda-platform-values-secrets.yaml
+else ifeq ($(scenario),secrets-control)
+ifeq ($(scenario_max_override_key),)
+$(error scenario=secrets-control requires scenario_max_override_key to be declared by the version Makefile)
+endif
+# The attribution run for `secrets`: same rate, same payload, same number of process
+# definition variants, but an input mapping that reads a plain process variable instead of
+# a secret. The difference between the two runs is the secret resolution itself.
+_scenario_load_test_flags = -f load-tester-values-secret-benchmark.yaml --set load-tester.starter.rate=100 --set load-tester.starter.processId=secret-bench --set load-tester.starter.bpmnXmlPath=bpmn/secret_task_control.bpmn --set load-tester.starter.payloadPath=bpmn/deep_payload_30kb.json --set load-tester.workers.worker.replicas=6 --set load-tester.workers.worker.payloadPath=bpmn/emptyPayload.json
+_scenario_platform_flags = --set-file '$(scenario_max_override_key)./camunda-platform-override-values-secrets.yaml' -f camunda-platform-values-secrets.yaml
 else ifeq ($(scenario),archiver)
 _scenario_load_test_flags = --set load-tester.starter.rate=1 --set load-tester.starter.rateDuration=10m --set load-tester.starter.processId=multiInstanceElements --set load-tester.starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set load-tester.starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set load-tester.workers.worker.replicas=0
 _scenario_platform_flags =
@@ -375,7 +395,7 @@ install-stable-chaos:
 
 # Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
 # For stable VMs, use: make install-stable scenario=<name>
-.PHONY: latency realistic typical max archiver
+.PHONY: latency realistic typical max archiver secrets secrets-control
 latency:
 	$(MAKE) install scenario=latency
 realistic:
@@ -386,6 +406,10 @@ max:
 	$(MAKE) install scenario=max
 archiver:
 	$(MAKE) install scenario=archiver
+secrets:
+	$(MAKE) install scenario=secrets
+secrets-control:
+	$(MAKE) install scenario=secrets-control
 
 .PHONY: clean
 clean:

--- a/load-tests/setup/main/values/camunda-platform-override-values-secrets.yaml
+++ b/load-tests/setup/main/values/camunda-platform-override-values-secrets.yaml
@@ -1,0 +1,25 @@
+# Broker configuration for the `secrets` and `secrets-control` scenarios.
+# Injected as application-override.yml (loaded after and overrides application.yml)
+# via --set-file, the same slot scenario=max uses.
+
+# The one supported store per tenant, backed by the directory the seed init container
+# fills. See camunda-platform-values-secrets.yaml for the volume and the seeding.
+camunda.secrets.stores.file.default.path: "/etc/camunda/secrets"
+
+# Restated at their product defaults on purpose. The scenario deploys 1500 secret
+# references and picks one uniformly at random per job, so a 1000-entry cache is what
+# produces the ~1/3 miss rate the run is built around. Pinning them here means a later
+# change of the defaults shows up as a change of the benchmark, not of its results.
+camunda.secrets.cache.max-size: 1000
+camunda.secrets.cache.ttl: "20m"
+
+# The engine's process definition cache defaults to 1000, below the 1500 definitions this
+# scenario deploys. Left at the default, a third of the instances would also take a
+# definition cache miss, which lands on the same activation path as the secret miss and
+# cannot be told apart from it afterwards.
+zeebe.broker.experimental.engine.caches.processCacheCapacity: 2000
+
+# Same reasoning as camunda-platform-override-values.yaml (scenario=max): the checks are
+# overhead that adds variance to the very percentiles this scenario measures.
+zeebe.broker.experimental.consistencyChecks.enablePreconditions: "false"
+zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "false"

--- a/load-tests/setup/main/values/camunda-platform-values-secrets.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-secrets.yaml
@@ -1,0 +1,41 @@
+# Secret store backing for the `secrets` and `secrets-control` scenarios: an emptyDir
+# filled with one file per secret by an init container, which is the layout
+# FileBasedSecretStore expects and the one a mounted Kubernetes Secret produces.
+#
+# The number of secrets seeded here must match LOAD_TESTER_STARTER_SECRET_VARIANTS in
+# load-tester-values-secret-benchmark.yaml. A reference the store cannot answer ends in
+# a RESOLUTION_FAIL and an incident, so a mismatch is visible within a minute of the run.
+orchestration:
+  # Helm replaces lists instead of merging them, so `logs` from
+  # camunda-platform-values-defaults.yaml is re-declared here.
+  extraVolumes:
+    - name: logs
+      emptyDir: {}
+    - name: secrets
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: logs
+      mountPath: /usr/local/camunda/logs
+    - name: secrets
+      mountPath: /etc/camunda/secrets
+  initContainers:
+    - name: seed-secrets
+      image: busybox:1.37.0
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set -eu
+          i=0
+          while [ "$i" -lt 1500 ]; do
+            printf 'secret-value-%s' "$i" > /etc/camunda/secrets/s$i
+            i=$((i + 1))
+          done
+          echo "seeded $(ls /etc/camunda/secrets | wc -l) secrets"
+      volumeMounts:
+        - name: secrets
+          mountPath: /etc/camunda/secrets
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -171,8 +171,8 @@ echo "Creating new load test in: $TARGET_DIRECTORY"
 mkdir -p "$TARGET_DIRECTORY"
 
 # Scaffold the always-copied files into the namespace folder root: the
-# Makefile, the resources/ manifests, four storage-agnostic values files
-# (defaults + override + load-test + stable), and the matching
+# Makefile, the resources/ manifests, the storage-agnostic values files
+# (defaults + overrides + load-test scenarios + stable), and the matching
 # camunda-platform-values-${secondary_storage}.yaml. Flat layout so the
 # per-namespace Makefile's -f <file>.yaml references resolve unchanged.
 cp -v  "$VERSION_DIR/Makefile"                                                  "$TARGET_DIRECTORY/"
@@ -181,8 +181,18 @@ cp -v  "$VERSION_DIR/values/camunda-platform-override-values.yaml"              
 cp -v  "$SCRIPT_DIR/scenarios/load-tester-values-defaults.yaml"                 "$TARGET_DIRECTORY/"
 cp -v  "$VERSION_DIR/values/values-stable.yaml"                                 "$TARGET_DIRECTORY/"
 cp -v  "$SCRIPT_DIR/scenarios/load-tester-values-realistic-benchmark.yaml"      "$TARGET_DIRECTORY/"
+cp -v  "$SCRIPT_DIR/scenarios/load-tester-values-secret-benchmark.yaml"         "$TARGET_DIRECTORY/"
 cp -v  "$VERSION_DIR/values/camunda-platform-values-defaults.yaml"              "$TARGET_DIRECTORY/"
 cp -v  "$VERSION_DIR/values/camunda-platform-values-${secondary_storage}.yaml"   "$TARGET_DIRECTORY/"
+
+# The secret benchmark's platform values only exist on versions that support it; the
+# scenario itself then fails on the missing -f file rather than rendering half of it.
+for secret_values in camunda-platform-values-secrets.yaml \
+                     camunda-platform-override-values-secrets.yaml; do
+  if [ -f "$VERSION_DIR/values/$secret_values" ]; then
+    cp -v "$VERSION_DIR/values/$secret_values" "$TARGET_DIRECTORY/"
+  fi
+done
 
 # Don't configure Elasticsearch unless specifically enabled (secondary storage,
 # or via Optimize)

--- a/load-tests/setup/scenarios/load-tester-values-secret-benchmark.yaml
+++ b/load-tests/setup/scenarios/load-tester-values-secret-benchmark.yaml
@@ -1,0 +1,30 @@
+# Secret benchmark scenario values for the load-tester subchart, used by
+# scenario=secrets and scenario=secrets-control.
+#
+# Only the env vars live here; the workload knobs (rate, models, payload, worker
+# replicas) are passed as --set flags from common.mk like every other scenario.
+global:
+  # Helm replaces lists instead of merging them, so every entry of
+  # scenarios/load-tester-values-defaults.yaml is re-declared here. Keep the two in sync.
+  extraEnvVars:
+    - name: LOAD_TESTER_LOG_APPENDER
+      value: Stackdriver
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+      value: load-tester
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: camunda-credentials
+          key: identity-optimize-loadtest-client-secret
+    # How many variants of the starter's BPMN template are deployed, and therefore how
+    # many distinct secret references exist. Against the 1000-entry secret cache, 1500
+    # references picked uniformly at random settle at a ~1/3 miss rate.
+    #
+    # Must match the number of secrets seeded by
+    # main/values/camunda-platform-values-secrets.yaml.
+    - name: LOAD_TESTER_STARTER_SECRET_VARIANTS
+      value: "1500"

--- a/load-tests/setup/scenarios/load-tester-values-secret-benchmark.yaml
+++ b/load-tests/setup/scenarios/load-tester-values-secret-benchmark.yaml
@@ -28,3 +28,8 @@ global:
     # main/values/camunda-platform-values-secrets.yaml.
     - name: LOAD_TESTER_STARTER_SECRET_VARIANTS
       value: "1500"
+    # Long-poll the worker instead of streaming jobs: job push already checks a job's secret
+    # references at creation, so this scenario's default (stream-enabled: true) never exercises
+    # the long-poll path's own resolution request/park cycle. Isolated measurement of that path.
+    - name: LOAD_TESTER_WORKER_STREAM_ENABLED
+      value: "false"

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -316,6 +316,12 @@ public class BpmnJobActivationBehavior {
    * create or reactivate the job - a warmup failure must not fail that unrelated command. The next
    * poll or push still runs the real check and surfaces the same failure through its own, correct
    * path.
+   *
+   * <p>Wakes the scheduler too, same as {@code JobBatchActivateProcessor#requestSecretResolution}
+   * and {@link #requestResolutionAndPark}: this is exactly the kind of activation {@link
+   * SecretResolutionScheduler#stayAwake()} exists for, and this is often the earliest such
+   * activation for a reference - deduped requests from a later poll or push never call it, so
+   * skipping it here would leave the reference's only wake-up call unmade.
    */
   private void requestWarmResolution(final long jobKey, final JobRecord jobRecord) {
     final SecretCheckResult secrets;
@@ -334,6 +340,7 @@ public class BpmnJobActivationBehavior {
       return;
     }
     final Set<SecretReference> requested = new HashSet<>();
+    boolean anyRequested = false;
     for (final Secret secret : secrets.nonCachedSecrets()) {
       final SecretReference reference = secret.reference();
       if (!requested.add(reference)
@@ -346,10 +353,15 @@ public class BpmnJobActivationBehavior {
               .setSecretReference(reference.name());
       if (!stateWriter.canWriteEventOfLength(
           event.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
-        return;
+        break;
       }
       stateWriter.appendFollowUpEvent(
           keyGenerator.nextKey(), SecretReferenceIntent.RESOLUTION_REQUESTED, event);
+      anyRequested = true;
+    }
+    if (anyRequested) {
+      // once per activation rather than per reference, same as the other two request sites
+      secretResolutionScheduler.stayAwake();
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWrit
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
@@ -81,6 +82,7 @@ public class BpmnJobActivationBehavior {
   private final CslTenantCheck tenantCheck;
   private final JobAuthorizationLogger jobAuthorizationLogger;
   private final JobSecretLookup secretLookup;
+  private final SecretReferenceState secretReferenceState;
   private final BpmnIncidentBehavior incidentBehavior;
 
   public BpmnJobActivationBehavior(
@@ -107,6 +109,7 @@ public class BpmnJobActivationBehavior {
     this.tenantCheck = tenantCheck;
     jobAuthorizationLogger = JobAuthorizationLogger.createDefault();
     secretLookup = new JobSecretLookup(secretStoreRegistry);
+    secretReferenceState = state.getSecretReferenceState();
     this.incidentBehavior = incidentBehavior;
   }
 
@@ -119,6 +122,12 @@ public class BpmnJobActivationBehavior {
    * job with a non-cached reference is not activated at all: its resolution is requested and the
    * job is parked until it resolves, which pushes it (see {@code
    * SecretReferenceBatchReactivateJobsProcessor}).
+   *
+   * <p>A job that stays activatable because no stream matched its type has its non-cached
+   * references warmed instead: the resolution is requested without parking the job, so a long
+   * poll's own check (see {@code JobBatchCollector}) is more likely to find the value already
+   * cached by the time it runs. That poll still parks the job itself on a miss; this only gives the
+   * resolution a head start over it.
    */
   public void publishWork(final long jobKey, final JobRecord jobRecord) {
     publishWork(jobKey, jobRecord, new HashSet<>());
@@ -178,7 +187,9 @@ public class BpmnJobActivationBehavior {
               jobMetrics.countJobEvent(JobAction.SKIPPED_LEASED, jobKind, jobType);
             });
       }
-      // the job stays activatable; a long poll checks its secret references when it collects it
+      // the job stays activatable; a long poll checks its secret references when it collects it.
+      // Warming the resolution here only gives that check a head start, it never replaces it
+      requestWarmResolution(jobKey, wrappedJobRecord);
       notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
       return true;
     }
@@ -285,6 +296,61 @@ public class BpmnJobActivationBehavior {
       notifyJobAvailableOnce(jobType, jobKind, notifiedJobTypes);
     }
     return batchHadRoom;
+  }
+
+  /**
+   * Requests the background resolution of the job's non-cached references without parking the job
+   * or its jobs keys: a long poll still runs {@link JobSecretLookup#check} itself when it collects
+   * the job (see {@code JobBatchCollector}) and parks it on a miss exactly as it does today, so
+   * this only gives the resolution a head start over that first poll. A reference already pending
+   * is not requested again, so many jobs referencing the same non-cached secret in one window cost
+   * one request, not one per job.
+   *
+   * <p>Stops appending once the record batch is full instead of letting the append overflow and
+   * roll back the command being processed; the references left out are requested again by whichever
+   * poll or push eventually reaches the job, exactly as if this warmup had not run.
+   *
+   * <p>A failing check is caught rather than left to propagate: unlike the poll's own check (see
+   * {@code JobBatchCollector}) or the push's real check above, whose failure is the caller's only
+   * way to learn a secret store is broken, this runs piggy-backed on whatever command happened to
+   * create or reactivate the job - a warmup failure must not fail that unrelated command. The next
+   * poll or push still runs the real check and surfaces the same failure through its own, correct
+   * path.
+   */
+  private void requestWarmResolution(final long jobKey, final JobRecord jobRecord) {
+    final SecretCheckResult secrets;
+    try {
+      secrets = secretLookup.check(jobRecord);
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Failed to warm the secret resolution of the job with key {} of type '{}'; a later poll "
+              + "or push will check its references again",
+          jobKey,
+          jobRecord.getType(),
+          e);
+      return;
+    }
+    if (secrets.nonCachedSecrets().isEmpty()) {
+      return;
+    }
+    final Set<SecretReference> requested = new HashSet<>();
+    for (final Secret secret : secrets.nonCachedSecrets()) {
+      final SecretReference reference = secret.reference();
+      if (!requested.add(reference)
+          || secretReferenceState.isPending(reference.storeId(), reference.name())) {
+        continue;
+      }
+      final var event =
+          new SecretReferenceRecord()
+              .setStoreId(reference.storeId())
+              .setSecretReference(reference.name());
+      if (!stateWriter.canWriteEventOfLength(
+          event.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
+        return;
+      }
+      stateWriter.appendFollowUpEvent(
+          keyGenerator.nextKey(), SecretReferenceIntent.RESOLUTION_REQUESTED, event);
+    }
   }
 
   /** Notifies the workers of the job type unless this batch of jobs already did. */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -111,10 +111,13 @@ public final class JobSecretActivationInjectionTest {
     assertThat(activated.getValue().getJobKeys()).isEmpty();
     assertThat(secretActivation.awaitActivationResponse().getJobs()).isEmpty();
 
-    // and - a RESOLUTION_REQUESTED event is written for the missing reference with the job key
+    // and - a RESOLUTION_REQUESTED event is written for the missing reference with the job key.
+    // The creation-time warmup already requested it too, carrying no job key of its own (see
+    // SecretResolutionWarmupTest) - this is the poll-driven one, which parks this job
     final Record<SecretReferenceRecordValue> requested =
         RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
             .withSecretReference("token")
+            .filter(record -> record.getValue().getJobKeys().contains(jobKey))
             .getFirst();
     assertThat(requested.getValue().getStoreId()).isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
     assertThat(requested.getValue().getJobKeys()).containsExactly(jobKey);
@@ -141,10 +144,14 @@ public final class JobSecretActivationInjectionTest {
     // when
     engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
 
-    // then - a single RESOLUTION_REQUESTED event carries both waiting job keys
+    // then - a single RESOLUTION_REQUESTED event carries both waiting job keys. The first job's
+    // creation-time warmup already requested this reference too (see SecretResolutionWarmupTest);
+    // the second job's warmup found it already pending and requested nothing, so only the
+    // poll-driven request below names any job key at all
     final Record<SecretReferenceRecordValue> requested =
         RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
             .withSecretReference("token")
+            .filter(record -> !record.getValue().getJobKeys().isEmpty())
             .getFirst();
     assertThat(requested.getValue().getJobKeys())
         .containsExactlyInAnyOrder(firstJobKey, secondJobKey);
@@ -162,9 +169,12 @@ public final class JobSecretActivationInjectionTest {
     // when
     engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
 
-    // then - one RESOLUTION_REQUESTED event per reference, each carrying the job key
+    // then - one RESOLUTION_REQUESTED event per reference, each carrying the job key. The
+    // creation-time warmup already requested both references too, carrying no job key of their
+    // own (see SecretResolutionWarmupTest) - filtered out here, leaving only the poll-driven pair
     final var requested =
         RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .filter(record -> record.getValue().getJobKeys().contains(jobKey))
             .limit(2)
             .asList();
     assertThat(requested)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretPushInjectionTest.java
@@ -442,13 +442,18 @@ public final class JobSecretPushInjectionTest {
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
     final long jobKey = jobKeyOf(processInstanceKey);
 
-    // then - the job stays activatable for a long poll, which owns the check on that path
+    // then - the job stays activatable for a long poll, which owns the check on that path; the
+    // resolution is nonetheless requested right away as a warmup, without parking the job or
+    // naming its key (see SecretResolutionWarmupTest)
     Awaitility.await("until the workers are notified")
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(() -> assertThat(JOB_STREAMER.notificationsForJob(JOB_TYPE)).isPositive());
     assertThat(jobState(jobKey)).isEqualTo(State.ACTIVATABLE);
-    assertThat(RecordingExporter.getRecords())
-        .noneMatch(record -> record.getValueType() == ValueType.SECRET_REFERENCE);
+    final Record<SecretReferenceRecordValue> requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference(SECRET_NAME)
+            .getFirst();
+    assertThat(requested.getValue().getJobKeys()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionSecretResumeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionSecretResumeTest.java
@@ -201,9 +201,13 @@ public final class JobSuspensionSecretResumeTest {
     final Record<JobBatchRecordValue> parked =
         engine.jobs().withType(jobType).withRequestStreamId(1).withRequestId(1L).activate();
     assertThat(parked.getValue().getJobs()).isEmpty();
+    // the creation-time warmup already requested this reference too, carrying no job key of its
+    // own (see SecretResolutionWarmupTest) - the poll-driven request that actually parked this
+    // job is whichever one names its key
     final var requested =
         RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
             .withSecretReference(SECRET_NAME)
+            .filter(record -> record.getValue().getJobKeys().contains(jobKey))
             .getFirst();
     assertThat(requested.getValue().getJobKeys()).contains(jobKey);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobWaitingForSecretResolutionTest.java
@@ -63,9 +63,12 @@ public final class JobWaitingForSecretResolutionTest {
     deploy();
     final long jobKey = parkedJob();
 
-    // then
+    // then - the creation-time warmup also requests this reference (carrying no job key of its
+    // own, see SecretResolutionWarmupTest), so the request that actually parked this job is
+    // whichever one names its key rather than necessarily the first
     assertThat(
             RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+                .filter(record -> record.getValue().getJobKeys().contains(jobKey))
                 .getFirst()
                 .getValue()
                 .getJobKeys())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionLifecycleTest.java
@@ -88,10 +88,13 @@ public final class SecretResolutionLifecycleTest {
         engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
     assertThat(parked.getValue().getJobs()).isEmpty();
 
-    // then - the request addresses the default store, which is the one configured
+    // then - the request addresses the default store, which is the one configured. The first
+    // RESOLUTION_REQUESTED for this reference is the creation-time warmup, which carries no job
+    // key (see SecretResolutionWarmupTest) - this is the poll-driven one, which parks this job
     final Record<SecretReferenceRecordValue> requested =
         RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
             .withSecretReference("token")
+            .filter(record -> record.getValue().getJobKeys().contains(jobKey))
             .getFirst();
     assertThat(requested.getValue().getStoreId()).isEqualTo(SecretStoreRegistry.DEFAULT_STORE_ID);
     assertThat(requested.getValue().getJobKeys()).containsExactly(jobKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionWarmupDedupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionWarmupDedupTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.SecretStoreRegistries;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Companion to {@link SecretResolutionWarmupTest}: the resolution interval here is deliberately an
+ * hour, so the reference the first job's warmup requests is still pending by the time the second
+ * job is created - this is what makes the dedup assertion deterministic instead of racing the
+ * scheduler's own cycle.
+ */
+public final class SecretResolutionWarmupDedupTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+  private static final String SECRET_VALUE = "resolved-secret";
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecretStoreRegistry(
+              SecretStoreRegistries.resolvingFromStore(Map.of("token", SECRET_VALUE)))
+          .withEngineConfig(config -> config.setSecretResolutionInterval(Duration.ofHours(1)));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldNotRequestResolutionTwiceForAReferenceAlreadyPending() {
+    // given
+    deploy();
+
+    // when - two jobs referencing the same non-cached secret are created back to back
+    final long firstInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    awaitJob(firstInstanceKey);
+    final long secondInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    awaitJob(secondInstanceKey);
+
+    // then - only the first job's warmup requested the resolution; the second found it pending
+    // already. Both jobs' CREATED events and their own warmup follow-up (if any) commit and export
+    // in the same batch as that job's creation command, so waiting for the second job's CREATED
+    // record above is what makes a snapshot read here safe: a second request, if the dedup had not
+    // fired, would already be visible by now rather than merely not-yet-exported
+    assertThat(RecordingExporter.getRecords())
+        .filteredOn(
+            record ->
+                record.getIntent() == SecretReferenceIntent.RESOLUTION_REQUESTED
+                    && ((SecretReferenceRecordValue) record.getValue())
+                        .getSecretReference()
+                        .equals("token"))
+        .hasSize(1);
+  }
+
+  /** Returns the key of the job the given instance waits on, once that job exists. */
+  private long awaitJob(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
+  }
+
+  private void deploy() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secrets.token", "authorization"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionWarmupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionWarmupTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.SecretStoreRegistries;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Covers the warmup this behavior adds on top of {@link SecretResolutionLifecycleTest}'s park/drain
+ * loop: a job with a non-cached secret reference requests its resolution as soon as the job is
+ * created, without parking the job, so a long poll that arrives after the resolution completes
+ * needs no round trip of its own. A long poll that arrives before the resolution completes still
+ * parks the job and drains it exactly as {@link SecretResolutionLifecycleTest} covers - this warmup
+ * only gives that resolution a head start, it never replaces the poll-driven path.
+ */
+public final class SecretResolutionWarmupTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+  private static final String SECRET_VALUE = "resolved-secret";
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecretStoreRegistry(
+              SecretStoreRegistries.resolvingFromStore(Map.of("token", SECRET_VALUE)))
+          // the default interval is 5s, which would make every assertion below wait on it
+          .withEngineConfig(config -> config.setSecretResolutionInterval(Duration.ofMillis(100)));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRequestResolutionAtJobCreationWithoutParkingTheJob() {
+    // given - a job whose secret the store holds but the cache does not
+    deploy();
+
+    // when - the job is created; no activation has been requested yet
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long jobKey = awaitJob(processInstanceKey);
+
+    // then - the resolution is requested right away, addressing no particular job
+    final Record<SecretReferenceRecordValue> requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(requested.getValue().getJobKeys()).isEmpty();
+
+    // and - the background resolution succeeds before any poll ever reaches this job
+    final Record<SecretReferenceRecordValue> resolved =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_COMPLETED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(resolved.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
+
+    // and - the job was never parked: nothing ever drains a waiting entry for this reference
+    assertThat(RecordingExporter.getRecords())
+        .filteredOn(record -> record.getIntent() == SecretReferenceIntent.BATCH_JOBS_REACTIVATED)
+        .isEmpty();
+
+    // when - the first ever poll for this job arrives
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - a single poll is enough: the value was already cached by the warmup
+    assertThat(activated.getValue().getJobKeys()).containsExactly(jobKey);
+
+    // and - the job completes and the instance reaches its end, so nothing further will be
+    // processed: only then does the absence of an incident below mean the run never raised one
+    engine.job().withKey(jobKey).complete();
+    RecordingExporter.jobRecords(JobIntent.COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    assertThat(RecordingExporter.getRecords())
+        .filteredOn(record -> record.getIntent() == IncidentIntent.CREATED)
+        .isEmpty();
+  }
+
+  /** Returns the key of the job the given instance waits on, once that job exists. */
+  private long awaitJob(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
+  }
+
+  private void deploy() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secrets.token", "authorization"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+  }
+}


### PR DESCRIPTION
## Status: not recommended for merge (kept as a documented investigation)

Rebased onto #61448 (merging soon) and re-benchmarked under load with a proper same-day control.
Conclusion: no benefit clears the noise floor under the only load profile tested (a continuously
saturated poller). Recommend holding this branch/PR as reference rather than merging - see
"Under-load result" below. Converted to draft; #61509 has the full writeup and the acceptance
criteria for the one regime (slow/starved pollers) that could still show a real gain.

## Summary
- Request the resolution of a job's non-cached secret references at creation on the long-poll path too, without parking the job or naming it on the request. The push path already did this; the no-stream branch of `publishWork` returned before ever checking. A reference already pending is deduped via `SecretReferenceState.isPending`, and the lookup itself is caught rather than propagated, since it now runs inside job creation/fail/recur-after-backoff/incident-resolve/resume rather than only a client-facing poll/push command.
- Make the `secrets`/`secrets-control` load test scenarios exercise the long-poll path (`stream-enabled: false` via a new `LOAD_TESTER_WORKER_STREAM_ENABLED` env var), since their default only ever exercised push.
- After rebasing onto #61448: also wake the scheduler from the warmup request (`SecretResolutionScheduler.stayAwake()`), mirroring the two existing call sites - the warmup is exactly the kind of activation that call is documented for, and is often the earliest request for a reference.

## Under-load result (2026-09-01, post-rebase onto #61448)

Same-day, same-cluster control - wake fix alone vs wake fix + this warmup, both poll path,
30-min-class steady-state window:

| | wake-only (no warmup) | wake + warmup |
|---|---|---|
| PI exec p90 | 245ms | 235ms |
| PI exec p99 | 534ms | 514ms |
| job activation within 1s | 99.91% | 99.93% |
| secret cache miss rate | 25.4% | 26.4% |

~4% delta on p90/p99, essentially flat on within-1s. That's *smaller* than the ~7-8% run-to-run
noise measured on the job-push path in the same session, where this change contributes zero new
code (push already warmed at creation before this PR). Not distinguishable from noise.

Permanent cost: the change doubles secret-cache lookup volume for every poll-eligible job with a
secret reference (one check at creation, one at the real poll/push check) - cheap (in-memory,
no store IO) and error-free in every run, but a real, permanent cost against an unproven return.

Also checked the cold cluster-warm-up transient specifically (cache empty, near-100% miss rate for
the first ~90-120s after traffic starts): the penalty is real (PI exec p90 ~3-4s cold vs ~0.3-0.4s
steady), but the two runs' curves through it are mixed - worse for the warmup at t=0-30s, tied at
t=60-90s, better at t=120s, roughly tied after. Mechanistically this tracks: the warm-up penalty is
a scheduler *throughput* problem (how many distinct refs can be drained per cycle), not a
request-*timing* problem, so there's no strong reason to expect this change to help there more than
in steady state.

Full numbers, methodology, and the mechanistic reasoning for why the head start doesn't survive a
saturated poller are in #61509.

## Test plan
- [x] `SecretResolutionWarmupTest` / `SecretResolutionWarmupDedupTest`: creation-time request without park, single poll suffices, no incident, dedup against an already-pending reference
- [x] Updated `SecretResolutionLifecycleTest`, `JobWaitingForSecretResolutionTest`, `JobSuspensionSecretResumeTest`, `JobSecretActivationInjectionTest`, `JobSecretPushInjectionTest` for the new request ordering (a reference can now have an earlier, keyless warmup request ahead of the one that actually parks a job)
- [x] Full secret-reference / job-secret regression surface in `zeebe-engine` green (189 tests, including #61448's own new coverage)
- [x] A/B and same-day control load tests on the `secrets` scenario, both activation paths, all namespaces healthy, no errors traced to the new code path in any run
