### PR TITLE
test: align identity/operate/batch nightly e2e tests with product behaviour

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {waitForItemInList} from 'utils/waitForItemInList';
+import {sleep} from 'utils/sleep';
 
 export class IdentityRolesDetailsPage {
   private page: Page;
@@ -44,10 +45,16 @@ export class IdentityRolesDetailsPage {
     this.closeAssignUserModal = this.assignUserModal.getByRole('button', {
       name: 'Close',
     });
-    this.assignUserModalSearchField =
-      this.assignUserModal.getByRole('searchbox');
-    this.assignUserModalSearchResult =
-      this.assignUserModal.getByRole('listbox');
+    // On the new design system the assign-user modal's search field is a cmdk
+    // combobox ("Search by Username or Name") rather than Carbon's searchbox.
+    this.assignUserModalSearchField = this.assignUserModal.getByRole(
+      'combobox',
+      {name: 'Search by Username or Name'},
+    );
+    // The results render in a Radix popover that portals as a *sibling* of the
+    // dialog (DS #496), so the listbox is not a descendant of the modal —
+    // scope it to the page, not to `assignUserModal`.
+    this.assignUserModalSearchResult = page.getByRole('listbox');
     this.assignUserModalCancelButton = this.assignUserModal.getByRole(
       'button',
       {
@@ -89,20 +96,46 @@ export class IdentityRolesDetailsPage {
     email: string;
     password: string;
   }) {
-    await this.assignUserButton.click();
-    await expect(this.assignUserModal).toBeVisible();
-    await this.assignUserModalSearchField.fill(user.username);
-    await this.assignUserModalSearchResult.getByText(user.name).click();
-    await this.assignUserModalAssignButton.click();
-    await expect(this.assignUserModal).toBeHidden();
+    // The assign-user modal's cmdk search is debounced + server-driven, and
+    // the option for a just-created user is eventually consistent: a single
+    // query can return empty and get cached by react-query, so simply waiting
+    // longer on one search does not recover. Mirror the authorizations owner
+    // search (#51442) remedy: on failure, reload to reset the query cache and
+    // retry the whole open-search-select flow.
+    const maxRetries = 3;
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await this.assignUserButton.click();
+        await expect(this.assignUserModal).toBeVisible();
+        await this.assignUserModalSearchField.fill(user.username);
+        // Match on the username: it is the option's title and is always
+        // present regardless of the user's display name.
+        const option = this.assignUserModalSearchResult
+          .getByRole('option')
+          .filter({hasText: user.username})
+          .first();
+        await expect(option).toBeVisible({timeout: 30000});
+        await option.click({timeout: 20000, force: true});
+        await this.assignUserModalAssignButton.click();
+        await expect(this.assignUserModal).toBeHidden();
 
-    const item = this.assignedUsersList.getByRole('cell', {
-      name: user.email,
-    });
-
-    await waitForItemInList(this.page, item, {
-      emptyStateLocator: this.emptyState,
-    });
+        const item = this.assignedUsersList.getByRole('cell', {
+          name: user.email,
+        });
+        await waitForItemInList(this.page, item, {
+          emptyStateLocator: this.emptyState,
+        });
+        return;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt < maxRetries) {
+          await sleep(10000);
+          await this.page.reload();
+        }
+      }
+    }
+    throw lastError;
   }
 
   async unassignUserFromRole(userName: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
@@ -96,46 +96,57 @@ export class IdentityRolesDetailsPage {
     email: string;
     password: string;
   }) {
-    // The assign-user modal's cmdk search is debounced + server-driven, and
-    // the option for a just-created user is eventually consistent: a single
-    // query can return empty and get cached by react-query, so simply waiting
-    // longer on one search does not recover. Mirror the authorizations owner
-    // search (#51442) remedy: on failure, reload to reset the query cache and
-    // retry the whole open-search-select flow.
+    const assignedCell = this.assignedUsersList.getByRole('cell', {
+      name: user.email,
+    });
+
+    // The assign-user modal's cmdk search is debounced + server-driven, and the
+    // option for a just-created user is eventually consistent: a single query
+    // can return empty and get cached by react-query, so waiting longer on one
+    // search does not recover. Mirror the authorizations owner search (#51442)
+    // remedy and reload between attempts to reset the query cache.
+    //
+    // Only the modal interaction is retried, and only while the user is still
+    // unassigned: `AssignMembersModal` passes the assigned users as `excluded`,
+    // so once a submit has landed the option is gone from the results for good
+    // and re-running the search could only ever fail.
     const maxRetries = 3;
-    let lastError: Error | null = null;
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        await this.assignUserButton.click();
-        await expect(this.assignUserModal).toBeVisible();
-        await this.assignUserModalSearchField.fill(user.username);
-        // Match on the username: it is the option's title and is always
-        // present regardless of the user's display name.
-        const option = this.assignUserModalSearchResult
-          .getByRole('option')
-          .filter({hasText: user.username})
-          .first();
-        await expect(option).toBeVisible({timeout: 30000});
-        await option.click({timeout: 20000, force: true});
-        await this.assignUserModalAssignButton.click();
-        await expect(this.assignUserModal).toBeHidden();
-
-        const item = this.assignedUsersList.getByRole('cell', {
-          name: user.email,
-        });
-        await waitForItemInList(this.page, item, {
-          emptyStateLocator: this.emptyState,
-        });
-        return;
+        await this.selectUserInAssignModal(user.username);
+        break;
       } catch (error) {
-        lastError = error as Error;
-        if (attempt < maxRetries) {
-          await sleep(10000);
-          await this.page.reload();
+        if (attempt === maxRetries) {
+          throw error;
+        }
+        await sleep(10000);
+        await this.page.reload();
+        if (await assignedCell.isVisible()) {
+          break;
         }
       }
     }
-    throw lastError;
+
+    await waitForItemInList(this.page, assignedCell, {
+      timeout: 60000,
+      emptyStateLocator: this.emptyState,
+    });
+  }
+
+  private async selectUserInAssignModal(username: string): Promise<void> {
+    await this.assignUserButton.click();
+    await expect(this.assignUserModal).toBeVisible();
+    await this.assignUserModalSearchField.fill(username);
+    // Match on the username: `EntitySearchMultiSelect` passes `getId` as the
+    // option title, so it is always present regardless of the display name.
+    const option = this.assignUserModalSearchResult
+      .getByRole('option')
+      .filter({hasText: username})
+      .first();
+    await expect(option).toBeVisible({timeout: 30000});
+    await option.click({timeout: 20000});
+    await this.assignUserModalAssignButton.click();
+    await expect(this.assignUserModal).toBeHidden();
   }
 
   async unassignUserFromRole(userName: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesPage.ts
@@ -48,8 +48,15 @@ export class IdentityRolesPage {
     });
     this.editRoleButton = (rowName) =>
       this.rolesList.getByRole('row', {name: rowName}).getByLabel('Edit role');
+    // The design-system list renders the destructive row action as a button
+    // labelled by its visible text, not by `aria-label` (`entityListV2` sets
+    // `iconOnly: !!Icon && !isDangerous`), so match it by role and accessible
+    // name, as `IdentityUsersPage.deleteUserButton` already does. Edit stays on
+    // `getByLabel` because it is icon-only and keeps its `aria-label`.
     this.deleteRoleButton = (rowName) =>
-      this.rolesList.getByRole('row', {name: rowName}).getByLabel('Delete');
+      this.rolesList
+        .getByRole('row', {name: rowName})
+        .getByRole('button', {name: 'Delete', exact: true});
     this.createRoleModal = page.getByRole('dialog', {
       name: 'Create role',
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
@@ -25,7 +25,14 @@ export class LoginPage {
     this.usernameInput = page.getByRole('textbox', {name: 'Username'});
     this.passwordInput = page.getByRole('textbox', {name: 'password'});
     this.loginButton = page.getByRole('button', {name: 'Login'});
-    this.errorMessage = page.locator('.cds--inline-notification__title');
+    // The admin/login page renders its error via Carbon's InlineNotification
+    // (`.cds--inline-notification__title`) on the legacy design system and via
+    // the new design system's Alert (`[data-slot="alert-title"]`) once
+    // IS_NEW_DESIGN_SYSTEM_ENABLED is on. Match either so the assertion works
+    // regardless of which design system the build ships.
+    this.errorMessage = page.locator(
+      '.cds--inline-notification__title, [data-slot="alert-title"]',
+    );
     this.invalidCredentialsError = page
       .getByRole('alert')
       .getByText(/Username and [Pp]assword do(?: not|n't) match/);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
@@ -14,7 +14,6 @@ export class LoginPage {
   readonly usernameInput: Locator;
   readonly passwordInput: Locator;
   readonly loginButton: Locator;
-  readonly errorMessage: Locator;
   readonly invalidCredentialsError: Locator;
   readonly tasklistHeading: Locator;
   readonly operateHeading: Locator;
@@ -25,14 +24,12 @@ export class LoginPage {
     this.usernameInput = page.getByRole('textbox', {name: 'Username'});
     this.passwordInput = page.getByRole('textbox', {name: 'password'});
     this.loginButton = page.getByRole('button', {name: 'Login'});
-    // The admin/login page renders its error via Carbon's InlineNotification
-    // (`.cds--inline-notification__title`) on the legacy design system and via
-    // the new design system's Alert (`[data-slot="alert-title"]`) once
-    // IS_NEW_DESIGN_SYSTEM_ENABLED is on. Match either so the assertion works
-    // regardless of which design system the build ships.
-    this.errorMessage = page.locator(
-      '.cds--inline-notification__title, [data-slot="alert-title"]',
-    );
+    // Carbon's InlineNotification (Operate, Tasklist) and the new design
+    // system's Alert (admin) both expose `role="alert"`, so match on the role
+    // and the message rather than on either framework's markup. The text
+    // filter also matters: the Operate login page renders an empty alert
+    // region before any error, so the role alone can resolve to more than one
+    // element.
     this.invalidCredentialsError = page
       .getByRole('alert')
       .getByText(/Username and [Pp]assword do(?: not|n't) match/);
@@ -106,8 +103,6 @@ export class LoginPage {
   }
 
   async expectInvalidCredentialsError(): Promise<void> {
-    await expect(this.errorMessage).toContainText(
-      /Username and [Pp]assword do(?: not|n't) match/,
-    );
+    await expect(this.invalidCredentialsError).toBeVisible();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -35,7 +35,6 @@ class OperateProcessesPage {
   readonly continueMigrationDialogButton: Locator;
   readonly cancelProcessInstanceButton: Locator;
   readonly cancelProcessInstanceDialogButton: Locator;
-  readonly singleOperationSpinner: Locator;
   readonly diagram: InstanceType<typeof OperateDiagramPage>;
   readonly processActiveCheckbox: Locator;
   readonly processCompletedCheckbox: Locator;
@@ -138,13 +137,6 @@ class OperateProcessesPage {
     this.cancelProcessInstanceDialogButton = page
       .getByRole('dialog')
       .getByRole('button', {name: 'Apply'});
-    // The per-row operation spinner in the instances list is a Carbon
-    // InlineLoading (no data-testid) rendered only while a single operation is
-    // in progress; scope to the list so it never matches the incidents-table
-    // spinner on the instance detail page.
-    this.singleOperationSpinner = page
-      .getByTestId('data-list')
-      .locator('.cds--inline-loading');
     this.processActiveCheckbox = page
       .locator('label')
       .filter({hasText: 'Active'});
@@ -319,6 +311,19 @@ class OperateProcessesPage {
     return this.page.getByRole('button', {
       name: `Cancel Instance ${processInstanceKey}`,
     });
+  }
+
+  // The per-row operation spinner is a Carbon InlineLoading (no data-testid)
+  // rendered while an operation on that instance is in progress. Each scheduled
+  // operation also leaves an `aria-live` announcer with the same
+  // `.cds--inline-loading` class in the data-list, so a list-wide selector
+  // matches every instance that ever had an operation and trips strict mode.
+  // Scope to the target instance's row so exactly one element is matched.
+  getSingleOperationSpinner(processInstanceKey: string): Locator {
+    return OperateProcessesPage.getRowByProcessInstanceKey(
+      this.page,
+      processInstanceKey,
+    ).locator('.cds--inline-loading');
   }
 
   async clickRetryInstanceButton(processInstanceKey: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -20,6 +20,7 @@ import {
   createCancellationBatch,
   cancelBatchOperation,
   createCompletedBatchOperation,
+  suspendBatchOperation,
   expectBatchState,
 } from '@requestHelpers';
 /* eslint-disable playwright/expect-expect */
@@ -42,11 +43,27 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
   }) => {
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        // 30 instances (matching the suspend suite) keep the batch running
-        // long enough to cancel before it completes; a 10-instance batch can
-        // finish first, making the cancel return 404 instead of 204.
         return createCancellationBatch(request, 30);
       });
+
+    // A CANCEL batch over these instances reaches COMPLETED in ~2-4s
+    // regardless of the instance count (the engine terminates the waiting
+    // service-task instances in parallel, so more instances do not lengthen
+    // the run). Racing a cancel against a still-ACTIVE batch is therefore
+    // inherently flaky: under this spec's parallel load the batch can finish
+    // first, and cancelling a COMPLETED batch correctly returns 404 — which
+    // the 240s retry can never recover from. Suspend the batch first to freeze
+    // it in an in-progress state (the same mechanism the sibling suspend suite
+    // relies on) so the subsequent cancel deterministically exercises the
+    // 204 -> CANCELED path.
+    await test.step('Suspend batch operation to keep it in progress', async () => {
+      const res = await suspendBatchOperation(request, key);
+      await assertStatusCode(res, 204);
+    });
+
+    await test.step('Wait for suspended state', async () => {
+      await expectBatchState(request, key, 'SUSPENDED');
+    });
 
     await test.step('Cancel batch operation', async () => {
       const res = await cancelBatchOperation(request, key);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -20,7 +20,6 @@ import {
   createCancellationBatch,
   cancelBatchOperation,
   createCompletedBatchOperation,
-  suspendBatchOperation,
   expectBatchState,
 } from '@requestHelpers';
 /* eslint-disable playwright/expect-expect */
@@ -41,29 +40,18 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
   test('Cancel active batch operation returns 204 and status becomes CANCELED', async ({
     request,
   }) => {
+    // Use a large instance count so the batch stays ACTIVE long enough for the
+    // cancel command to catch it in flight. Cancellation time scales with the
+    // instance count: a 3-instance batch completes in ~2.5s, so a 30-instance
+    // batch can reach a terminal state between the accepted create and the
+    // first cancel retry, and cancelling a finished batch correctly returns a
+    // permanent 404 that the 240s retry budget cannot recover from. Mirrors the
+    // instance count the sibling suspend suite already relies on for the same
+    // reason.
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        return createCancellationBatch(request, 30);
+        return createCancellationBatch(request, 500);
       });
-
-    // A CANCEL batch over these instances reaches COMPLETED in ~2-4s
-    // regardless of the instance count (the engine terminates the waiting
-    // service-task instances in parallel, so more instances do not lengthen
-    // the run). Racing a cancel against a still-ACTIVE batch is therefore
-    // inherently flaky: under this spec's parallel load the batch can finish
-    // first, and cancelling a COMPLETED batch correctly returns 404 — which
-    // the 240s retry can never recover from. Suspend the batch first to freeze
-    // it in an in-progress state (the same mechanism the sibling suspend suite
-    // relies on) so the subsequent cancel deterministically exercises the
-    // 204 -> CANCELED path.
-    await test.step('Suspend batch operation to keep it in progress', async () => {
-      const res = await suspendBatchOperation(request, key);
-      await assertStatusCode(res, 204);
-    });
-
-    await test.step('Wait for suspended state', async () => {
-      await expectBatchState(request, key, 'SUSPENDED');
-    });
 
     await test.step('Cancel batch operation', async () => {
       const res = await cancelBatchOperation(request, key);
@@ -78,12 +66,11 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
   test('Cancel batch operation twice fails on second request', async ({
     request,
   }) => {
+    // Same reason as the test above: the first cancel has to land while the
+    // batch is still ACTIVE, and 30 instances can finish before it does.
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        // 30 instances (matching the suspend suite) keep the batch running
-        // long enough to cancel before it completes; a 10-instance batch can
-        // finish first, making the cancel return 404 instead of 204.
-        return createCancellationBatch(request, 30);
+        return createCancellationBatch(request, 500);
       });
 
     await test.step('Send first cancel request', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -59,9 +59,18 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   test('Suspend batch operation twice fails on second request, finally resumes', async ({
     request,
   }) => {
+    // Use a large instance count so the batch stays ACTIVE long enough for the
+    // suspend command to catch it in flight and be observed as SUSPENDED before
+    // it reaches a terminal state. 30 instances can finish first, making
+    // /suspension return a permanent 404 that the retry budget cannot recover
+    // from. Same remedy as the 500-instance tests below.
     const key =
       await test.step('Create cancelable batch operation', async () => {
-        return createCancellationBatch(request, 30, 'batch_suspension_process');
+        return createCancellationBatch(
+          request,
+          500,
+          'batch_suspension_process',
+        );
       });
 
     await test.step('Suspend batch operation once', async () => {
@@ -141,8 +150,13 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   test('Suspend active batch operation returns 204 and status becomes SUSPENDED without resume', async ({
     request,
   }) => {
+    // Use a large instance count so the batch stays ACTIVE long enough for the
+    // suspend command to catch it in flight and be observed as SUSPENDED before
+    // it reaches a terminal state. 30 instances can finish first, making
+    // /suspension return a permanent 404 that the retry budget cannot recover
+    // from. Same remedy as the 500-instance tests below.
     const key = await test.step('Create cancel batch operation', async () => {
-      return createCancellationBatch(request, 30, 'batch_suspension_process');
+      return createCancellationBatch(request, 500, 'batch_suspension_process');
     });
 
     await test.step('Send suspend request', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -18,7 +18,10 @@ import {
   encode,
   assertForbiddenRequest,
 } from '../../../../utils/http';
-import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  defaultAssertionOptions,
+  extendedAssertionOptions,
+} from '../../../../utils/constants';
 import {
   createMammalProcessInstanceAndDeployMammalDecision,
   createUser,
@@ -137,7 +140,11 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
         expect(json.batchOperationType).toBe('DELETE_DECISION_INSTANCE');
         expect(json.operationsTotalCount).toBeGreaterThanOrEqual(2);
         expect(json.operationsCompletedCount).toBe(2);
-      }).toPass(defaultAssertionOptions);
+        // The completion counters reach the read API through the
+        // secondary-storage indexer, which lags behind the engine on a loaded
+        // shared cluster: the nightly saw 0 then 1 of 2 completed inside the
+        // 30s default budget.
+      }).toPass(extendedAssertionOptions);
     });
 
     await test.step('Verify Decision Instance is Deleted', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
@@ -28,9 +28,7 @@ test.describe.parallel('login page', () => {
     await loginPage.login('demo', 'wrong-password');
     await expect(page).toHaveURL(`${relativizePath(Paths.login('admin'))}`);
 
-    await expect(loginPage.errorMessage).toContainText(
-      "Username and password don't match",
-    );
+    await expect(loginPage.invalidCredentialsError).toBeVisible();
 
     await expect(page).toHaveURL(`${relativizePath(Paths.login('admin'))}`);
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/roles.spec.ts
@@ -56,8 +56,11 @@ test.describe.serial('roles CRUD', () => {
     await expect(identityRolesPage.createRoleModal).toContainText(
       'Please enter a valid role ID',
     );
+    // The Create role modal now renders on the new design system, whose Input
+    // marks a failed field with `aria-invalid` instead of Carbon's
+    // `data-invalid`.
     await expect(identityRolesPage.idField).toHaveAttribute(
-      'data-invalid',
+      'aria-invalid',
       'true',
     );
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -96,8 +96,11 @@ test.describe('Operations', () => {
         instance.processInstanceKey,
       );
 
-      await expect(operateProcessesPage.singleOperationSpinner).toBeVisible();
-      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden({
+      const operationSpinner = operateProcessesPage.getSingleOperationSpinner(
+        instance.processInstanceKey,
+      );
+      await expect(operationSpinner).toBeVisible();
+      await expect(operationSpinner).toBeHidden({
         timeout: 60000,
       });
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/login.spec.ts
@@ -40,9 +40,7 @@ test.describe.parallel('Login Tests', () => {
   }) => {
     await loginPage.login('demo', 'wrong');
     await expect(page).toHaveURL('/tasklist/login');
-    await expect(loginPage.errorMessage).toContainText(
-      'Username and password do not match',
-    );
+    await expect(loginPage.invalidCredentialsError).toBeVisible();
 
     const results = await makeAxeBuilder().analyze();
 


### PR DESCRIPTION
Fixes six orchestration-cluster nightly failures on `main`. All are test drift, **not** product regressions — verified against a fresh local Docker (Elasticsearch, tasklist v2) stack.

## Root cause & fix

### Identity — new design system (shadcn) migration
The admin app now renders on the Camunda design system instead of Carbon on several surfaces:

- **Login error** no longer renders Carbon's `.cds--inline-notification__title`; the design system's Alert carries the message in `[data-slot="alert-title"]`. Rather than widen the selector to a union of both markups, the assertions reuse `LoginPage.invalidCredentialsError`, which was already in the file and already proven on the Carbon surface by `tests/operate/login.spec.ts`. It matches `role="alert"` plus the message text, so it holds on both design systems and needs no edit the next time either changes. The text filter is load-bearing: the Operate login page renders an empty alert region before any error, so matching the role alone can resolve to more than one element. `errorMessage` had no callers left and is removed.
  - Fixes `tests/identity/login.spec.ts › Log in with invalid user account`
  - Fixes `tests/common-flows/identity-users-flows.spec.ts › Admin user can delete user`
- **Create role modal** Input marks an invalid field with `aria-invalid`, not Carbon's `data-invalid`.
  - Fixes `tests/identity/roles.spec.ts › tries to create a role with invalid id`
- **Roles list delete action**, uncovered by the fix above. `roles CRUD` is a `test.describe.serial` block, so the stale `data-invalid` assertion was short-circuiting it: on `main`, `tries to create a role with invalid id` failed and `creates a role` and `deletes a role` were **skipped and never ran** (visible as `-` in the nightly log). With the first test repaired the block runs to completion, and `deletes a role` fails the first time it has actually executed. So this is a latent failure the PR reveals, not one it introduces.

  The cause is the same design-system migration. The row's action cell holds an icon-only Edit button carrying `aria-label="Edit role"` and a destructive Delete button with an `aria-hidden` icon plus the visible text `Delete` and no aria-label — `entityListV2` sets `iconOnly: !!Icon && !isDangerous`, and `roles/ListV2.tsx` marks the delete item `isDangerous: true`. `getByLabel` matches only aria-label, aria-labelledby or an associated label, never text content, so the locator resolved to nothing. It now matches by role and accessible name, as `IdentityUsersPage.deleteUserButton` already does for the same list component. Sibling lists are deliberately untouched: groups and tenants have no `ListV2` variant, and their deletes plus users' and authorizations' all pass.
  - Fixes `tests/identity/roles.spec.ts › deletes a role`
- **Role detail assign-user modal** is now a cmdk combobox (“Search by Username or Name”) whose results render in a Radix popover that **portals as a sibling of the dialog** (DS #496) — so the listbox is scoped to the page, not the modal. This selector change is what fixes the failure; the nightly died on `locator.fill` against `getByRole('searchbox')`, before any assignment. The search is also debounced and eventually consistent, so the flow keeps a reload-and-retry (mirroring the authorizations owner search `#51442`) — but retries **only** the modal interaction, and stops as soon as the assigned-users table shows the user. Retrying the whole flow cannot work: `AssignMembersModal` passes the assigned users to `UserMultiSelect` as `excluded`, so once a submit has landed the option is absent from the results and any further attempt fails on the option locator, reporting that instead of the real error. The list wait moved out of the loop with a 60s budget, since its 10s default has to cover a full reload of the Identity SPA. The option click does not force: it is asserted visible on the line above, and `force` would skip the hit-target check that names the cause if the `pointer-events` workaround in `DropdownSearch.tsx` ever regressed.
  - Fixes `tests/identity/authorizations.spec.ts › create user authorization`

### Operate — accumulated `aria-live` announcers
Each scheduled operation leaves an `aria-live` announcer carrying the same `.cds--inline-loading` class in the data-list, so the list-wide spinner selector matched every instance that ever had an operation and tripped strict mode — 7 elements in the failing run, each for a different instance key. The spinner is now scoped to the target instance's row.
- Fixes `tests/operate/operations.spec.ts › Retry and cancel single instance`

### Batch API — cancel lands after the batch has already finished
The failure is a permanent 404: ten POSTs to `/batch-operations/{key}/cancellation`, all 404, the 240s retry budget expired, twice. The first cancel fired 132ms after the create returned, too early for the batch to be addressable; the next poll was 5.1s later, by which point the batch had finished and the 404 was permanent.

Cancellation time scales with the instance count. In the same run the `beforeAll` 3-instance batch went `startDate 01:49:00.128` → `endDate 01:49:02.655`, so ~2.5s for three instances, and a 30-instance batch therefore reaches a terminal state inside the first retry interval.

So the fix is the count, not the mechanism: `createCancellationBatch(request, 500)`. That is the same remedy and the same number the sibling suspend suite already uses for this exact race, documented in two comments in `batch-operations-suspend-api-tests.spec.ts`. Applied to `Cancel batch operation twice fails on second request` as well, since its first cancel has the same requirement and its comment claiming 30 instances are enough contradicted the sibling suite.

Suspending the batch first was considered and dropped. It races completion in the same window (suspend on a finished batch also 404s permanently, per `Suspend finished batch operation returns 404`), it would make this test a duplicate of the already-green `Suspend & Resume › Cancel suspended batch operation transitions to CANCELED`, and it would remove the suite's only coverage of cancelling an ACTIVE batch.
- Fixes `tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts › Cancel active batch operation returns 204 and status becomes CANCELED`

Note: a 500-instance batch cancelled mid-flight leaves more instances un-terminated than a 30-instance one. Both sibling 500-instance tests already do this and the api nightly runs against an ephemeral stack, so no teardown is added.

Two further batch failures surfaced in the post-rebase run and are fixed here too.

**The suspend side of the same race.** `Suspend active batch operation returns 204 and status becomes SUSPENDED without resume` failed in the profiles job while passing in all-in-one — a batch finishing before the suspend command lands, after which `/suspension` returns a permanent 404 the retry budget cannot recover from. Raised to 500 instances, the remedy this file already applies four times; two earlier commits (`keep cancellation batch active for suspend catch`, `stabilize batch suspend and dashboard error nightly failures`) fixed the same failure one test at a time as each surfaced. Also applied to `Suspend batch operation twice fails on second request`, which flaked locally the same way. `SUSPENDED, finally resumes` has the identical shape but no observed failure, so it is left alone, matching how this file has been maintained.
- Fixes `tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts › Suspend active batch operation returns 204 and status becomes SUSPENDED without resume`

**A completion poll that was too tight.** `Delete Decision Instance With Batch` failed on `operationsCompletedCount` — expected 2, observed 0, then 1 on retry, inside the 30s `defaultAssertionOptions` budget. The batch was executing, just not finishing in time: those counters reach the read API through the secondary-storage indexer, which lags the engine under contention. Switched to `extendedAssertionOptions` (90s), which documents itself for exactly this ("data that has to propagate through the secondary-storage indexer on a loaded shared cluster (e.g. post-batch ...)") and which `process-instance-create-batch-to-modify-api.spec.ts` already uses for a batch poll. The assertion is unchanged — still exactly 2 completed operations. Locally this poll measured 15.5s, 31.1s and 15.7s across three runs of the same suites, so it sits at the edge of the 30s budget and the observed spread alone crosses it.
- Fixes `tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts › Delete Decision Instance With Batch`

## Verification
Reproduced every failure unmodified, then confirmed green on a local ES + tasklist-v2 Docker stack:

- `batch-operations-cancel-api-tests.spec.ts` with `--repeat-each=5`: 30/30 expected, 0 unexpected, 0 flaky. The previously-failing test now completes in 17.2s against 466s failing; `Cancel batch operation twice` goes 6.5s → 12.0s.
- Whole `tests/api/v2/batch-operation/` directory: 33 passed. The one flaky result was the then-30-instance `Suspend batch operation twice fails on second request`, failing inside `suspendBatchOperation` — independent corroboration of the same root cause, and now raised to 500 as well.
- Full `api-tests` project locally: 1105 passed, 0 flaky, with the raised suspend tests at 11-12s and the decision batch delete poll at 15.7s.
- `tests/identity/login.spec.ts`, `tests/tasklist/login.spec.ts`, `tests/operate/login.spec.ts`: 17 passed, covering the error locator on all three login surfaces (admin on the design system, Tasklist and Operate on Carbon).
- `tests/identity/authorizations.spec.ts` and `tests/identity/roles.spec.ts` with `--repeat-each=3`: `create user authorization` 3/3 in 23.1s with no retry attempts consumed, `tries to create a role with invalid id` 3/3.
- Whole `tests/identity/` directory: no failures. `deletes a role` goes from failing on both attempts (32.7s, 32.8s) to passing in 3.8s with no retry, and the sibling row deletes stay green — groups 5.8s, authorizations 12.7s, tenants 5.1s, users 6.6s.
- On-demand run [33489339622](https://github.com/camunda/camunda/actions/runs/33489339622) on this branch: all four API jobs green, and every identity test this PR targets green (`Log in with invalid user account` 899ms, `Admin user can delete user` 19.2s, `create user authorization` 32.9s). `deletes a role` was the one identity failure there, which the commit above addresses.
- `npm run lint`: 0 errors, TestRail automation-id check clean.

## Known failures, out of scope

### Groups design-system drift — handled separately

Three tests fail on the current SNAPSHOT and are **not** addressed here:

- `tests/identity/groups.spec.ts › groups CRUD › tries to create a group with invalid id`
- `tests/identity/groups.spec.ts › Groups functionalities › As an Admin user can create a group with particular permissions and assign it to Test user`
- `tests/common-flows/identity-users-flows.spec.ts › Identity User Flows › New user can inherit permissions when assigned to a group`

They are the same two migration patterns this PR fixes for login, roles and authorizations, but for groups: `toHaveAttribute` expecting `"true"` where the design-system Input now sets `aria-invalid` instead of Carbon's `data-invalid`, and `IdentityGroupsPage.assignUserToGroup` timing out on `getByRole('searchbox')` where the assign-user field is now a cmdk combobox.

Groups was migrated on `main` on 2026-08-31 (`7baee2bd6`, `a08f244f2`, `3259ba32b`, `3e0644403`), after this branch was cut, and no test-suite update shipped with it. Rebasing does not resolve it: the rebase onto `1efd05f7` pulled those product commits in but changed nothing under `qa/c8-orchestration-cluster-e2e-test-suite/` except `package-lock.json`. Keeping the groups locators in a separate change keeps this PR reviewable.

Note `groups CRUD` is `test.describe.serial`, so the invalid-id failure also skips `creates a group`, `edits a group` and `deletes a group` — the same masking that hid `deletes a role` before this PR.

### Also unrelated to this PR

- `tests/operate/processInstancesFilters.spec.ts › Variable filtering with single and multiple values` and `tests/tasklist/task-details.spec.ts › task completion with number form by buttons`, plus flaky `operate/dashboard`, `operate/miSubprocessModifications` and `operate/operations.spec.ts › Retry and cancel single instance`. All present in `main` nightlies without this branch.
- `tests/api/v2/batch-operation/batch-operations-search-api.spec.ts › Search Batch Operations Filter By State And Type` asserts `items).toHaveLength(page.totalItems)` without setting a page limit, so it only holds while fewer than 100 completed cancel batches exist. It passes on the ephemeral CI stacks and failed only on a local stack that had accumulated 134 of them over several hours. A latent bug in that test, not touched here.

## Links
- Nightly e2e run: https://github.com/camunda/camunda/actions/runs/33460840026
- Nightly api run: https://github.com/camunda/camunda/actions/runs/33459987049
- Triage run: https://github.com/camunda/camunda/actions/runs/33467231469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## On-demand verification runs
- https://github.com/camunda/camunda/actions/runs/33471423338
- https://github.com/camunda/camunda/actions/runs/33489339622
- https://github.com/camunda/camunda/actions/runs/33495564880
- https://github.com/camunda/camunda/actions/runs/33498072987 (after rebase onto `1efd05f7`)
- https://github.com/camunda/camunda/actions/runs/33507137917 - every test this PR targets green, including `deletes a role`; both H2/RDBMS API jobs green. Remaining failures are the out-of-scope ones listed above.



