### PR TITLE
feat: show a business-value target on the overview as soon as it is saved

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
@@ -16,6 +16,8 @@ import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.CycleTimeTargetDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
@@ -50,12 +52,14 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
   private BusinessValueTargetWriter targetWriter;
   private BusinessValueOverviewComputeService computeService;
   private BusinessValueOverviewRepository overviewRepository;
+  private BusinessValueTargetService targetService;
 
   @BeforeEach
   void setUp() {
     targetWriter = embeddedOptimizeExtension.getBean(BusinessValueTargetWriter.class);
     computeService = embeddedOptimizeExtension.getBean(BusinessValueOverviewComputeService.class);
     overviewRepository = embeddedOptimizeExtension.getBean(BusinessValueOverviewRepository.class);
+    targetService = embeddedOptimizeExtension.getBean(BusinessValueTargetService.class);
     // AbstractBrokerlessZeebeCCSMIT.cleanupOptimizeData() wipes Optimize data between tests, so
     // the ApplicationReadyEvent-driven seed is only visible to the first test. Reseed here so the
     // compute service can look up the two per-process seeded reports on every run.
@@ -260,6 +264,44 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(overviewRepository.getByKey(DEFAULT_TENANT, neverRun, MetricRange.SEVEN_DAYS))
         .isPresent()
         .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isNull());
+  }
+
+  /**
+   * The bug this whole path exists for: a target saved between sweeps used to sit in the target
+   * index while the overview row kept the target it was last computed with, so L0 showed the old
+   * verdict for a full refresh interval. Deliberately runs no sweep between the save and the read —
+   * a test that swept in between would pass on the broken behaviour too.
+   */
+  @Test
+  void shouldReflectATargetOnTheOverviewRowsWithoutWaitingForASweep() {
+    // given a definition measured by a sweep, with no target yet
+    persistProcessDefinitions(List.of(bvdDefinition(PROCESS_KEY, DEFAULT_TENANT)));
+    computeService.computeOverviewRows(List.of(MetricRange.values()));
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.isHasAnyTarget()).isFalse());
+
+    // when a target is saved through the service, and no sweep runs afterwards
+    targetService.upsertTarget(
+        "sherrin@camunda.com",
+        DEFAULT_TENANT,
+        PROCESS_KEY,
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, null), AUTOMATION_TARGET_PCT));
+
+    // then every range preset already carries the target and its verdict
+    for (final MetricRange range : MetricRange.values()) {
+      assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, range))
+          .as("row for range %s", range)
+          .isPresent()
+          .hasValueSatisfying(
+              r -> {
+                assertThat(r.getCycleTime().getTarget()).isEqualTo(CYCLE_TARGET_MILLIS);
+                assertThat(r.getAutomationRate().getTarget()).isEqualTo(AUTOMATION_TARGET_PCT);
+                assertThat(r.isHasAnyTarget()).isTrue();
+                assertThat(r.getTargetsSet()).isEqualTo(2);
+              });
+    }
   }
 
   private static ProcessDefinitionOptimizeDto bvdDefinition(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -30,6 +30,7 @@ import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
 import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
@@ -72,6 +73,12 @@ import org.springframework.stereotype.Component;
  * scheduler tick, so two full-scope sweeps may build chunk state and upsert the same document ids
  * at once. That is tolerable because a row is a pure function of its inputs and the writes are
  * idempotent, but it is worth knowing before adding per-sweep state that is not.
+ *
+ * <p>That purity holds only because targets are read immediately before the write rather than at
+ * the start of the sweep — a snapshot taken minutes earlier is a second input with a lifetime of
+ * its own, and two overlapping sweeps holding different ones produce different rows for the same
+ * id. {@link #refreshTargetOnRows} is a third writer for the same reason, scoped to a single
+ * definition. Keep target reads adjacent to the write if this is restructured.
  */
 @Component
 public class BusinessValueOverviewComputeService {
@@ -97,6 +104,7 @@ public class BusinessValueOverviewComputeService {
       org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewComputeService.class);
 
   private final BusinessValueTargetRepository targetRepository;
+  private final BusinessValueOverviewRepository overviewRepository;
   private final BusinessValueOverviewWriter overviewWriter;
   private final DefinitionService definitionService;
   private final ReportService reportService;
@@ -107,6 +115,7 @@ public class BusinessValueOverviewComputeService {
 
   public BusinessValueOverviewComputeService(
       final BusinessValueTargetRepository targetRepository,
+      final BusinessValueOverviewRepository overviewRepository,
       final BusinessValueOverviewWriter overviewWriter,
       final DefinitionService definitionService,
       final ReportService reportService,
@@ -115,6 +124,7 @@ public class BusinessValueOverviewComputeService {
       final SearchLimitsRepository searchLimitsRepository,
       final ConfigurationService configurationService) {
     this.targetRepository = targetRepository;
+    this.overviewRepository = overviewRepository;
     this.overviewWriter = overviewWriter;
     this.definitionService = definitionService;
     this.reportService = reportService;
@@ -146,7 +156,6 @@ public class BusinessValueOverviewComputeService {
       return;
     }
 
-    final Map<String, BusinessValueTargetDto> targetsByDocId = readTargets();
     final Set<String> keysWithInstanceIndex =
         mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex();
     final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
@@ -162,15 +171,111 @@ public class BusinessValueOverviewComputeService {
         definitionsByTenant.entrySet()) {
       rowsToUpsert.addAll(
           rowsForTenant(
-              perTenant.getKey(),
-              perTenant.getValue(),
-              ranges,
-              keysWithInstanceIndex,
-              targetsByDocId,
-              now));
+              perTenant.getKey(), perTenant.getValue(), ranges, keysWithInstanceIndex, now));
+    }
+
+    // Targets are read here, after every evaluation has returned, rather than up front: the row
+    // carries the target it was written with, and a target saved while the sweep was still
+    // evaluating would otherwise be overwritten by the snapshot taken before it existed. The upsert
+    // is a blind write with no version precondition, so the sweep always wins that exchange and the
+    // user's target silently reverts until the next tick. Reading last narrows the window from the
+    // whole sweep — tens of seconds, and longer the bigger the catalog — to the bulk write itself.
+    final Map<String, BusinessValueTargetDto> targetsByDocId = readTargets();
+    for (final BusinessValueOverviewDto row : rowsToUpsert) {
+      applyTarget(
+          row, targetsByDocId.get(targetDocId(row.getTenantId(), row.getProcessDefinitionKey())));
     }
 
     overviewWriter.bulkUpsertFromScheduler(rowsToUpsert);
+  }
+
+  /**
+   * Writes a target and the verdict it implies onto a row that already carries its measured values.
+   * A {@code null} target clears both, which is what a cleared target must produce.
+   *
+   * <p>Shared by the sweep and by {@link #refreshTargetOnRows}, and that sharing is the point: a
+   * target write does not change what was measured, so re-deriving the verdict from the value
+   * already on the row yields exactly what a full recompute would have produced at that instant —
+   * without evaluating a single report. {@link BusinessValueVerdict} is a pure function of the
+   * measured value and the target, which is what makes that equivalence hold.
+   *
+   * <p>All five fields move together because {@code BusinessValueOverviewWriter} rejects a row
+   * whose {@code targetsSet} or {@code hasAnyTarget} disagrees with its blocks.
+   */
+  static void applyTarget(final BusinessValueOverviewDto row, final BusinessValueTargetDto target) {
+    final CycleTimeBlock cycleTime =
+        BusinessValueVerdict.cycleTimeBlock(
+            row.getCycleTime() == null ? null : row.getCycleTime().getValue(),
+            target == null ? null : target.getCycleTimeTargetMillis());
+    final AutomationRateBlock automationRate =
+        BusinessValueVerdict.automationRateBlock(
+            row.getAutomationRate() == null ? null : row.getAutomationRate().getValue(),
+            target == null ? null : target.getAutomationRateTargetPct());
+
+    final int targetsSet =
+        (cycleTime.getTarget() != null ? 1 : 0) + (automationRate.getTarget() != null ? 1 : 0);
+    final int targetsMet =
+        (Boolean.TRUE.equals(cycleTime.getMet()) ? 1 : 0)
+            + (Boolean.TRUE.equals(automationRate.getMet()) ? 1 : 0);
+
+    row.setCycleTime(cycleTime);
+    row.setAutomationRate(automationRate);
+    row.setHasAnyTarget(targetsSet > 0);
+    row.setTargetsSet(targetsSet);
+    row.setTargetsMet(targetsMet);
+  }
+
+  /**
+   * Re-derives the verdict on one definition's existing overview rows against a target that has
+   * just been written, so the next {@code GET /business-value/overview} reflects it instead of
+   * waiting out a sweep interval.
+   *
+   * <p>No report is evaluated. Setting a target does not change what was measured, so the stored
+   * value is exactly the input a full recompute would have used — see {@link #applyTarget}. The
+   * cost is one get per range preset plus one bulk write, which is what makes this affordable on
+   * the request path where a scoped recompute would not be.
+   *
+   * <p>{@link BusinessValueOverviewDto#getLastComputedAt()} is deliberately left as it was. It
+   * records when the values were measured, and nothing was measured here; bumping it would hide a
+   * genuinely stale row from the read path's staleness backstop for another two intervals.
+   *
+   * <p>A definition with no row yet is skipped rather than given one. It has no measured values to
+   * pair with the target, and {@code BusinessValueOverviewReadService} already surfaces that case
+   * by joining live targets against the rows it reads.
+   *
+   * <p>Not gated by {@code overviewComputeEnabled}. That switch exists to shed the sweep's
+   * Elasticsearch load; this path evaluates nothing, and letting targets stay coherent while the
+   * values freeze is the behaviour the switch is meant to preserve.
+   *
+   * @param target the target exactly as persisted — passed in rather than re-read so that two
+   *     concurrent saves for the same definition cannot each apply the other's value
+   */
+  public void refreshTargetOnRows(final BusinessValueTargetDto target) {
+    if (target == null) {
+      throw new IllegalArgumentException("target must not be null");
+    }
+
+    final List<BusinessValueOverviewDto> rows = new ArrayList<>();
+    for (final MetricRange range : MetricRange.values()) {
+      overviewRepository
+          .getByKey(target.getTenantId(), target.getProcessDefinitionKey(), range)
+          .ifPresent(
+              row -> {
+                applyTarget(row, target);
+                rows.add(row);
+              });
+    }
+
+    if (rows.isEmpty()) {
+      LOG.debug(
+          "No business-value overview rows yet for tenant [{}] definition [{}]; the target will be "
+              + "reflected once the sweep computes them",
+          target.getTenantId(),
+          target.getProcessDefinitionKey());
+      return;
+    }
+
+    overviewWriter.bulkUpsertFromTargetWrite(rows);
   }
 
   /**
@@ -183,7 +288,6 @@ public class BusinessValueOverviewComputeService {
       final List<DefinitionEntry> tenantDefinitions,
       final List<MetricRange> ranges,
       final Set<String> keysWithInstanceIndex,
-      final Map<String, BusinessValueTargetDto> targetsByDocId,
       final OffsetDateTime now) {
     final List<List<DefinitionEntry>> chunks =
         chunk(evaluableDefinitions(tenantDefinitions, keysWithInstanceIndex));
@@ -207,7 +311,6 @@ public class BusinessValueOverviewComputeService {
                 range,
                 cycleMillisByKey.get(def.processDefinitionKey()),
                 automationPctByKey.get(def.processDefinitionKey()),
-                targetsByDocId,
                 now));
       }
     }
@@ -327,40 +430,28 @@ public class BusinessValueOverviewComputeService {
         || c == '~';
   }
 
+  /**
+   * Builds a row carrying its measured values and no target. {@link #applyTarget} fills in the
+   * target and the verdict it implies once every evaluation has returned — see {@link
+   * #computeOverviewRows} for why that happens last rather than here.
+   */
   private BusinessValueOverviewDto buildRow(
       final DefinitionEntry def,
       final MetricRange range,
       final Double cycleMillis,
       final Double automationPct,
-      final Map<String, BusinessValueTargetDto> targetsByDocId,
       final OffsetDateTime now) {
-    final BusinessValueTargetDto target =
-        targetsByDocId.get(targetDocId(def.tenantId(), def.processDefinitionKey()));
-
-    final CycleTimeBlock cycleTime =
-        BusinessValueVerdict.cycleTimeBlock(
-            toLongMillis(cycleMillis), target == null ? null : target.getCycleTimeTargetMillis());
-    final AutomationRateBlock automationRate =
-        BusinessValueVerdict.automationRateBlock(
-            automationPct, target == null ? null : target.getAutomationRateTargetPct());
-
-    final int targetsSet =
-        (cycleTime.getTarget() != null ? 1 : 0) + (automationRate.getTarget() != null ? 1 : 0);
-    final int targetsMet =
-        (Boolean.TRUE.equals(cycleTime.getMet()) ? 1 : 0)
-            + (Boolean.TRUE.equals(automationRate.getMet()) ? 1 : 0);
-
     return new BusinessValueOverviewDto(
         def.tenantId(),
         def.processDefinitionKey(),
         def.processDefinitionName(),
         range,
         now,
-        cycleTime,
-        automationRate,
-        targetsSet > 0,
-        targetsSet,
-        targetsMet);
+        BusinessValueVerdict.cycleTimeBlock(toLongMillis(cycleMillis), null),
+        BusinessValueVerdict.automationRateBlock(automationPct, null),
+        false,
+        0,
+        0);
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
@@ -17,18 +17,22 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CategoryDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CoverageDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,6 +75,7 @@ public class BusinessValueOverviewReadService {
       org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewReadService.class);
 
   private final BusinessValueOverviewRepository overviewRepository;
+  private final BusinessValueTargetRepository targetRepository;
   private final TenantService tenantService;
   private final DefinitionService definitionService;
   private final BusinessValueOverviewComputeService computeService;
@@ -85,11 +90,13 @@ public class BusinessValueOverviewReadService {
 
   public BusinessValueOverviewReadService(
       final BusinessValueOverviewRepository overviewRepository,
+      final BusinessValueTargetRepository targetRepository,
       final TenantService tenantService,
       final DefinitionService definitionService,
       final BusinessValueOverviewComputeService computeService,
       final ConfigurationService configurationService) {
     this.overviewRepository = overviewRepository;
+    this.targetRepository = targetRepository;
     this.tenantService = tenantService;
     this.definitionService = definitionService;
     this.computeService = computeService;
@@ -111,30 +118,30 @@ public class BusinessValueOverviewReadService {
           DatabaseConstants.LIST_FETCH_LIMIT);
     }
 
-    if (rawRows.isEmpty()) {
-      return emptyResponse();
-    }
-
     // Overview rows for deleted process definitions would otherwise persist forever — the
     // scheduler stops upserting them but the repository has no deletion path today. Intersecting
     // against the current fully-imported definition set at read time hides orphans immediately,
     // and skipping them here also prevents the stale-read backstop from resurrecting them via
     // computeService (which would otherwise fall back to a synthetic definition entry).
     // Storage-level cleanup is tracked separately.
-    final Set<DefinitionKey> currentDefinitions = currentDefinitions();
-    final List<BusinessValueOverviewDto> rows =
+    final Map<DefinitionKey, String> currentDefinitions = currentDefinitions();
+    final List<BusinessValueOverviewDto> computedRows =
         rawRows.stream()
             .filter(
                 row ->
-                    currentDefinitions.contains(
+                    currentDefinitions.containsKey(
                         new DefinitionKey(row.getTenantId(), row.getProcessDefinitionKey())))
             .toList();
+
+    final OffsetDateTime now = OffsetDateTime.now();
+    final List<BusinessValueOverviewDto> rows =
+        withTargetOnlyDefinitions(
+            computedRows, currentDefinitions, authorizedTenantIds, range, now);
 
     if (rows.isEmpty()) {
       return emptyResponse();
     }
 
-    final OffsetDateTime now = OffsetDateTime.now();
     final Duration staleThreshold = staleThreshold();
 
     int totalProcesses = 0;
@@ -265,16 +272,76 @@ public class BusinessValueOverviewReadService {
         List.of());
   }
 
-  private Set<DefinitionKey> currentDefinitions() {
+  private Map<DefinitionKey, String> currentDefinitions() {
     final List<DefinitionWithTenantIdsDto> definitions =
         definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS);
-    final Set<DefinitionKey> keys = new HashSet<>();
+    final Map<DefinitionKey, String> keys = new HashMap<>();
     for (final DefinitionWithTenantIdsDto definition : definitions) {
+      final String name = definition.getName() != null ? definition.getName() : definition.getKey();
       for (final String tenantId : definition.getTenantIds()) {
-        keys.add(new DefinitionKey(tenantId, definition.getKey()));
+        keys.put(new DefinitionKey(tenantId, definition.getKey()), name);
       }
     }
     return keys;
+  }
+
+  /**
+   * Adds an entry for every definition that has a target but no computed row yet, so setting a
+   * target on a freshly imported definition shows up straight away instead of leaving it absent
+   * from L0 until the sweep first measures it.
+   *
+   * <p>The entry carries the target and no values, which is what it is: the target is known, the
+   * measurement is not. It therefore contributes to coverage and to the targets-set count, but is
+   * excluded from the off-target list by the existing null-value guards — there is no measurement
+   * to be off by.
+   *
+   * <p>Stamped with the current time so it never reads as stale. These rows were never computed, so
+   * a truthful timestamp would trip the backstop into a fleet-wide recompute on every read for as
+   * long as one target-only definition exists.
+   *
+   * <p>Not persisted. The sweep owns the index; this only shapes the response.
+   */
+  private List<BusinessValueOverviewDto> withTargetOnlyDefinitions(
+      final List<BusinessValueOverviewDto> computedRows,
+      final Map<DefinitionKey, String> currentDefinitions,
+      final List<String> authorizedTenantIds,
+      final MetricRange range,
+      final OffsetDateTime now) {
+    final Set<DefinitionKey> alreadyComputed = new HashSet<>();
+    for (final BusinessValueOverviewDto row : computedRows) {
+      alreadyComputed.add(new DefinitionKey(row.getTenantId(), row.getProcessDefinitionKey()));
+    }
+
+    final List<BusinessValueOverviewDto> synthesized = new ArrayList<>();
+    for (final BusinessValueTargetDto target :
+        targetRepository.readByTenants(authorizedTenantIds)) {
+      final DefinitionKey key =
+          new DefinitionKey(target.getTenantId(), target.getProcessDefinitionKey());
+      if (alreadyComputed.contains(key) || !currentDefinitions.containsKey(key)) {
+        continue;
+      }
+      final BusinessValueOverviewDto row =
+          new BusinessValueOverviewDto(
+              target.getTenantId(),
+              target.getProcessDefinitionKey(),
+              currentDefinitions.get(key),
+              range,
+              now,
+              BusinessValueVerdict.cycleTimeBlock(null, null),
+              BusinessValueVerdict.automationRateBlock(null, null),
+              false,
+              0,
+              0);
+      BusinessValueOverviewComputeService.applyTarget(row, target);
+      synthesized.add(row);
+    }
+
+    if (synthesized.isEmpty()) {
+      return computedRows;
+    }
+    final List<BusinessValueOverviewDto> all = new ArrayList<>(computedRows);
+    all.addAll(synthesized);
+    return all;
   }
 
   private Duration staleThreshold() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerService.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
  * io.camunda.optimize.service.dashboard.BusinessValueDashboardService#init()} (annotated {@link
  * Ordered#HIGHEST_PRECEDENCE}) has seeded the per-process reports the compute path evaluates.
  * Without this ordering the first tick can run before the reports exist, fail, and then wait the
- * full refresh interval (24h by default) before retrying.
+ * full refresh interval (1h by default) before retrying.
  */
 @Component
 public class BusinessValueOverviewSchedulerService extends AbstractScheduledService {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
@@ -25,20 +25,20 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 /**
  * Application-layer entry point for the two BVD target REST endpoints. Delegates persistence to
  * {@link BusinessValueTargetWriter} / {@link BusinessValueTargetRepository}.
  *
- * <p>Target-write → overview coherence is eventual: the {@link
- * BusinessValueOverviewSchedulerService} refreshes the overview index on a tiered cadence, and the
- * stale-read backstop on {@code /overview} (see {@code BusinessValueOverviewReadService}) triggers
- * a targeted recompute the first time a reader observes a row older than {@code 2 ×} the refresh
- * interval. A per-write synchronous recompute is intentionally omitted here — the compute service
- * on the sibling M2.4 branch has been refactored to a single scheduler-driven entry point, and
- * blasting a cluster-wide recompute on every modal save is too expensive relative to the stale-read
- * latency budget documented in {@code bvd-target-technical-design.md} §3.4.
+ * <p>A target write refreshes the definition's overview rows synchronously, via {@link
+ * BusinessValueOverviewComputeService#refreshTargetOnRows}, so the caller's next {@code GET
+ * /business-value/overview} shows the new verdict. Without it the row keeps the target it was last
+ * swept with, and the stale-read backstop does not help: it fires on the age of the measurement,
+ * and a row measured an hour ago carrying an hour-old target is not stale by that measure. No
+ * report is evaluated on this path — the verdict is re-derived from the values already on the row,
+ * which is what keeps it cheap enough to run inside the request.
  *
  * <p>Field-level input validation ({@code automationRateTargetPct ∈ [0, 100]}, {@code
  * cycleTimeTarget.value ≥ 0}) is expressed as JSR-380 annotations on {@link
@@ -53,20 +53,26 @@ public class BusinessValueTargetService {
   private static final Map<TargetValueUnit, Duration> UNIT_DURATIONS =
       BusinessValueTargetWriter.SUPPORTED_CYCLE_TIME_UNIT_DURATIONS;
 
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueTargetService.class);
+
   private final BusinessValueTargetWriter writer;
   private final BusinessValueTargetRepository repository;
   private final TenantService tenantService;
   private final DefinitionService definitionService;
+  private final BusinessValueOverviewComputeService overviewComputeService;
 
   public BusinessValueTargetService(
       final BusinessValueTargetWriter writer,
       final BusinessValueTargetRepository repository,
       final TenantService tenantService,
-      final DefinitionService definitionService) {
+      final DefinitionService definitionService,
+      final BusinessValueOverviewComputeService overviewComputeService) {
     this.writer = writer;
     this.repository = repository;
     this.tenantService = tenantService;
     this.definitionService = definitionService;
+    this.overviewComputeService = overviewComputeService;
   }
 
   public BusinessValueTargetResponseDto readTarget(
@@ -89,7 +95,29 @@ public class BusinessValueTargetService {
     final BusinessValueTargetDto toWrite =
         toPersistenceDto(tenantId, processDefinitionKey, request, userId);
     writer.upsertTarget(toWrite);
+    refreshOverviewRows(toWrite);
     return toResponseDto(toWrite);
+  }
+
+  /**
+   * Propagates the saved target onto the overview rows, after the target itself is durable.
+   *
+   * <p>A failure here is logged rather than surfaced: the target is already persisted, and the next
+   * sweep re-derives the rows from it, so the only cost is that L0 lags until then. Failing the
+   * request instead would leave the caller unable to tell whether their target was saved — the
+   * worse of the two outcomes, and the reason this runs after the write rather than as part of it.
+   */
+  private void refreshOverviewRows(final BusinessValueTargetDto target) {
+    try {
+      overviewComputeService.refreshTargetOnRows(target);
+    } catch (final Exception e) {
+      LOG.warn(
+          "Business-value target for tenant [{}] definition [{}] was saved, but refreshing its "
+              + "overview rows failed; the overview will catch up on the next sweep.",
+          target.getTenantId(),
+          target.getProcessDefinitionKey(),
+          e);
+    }
   }
 
   private void ensureTenantAccess(final String userId, final String tenantId) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.db.repository;
 
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +22,17 @@ public interface BusinessValueTargetRepository {
   Optional<BusinessValueTargetDto> getByKey(String tenantId, String processDefinitionKey);
 
   List<BusinessValueTargetDto> scanAll();
+
+  /**
+   * Reads the targets belonging to the given tenants.
+   *
+   * <p>Passing {@code null} returns every target and is reserved for internal, tenant-agnostic
+   * callers. Passing an empty collection returns no targets — a shortcut for callers that have
+   * already determined the caller sees no tenants. Any non-empty collection is pushed down to a
+   * {@code terms} filter so a request path never pulls another tenant's rows back to filter them in
+   * memory, and so the fetch limit bounds what this caller can see rather than the whole fleet.
+   */
+  List<BusinessValueTargetDto> readByTenants(Collection<String> tenantIds);
 
   static String documentId(final String tenantId, final String processDefinitionKey) {
     if (StringUtils.isBlank(tenantId)) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.es;
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch.core.IndexResponse;
@@ -23,9 +24,11 @@ import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.schema.index.BusinessValueTargetIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -96,6 +99,48 @@ public class BusinessValueTargetRepositoryES implements BusinessValueTargetRepos
       LOG.error(errorMessage, e);
       throw new OptimizeRuntimeException(errorMessage, e);
     }
+  }
+
+  @Override
+  public List<BusinessValueTargetDto> readByTenants(final Collection<String> tenantIds) {
+    if (tenantIds != null && tenantIds.isEmpty()) {
+      return List.of();
+    }
+    final List<FieldValue> tenantFieldValues =
+        tenantIds == null ? null : tenantIds.stream().map(FieldValue::of).toList();
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME)
+                    .query(
+                        q ->
+                            tenantFieldValues == null
+                                ? q.matchAll(m -> m)
+                                : q.terms(
+                                    t ->
+                                        t.field(BusinessValueTargetIndex.TENANT_ID)
+                                            .terms(tt -> tt.value(tenantFieldValues))))
+                    .size(LIST_FETCH_LIMIT));
+    final SearchResponse<BusinessValueTargetDto> response;
+    try {
+      response = esClient.search(searchRequest, BusinessValueTargetDto.class);
+    } catch (final IOException e) {
+      final String errorMessage = "Could not read business-value targets for the given tenants.";
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+    final List<BusinessValueTargetDto> targets =
+        ElasticsearchReaderUtil.mapHits(
+            response.hits(), BusinessValueTargetDto.class, objectMapper);
+    if (targets.size() >= LIST_FETCH_LIMIT) {
+      throw new OptimizeRuntimeException(
+          String.format(
+              "business-value target readByTenants returned %d rows, hitting the "
+                  + "LIST_FETCH_LIMIT cap. Pagination must be introduced before the read path can "
+                  + "rely on complete results.",
+              targets.size()));
+    }
+    return targets;
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
@@ -10,14 +10,17 @@ package io.camunda.optimize.service.db.repository.os;
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.stringTerms;
 import static java.lang.String.format;
 
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.db.schema.index.BusinessValueTargetIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -86,6 +89,32 @@ public class BusinessValueTargetRepositoryOS implements BusinessValueTargetRepos
     final GetResponse<BusinessValueTargetDto> response =
         osClient.get(requestBuilder, BusinessValueTargetDto.class, errorMessage);
     return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+  }
+
+  @Override
+  public List<BusinessValueTargetDto> readByTenants(final Collection<String> tenantIds) {
+    if (tenantIds != null && tenantIds.isEmpty()) {
+      return List.of();
+    }
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_TARGET_INDEX_NAME))
+            .query(
+                tenantIds == null
+                    ? matchAll()
+                    : stringTerms(BusinessValueTargetIndex.TENANT_ID, tenantIds))
+            .size(LIST_FETCH_LIMIT);
+    final List<BusinessValueTargetDto> targets =
+        osClient.searchValues(requestBuilder, BusinessValueTargetDto.class);
+    if (targets.size() >= LIST_FETCH_LIMIT) {
+      throw new OptimizeRuntimeException(
+          format(
+              "business-value target readByTenants returned %d rows, hitting the "
+                  + "LIST_FETCH_LIMIT cap. Pagination must be introduced before the read path can "
+                  + "rely on complete results.",
+              targets.size()));
+    }
+    return targets;
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.businessvalue;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -16,11 +17,14 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.RoleType;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.dto.optimize.query.report.AuthorizedReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
@@ -32,6 +36,7 @@ import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
@@ -39,9 +44,11 @@ import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,6 +64,7 @@ class BusinessValueOverviewComputeKillSwitchTest {
   private BusinessValueOverviewWriter overviewWriter;
   private PlainReportEvaluationHandler reportEvaluationHandler;
   private BusinessValueTargetRepository targetRepository;
+  private BusinessValueOverviewRepository overviewRepository;
   private DefinitionService definitionService;
   private MappingMetadataRepository mappingMetadataRepository;
   private SearchLimitsRepository searchLimitsRepository;
@@ -66,6 +74,7 @@ class BusinessValueOverviewComputeKillSwitchTest {
   @BeforeEach
   void setUp() {
     targetRepository = mock(BusinessValueTargetRepository.class);
+    overviewRepository = mock(BusinessValueOverviewRepository.class);
     overviewWriter = mock(BusinessValueOverviewWriter.class);
     definitionService = mock(DefinitionService.class);
     final ReportService reportService = mock(ReportService.class);
@@ -99,6 +108,7 @@ class BusinessValueOverviewComputeKillSwitchTest {
     computeService =
         new BusinessValueOverviewComputeService(
             targetRepository,
+            overviewRepository,
             overviewWriter,
             definitionService,
             reportService,
@@ -150,6 +160,50 @@ class BusinessValueOverviewComputeKillSwitchTest {
         targetRepository,
         mappingMetadataRepository,
         searchLimitsRepository);
+  }
+
+  /**
+   * The switch sheds the sweep's Elasticsearch load, and a target refresh evaluates no reports — it
+   * re-derives the verdict from values already on the row. Gating it too would mean a target saved
+   * during an incident silently fails to show up, which is a correctness regression bought for no
+   * load saving at all.
+   */
+  @Test
+  void shouldStillRefreshTargetsOnRowsWhenComputeIsDisabled() {
+    // given the sweep is switched off, and a definition with a computed row
+    businessValueConfiguration.setOverviewComputeEnabled(false);
+    final BusinessValueTargetDto target =
+        new BusinessValueTargetDto(
+            "invoice-process",
+            TENANT,
+            1_000L,
+            TargetValueUnit.MILLIS,
+            90,
+            OffsetDateTime.now(),
+            "u");
+    when(overviewRepository.getByKey(eq(TENANT), eq("invoice-process"), any()))
+        .thenAnswer(invocation -> Optional.of(rowFor(invocation.getArgument(2))));
+
+    // when a target is saved
+    computeService.refreshTargetOnRows(target);
+
+    // then the rows are still brought up to date, without evaluating a report
+    verify(overviewWriter).bulkUpsertFromTargetWrite(any());
+    verifyNoInteractions(reportEvaluationHandler);
+  }
+
+  private static BusinessValueOverviewDto rowFor(final MetricRange range) {
+    return new BusinessValueOverviewDto(
+        TENANT,
+        "invoice-process",
+        "Invoice",
+        range,
+        OffsetDateTime.now(),
+        new BusinessValueOverviewDto.CycleTimeBlock(5_000L, null, null),
+        new BusinessValueOverviewDto.AutomationRateBlock(50d, null, null),
+        false,
+        0,
+        0);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
@@ -10,7 +10,9 @@ package io.camunda.optimize.service.businessvalue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -21,11 +23,13 @@ import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.dto.optimize.query.report.AuthorizedReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
@@ -38,6 +42,7 @@ import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
 import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
@@ -45,6 +50,7 @@ import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +59,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -60,6 +67,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 /**
  * Guards the property the fan-in exists for: report evaluations per sweep scale with the number of
@@ -72,6 +80,7 @@ class BusinessValueOverviewComputeServiceTest {
   private static final String DEFAULT_TENANT = "<default>";
 
   private BusinessValueTargetRepository targetRepository;
+  private BusinessValueOverviewRepository overviewRepository;
   private BusinessValueOverviewWriter overviewWriter;
   private DefinitionService definitionService;
   private ReportService reportService;
@@ -100,6 +109,7 @@ class BusinessValueOverviewComputeServiceTest {
   @BeforeEach
   void setUp() {
     targetRepository = mock(BusinessValueTargetRepository.class);
+    overviewRepository = mock(BusinessValueOverviewRepository.class);
     overviewWriter = mock(BusinessValueOverviewWriter.class);
     definitionService = mock(DefinitionService.class);
     reportService = mock(ReportService.class);
@@ -114,6 +124,7 @@ class BusinessValueOverviewComputeServiceTest {
     computeService =
         new BusinessValueOverviewComputeService(
             targetRepository,
+            overviewRepository,
             overviewWriter,
             definitionService,
             reportService,
@@ -132,6 +143,154 @@ class BusinessValueOverviewComputeServiceTest {
               final ProcessReportDataDto reportData =
                   (ProcessReportDataDto) info.getReport().getData();
               return evaluationResultFor(reportData);
+            });
+  }
+
+  /**
+   * The sweep must take its target snapshot after the last evaluation returns, not before the
+   * first. Evaluating a whole catalog takes long enough for a user to save a target in the middle
+   * of it, and the upsert has no version precondition — so a snapshot read up front means the sweep
+   * writes back the target as it was before the save, silently reverting it until the next tick.
+   *
+   * <p>Asserted as an ordering rather than a value because a test that only checked the written row
+   * would pass on a sweep that read early and got lucky on timing.
+   */
+  @Test
+  void shouldReadTargetsAfterEvaluatingAndImmediatelyBeforeWriting() {
+    // given a catalog to sweep
+    givenDefinitions(DEFAULT_TENANT, 2);
+
+    // when a sweep runs
+    computeService.computeOverviewRows(allRanges());
+
+    // then targets are read only once every evaluation has returned, and the write follows
+    final InOrder inOrder = inOrder(reportEvaluationHandler, targetRepository, overviewWriter);
+    inOrder.verify(reportEvaluationHandler, atLeastOnce()).evaluateReport(any());
+    inOrder.verify(targetRepository).scanAll();
+    inOrder.verify(overviewWriter).bulkUpsertFromScheduler(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  /**
+   * The measured value belongs to the row that was just evaluated; the target is applied on top of
+   * it afterwards. This pins that the late target read still lands on the right row rather than
+   * being dropped by the reordering.
+   */
+  @Test
+  void shouldApplyTheTargetItReadToTheRowItEvaluated() {
+    // given one definition measured at 5s against a 1s cycle-time target, and no automation target
+    givenDefinitions(DEFAULT_TENANT, 1);
+    final String key = "process-0";
+    stubbedValuesByKey.put(key, 5_000d);
+    when(targetRepository.scanAll())
+        .thenReturn(List.of(cycleTimeTarget(DEFAULT_TENANT, key, 1_000L)));
+
+    // when a sweep runs for a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the written row pairs the evaluated value with the target and the verdict it implies
+    final BusinessValueOverviewDto row = capturedRows().getFirst();
+    assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+    assertThat(row.getCycleTime().getTarget()).isEqualTo(1_000L);
+    assertThat(row.getCycleTime().getMet()).isFalse();
+    assertThat(row.getAutomationRate().getTarget()).isNull();
+    assertThat(row.getTargetsSet()).isEqualTo(1);
+    assertThat(row.getTargetsMet()).isZero();
+    assertThat(row.isHasAnyTarget()).isTrue();
+  }
+
+  // --- refreshTargetOnRows: the target-write path ---
+
+  /**
+   * The whole point of this path is that it costs nothing an HTTP request cannot absorb. Evaluating
+   * reports here would put eight aggregations inside a modal save and tie the save's success to the
+   * report path being healthy — neither of which is needed, because a target write does not change
+   * what was measured.
+   */
+  @Test
+  void shouldRefreshEveryRangeFromStoredValuesWithoutEvaluatingReports() {
+    // given a definition with a computed row for every range, measured at 5s
+    givenExistingRowsForAllRanges(DEFAULT_TENANT, "process-0", 5_000L, 50d);
+
+    // when a 1s cycle-time target is saved
+    computeService.refreshTargetOnRows(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L));
+
+    // then all four rows carry the target and the verdict, and no report was evaluated
+    final List<BusinessValueOverviewDto> written = capturedTargetWriteRows();
+    assertThat(written).hasSize(MetricRange.values().length);
+    assertThat(written)
+        .allSatisfy(
+            row -> {
+              assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+              assertThat(row.getCycleTime().getTarget()).isEqualTo(1_000L);
+              assertThat(row.getCycleTime().getMet()).isFalse();
+              assertThat(row.isHasAnyTarget()).isTrue();
+              assertThat(row.getTargetsSet()).isEqualTo(1);
+            });
+    assertThat(written)
+        .extracting(BusinessValueOverviewDto::getMetricRange)
+        .containsExactlyInAnyOrder(MetricRange.values());
+    verify(reportEvaluationHandler, never()).evaluateReport(any());
+  }
+
+  /**
+   * {@code lastComputedAt} records when the values were measured, and a target write measures
+   * nothing. Bumping it would tell the read path's staleness backstop that a genuinely stale row is
+   * fresh, suppressing the recompute it exists to trigger for another two intervals.
+   */
+  @Test
+  void shouldLeaveLastComputedAtUntouchedWhenRefreshingATarget() {
+    // given a row last measured a long time ago
+    final OffsetDateTime measuredAt = OffsetDateTime.parse("2026-01-01T00:00:00Z");
+    givenExistingRowsForAllRanges(DEFAULT_TENANT, "process-0", 5_000L, 50d, measuredAt);
+
+    // when a target is saved now
+    computeService.refreshTargetOnRows(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L));
+
+    // then the measurement timestamp is preserved
+    assertThat(capturedTargetWriteRows())
+        .allSatisfy(row -> assertThat(row.getLastComputedAt()).isEqualTo(measuredAt));
+  }
+
+  /**
+   * A definition imported since the last sweep has no row to carry a value, and inventing one here
+   * would persist a permanent value-less row that the sweep then has to correct. The read path
+   * surfaces this case instead, by joining live targets onto the rows it reads.
+   */
+  @Test
+  void shouldWriteNothingWhenTheDefinitionHasNoRowsYet() {
+    // given no computed rows for the definition
+    when(overviewRepository.getByKey(anyString(), anyString(), any())).thenReturn(Optional.empty());
+
+    // when a target is saved
+    computeService.refreshTargetOnRows(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L));
+
+    // then nothing is written
+    verify(overviewWriter, never()).bulkUpsertFromTargetWrite(any());
+  }
+
+  /** Clearing a target has to clear the verdict with it, not leave the last one standing. */
+  @Test
+  void shouldClearTheVerdictWhenTheTargetIsCleared() {
+    // given rows that currently carry a target and a verdict
+    givenExistingRowsForAllRanges(DEFAULT_TENANT, "process-0", 5_000L, 50d);
+
+    // when the target is cleared
+    final BusinessValueTargetDto cleared =
+        new BusinessValueTargetDto(
+            "process-0", DEFAULT_TENANT, null, null, null, OffsetDateTime.now(), "someone");
+    computeService.refreshTargetOnRows(cleared);
+
+    // then the rows keep their measurements but carry no target, verdict or counters
+    assertThat(capturedTargetWriteRows())
+        .allSatisfy(
+            row -> {
+              assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+              assertThat(row.getCycleTime().getTarget()).isNull();
+              assertThat(row.getCycleTime().getMet()).isNull();
+              assertThat(row.isHasAnyTarget()).isFalse();
+              assertThat(row.getTargetsSet()).isZero();
+              assertThat(row.getTargetsMet()).isZero();
             });
   }
 
@@ -532,6 +691,7 @@ class BusinessValueOverviewComputeServiceTest {
       final SearchLimitsRepository searchLimits) {
     return new BusinessValueOverviewComputeService(
         targetRepository,
+        overviewRepository,
         overviewWriter,
         definitionService,
         reportService,
@@ -597,6 +757,57 @@ class BusinessValueOverviewComputeServiceTest {
     when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
         .thenReturn(definitions);
     when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex()).thenReturn(keys);
+  }
+
+  private static BusinessValueTargetDto cycleTimeTarget(
+      final String tenantId, final String processDefinitionKey, final long cycleTimeMillis) {
+    return new BusinessValueTargetDto(
+        processDefinitionKey,
+        tenantId,
+        cycleTimeMillis,
+        TargetValueUnit.MILLIS,
+        null,
+        OffsetDateTime.now(),
+        "someone");
+  }
+
+  private void givenExistingRowsForAllRanges(
+      final String tenantId,
+      final String processDefinitionKey,
+      final Long cycleMillis,
+      final Double automationPct) {
+    givenExistingRowsForAllRanges(
+        tenantId, processDefinitionKey, cycleMillis, automationPct, OffsetDateTime.now());
+  }
+
+  private void givenExistingRowsForAllRanges(
+      final String tenantId,
+      final String processDefinitionKey,
+      final Long cycleMillis,
+      final Double automationPct,
+      final OffsetDateTime lastComputedAt) {
+    when(overviewRepository.getByKey(eq(tenantId), eq(processDefinitionKey), any()))
+        .thenAnswer(
+            invocation ->
+                Optional.of(
+                    new BusinessValueOverviewDto(
+                        tenantId,
+                        processDefinitionKey,
+                        processDefinitionKey,
+                        invocation.getArgument(2),
+                        lastComputedAt,
+                        new BusinessValueOverviewDto.CycleTimeBlock(cycleMillis, 9L, true),
+                        new BusinessValueOverviewDto.AutomationRateBlock(automationPct, 1, true),
+                        true,
+                        2,
+                        2)));
+  }
+
+  private List<BusinessValueOverviewDto> capturedTargetWriteRows() {
+    final ArgumentCaptor<List<BusinessValueOverviewDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(overviewWriter).bulkUpsertFromTargetWrite(captor.capture());
+    return captor.getValue();
   }
 
   private List<BusinessValueOverviewDto> capturedRows() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -24,9 +24,12 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -51,6 +54,7 @@ class BusinessValueOverviewReadServiceTest {
   private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC);
 
   private BusinessValueOverviewRepository overviewRepository;
+  private BusinessValueTargetRepository targetRepository;
   private TenantService tenantService;
   private DefinitionService definitionService;
   private BusinessValueOverviewComputeService computeService;
@@ -60,6 +64,8 @@ class BusinessValueOverviewReadServiceTest {
   @BeforeEach
   void setUp() {
     overviewRepository = mock(BusinessValueOverviewRepository.class);
+    targetRepository = mock(BusinessValueTargetRepository.class);
+    when(targetRepository.readByTenants(any())).thenReturn(List.of());
     tenantService = mock(TenantService.class);
     definitionService = mock(DefinitionService.class);
     computeService = mock(BusinessValueOverviewComputeService.class);
@@ -74,6 +80,7 @@ class BusinessValueOverviewReadServiceTest {
     readService =
         new BusinessValueOverviewReadService(
             overviewRepository,
+            targetRepository,
             tenantService,
             definitionService,
             computeService,
@@ -529,6 +536,124 @@ class BusinessValueOverviewReadServiceTest {
               entry.getKey(), entry.getKey(), DefinitionType.PROCESS, entry.getValue(), Set.of()));
     }
     when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS)).thenReturn(dtos);
+  }
+
+  // --- target-only definitions: imported since the last sweep, so no computed row yet ---
+
+  /**
+   * Setting a target on a definition the sweep has not measured yet used to leave it absent from L0
+   * entirely — the target was saved, and nothing showed it. The entry is what is actually known: a
+   * target, and no measurement to judge it against.
+   */
+  @Test
+  void shouldSurfaceADefinitionThatHasATargetButNoComputedRow() {
+    // given a current definition with a target and no row
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "fresh-import"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "fresh-import", 1_000L, 90)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then it counts towards coverage and targets set, but nothing is claimed to be met
+    assertThat(response.isHasAnyTarget()).isTrue();
+    assertThat(response.getCoverage().getProcessesWithTarget()).isEqualTo(1);
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(1);
+    assertThat(response.getAttainment().getTargetsSet()).isEqualTo(2);
+    assertThat(response.getAttainment().getTargetsMet()).isZero();
+  }
+
+  /** There is no measurement, so there is no gap to rank — an entry here would be fabricated. */
+  @Test
+  void shouldNotListATargetOnlyDefinitionAsOffTarget() {
+    // given
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "fresh-import"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "fresh-import", 1_000L, 90)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.getOffTarget()).isEmpty();
+  }
+
+  /**
+   * These rows were never computed, so an honest timestamp would read as stale and fire a
+   * fleet-wide recompute on every single read for as long as one target-only definition exists.
+   */
+  @Test
+  void shouldNotTriggerTheBackstopForATargetOnlyDefinition() {
+    // given only a target-only definition, and a sweep that is otherwise up to date
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "fresh-import"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "fresh-import", 1_000L, 90)));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    verify(computeService, never()).computeOverviewRows(any());
+  }
+
+  /** A definition that already has a row must not be counted twice. */
+  @Test
+  void shouldNotDuplicateADefinitionThatAlreadyHasAComputedRow() {
+    // given a definition with both a computed row and a target
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(
+            List.of(fresh(row(TENANT_A, "invoice", cyc(5_000L, 1_000L, false), autoNull(), 1, 0))));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "invoice"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "invoice", 1_000L, null)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(1);
+  }
+
+  /**
+   * The orphan filter applies to target-only entries too. A target outliving its definition would
+   * otherwise resurrect it on L0 with no way to remove it.
+   */
+  @Test
+  void shouldIgnoreATargetWhoseDefinitionNoLongerExists() {
+    // given a target for a definition that is no longer imported
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions();
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "deleted-process", 1_000L, 90)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.isHasAnyTarget()).isFalse();
+    assertThat(response.getCoverage().getTotalProcesses()).isZero();
+  }
+
+  private static BusinessValueTargetDto target(
+      final String tenantId,
+      final String processKey,
+      final Long cycleTimeMillis,
+      final Integer automationRatePct) {
+    return new BusinessValueTargetDto(
+        processKey,
+        tenantId,
+        cycleTimeMillis,
+        cycleTimeMillis == null ? null : TargetValueUnit.MILLIS,
+        automationRatePct,
+        OffsetDateTime.now(ZoneOffset.UTC),
+        "someone");
   }
 
   private static BusinessValueOverviewDto row(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 class BusinessValueTargetServiceTest {
 
@@ -49,6 +52,7 @@ class BusinessValueTargetServiceTest {
   private BusinessValueTargetRepository repository;
   private TenantService tenantService;
   private DefinitionService definitionService;
+  private BusinessValueOverviewComputeService overviewComputeService;
   private BusinessValueTargetService service;
 
   @BeforeEach
@@ -57,9 +61,12 @@ class BusinessValueTargetServiceTest {
     repository = mock(BusinessValueTargetRepository.class);
     tenantService = mock(TenantService.class);
     definitionService = mock(DefinitionService.class);
+    overviewComputeService = mock(BusinessValueOverviewComputeService.class);
     when(tenantService.isAuthorizedToSeeTenant(anyString(), anyString())).thenReturn(true);
     stubDefinitionExists(PROCESS_KEY, TENANT);
-    service = new BusinessValueTargetService(writer, repository, tenantService, definitionService);
+    service =
+        new BusinessValueTargetService(
+            writer, repository, tenantService, definitionService, overviewComputeService);
   }
 
   private void stubDefinitionExists(final String processDefinitionKey, final String... tenantIds) {
@@ -138,6 +145,75 @@ class BusinessValueTargetServiceTest {
     // and — response echoes the written state
     assertThat(response.cycleTimeTarget().millis()).isEqualTo(172_800_000L);
     assertThat(response.automationRateTargetPct()).isEqualTo(90);
+  }
+
+  // --- upsert: overview coherence ---
+
+  /**
+   * Without this the saved target does not reach L0 until the next sweep, because the overview row
+   * carries the target it was last computed with and the stale-read backstop keys off the age of
+   * the measurement, not of the target — a freshly measured row holding a stale target looks
+   * perfectly fresh to it.
+   */
+  @Test
+  void shouldRefreshOverviewRowsWithTheTargetItJustWrote() {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(2L, TargetValueUnit.DAYS, null), 90);
+
+    // when
+    service.upsertTarget(USER, TENANT, PROCESS_KEY, request);
+
+    // then the refresh runs after the target is durable, and on exactly what was persisted
+    final ArgumentCaptor<BusinessValueTargetDto> refreshCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    final InOrder inOrder = inOrder(writer, overviewComputeService);
+    inOrder.verify(writer).upsertTarget(any(BusinessValueTargetDto.class));
+    inOrder.verify(overviewComputeService).refreshTargetOnRows(refreshCaptor.capture());
+    final BusinessValueTargetDto refreshed = refreshCaptor.getValue();
+    assertThat(refreshed.getTenantId()).isEqualTo(TENANT);
+    assertThat(refreshed.getProcessDefinitionKey()).isEqualTo(PROCESS_KEY);
+    assertThat(refreshed.getCycleTimeTargetMillis()).isEqualTo(172_800_000L);
+    assertThat(refreshed.getAutomationRateTargetPct()).isEqualTo(90);
+  }
+
+  /**
+   * The target is already durable by the time the refresh runs, and the next sweep re-derives the
+   * rows from it. Failing the request instead would leave the caller unable to tell whether their
+   * target saved — worse than an overview that lags one interval.
+   */
+  @Test
+  void shouldStillReturnTheSavedTargetWhenRefreshingTheOverviewFails() {
+    // given a refresh that blows up
+    doThrow(new IllegalStateException("elasticsearch is having a moment"))
+        .when(overviewComputeService)
+        .refreshTargetOnRows(any());
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(2L, TargetValueUnit.DAYS, null), 90);
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        service.upsertTarget(USER, TENANT, PROCESS_KEY, request);
+
+    // then the save stands and the caller sees what was persisted
+    verify(writer).upsertTarget(any(BusinessValueTargetDto.class));
+    assertThat(response.cycleTimeTarget().millis()).isEqualTo(172_800_000L);
+    assertThat(response.automationRateTargetPct()).isEqualTo(90);
+  }
+
+  /** A rejected upsert must not touch the overview — there is no new target to propagate. */
+  @Test
+  void shouldNotRefreshOverviewRowsWhenTheUpsertIsRejected() {
+    // given a request that fails the service's own cross-field validation
+    final BusinessValueTargetUpsertRequestDto missingUnit =
+        new BusinessValueTargetUpsertRequestDto(new CycleTimeTargetDto(2L, null, null), 90);
+
+    // when / then
+    assertThatThrownBy(() -> service.upsertTarget(USER, TENANT, PROCESS_KEY, missingUnit))
+        .isInstanceOf(BadRequestException.class);
+    verify(overviewComputeService, never()).refreshTargetOnRows(any());
   }
 
   // --- upsert: clear semantics ---

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
@@ -9,11 +9,39 @@ package io.camunda.optimize.service.db.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.repository.es.BusinessValueTargetRepositoryES;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class BusinessValueTargetRepositoryTest {
+
+  /**
+   * An empty authorized-tenant list means the caller may see nothing, and it must not be allowed to
+   * fall through to the unfiltered read that {@code null} selects. Verified by asserting the client
+   * is never touched rather than that the result is empty — a query that ran and happened to match
+   * nothing would satisfy the weaker assertion while still having read every tenant's targets.
+   */
+  @Test
+  void shouldReadNothingWithoutQueryingWhenTheCallerSeesNoTenants() {
+    // given
+    final OptimizeElasticsearchClient esClient = mock(OptimizeElasticsearchClient.class);
+    final BusinessValueTargetRepositoryES repository =
+        new BusinessValueTargetRepositoryES(esClient, new ObjectMapper());
+
+    // when
+    final List<BusinessValueTargetDto> targets = repository.readByTenants(List.of());
+
+    // then
+    assertThat(targets).isEmpty();
+    verifyNoInteractions(esClient);
+  }
 
   @Test
   void shouldCombineTenantAndProcessKeyIntoDocumentId() {

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -587,6 +587,9 @@ businessValue:
   # numbers simply stop advancing until it is re-enabled. Requires an Optimize restart to take
   # effect, as configuration is read once at startup. Scoped to the sweep only — it does not affect
   # the overview or target endpoints, nor the dashboard tiles, which are evaluated per request.
+  # Saving a target still refreshes that definition's existing overview rows while this is off: it
+  # evaluates no reports, so it adds none of the load this switch sheds, and targets staying
+  # coherent while the measured values freeze is the behaviour the switch is meant to preserve.
   overviewComputeEnabled: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_COMPUTE_ENABLED:true}
 
 export:

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -580,8 +580,11 @@ entity:
 
 businessValue:
   # How often the business-value overview index is refreshed for all definitions and all range
-  # presets (7d, 30d, 3m, 6m). The given number is the interval in seconds. Default: 24h.
-  overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:86400}
+  # presets (7d, 30d, 3m, 6m). The given number is the interval in seconds. Default: 1h. This also
+  # sets how long a definition imported after the last sweep waits before its measured values
+  # appear. The stale-read threshold derives from it at twice its value. Raise it on a large
+  # catalog, where the 3m and 6m presets scan the most instance data per sweep.
+  overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:3600}
   # Kill switch for the background overview computation. Set to false to stop the sweep without
   # taking the dashboard down: existing rows stay readable and the endpoint keeps serving, the
   # numbers simply stop advancing until it is re-enabled. Requires an Optimize restart to take


### PR DESCRIPTION
## Why

Setting a target on the Business Value Dashboard did not change L0. The target reached its own index straight away, but the overview row kept the target it was last swept with, so coverage, attainment and the off-target list all answered from the previous target — for up to a full refresh interval, which defaulted to 24h.

The stale-read backstop does not cover this: it fires on the age of the *measurement*, and a row measured minutes ago carrying an hour-old target is not stale by that test.

The insight the fix rests on: **a target write does not change what was measured.** `BusinessValueVerdict` is a pure function of the measured value and the target, so re-deriving the verdict from the value already on the row produces exactly what a full recompute would — with no report evaluation at all.

## What

**1. Show a target on the overview as soon as it is saved**

- The sweep read every target once at the top and wrote rows a whole sweep later, so a target saved in between was overwritten by a blind upsert with no version precondition. Targets are now read after the last evaluation, immediately before the bulk write, cutting that window from tens of seconds to the write itself. `applyTarget` is extracted so the derivation lives in one place.
- `refreshTargetOnRows` re-derives the verdict on the definition's rows on save and writes them back with an immediate refresh. One get per range preset plus one bulk write — no report evaluation, cheap enough to sit inside the request. `lastComputedAt` is deliberately not bumped; nothing was measured.

**2. Surface a definition whose target has no computed row yet**

A definition imported since the last sweep had no row, so setting a target left it invisible entirely. `/overview` now joins live targets onto the rows it read and adds an entry carrying the target and no values. It counts toward coverage, stays out of the off-target list, and is stamped fresh so it cannot trip the backstop. Adds a tenant-filtered `readByTenants` rather than reusing the unfiltered, capped `scanAll` on a request path.

**3. Sweep hourly instead of daily**

`overviewRefreshInterval` 86400 → 3600.

## Sizing the hourly default

On a 1000-definition catalog the fanned-in sweep costs 32 evaluations per tick, so hourly is ~768/day. `KpiEvaluationSchedulerService` — already shipped, on a plain per-definition fan-out — runs every 600s for something closer to 144,000/day.

## Testing

241 BVD unit tests green; repo-wide `install -Dquickly` green; each commit compiles standalone.

The ordering guard is mutation-verified: moving `readTargets()` back to the top fails `shouldReadTargetsAfterEvaluatingAndImmediatelyBeforeWriting`.

## Notes for the reviewer

- `refreshTargetOnRows` is **not** gated by `overviewComputeEnabled`, by design: it evaluates nothing, so it adds none of the load that switch sheds, and gating it would mean a target saved during an incident silently fails to appear. Documented on the switch in `service-config.yaml`.
- `BusinessValueTargetRestService`'s javadoc already claimed this behaviour. This makes it true.

