### PR TITLE
Rename ambiguous `versionTag` to `processDefinitionVersionTag` across the AgentInstance stack

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -149,7 +149,7 @@
       <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
       <column name="PROCESS_DEFINITION_VERSION" type="SMALLINT"/>
-      <column name="VERSION_TAG" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_VERSION_TAG" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
       <column name="PARTITION_ID" type="INTEGER"/>
       <column name="STATUS" type="VARCHAR(20)"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapper.java
@@ -48,7 +48,7 @@ public class AgentInstanceEntityMapper {
         dbModel.processDefinitionKey(),
         nullToEmpty(dbModel.processDefinitionId()),
         dbModel.processDefinitionVersion(),
-        dbModel.versionTag(),
+        dbModel.processDefinitionVersionTag(),
         nullToEmpty(dbModel.tenantId()),
         dbModel.creationDate(),
         dbModel.lastUpdatedDate(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentInstanceDbModel.java
@@ -33,7 +33,7 @@ public record AgentInstanceDbModel(
     String processDefinitionId,
     long processDefinitionKey,
     int processDefinitionVersion,
-    String versionTag,
+    String processDefinitionVersionTag,
     String tenantId,
     int partitionId,
     AgentInstanceStatus status,
@@ -74,7 +74,7 @@ public record AgentInstanceDbModel(
       final String processDefinitionId,
       final long processDefinitionKey,
       final int processDefinitionVersion,
-      final String versionTag,
+      final String processDefinitionVersionTag,
       final String tenantId,
       final int partitionId,
       final AgentInstanceStatus status,
@@ -101,7 +101,7 @@ public record AgentInstanceDbModel(
         processDefinitionId,
         processDefinitionKey,
         processDefinitionVersion,
-        versionTag,
+        processDefinitionVersionTag,
         tenantId,
         partitionId,
         status,
@@ -146,7 +146,7 @@ public record AgentInstanceDbModel(
         processDefinitionId,
         processDefinitionKey,
         processDefinitionVersion,
-        versionTag,
+        processDefinitionVersionTag,
         tenantId,
         partitionId,
         status,
@@ -247,7 +247,7 @@ public record AgentInstanceDbModel(
         .processDefinitionId(processDefinitionId)
         .processDefinitionKey(processDefinitionKey)
         .processDefinitionVersion(processDefinitionVersion)
-        .versionTag(versionTag)
+        .processDefinitionVersionTag(processDefinitionVersionTag)
         .tenantId(tenantId)
         .partitionId(partitionId)
         .status(status)
@@ -277,7 +277,7 @@ public record AgentInstanceDbModel(
     private String processDefinitionId;
     private long processDefinitionKey;
     private int processDefinitionVersion;
-    private String versionTag;
+    private String processDefinitionVersionTag;
     private String tenantId;
     private int partitionId;
     private AgentInstanceStatus status;
@@ -348,8 +348,8 @@ public record AgentInstanceDbModel(
       return this;
     }
 
-    public Builder versionTag(final String versionTag) {
-      this.versionTag = versionTag;
+    public Builder processDefinitionVersionTag(final String processDefinitionVersionTag) {
+      this.processDefinitionVersionTag = processDefinitionVersionTag;
       return this;
     }
 
@@ -465,7 +465,7 @@ public record AgentInstanceDbModel(
           processDefinitionId,
           processDefinitionKey,
           processDefinitionVersion,
-          versionTag,
+          processDefinitionVersionTag,
           tenantId,
           partitionId,
           status,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
@@ -58,7 +58,7 @@ public class AgentInstanceWriter extends ProcessInstanceDependant implements Rdb
                   .processDefinitionId(agentInstance.processDefinitionId())
                   .processDefinitionKey(agentInstance.processDefinitionKey())
                   .processDefinitionVersion(agentInstance.processDefinitionVersion())
-                  .versionTag(agentInstance.versionTag())
+                  .processDefinitionVersionTag(agentInstance.processDefinitionVersionTag())
                   .elementId(agentInstance.elementId())
                   .status(agentInstance.status())
                   .model(agentInstance.model())

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -25,7 +25,7 @@
       PROCESS_DEFINITION_ID,
       PROCESS_DEFINITION_KEY,
       PROCESS_DEFINITION_VERSION,
-      VERSION_TAG,
+      PROCESS_DEFINITION_VERSION_TAG,
       TENANT_ID,
       PARTITION_ID,
       STATUS,
@@ -53,7 +53,7 @@
       #{processDefinitionId},
       #{processDefinitionKey},
       #{processDefinitionVersion},
-      #{versionTag},
+      #{processDefinitionVersionTag},
       #{tenantId},
       #{partitionId},
       #{status},
@@ -83,25 +83,25 @@
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
     UPDATE ${prefix}AGENT_INSTANCE
     SET
-      AGENT_DEFINITION_KEY       = #{agentDefinitionKey},
-      PROCESS_DEFINITION_ID      = #{processDefinitionId},
-      PROCESS_DEFINITION_KEY     = #{processDefinitionKey},
-      PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
-      VERSION_TAG                = #{versionTag},
-      ELEMENT_ID                 = #{elementId},
-      STATUS                     = #{status},
-      MODEL                      = #{model},
-      PROVIDER                   = #{provider},
-      SYSTEM_PROMPT              = #{systemPrompt, jdbcType=CLOB},
-      MAX_TOKENS                 = #{maxTokens},
-      MAX_MODEL_CALLS            = #{maxModelCalls},
-      MAX_TOOL_CALLS             = #{maxToolCalls},
-      INPUT_TOKENS               = #{inputTokens},
-      OUTPUT_TOKENS              = #{outputTokens},
-      MODEL_CALLS                = #{modelCalls},
-      TOOL_CALLS                 = #{toolCalls},
-      TOOLS                      = #{tools, jdbcType=CLOB},
-      LAST_UPDATED_DATE          = #{lastUpdatedDate, jdbcType=TIMESTAMP}
+      AGENT_DEFINITION_KEY            = #{agentDefinitionKey},
+      PROCESS_DEFINITION_ID           = #{processDefinitionId},
+      PROCESS_DEFINITION_KEY          = #{processDefinitionKey},
+      PROCESS_DEFINITION_VERSION      = #{processDefinitionVersion},
+      PROCESS_DEFINITION_VERSION_TAG  = #{processDefinitionVersionTag},
+      ELEMENT_ID                      = #{elementId},
+      STATUS                          = #{status},
+      MODEL                           = #{model},
+      PROVIDER                        = #{provider},
+      SYSTEM_PROMPT                   = #{systemPrompt, jdbcType=CLOB},
+      MAX_TOKENS                      = #{maxTokens},
+      MAX_MODEL_CALLS                 = #{maxModelCalls},
+      MAX_TOOL_CALLS                  = #{maxToolCalls},
+      INPUT_TOKENS                    = #{inputTokens},
+      OUTPUT_TOKENS                   = #{outputTokens},
+      MODEL_CALLS                     = #{modelCalls},
+      TOOL_CALLS                      = #{toolCalls},
+      TOOLS                           = #{tools, jdbcType=CLOB},
+      LAST_UPDATED_DATE               = #{lastUpdatedDate, jdbcType=TIMESTAMP}
       <if test="completionDate != null">
         , COMPLETION_DATE = #{completionDate, jdbcType=TIMESTAMP}
       </if>
@@ -166,7 +166,7 @@
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String" name="processDefinitionId"/>
       <arg column="PROCESS_DEFINITION_KEY" javaType="_long" name="processDefinitionKey"/>
       <arg column="PROCESS_DEFINITION_VERSION" javaType="_int" name="processDefinitionVersion"/>
-      <arg column="VERSION_TAG" javaType="java.lang.String" name="versionTag"/>
+      <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String" name="processDefinitionVersionTag"/>
       <arg column="TENANT_ID" javaType="java.lang.String" name="tenantId"/>
       <arg column="PARTITION_ID" javaType="_int" name="partitionId"/>
       <arg column="STATUS" javaType="io.camunda.search.entities.AgentInstanceEntity$AgentInstanceStatus" name="status"/>
@@ -208,7 +208,7 @@
             ai.PROCESS_DEFINITION_ID,
             ai.PROCESS_DEFINITION_KEY,
             ai.PROCESS_DEFINITION_VERSION,
-            ai.VERSION_TAG,
+            ai.PROCESS_DEFINITION_VERSION_TAG,
             ai.TENANT_ID,
             ai.PARTITION_ID,
             ai.STATUS,
@@ -309,9 +309,9 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
-      <if test="filter.versionTagOperations != null and !filter.versionTagOperations.isEmpty()">
-        <foreach collection="filter.versionTagOperations" item="operation">
-          AND ai.VERSION_TAG
+      <if test="filter.processDefinitionVersionTagOperations != null and !filter.processDefinitionVersionTagOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionVersionTagOperations" item="operation">
+          AND ai.PROCESS_DEFINITION_VERSION_TAG
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentInstanceEntityMapperTest.java
@@ -38,7 +38,7 @@ class AgentInstanceEntityMapperTest {
               key.processDefinitionId("myProcess");
               key.processDefinitionKey(400L);
               key.processDefinitionVersion(2);
-              key.versionTag("v1");
+              key.processDefinitionVersionTag("v1");
               key.tenantId("<default>");
               key.partitionId(1);
               key.status(AgentInstanceStatus.THINKING);
@@ -70,7 +70,7 @@ class AgentInstanceEntityMapperTest {
     assertThat(entity.processDefinitionId()).isEqualTo("myProcess");
     assertThat(entity.processDefinitionKey()).isEqualTo(400L);
     assertThat(entity.processDefinitionVersion()).isEqualTo(2);
-    assertThat(entity.versionTag()).isEqualTo("v1");
+    assertThat(entity.processDefinitionVersionTag()).isEqualTo("v1");
     assertThat(entity.tenantId()).isEqualTo("<default>");
     assertThat(entity.status()).isEqualTo(AgentInstanceStatus.THINKING);
     assertThat(entity.definition().model()).isEqualTo("gpt-4");

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1685,7 +1685,7 @@ public class SearchQueryFilterMapper {
           .ifPresent(builder::processDefinitionVersionOperations);
       ofNullable(filter.getProcessDefinitionVersionTag())
           .map(mapToStringOperations())
-          .ifPresent(builder::versionTagOperations);
+          .ifPresent(builder::processDefinitionVersionTagOperations);
     }
 
     return validationErrors.isEmpty()

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2223,7 +2223,7 @@ public final class SearchQueryResponseMapper {
         .processDefinitionKey(keyToString(entity.processDefinitionKey()))
         .processDefinitionId(entity.processDefinitionId())
         .processDefinitionVersion(entity.processDefinitionVersion())
-        .processDefinitionVersionTag(entity.versionTag())
+        .processDefinitionVersionTag(entity.processDefinitionVersionTag())
         .tenantId(entity.tenantId())
         .creationDate(formatDate(entity.creationDate()))
         .lastUpdatedDate(formatDate(entity.lastUpdatedDate()))

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1060,7 +1060,7 @@ class SearchQueryResponseMapperTest {
             321L, // processDefinitionKey
             "processId", // processDefinitionId
             1, // processDefinitionVersion
-            "v1", // versionTag
+            "v1", // processDefinitionVersionTag
             "tenant", // tenantId
             OffsetDateTime.now(), // creationDate
             OffsetDateTime.now(), // lastUpdatedDate

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -140,7 +140,7 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
   }
 
   @Override
-  public String getVersionTag() {
+  public String getProcessDefinitionVersionTag() {
     return null;
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceFilterIT.java
@@ -148,6 +148,25 @@ public class AgentInstanceFilterIT {
   }
 
   @TestTemplate
+  public void shouldFilterByProcessDefinitionVersionTag(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String versionTag = "v-" + nextStringId();
+    final var model =
+        createAndSaveRandomAgentInstance(
+            testApplication, b -> b.processDefinitionVersionTag(versionTag));
+    createAndSaveRandomAgentInstance(testApplication, b -> b.processDefinitionVersionTag("other"));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceFilter.Builder().processDefinitionVersionTags(versionTag).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().agentInstanceKey()).isEqualTo(model.agentInstanceKey());
+    assertThat(result.items().getFirst().processDefinitionVersionTag()).isEqualTo(versionTag);
+  }
+
+  @TestTemplate
   public void shouldFilterByStatus(final CamundaRdbmsTestApplication testApplication) {
     final String procDefId = "proc-status-" + nextStringId();
     createAndSaveRandomAgentInstance(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -64,7 +64,7 @@ public class AgentInstanceIT {
                     .processDefinitionId("migrated-" + nextStringId())
                     .processDefinitionKey(model.processDefinitionKey() + 1)
                     .processDefinitionVersion(model.processDefinitionVersion() + 1)
-                    .versionTag("v2")
+                    .processDefinitionVersionTag("v2")
                     .agentDefinitionKey(model.agentDefinitionKey() + 1)
                     .elementId("migrated-element"));
     final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
@@ -80,7 +80,7 @@ public class AgentInstanceIT {
     assertThat(entity.processDefinitionId()).isEqualTo(migrated.processDefinitionId());
     assertThat(entity.processDefinitionKey()).isEqualTo(migrated.processDefinitionKey());
     assertThat(entity.processDefinitionVersion()).isEqualTo(migrated.processDefinitionVersion());
-    assertThat(entity.versionTag()).isEqualTo("v2");
+    assertThat(entity.processDefinitionVersionTag()).isEqualTo("v2");
     assertThat(entity.agentDefinitionKey()).isEqualTo(migrated.agentDefinitionKey());
     assertThat(entity.elementId()).isEqualTo("migrated-element");
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformer.java
@@ -59,7 +59,7 @@ public class AgentInstanceEntityTransformer
         source.getProcessDefinitionKey(),
         source.getBpmnProcessId(),
         source.getProcessDefinitionVersion(),
-        source.getVersionTag(),
+        source.getProcessDefinitionVersionTag(),
         source.getTenantId(),
         source.getCreationDate(),
         source.getLastUpdatedDate(),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformer.java
@@ -25,9 +25,9 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION_TAG;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TENANT_ID;
-import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.AgentInstanceFilter;
@@ -54,7 +54,9 @@ public class AgentInstanceFilterTransformer extends IndexFilterTransformer<Agent
     queries.addAll(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()));
     queries.addAll(
         intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()));
-    queries.addAll(stringOperations(VERSION_TAG, filter.versionTagOperations()));
+    queries.addAll(
+        stringOperations(
+            PROCESS_DEFINITION_VERSION_TAG, filter.processDefinitionVersionTagOperations()));
     queries.addAll(stringOperations(ELEMENT_ID, filter.elementIdOperations()));
     queries.addAll(stringOperations(STATUS, filter.statusOperations()));
     queries.addAll(stringOperations(TENANT_ID, filter.tenantIdOperations()));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentInstanceEntityTransformerTest.java
@@ -55,7 +55,7 @@ class AgentInstanceEntityTransformerTest {
     source.setProcessDefinitionKey(400L);
     source.setBpmnProcessId("myProcess");
     source.setProcessDefinitionVersion(2);
-    source.setVersionTag("v2");
+    source.setProcessDefinitionVersionTag("v2");
     source.setTenantId("<default>");
     source.setCreationDate(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
     source.setLastUpdatedDate(OffsetDateTime.parse("2024-01-02T00:00:00Z"));
@@ -95,7 +95,7 @@ class AgentInstanceEntityTransformerTest {
     assertThat(result.processDefinitionKey()).isEqualTo(400L);
     assertThat(result.processDefinitionId()).isEqualTo("myProcess");
     assertThat(result.processDefinitionVersion()).isEqualTo(2);
-    assertThat(result.versionTag()).isEqualTo("v2");
+    assertThat(result.processDefinitionVersionTag()).isEqualTo("v2");
     assertThat(result.tenantId()).isEqualTo("<default>");
     assertThat(result.creationDate()).isEqualTo(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
     assertThat(result.lastUpdatedDate()).isEqualTo(OffsetDateTime.parse("2024-01-02T00:00:00Z"));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentInstanceFilterTransformerTest.java
@@ -124,8 +124,8 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
-  void shouldQueryByVersionTag() {
-    final var filter = FilterBuilders.agentInstance(f -> f.versionTags("v1"));
+  void shouldQueryByProcessDefinitionVersionTag() {
+    final var filter = FilterBuilders.agentInstance(f -> f.processDefinitionVersionTags("v1"));
 
     final var searchRequest = transformQuery(filter);
 
@@ -133,7 +133,7 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
-              assertThat(t.field()).isEqualTo("versionTag");
+              assertThat(t.field()).isEqualTo("processDefinitionVersionTag");
               assertThat(t.value().stringValue()).isEqualTo("v1");
             });
   }
@@ -262,7 +262,7 @@ class AgentInstanceFilterTransformerTest extends AbstractTransformerTest {
                     .processDefinitionKeys(400L)
                     .processDefinitionIds("myProcess")
                     .processDefinitionVersions(2)
-                    .versionTags("v1")
+                    .processDefinitionVersionTags("v1")
                     .elementIds("Task_1")
                     .statuses("RUNNING")
                     .tenantIds("<default>")

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceEntity.java
@@ -31,7 +31,7 @@ public record AgentInstanceEntity(
     Long processDefinitionKey,
     String processDefinitionId,
     Integer processDefinitionVersion,
-    @Nullable String versionTag,
+    @Nullable String processDefinitionVersionTag,
     String tenantId,
     OffsetDateTime creationDate,
     OffsetDateTime lastUpdatedDate,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceFilter.java
@@ -27,7 +27,7 @@ public record AgentInstanceFilter(
     List<Operation<Long>> processDefinitionKeyOperations,
     List<Operation<String>> processDefinitionIdOperations,
     List<Operation<Integer>> processDefinitionVersionOperations,
-    List<Operation<String>> versionTagOperations,
+    List<Operation<String>> processDefinitionVersionTagOperations,
     List<Operation<String>> elementIdOperations,
     List<Operation<String>> statusOperations,
     List<Operation<String>> tenantIdOperations,
@@ -51,7 +51,7 @@ public record AgentInstanceFilter(
     private List<Operation<Long>> processDefinitionKeyOperations;
     private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<Integer>> processDefinitionVersionOperations;
-    private List<Operation<String>> versionTagOperations;
+    private List<Operation<String>> processDefinitionVersionTagOperations;
     private List<Operation<String>> elementIdOperations;
     private List<Operation<String>> statusOperations;
     private List<Operation<String>> tenantIdOperations;
@@ -181,19 +181,20 @@ public record AgentInstanceFilter(
       return processDefinitionVersionOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder versionTagOperations(final List<Operation<String>> operations) {
-      versionTagOperations = addValuesToList(versionTagOperations, operations);
+    public Builder processDefinitionVersionTagOperations(final List<Operation<String>> operations) {
+      processDefinitionVersionTagOperations =
+          addValuesToList(processDefinitionVersionTagOperations, operations);
       return this;
     }
 
     @SafeVarargs
-    public final Builder versionTagOperations(
+    public final Builder processDefinitionVersionTagOperations(
         final Operation<String> operation, final Operation<String>... operations) {
-      return versionTagOperations(collectValues(operation, operations));
+      return processDefinitionVersionTagOperations(collectValues(operation, operations));
     }
 
-    public Builder versionTags(final String value, final String... values) {
-      return versionTagOperations(FilterUtil.mapDefaultToOperation(value, values));
+    public Builder processDefinitionVersionTags(final String value, final String... values) {
+      return processDefinitionVersionTagOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder elementIdOperations(final List<Operation<String>> operations) {
@@ -285,7 +286,8 @@ public record AgentInstanceFilter(
           Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(versionTagOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(
+              processDefinitionVersionTagOperations, Collections.emptyList()),
           Objects.requireNonNullElse(elementIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(statusOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentInstanceTemplate.java
@@ -26,7 +26,7 @@ public class AgentInstanceTemplate extends AbstractTemplateDescriptor
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
-  public static final String VERSION_TAG = "versionTag";
+  public static final String PROCESS_DEFINITION_VERSION_TAG = "processDefinitionVersionTag";
   public static final String TENANT_ID = "tenantId";
   public static final String STATUS = "status";
   public static final String MODEL = "model";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agentinstance/AgentInstanceEntity.java
@@ -52,7 +52,7 @@ public final class AgentInstanceEntity
   private int processDefinitionVersion;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private String versionTag;
+  private String processDefinitionVersionTag;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String tenantId;
@@ -195,12 +195,13 @@ public final class AgentInstanceEntity
     return this;
   }
 
-  public String getVersionTag() {
-    return versionTag;
+  public String getProcessDefinitionVersionTag() {
+    return processDefinitionVersionTag;
   }
 
-  public AgentInstanceEntity setVersionTag(final String versionTag) {
-    this.versionTag = versionTag;
+  public AgentInstanceEntity setProcessDefinitionVersionTag(
+      final String processDefinitionVersionTag) {
+    this.processDefinitionVersionTag = processDefinitionVersionTag;
     return this;
   }
 
@@ -389,7 +390,7 @@ public final class AgentInstanceEntity
         bpmnProcessId,
         processDefinitionKey,
         processDefinitionVersion,
-        versionTag,
+        processDefinitionVersionTag,
         tenantId,
         partitionId,
         status,
@@ -428,7 +429,7 @@ public final class AgentInstanceEntity
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && processDefinitionKey == that.processDefinitionKey
         && processDefinitionVersion == that.processDefinitionVersion
-        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(processDefinitionVersionTag, that.processDefinitionVersionTag)
         && Objects.equals(tenantId, that.tenantId)
         && partitionId == that.partitionId
         && Objects.equals(status, that.status)
@@ -474,8 +475,8 @@ public final class AgentInstanceEntity
         + processDefinitionKey
         + ", processDefinitionVersion="
         + processDefinitionVersion
-        + ", versionTag='"
-        + versionTag
+        + ", processDefinitionVersionTag='"
+        + processDefinitionVersionTag
         + '\''
         + ", tenantId='"
         + tenantId

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-instance.json
@@ -32,7 +32,7 @@
       "processDefinitionVersion": {
         "type": "integer"
       },
-      "versionTag": {
+      "processDefinitionVersionTag": {
         "type": "keyword"
       },
       "tenantId": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-instance.json
@@ -32,7 +32,7 @@
       "processDefinitionVersion": {
         "type": "integer"
       },
-      "versionTag": {
+      "processDefinitionVersionTag": {
         "type": "keyword"
       },
       "tenantId": {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -200,7 +200,8 @@ public final class AgentInstanceCreateProcessor
             .setProcessDefinitionKey(elementInstanceValue.getProcessDefinitionKey())
             .setProcessDefinitionVersion(elementInstanceValue.getVersion())
             .setAgentDefinitionKey(agentDefinitionKey)
-            .setVersionTag(deployedProcess == null ? "" : deployedProcess.getVersionTag())
+            .setProcessDefinitionVersionTag(
+                deployedProcess == null ? "" : deployedProcess.getVersionTag())
             .setTenantId(elementInstanceValue.getTenantId())
             .setStatus(AgentInstanceStatus.INITIALIZING);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
@@ -127,7 +127,7 @@ public class ProcessInstanceMigrationAgentInstanceBehavior {
             .setProcessDefinitionKey(targetProcessDefinition.getKey())
             .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
             .setBpmnProcessId(BufferUtil.bufferAsString(targetProcessDefinition.getBpmnProcessId()))
-            .setVersionTag(targetProcessDefinition.getVersionTag())
+            .setProcessDefinitionVersionTag(targetProcessDefinition.getVersionTag())
             .setElementId(targetElementId)
             .setAgentDefinitionKey(
                 resolveAgentDefinitionKey(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -187,14 +187,14 @@ public class AgentInstanceCreateTest {
   }
 
   @Test
-  public void shouldFetchVersionTagFromProcessState() {
+  public void shouldFetchProcessDefinitionVersionTagFromProcessState() {
     // given
-    final var versionTag = "v1.2.3";
+    final var processDefinitionVersionTag = "v1.2.3";
     ENGINE
         .deployment()
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
-                .versionTag(versionTag)
+                .versionTag(processDefinitionVersionTag)
                 .startEvent()
                 .serviceTask(
                     SERVICE_TASK_ID, t -> t.zeebeJobType("agent").zeebeAiAgentTaskDefinition())
@@ -210,7 +210,8 @@ public class AgentInstanceCreateTest {
         ENGINE.agentInstances().withElementInstanceKey(serviceTaskInstance.getKey()).create();
 
     // then
-    assertThat(created.getValue().getVersionTag()).isEqualTo(versionTag);
+    assertThat(created.getValue().getProcessDefinitionVersionTag())
+        .isEqualTo(processDefinitionVersionTag);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -125,7 +125,7 @@ public class MigrateAgentInstanceTest {
         .describedAs("Definition fields are updated to the target process definition")
         .hasProcessDefinitionKey(targetProcessDefinitionKey)
         .hasBpmnProcessId(targetProcessId)
-        .hasVersionTag("v2")
+        .hasProcessDefinitionVersionTag("v2")
         .describedAs("elementId is remapped despite \"A\" having no active element instance")
         .hasElementId("A2");
   }
@@ -316,7 +316,7 @@ public class MigrateAgentInstanceTest {
         .hasProcessDefinitionKey(targetProcessDefinitionKey)
         .hasBpmnProcessId(targetProcessId)
         .hasProcessDefinitionVersion(1)
-        .hasVersionTag("v2")
+        .hasProcessDefinitionVersionTag("v2")
         .hasElementId("A2")
         .describedAs(
             "Properties migration must not touch stay exactly as they were before migration")
@@ -338,7 +338,7 @@ public class MigrateAgentInstanceTest {
         .hasProcessDefinitionKey(targetProcessDefinitionKey)
         .hasBpmnProcessId(targetProcessId)
         .hasProcessDefinitionVersion(1)
-        .hasVersionTag("v2")
+        .hasProcessDefinitionVersionTag("v2")
         .hasElementId("B")
         .describedAs(
             "Properties migration must not touch stay exactly as they were before migration")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceMigratedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceMigratedApplierTest.java
@@ -53,7 +53,7 @@ public class AgentInstanceMigratedApplierTest {
     assertThat(stored.getProcessDefinitionKey()).isEqualTo(200L);
     assertThat(stored.getProcessDefinitionVersion()).isEqualTo(2);
     assertThat(stored.getBpmnProcessId()).isEqualTo("target-process");
-    assertThat(stored.getVersionTag()).isEqualTo("v2.0");
+    assertThat(stored.getProcessDefinitionVersionTag()).isEqualTo("v2.0");
     assertThat(stored.getElementId()).isEqualTo("agent2");
   }
 
@@ -78,7 +78,7 @@ public class AgentInstanceMigratedApplierTest {
         .setProcessDefinitionKey(100L)
         .setProcessDefinitionVersion(1)
         .setBpmnProcessId("source-process")
-        .setVersionTag("v1.0")
+        .setProcessDefinitionVersionTag("v1.0")
         .setElementId("agent")
         .setStatus(AgentInstanceStatus.INITIALIZING);
   }
@@ -90,7 +90,7 @@ public class AgentInstanceMigratedApplierTest {
         .setProcessDefinitionKey(200L)
         .setProcessDefinitionVersion(2)
         .setBpmnProcessId("target-process")
-        .setVersionTag("v2.0")
+        .setProcessDefinitionVersionTag("v2.0")
         .setElementId("agent2")
         .setStatus(AgentInstanceStatus.INITIALIZING);
   }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AgentInstanceCreatedHandlerTest.java
@@ -52,7 +52,7 @@ class AgentInstanceCreatedHandlerTest {
             .withProcessInstanceKey(22L)
             .withRootProcessInstanceKey(9L)
             .withTenantId("acme")
-            .withVersionTag("release-2026-q1")
+            .withProcessDefinitionVersionTag("release-2026-q1")
             .withDefinition(
                 b ->
                     b.withModel("claude-sonnet-4-5")

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -22,12 +22,12 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.OUTPUT_TOKENS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION_TAG;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROVIDER;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.SYSTEM_PROMPT;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
-import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
 
 import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
@@ -112,7 +112,8 @@ public class AgentInstanceHandler
         .setBpmnProcessId(value.getBpmnProcessId())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
         .setProcessDefinitionVersion(value.getProcessDefinitionVersion())
-        .setVersionTag(ExporterUtil.emptyToNull(value.getVersionTag()))
+        .setProcessDefinitionVersionTag(
+            ExporterUtil.emptyToNull(value.getProcessDefinitionVersionTag()))
         .setTenantId(value.getTenantId())
         .setStatus(mapStatus(value.getStatus()))
         .setModel(value.getDefinition().getModel())
@@ -151,7 +152,7 @@ public class AgentInstanceHandler
     updateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     updateFields.put(AGENT_DEFINITION_KEY, entity.getAgentDefinitionKey());
     updateFields.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
-    updateFields.put(VERSION_TAG, entity.getVersionTag());
+    updateFields.put(PROCESS_DEFINITION_VERSION_TAG, entity.getProcessDefinitionVersionTag());
     updateFields.put(ELEMENT_ID, entity.getElementId());
 
     // Runtime fields

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -22,12 +22,12 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.OUTPUT_TOKENS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION_TAG;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROVIDER;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.SYSTEM_PROMPT;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
-import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -126,7 +126,7 @@ final class AgentInstanceHandlerTest {
     final long processDefinitionKey = 400L;
     final long agentDefinitionKey = 401L;
     final int processDefinitionVersion = 2;
-    final String versionTag = "v2";
+    final String processDefinitionVersionTag = "v2";
     final String tenantId = "<default>";
     final String model = "gpt-4o";
     final String provider = "openai";
@@ -162,7 +162,7 @@ final class AgentInstanceHandlerTest {
             .withProcessDefinitionKey(processDefinitionKey)
             .withAgentDefinitionKey(agentDefinitionKey)
             .withProcessDefinitionVersion(processDefinitionVersion)
-            .withVersionTag(versionTag)
+            .withProcessDefinitionVersionTag(processDefinitionVersionTag)
             .withTenantId(tenantId)
             .withStatus(io.camunda.zeebe.protocol.record.value.AgentInstanceStatus.INITIALIZING)
             .withDefinition(
@@ -215,7 +215,7 @@ final class AgentInstanceHandlerTest {
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
     assertThat(entity.getAgentDefinitionKey()).isEqualTo(agentDefinitionKey);
     assertThat(entity.getProcessDefinitionVersion()).isEqualTo(processDefinitionVersion);
-    assertThat(entity.getVersionTag()).isEqualTo(versionTag);
+    assertThat(entity.getProcessDefinitionVersionTag()).isEqualTo(processDefinitionVersionTag);
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
     assertThat(entity.getStatus()).isEqualTo(AgentInstanceStatus.INITIALIZING);
     assertThat(entity.getModel()).isEqualTo(model);
@@ -466,7 +466,8 @@ final class AgentInstanceHandlerTest {
     expectedUpdateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     expectedUpdateFields.put(AGENT_DEFINITION_KEY, entity.getAgentDefinitionKey());
     expectedUpdateFields.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
-    expectedUpdateFields.put(VERSION_TAG, entity.getVersionTag());
+    expectedUpdateFields.put(
+        PROCESS_DEFINITION_VERSION_TAG, entity.getProcessDefinitionVersionTag());
     expectedUpdateFields.put(ELEMENT_ID, entity.getElementId());
 
     verify(mockRequest, times(1)).upsert(index, entity.getId(), entity, expectedUpdateFields);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -49,7 +49,7 @@
             "processDefinitionVersion": {
               "type": "integer"
             },
-            "versionTag": {
+            "processDefinitionVersionTag": {
               "type": "keyword"
             },
             "tenantId": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -55,7 +55,7 @@
             "processDefinitionVersion": {
               "type": "integer"
             },
-            "versionTag": {
+            "processDefinitionVersionTag": {
               "type": "keyword"
             },
             "tenantId": {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
@@ -74,7 +74,8 @@ public class AgentInstanceExportHandler implements RdbmsExportHandler<AgentInsta
             .processDefinitionId(value.getBpmnProcessId())
             .processDefinitionKey(value.getProcessDefinitionKey())
             .processDefinitionVersion(value.getProcessDefinitionVersion())
-            .versionTag(ExportUtil.emptyToNull(value.getVersionTag()))
+            .processDefinitionVersionTag(
+                ExportUtil.emptyToNull(value.getProcessDefinitionVersionTag()))
             .tenantId(value.getTenantId())
             .partitionId(record.getPartitionId())
             .status(mapStatus(value.getStatus()))

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
@@ -124,7 +124,7 @@ class AgentInstanceExportHandlerTest {
     assertThat(model.processDefinitionId()).isEqualTo("myProcess");
     assertThat(model.processDefinitionKey()).isEqualTo(200L);
     assertThat(model.processDefinitionVersion()).isEqualTo(3);
-    assertThat(model.versionTag()).isEqualTo("v1.0");
+    assertThat(model.processDefinitionVersionTag()).isEqualTo("v1.0");
     assertThat(model.tenantId()).isEqualTo("myTenant");
     assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
     // status
@@ -188,7 +188,7 @@ class AgentInstanceExportHandlerTest {
             .withBpmnProcessId("targetProcess")
             .withProcessDefinitionKey(999L)
             .withProcessDefinitionVersion(4)
-            .withVersionTag("v2.0")
+            .withProcessDefinitionVersionTag("v2.0")
             .withElementId("targetElement")
             .withAgentDefinitionKey(888L)
             .build();
@@ -210,7 +210,7 @@ class AgentInstanceExportHandlerTest {
     assertThat(model.processDefinitionId()).isEqualTo("targetProcess");
     assertThat(model.processDefinitionKey()).isEqualTo(999L);
     assertThat(model.processDefinitionVersion()).isEqualTo(4);
-    assertThat(model.versionTag()).isEqualTo("v2.0");
+    assertThat(model.processDefinitionVersionTag()).isEqualTo("v2.0");
     assertThat(model.elementId()).isEqualTo("targetElement");
     assertThat(model.agentDefinitionKey()).isEqualTo(888L);
     assertThat(model.completionDate()).isNull();
@@ -313,7 +313,7 @@ class AgentInstanceExportHandlerTest {
     final var recordValue =
         ImmutableAgentInstanceRecordValue.builder()
             .from(buildRecordValue(agentKey))
-            .withVersionTag("") // process has no version tag
+            .withProcessDefinitionVersionTag("") // process has no version tag
             .withTools(List.of(tool))
             .build();
     final Record<AgentInstanceRecordValue> record =
@@ -328,7 +328,7 @@ class AgentInstanceExportHandlerTest {
     // then
     verify(writer).update(modelCaptor.capture());
     final AgentInstanceDbModel model = modelCaptor.getValue();
-    assertThat(model.versionTag()).isNull();
+    assertThat(model.processDefinitionVersionTag()).isNull();
     assertThat(model.toolValues()).hasSize(1);
     assertThat(model.toolValues().getFirst().description()).isNull();
     assertThat(model.toolValues().getFirst().elementId()).isNull();
@@ -352,7 +352,7 @@ class AgentInstanceExportHandlerTest {
         .withBpmnProcessId("myProcess")
         .withProcessDefinitionKey(200L)
         .withProcessDefinitionVersion(3)
-        .withVersionTag("v1.0")
+        .withProcessDefinitionVersionTag("v1.0")
         .withTenantId("myTenant")
         .withStatus(AgentInstanceStatus.INITIALIZING)
         .withDefinition(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -432,7 +432,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
                         new AgentInstanceFilter.Builder()
                             .processDefinitionIdOperations(List.of(Operation.eq("myProcessId")))
                             .processDefinitionVersionOperations(List.of(Operation.eq(1)))
-                            .versionTagOperations(List.of(Operation.eq("v1")))
+                            .processDefinitionVersionTagOperations(List.of(Operation.eq("v1")))
                             .build())
                     .build()),
             any());

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -58,7 +58,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1L);
   private final IntegerProperty processDefinitionVersionProp =
       new IntegerProperty("processDefinitionVersion", -1);
-  private final StringProperty versionTagProp = new StringProperty("versionTag", "");
+  private final StringProperty processDefinitionVersionTagProp =
+      new StringProperty("processDefinitionVersionTag", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final EnumProperty<AgentInstanceStatus> statusProp =
@@ -91,7 +92,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
-        .declareProperty(versionTagProp)
+        .declareProperty(processDefinitionVersionTagProp)
         .declareProperty(tenantIdProp)
         .declareProperty(statusProp)
         .declareProperty(definitionProp)
@@ -203,12 +204,13 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getVersionTag() {
-    return BufferUtil.bufferAsString(versionTagProp.getValue());
+  public String getProcessDefinitionVersionTag() {
+    return BufferUtil.bufferAsString(processDefinitionVersionTagProp.getValue());
   }
 
-  public AgentInstanceRecord setVersionTag(final String versionTag) {
-    versionTagProp.setValue(versionTag);
+  public AgentInstanceRecord setProcessDefinitionVersionTag(
+      final String processDefinitionVersionTag) {
+    processDefinitionVersionTagProp.setValue(processDefinitionVersionTag);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5245,7 +5245,7 @@ final class JsonSerializableToJsonTest {
                       .setProcessDefinitionKey(2251799813685100L)
                       .setProcessDefinitionVersion(3)
                       .setAgentDefinitionKey(2251799813685077L)
-                      .setVersionTag("v1.2")
+                      .setProcessDefinitionVersionTag("v1.2")
                       .setTenantId("<default>")
                       .setStatus(AgentInstanceStatus.TOOL_CALLING)
                       .setTools(
@@ -5289,7 +5289,7 @@ final class JsonSerializableToJsonTest {
           "processDefinitionKey": 2251799813685100,
           "processDefinitionVersion": 3,
           "agentDefinitionKey": 2251799813685077,
-          "versionTag": "v1.2",
+          "processDefinitionVersionTag": "v1.2",
           "tenantId": "<default>",
           "status": "TOOL_CALLING",
           "definition": {
@@ -5333,7 +5333,7 @@ final class JsonSerializableToJsonTest {
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,
           "agentDefinitionKey": -1,
-          "versionTag": "",
+          "processDefinitionVersionTag": "",
           "tenantId": "<default>",
           "status": "UNSPECIFIED",
           "definition": { "model": "", "provider": "", "systemPrompt": [] },
@@ -5393,7 +5393,7 @@ final class JsonSerializableToJsonTest {
           "processDefinitionKey": -1,
           "processDefinitionVersion": -1,
           "agentDefinitionKey": -1,
-          "versionTag": "",
+          "processDefinitionVersionTag": "",
           "tenantId": "<default>",
           "status": "UNSPECIFIED",
           "definition": { "model": "", "provider": "", "systemPrompt": [] },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecordTest.java
@@ -39,7 +39,7 @@ final class AgentInstanceRecordTest {
     assertThat(record.getRootProcessInstanceKey()).isEqualTo(-1L);
     assertThat(record.getProcessDefinitionVersion()).isEqualTo(-1);
     assertThat(record.getAgentDefinitionKey()).isEqualTo(-1L);
-    assertThat(record.getVersionTag()).isEmpty();
+    assertThat(record.getProcessDefinitionVersionTag()).isEmpty();
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
@@ -57,7 +57,7 @@ final class AgentInstanceRecordTest {
             .setRootProcessInstanceKey(2251799813685000L)
             .setProcessDefinitionVersion(3)
             .setAgentDefinitionKey(2251799813685077L)
-            .setVersionTag("v1.2")
+            .setProcessDefinitionVersionTag("v1.2")
             .setTenantId("acme");
 
     // when
@@ -75,7 +75,8 @@ final class AgentInstanceRecordTest {
     assertThat(copy.getProcessDefinitionVersion())
         .isEqualTo(original.getProcessDefinitionVersion());
     assertThat(copy.getAgentDefinitionKey()).isEqualTo(original.getAgentDefinitionKey());
-    assertThat(copy.getVersionTag()).isEqualTo(original.getVersionTag());
+    assertThat(copy.getProcessDefinitionVersionTag())
+        .isEqualTo(original.getProcessDefinitionVersionTag());
     assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -56,7 +56,8 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1L);
   private final IntegerProperty processDefinitionVersionProp =
       new IntegerProperty("processDefinitionVersion", -1);
-  private final StringProperty versionTagProp = new StringProperty("versionTag", "");
+  private final StringProperty processDefinitionVersionTagProp =
+      new StringProperty("processDefinitionVersionTag", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final EnumProperty<AgentInstanceStatus> statusProp =
@@ -89,7 +90,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
-        .declareProperty(versionTagProp)
+        .declareProperty(processDefinitionVersionTagProp)
         .declareProperty(tenantIdProp)
         .declareProperty(statusProp)
         .declareProperty(definitionProp)
@@ -201,12 +202,13 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getVersionTag() {
-    return BufferUtil.bufferAsString(versionTagProp.getValue());
+  public String getProcessDefinitionVersionTag() {
+    return BufferUtil.bufferAsString(processDefinitionVersionTagProp.getValue());
   }
 
-  public AgentInstanceRecord setVersionTag(final String versionTag) {
-    versionTagProp.setValue(versionTag);
+  public AgentInstanceRecord setProcessDefinitionVersionTag(
+      final String processDefinitionVersionTag) {
+    processDefinitionVersionTagProp.setValue(processDefinitionVersionTag);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -85,7 +85,7 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
   /**
    * @return the version tag of the process definition
    */
-  String getVersionTag();
+  String getProcessDefinitionVersionTag();
 
   /**
    * @return the ID of the tenant that owns this agent instance


### PR DESCRIPTION
## Description

### What changed

Renames `versionTag` → `processDefinitionVersionTag` (and `VERSION_TAG` → `PROCESS_DEFINITION_VERSION_TAG`) end-to-end across the `AgentInstance` stack: the protocol record itself, engine call sites, webapps-schema, camunda-exporter, the RDBMS write/read model and its Liquibase changeset, rdbms-exporter, search-domain, search-client-query-transformer, and gateway-mapping-http's REST mappers (`SearchQueryFilterMapper` / `SearchQueryResponseMapper`), which sit between the REST API and search-domain and are updated to match.

### Why

`AgentInstanceRecordValue`/`AgentInstanceRecord` and every internal layer built on top of it exposed a field named `versionTag`, but it never held the agent instance's own version — it holds the **version tag of the process definition** the agent instance belongs to. The REST API and Java client already expose this correctly as `processDefinitionVersionTag`, so every internal layer was out of sync with the public contract. This follows the same naming precedent already applied to `AgentDefinitionRecord` in #59904.

### What this enables

A single, unambiguous name for this field everywhere, removing a source of confusion for anyone reading engine/exporter/RDBMS code (is it the agent instance's own version tag, or the process definition's?). `AgentInstance` hasn't had a stable release yet — only `8.10.0-alphaN`/`rcN` pre-releases — so this rename can still land cleanly ahead of the first stable release, before any real backward-compatibility guarantee applies.

**Target branch:** this PR targets `stable/8.10` rather than `main`, with a feature-freeze exception approved for this epic. `AgentInstance` already shipped in tagged `8.10.0-alphaN`/`rcN` builds with the old `versionTag` field, so `schema-manager`'s `SchemaUpdateIT` — which validates schema upgrades against the last published minor's snapshot image — fails on `main`, where the current minor has already moved to `8.11`. Landing this on `stable/8.10` keeps the rename within the same minor line before its first stable release: the mutable `camunda/camunda:8.10-SNAPSHOT` tag gets republished with the fix, so no `AgentInstanceTemplate#INDEX_VERSION` bump is needed, and the same test is expected to pass once this is merged forward into `main`.

### Out of scope

The REST API spec (`agent-instances.yaml`) and the Java client (`AgentInstance` / `AgentInstanceImpl` / `AgentInstanceFilter` / `AgentInstanceFilterImpl`), which already use `processDefinitionVersionTag` and need no changes. Also explicitly untouched: `DeployedProcess#getVersionTag()` / `ProcessMetadataValue#getVersionTag()`, an unrelated, correctly-named API on the process definition model itself that only feeds a value into the renamed record.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59923

