### PR TITLE
ci: load-test: weekly release load tests

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -1,21 +1,29 @@
-# description: Runs parallel endurance tests weekly against main (TTL: 28 days).
-#              Variants: realistic, rdbms-realistic (PostgreSQL), opensearch-realistic, ECS.
-#              Naming pattern: medic-y-YYYY-cw-WW-<sha>
-# calls: camunda-load-test.yml (3 parallel calls, one per scenario) +
-#        camunda-ecs-weekly-load-test.yml (1 parallel call) — 4 load tests total
+# description: Runs weekly load tests against main and every supported stable branch.
+#              Main: parallel endurance tests (realistic, rdbms-realistic (PostgreSQL),
+#              opensearch-realistic, ECS), TTL 28 days.
+#              Stable branches (8.7, 8.8, 8.9): one realistic-workload load test each, TTL 7
+#              days, as a stability signal between patch releases.
+#              Naming pattern: medic-YYYY-WW-<sha> (main),
+#              weekly-YYYY-WW-<sha>-stable-<branch> (stable).
+# calls: camunda-load-test.yml (3 parallel calls, one per main scenario) +
+#        camunda-ecs-weekly-load-test.yml (1 parallel call) — 4 load tests on main +
+#        camunda-load-test.yml@stable/8.x (one call per stable branch, cross-branch ref) —
+#        each stable branch's own copy already sparse-checks-out its
+#        load-tests/setup/stable-8x folder from main, so no backport is needed to pick up
+#        setup changes.
 # type: CI
 # owner: @camunda/reliability-testing
-name: Camunda weekly medic load test
+name: Camunda weekly load tests
 on:
   workflow_dispatch:
      inputs:
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the weekly load tests. Allows to skip the docker image build step, can be used for recreating previous weekly tests.'
+        description: 'Docker image tag, that should be reused for the weekly main load tests. Allows to skip the docker image build step, can be used for recreating previous weekly tests. Does not affect the stable-branch load tests.'
         type: string
         default: ""
         required: false
       ttl:
-        description: 'Specifies after how many days the weekly load test namespace should be deleted. Useful to adjust if we recreate the weekly tests.'
+        description: 'Specifies after how many days the weekly main load test namespaces should be deleted. Useful to adjust if we recreate the weekly tests. Does not affect the stable-branch load tests, which are fixed at 7 days.'
         type: number
         default: 28
         required: false
@@ -42,6 +50,7 @@ jobs:
     permissions: { }
     outputs:
       image-tag: ${{ steps.data.outputs.image-tag }}
+      week-id: ${{ steps.data.outputs.week-id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -49,9 +58,11 @@ jobs:
       - name: Collect test data
         id: data
         run: |
+          suffix="$(date --utc "+%G-%V")-$(git rev-parse --short HEAD)"
+          echo "week-id=${suffix}" >> "$GITHUB_OUTPUT"
           if [[ -z "$REUSE_TAG" ]]; then
             echo "Creating new weekly test tag"
-            echo "image-tag=medic-$(date +%Y)-$(date +%V)-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "image-tag=medic-${suffix}" >> "$GITHUB_OUTPUT"
           else
             echo "Re-creating weekly test, with tag: $REUSE_TAG"
             echo "image-tag=$REUSE_TAG" >> "$GITHUB_OUTPUT"
@@ -259,11 +270,59 @@ jobs:
       environment: prod
       skip_destroy_previous: false
 
+  # One job per supported stable branch, each calling that branch's own copy of
+  # camunda-load-test.yml (cross-branch `uses:`, matching camunda-scheduled-release-load-tests.yml).
+  # `ref` is left unset, so it defaults to the branch itself, building fresh from its tip.
+  # When a branch is deprecated, remove its job; when a new minor version becomes stable, add one.
+  # Deliberately not passed `reuse-tag: needs.test-data.outputs.image-tag` — that tag is a build
+  # of `main`, and reusing it here would deploy main's image under a stable branch.
+  # Each job will build its own Docker image from that branch's tip.
+  weekly-8-7:
+    name: Weekly load test (stable/8.7)
+    needs: test-data
+    uses: camunda/camunda/.github/workflows/camunda-load-test.yml@stable/8.7
+    secrets: inherit
+    with:
+      name: ${{ needs.test-data.outputs.image-tag }}-stable-87
+      scenario: realistic
+      secondary-storage-type: elasticsearch
+      ttl: 7
+
+  weekly-8-8:
+    name: Weekly load test (stable/8.8)
+    needs: test-data
+    uses: camunda/camunda/.github/workflows/camunda-load-test.yml@stable/8.8
+    secrets: inherit
+    with:
+      name: ${{ needs.test-data.outputs.image-tag }}-stable-88
+      scenario: realistic
+      secondary-storage-type: elasticsearch
+      ttl: 7
+
+  weekly-8-9:
+    name: Weekly load test (stable/8.9)
+    needs: test-data
+    uses: camunda/camunda/.github/workflows/camunda-load-test.yml@stable/8.9
+    secrets: inherit
+    with:
+      name: ${{ needs.test-data.outputs.image-tag }}-stable-89
+      scenario: realistic
+      secondary-storage-type: elasticsearch
+      ttl: 7
 
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-opensearch-realistic-load-test, setup-realistic-test, setup-ecs-benchmark ]
+    needs:
+      - build-camunda-image
+      - build-load-test-images
+      - setup-rdbms-realistic-load-test
+      - setup-opensearch-realistic-load-test
+      - setup-realistic-test
+      - setup-ecs-benchmark
+      - weekly-8-7
+      - weekly-8-8
+      - weekly-8-9
     if: failure()
     timeout-minutes: 5
     permissions: { }
@@ -288,24 +347,16 @@ jobs:
           webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":warning: *Weekly Medic load test creation failed:*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "@reliability-testing-team Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":warning: *Weekly load test creation failed:*"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "@reliability-testing-team Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -76,8 +76,9 @@ graph TD
     VARIANT -- "always profiles first<br/>30min of each variant" --> PROFILE
     VARIANT -- "3hr soak, then<br/>snapshot metrics" --> METRICS
     VARIANT -- "delete namespace<br/>after metrics" --> DELETE
-    WEEKLY -- "3 parallel calls:<br/>realistic, opensearch-realistic,<br/>rdbms-realistic" --> CORE
-    WEEKLY -- "ECS" --> ECS
+    WEEKLY -- "main: 3 parallel calls,<br/>realistic, opensearch-realistic,<br/>rdbms-realistic" --> CORE
+    WEEKLY -- "main: ECS" --> ECS
+    WEEKLY -- "stable: 1 job per branch<br/>(cross-branch ref)" --> CORE
     ROLLING -- "latest release tag<br/>custom helm values" --> CORE
     RELEASE -- "scenario: realistic<br/>orchestration-tag" --> CORE
     PR -- "scenario: max" --> CORE


### PR DESCRIPTION
## Description

Extends `camunda-weekly-load-tests.yml` to also run a weekly realistic-workload load test for each supported stable branch (`stable/8.7`, `stable/8.8`, `stable/8.9`), running for one week (`ttl: 7`) as a stability signal between patch releases.

Each stable branch's job calls that branch's own copy of `camunda-load-test.yml` via a cross-branch `uses:` reference, building fresh from that branch's own tip. That copy already sparse-checks-out `load-tests/setup/stable-8x` from `main`, so this workflow never needs to be backported when the setup changes.

Also collapses the `test-data` job's two separate `date +%Y` / `date +%V` calls into one `date --utc "+%G-%V"`, making the year/week pair UTC-explicit and shared between the `image-tag` and `week-id` outputs.

Closes #55337

## Known gap

The issue also asks to alert on TTL expiry so metrics can be snapshotted before teardown. That isn't implemented here — `camunda-load-test-ttl-cleanup.yml` only posts to Slack after deleting expired namespaces, and the `camunda-load-test-metrics.yaml` time-anchor input is manual-only. Flagging for a follow-up rather than expanding scope here.
