### PR TITLE
feat: remove filtering from non-filterable search requests

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -80,6 +80,54 @@
           "old": "method SELF io.camunda.client.api.search.request.TypedPageableRequest<SELF extends io.camunda.client.api.search.request.TypedPageableRequest<SELF>>::page(io.camunda.client.api.search.request.SearchRequestPage)",
           "justification": "The page() method signature changed to accept typed pagination models (via SearchPagination<P>) instead of the legacy SearchRequestPage. The method is now available through TypedSearchRequest with type-safe pagination model parameters (AnyPage, OffsetPage, CursorForwardPage, etc.)."
         },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.ClientsByGroupSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.ClientsByRoleSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.ClientsByTenantSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.GroupsByRoleSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.GroupsByTenantSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.UsersByGroupSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.UsersByRoleSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method SELF io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF extends io.camunda.client.api.search.request.TypedFilterableRequest<F, SELF>>::filter(F) @ io.camunda.client.api.search.request.UsersByTenantSearchRequest",
+          "justification": "The membership / nested sub-collection search request no longer extends TypedFilterableRequest because its REST contract does not expose a filter property (the endpoint is scoped by a path parameter, so filtering never applied). The removed filter(...) methods previously threw UnsupportedOperationException at runtime and now fail at compile time instead."
+        },
 
         {
           "ignore": true,

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByGroupSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByGroupSearchRequest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.sort.ClientSort;
 
 public interface ClientsByGroupSearchRequest
-    extends TypedSearchRequest<ClientFilter, ClientSort, AnyPage, ClientsByGroupSearchRequest>,
+    extends TypedSortableRequest<ClientSort, ClientsByGroupSearchRequest>,
+        TypedPageableRequest<AnyPage, ClientsByGroupSearchRequest>,
         FinalSearchRequestStep<Client> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByRoleSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByRoleSearchRequest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.sort.ClientSort;
 
 public interface ClientsByRoleSearchRequest
-    extends TypedSearchRequest<ClientFilter, ClientSort, AnyPage, ClientsByRoleSearchRequest>,
+    extends TypedSortableRequest<ClientSort, ClientsByRoleSearchRequest>,
+        TypedPageableRequest<AnyPage, ClientsByRoleSearchRequest>,
         FinalSearchRequestStep<Client> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByTenantSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/ClientsByTenantSearchRequest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.sort.ClientSort;
 
 public interface ClientsByTenantSearchRequest
-    extends TypedSearchRequest<ClientFilter, ClientSort, AnyPage, ClientsByTenantSearchRequest>,
+    extends TypedSortableRequest<ClientSort, ClientsByTenantSearchRequest>,
+        TypedPageableRequest<AnyPage, ClientsByTenantSearchRequest>,
         FinalSearchRequestStep<Client> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByRoleSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByRoleSearchRequest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.RoleGroupFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.RoleGroup;
 import io.camunda.client.api.search.sort.RoleGroupSort;
 
 public interface GroupsByRoleSearchRequest
-    extends TypedSearchRequest<RoleGroupFilter, RoleGroupSort, AnyPage, GroupsByRoleSearchRequest>,
+    extends TypedSortableRequest<RoleGroupSort, GroupsByRoleSearchRequest>,
+        TypedPageableRequest<AnyPage, GroupsByRoleSearchRequest>,
         FinalSearchRequestStep<RoleGroup> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByTenantSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByTenantSearchRequest.java
@@ -15,12 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.TenantGroupFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.TenantGroup;
 import io.camunda.client.api.search.sort.TenantGroupSort;
 
 public interface GroupsByTenantSearchRequest
-    extends TypedSearchRequest<
-            TenantGroupFilter, TenantGroupSort, AnyPage, GroupsByTenantSearchRequest>,
+    extends TypedSortableRequest<TenantGroupSort, GroupsByTenantSearchRequest>,
+        TypedPageableRequest<AnyPage, GroupsByTenantSearchRequest>,
         FinalSearchRequestStep<TenantGroup> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/UsersByGroupSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/UsersByGroupSearchRequest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.GroupUserFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.sort.GroupUserSort;
 
 public interface UsersByGroupSearchRequest
-    extends TypedSearchRequest<GroupUserFilter, GroupUserSort, AnyPage, UsersByGroupSearchRequest>,
+    extends TypedSortableRequest<GroupUserSort, UsersByGroupSearchRequest>,
+        TypedPageableRequest<AnyPage, UsersByGroupSearchRequest>,
         FinalSearchRequestStep<GroupUser> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/UsersByRoleSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/UsersByRoleSearchRequest.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.RoleUserFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.RoleUser;
 import io.camunda.client.api.search.sort.RoleUserSort;
 
 public interface UsersByRoleSearchRequest
-    extends TypedSearchRequest<RoleUserFilter, RoleUserSort, AnyPage, UsersByRoleSearchRequest>,
+    extends TypedSortableRequest<RoleUserSort, UsersByRoleSearchRequest>,
+        TypedPageableRequest<AnyPage, UsersByRoleSearchRequest>,
         FinalSearchRequestStep<RoleUser> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/UsersByTenantSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/UsersByTenantSearchRequest.java
@@ -15,12 +15,11 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.filter.TenantUserFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.client.api.search.sort.TenantUserSort;
 
 public interface UsersByTenantSearchRequest
-    extends TypedSearchRequest<
-            TenantUserFilter, TenantUserSort, AnyPage, UsersByTenantSearchRequest>,
+    extends TypedSortableRequest<TenantUserSort, UsersByTenantSearchRequest>,
+        TypedPageableRequest<AnyPage, UsersByTenantSearchRequest>,
         FinalSearchRequestStep<TenantUser> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByGroupSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.clientS
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
@@ -75,18 +74,6 @@ public class ClientsByGroupSearchRequestImpl
         SearchResponseMapper::toGroupClientsResponse,
         result);
     return result;
-  }
-
-  @Override
-  public ClientsByGroupSearchRequest filter(final ClientFilter value) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public ClientsByGroupSearchRequest filter(final Consumer<ClientFilter> fn) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByRoleSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.clientS
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
@@ -75,18 +74,6 @@ public class ClientsByRoleSearchRequestImpl
         SearchResponseMapper::toClientsResponse,
         result);
     return result;
-  }
-
-  @Override
-  public ClientsByRoleSearchRequest filter(final ClientFilter value) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public ClientsByRoleSearchRequest filter(final Consumer<ClientFilter> fn) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/ClientsByTenantSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.clientS
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
@@ -75,18 +74,6 @@ public class ClientsByTenantSearchRequestImpl
         SearchResponseMapper::toTenantClientsResponse,
         result);
     return result;
-  }
-
-  @Override
-  public ClientsByTenantSearchRequest filter(final ClientFilter value) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public ClientsByTenantSearchRequest filter(final Consumer<ClientFilter> fn) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.roleGro
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.RoleGroupFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
@@ -75,18 +74,6 @@ public class GroupsByRoleSearchRequestImpl
         SearchResponseMapper::toRoleGroupsResponse,
         result);
     return result;
-  }
-
-  @Override
-  public GroupsByRoleSearchRequest filter(final RoleGroupFilter value) {
-    // this command does not support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public GroupsByRoleSearchRequest filter(final Consumer<RoleGroupFilter> fn) {
-    // this command does not support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByTenantSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.tenantG
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.TenantGroupFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
@@ -75,18 +74,6 @@ public class GroupsByTenantSearchRequestImpl
         SearchResponseMapper::toTenantGroupsResponse,
         result);
     return result;
-  }
-
-  @Override
-  public GroupsByTenantSearchRequest filter(final TenantGroupFilter value) {
-    // this command does not support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public GroupsByTenantSearchRequest filter(final Consumer<TenantGroupFilter> fn) {
-    // this command does not support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByGroupSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.groupUs
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.GroupUserFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.UsersByGroupSearchRequest;
@@ -75,18 +74,6 @@ public class UsersByGroupSearchRequestImpl
         SearchResponseMapper::toGroupUsersResponse,
         result);
     return result;
-  }
-
-  @Override
-  public UsersByGroupSearchRequest filter(final GroupUserFilter value) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public UsersByGroupSearchRequest filter(final Consumer<GroupUserFilter> fn) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByRoleSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.roleUse
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.RoleUserFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.UsersByRoleSearchRequest;
@@ -75,18 +74,6 @@ public class UsersByRoleSearchRequestImpl
         SearchResponseMapper::toRoleUsersResponse,
         result);
     return result;
-  }
-
-  @Override
-  public UsersByRoleSearchRequest filter(final RoleUserFilter value) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public UsersByRoleSearchRequest filter(final Consumer<RoleUserFilter> fn) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByTenantSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByTenantSearchRequestImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.client.api.search.request.SearchRequestBuilders.tenantU
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
-import io.camunda.client.api.search.filter.TenantUserFilter;
 import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.UsersByTenantSearchRequest;
@@ -75,18 +74,6 @@ public class UsersByTenantSearchRequestImpl
         SearchResponseMapper::toTenantUsersResponse,
         result);
     return result;
-  }
-
-  @Override
-  public UsersByTenantSearchRequest filter(final TenantUserFilter value) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
-  }
-
-  @Override
-  public UsersByTenantSearchRequest filter(final Consumer<TenantUserFilter> fn) {
-    // This command doesn't support filtering
-    throw new UnsupportedOperationException("This command does not support filtering");
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -20,8 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.search.filter.ClientFilter;
-import io.camunda.client.api.search.filter.GroupUserFilter;
 import io.camunda.client.api.search.sort.ClientSort;
 import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.api.search.sort.GroupUserSort;
@@ -98,27 +96,6 @@ public class GroupSearchTest extends ClientRestTest {
     final LoggedRequest request = gatewayService.getLastRequest();
     assertThat(request.getUrl()).isEqualTo("/v2/groups/groupId/users/search");
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingUsersByGroup() {
-    assertThatThrownBy(
-            () -> client.newUsersByGroupSearchRequest(GROUP_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingUsersByGroup() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUsersByGroupSearchRequest(GROUP_ID)
-                    .filter(new GroupUserFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 
   @Test
@@ -202,26 +179,5 @@ public class GroupSearchTest extends ClientRestTest {
     final String requestBody = lastRequest.getBodyAsString();
 
     assertThat(requestBody).contains("\"sort\":[{\"field\":\"clientId\",\"order\":\"DESC\"}]");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingClientsByGroup() {
-    assertThatThrownBy(
-            () -> client.newClientsByGroupSearchRequest(GROUP_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingClientsByGroup() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newClientsByGroupSearchRequest(GROUP_ID)
-                    .filter(new ClientFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.search.filter.RoleGroupFilter;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -62,26 +61,5 @@ public class GroupsByRoleSearchRequestTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newGroupsByRoleSearchRequest(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingGroupsByRole() {
-    assertThatThrownBy(
-            () -> client.newGroupsByRoleSearchRequest(ROLE_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingGroupsByRole() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newGroupsByRoleSearchRequest(ROLE_ID)
-                    .filter(new RoleGroupFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.api.search.sort.ClientSort;
 import io.camunda.client.api.search.sort.RoleSort;
 import io.camunda.client.protocol.rest.ProblemDetail;
@@ -79,27 +78,6 @@ public class SearchRoleTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newClientsByRoleSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be empty");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingClientsByRole() {
-    assertThatThrownBy(
-            () -> client.newClientsByRoleSearchRequest(ROLE_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingClientsByRole() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newClientsByRoleSearchRequest(ROLE_ID)
-                    .filter(new ClientFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/role/UsersByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/UsersByRoleSearchRequestTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.search.filter.RoleUserFilter;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -61,26 +60,5 @@ public class UsersByRoleSearchRequestTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newUsersByRoleSearchRequest(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingUsersByRole() {
-    assertThatThrownBy(
-            () -> client.newUsersByRoleSearchRequest(ROLE_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingUsersByRole() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUsersByRoleSearchRequest(ROLE_ID)
-                    .filter(new RoleUserFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/search/FilterTypeSafetyTest.java
+++ b/clients/java/src/test/java/io/camunda/client/search/FilterTypeSafetyTest.java
@@ -76,7 +76,7 @@ public class FilterTypeSafetyTest {
           RolesByTenantSearchRequest.class);
 
   @Test
-  void nonFilterableRequestsShouldNotExtendTypedFilterableRequest() {
+  void shouldNotExtendTypedFilterableRequestForNonFilterableRequests() {
     for (final Class<?> request : NON_FILTERABLE_REQUESTS) {
       assertThat(TypedFilterableRequest.class.isAssignableFrom(request))
           .as("%s must not extend TypedFilterableRequest", request.getSimpleName())
@@ -85,7 +85,7 @@ public class FilterTypeSafetyTest {
   }
 
   @Test
-  void nonFilterableRequestsShouldNotExposeAFilterMethod() {
+  void shouldNotExposeFilterMethodForNonFilterableRequests() {
     for (final Class<?> request : NON_FILTERABLE_REQUESTS) {
       assertThat(hasFilterMethod(request))
           .as("%s must not expose a filter(...) method", request.getSimpleName())
@@ -94,7 +94,7 @@ public class FilterTypeSafetyTest {
   }
 
   @Test
-  void nonFilterableRequestsShouldStillSupportSortingAndPagination() {
+  void shouldSupportSortingAndPaginationForNonFilterableRequests() {
     for (final Class<?> request : NON_FILTERABLE_REQUESTS) {
       assertThat(TypedSortableRequest.class.isAssignableFrom(request))
           .as("%s must still support sorting", request.getSimpleName())
@@ -106,7 +106,7 @@ public class FilterTypeSafetyTest {
   }
 
   @Test
-  void filterableRequestsShouldStillExposeFiltering() {
+  void shouldExposeFilteringForFilterableRequests() {
     for (final Class<?> request : FILTERABLE_REQUESTS) {
       assertThat(TypedFilterableRequest.class.isAssignableFrom(request))
           .as("%s must keep extending TypedFilterableRequest", request.getSimpleName())

--- a/clients/java/src/test/java/io/camunda/client/search/FilterTypeSafetyTest.java
+++ b/clients/java/src/test/java/io/camunda/client/search/FilterTypeSafetyTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.search.request.ClientsByGroupSearchRequest;
+import io.camunda.client.api.search.request.ClientsByRoleSearchRequest;
+import io.camunda.client.api.search.request.ClientsByTenantSearchRequest;
+import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
+import io.camunda.client.api.search.request.GroupsByTenantSearchRequest;
+import io.camunda.client.api.search.request.MappingRulesByGroupSearchRequest;
+import io.camunda.client.api.search.request.MappingRulesByRoleSearchRequest;
+import io.camunda.client.api.search.request.MappingRulesByTenantSearchRequest;
+import io.camunda.client.api.search.request.RolesByGroupSearchRequest;
+import io.camunda.client.api.search.request.RolesByTenantSearchRequest;
+import io.camunda.client.api.search.request.TypedFilterableRequest;
+import io.camunda.client.api.search.request.TypedPageableRequest;
+import io.camunda.client.api.search.request.TypedSortableRequest;
+import io.camunda.client.api.search.request.UsersByGroupSearchRequest;
+import io.camunda.client.api.search.request.UsersByRoleSearchRequest;
+import io.camunda.client.api.search.request.UsersByTenantSearchRequest;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that membership / nested sub-collection search requests, whose REST contract does not
+ * expose a {@code filter} property, do not offer filtering in the Java client either, while
+ * top-level collection requests reused by {@code …ByX} endpoints keep it.
+ *
+ * <p>These endpoints are scoped by a path parameter (the group / role / tenant id), so a membership
+ * listing has nothing left to filter on — it only offers sort + pagination. Removing {@code
+ * filter(...)} from these interfaces makes calling it a compile-time error instead of a runtime
+ * {@link UnsupportedOperationException}.
+ */
+public class FilterTypeSafetyTest {
+
+  /**
+   * Membership sub-collection requests that must NOT expose filtering (no REST filter property).
+   */
+  private static final List<Class<?>> NON_FILTERABLE_REQUESTS =
+      Arrays.asList(
+          UsersByGroupSearchRequest.class,
+          ClientsByGroupSearchRequest.class,
+          UsersByRoleSearchRequest.class,
+          ClientsByRoleSearchRequest.class,
+          GroupsByRoleSearchRequest.class,
+          UsersByTenantSearchRequest.class,
+          ClientsByTenantSearchRequest.class,
+          GroupsByTenantSearchRequest.class);
+
+  /**
+   * {@code …ByX} requests that reuse a filterable top-level REST schema and must keep filtering.
+   */
+  private static final List<Class<?>> FILTERABLE_REQUESTS =
+      Arrays.asList(
+          MappingRulesByGroupSearchRequest.class,
+          MappingRulesByRoleSearchRequest.class,
+          MappingRulesByTenantSearchRequest.class,
+          RolesByGroupSearchRequest.class,
+          RolesByTenantSearchRequest.class);
+
+  @Test
+  void nonFilterableRequestsShouldNotExtendTypedFilterableRequest() {
+    for (final Class<?> request : NON_FILTERABLE_REQUESTS) {
+      assertThat(TypedFilterableRequest.class.isAssignableFrom(request))
+          .as("%s must not extend TypedFilterableRequest", request.getSimpleName())
+          .isFalse();
+    }
+  }
+
+  @Test
+  void nonFilterableRequestsShouldNotExposeAFilterMethod() {
+    for (final Class<?> request : NON_FILTERABLE_REQUESTS) {
+      assertThat(hasFilterMethod(request))
+          .as("%s must not expose a filter(...) method", request.getSimpleName())
+          .isFalse();
+    }
+  }
+
+  @Test
+  void nonFilterableRequestsShouldStillSupportSortingAndPagination() {
+    for (final Class<?> request : NON_FILTERABLE_REQUESTS) {
+      assertThat(TypedSortableRequest.class.isAssignableFrom(request))
+          .as("%s must still support sorting", request.getSimpleName())
+          .isTrue();
+      assertThat(TypedPageableRequest.class.isAssignableFrom(request))
+          .as("%s must still support pagination", request.getSimpleName())
+          .isTrue();
+    }
+  }
+
+  @Test
+  void filterableRequestsShouldStillExposeFiltering() {
+    for (final Class<?> request : FILTERABLE_REQUESTS) {
+      assertThat(TypedFilterableRequest.class.isAssignableFrom(request))
+          .as("%s must keep extending TypedFilterableRequest", request.getSimpleName())
+          .isTrue();
+      assertThat(hasFilterMethod(request))
+          .as("%s must keep a filter(...) method", request.getSimpleName())
+          .isTrue();
+    }
+  }
+
+  private static boolean hasFilterMethod(final Class<?> request) {
+    return Arrays.stream(request.getMethods())
+        .map(Method::getName)
+        .anyMatch(name -> name.equals("filter"));
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchClientByTenantTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.search.filter.ClientFilter;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -71,26 +70,5 @@ public class SearchClientByTenantTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newClientsByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenSettingFilter() {
-    assertThatThrownBy(
-            () -> client.newClientsByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenSettingFiltering() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newClientsByTenantSearchRequest(TENANT_ID)
-                    .filter(new ClientFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchGroupsByTenantTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.search.filter.TenantGroupFilter;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -71,26 +70,5 @@ public class SearchGroupsByTenantTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newGroupsByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentAsFunction() {
-    assertThatThrownBy(
-            () -> client.newGroupsByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresent() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newGroupsByTenantSearchRequest(TENANT_ID)
-                    .filter(new TenantGroupFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/SearchUsersByTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/SearchUsersByTenantTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.camunda.client.api.search.filter.TenantUserFilter;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import org.junit.jupiter.api.Test;
@@ -62,26 +61,5 @@ public class SearchUsersByTenantTest extends ClientRestTest {
     assertThatThrownBy(() -> client.newUsersByTenantSearchRequest("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringFunctionIsPresentWhenSearchingUsersByTenant() {
-    assertThatThrownBy(
-            () -> client.newUsersByTenantSearchRequest(TENANT_ID).filter(fn -> {}).send().join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
-  }
-
-  @Test
-  void shouldRaiseExceptionWhenFilteringIsPresentWhenSearchingUsersByTenant() {
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUsersByTenantSearchRequest(TENANT_ID)
-                    .filter(new TenantUserFilter() {})
-                    .send()
-                    .join())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("This command does not support filtering");
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/compatibility/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/compatibility/EntityManager.java
@@ -15,7 +15,7 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.page.AnyPage;
-import io.camunda.client.api.search.request.TypedSearchRequest;
+import io.camunda.client.api.search.request.TypedPageableRequest;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.BaseResponse;
 import io.camunda.client.api.search.response.Client;
@@ -457,7 +457,7 @@ public final class EntityManager {
   private <
           T,
           R extends BaseResponse<T>,
-          S extends FinalCommandStep<R> & TypedSearchRequest<?, ?, AnyPage, S>>
+          S extends FinalCommandStep<R> & TypedPageableRequest<AnyPage, S>>
       SearchWithLimit<T> wrap(final S request) {
     return expected -> {
       final var response = request.page(p -> p.limit(expected)).send().join();

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.search.page.AnyPage;
-import io.camunda.client.api.search.request.TypedSearchRequest;
+import io.camunda.client.api.search.request.TypedPageableRequest;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.BaseResponse;
 import io.camunda.client.api.search.response.Client;
@@ -238,7 +238,7 @@ public final class EntityManager {
   private <
           T,
           R extends BaseResponse<T>,
-          S extends FinalCommandStep<R> & TypedSearchRequest<?, ?, AnyPage, S>>
+          S extends FinalCommandStep<R> & TypedPageableRequest<AnyPage, S>>
       SearchWithLimit<T> wrap(final S request) {
     return expected -> {
       final var response = request.page(p -> p.limit(expected)).send().join();


### PR DESCRIPTION
## Description

The search requests that do not support a filter in the REST contract should
not offer filtering in the Java client either. The **membership / nested
sub-collection** endpoints ("list the X that belong to a given group / role /
tenant") are scoped by a path parameter, so their REST schemas compose only
`sort` + pagination — there is **no `filter` property**. Yet the Java client
still inherited `filter(...)` via `TypedSearchRequest → TypedFilterableRequest`
and merely threw `UnsupportedOperationException` at runtime.

This PR inlines `TypedSearchRequest` for the 8 affected requests so they
implement `TypedSortableRequest` + `TypedPageableRequest` directly (dropping
`TypedFilterableRequest`), and removes the now-dead `filter(...)` overrides from
their implementations. Calling `filter(...)` on them is now a **compile-time
error** instead of a runtime exception.

### Requests changed (no `filter` in the REST schema)
- `UsersByGroupSearchRequest`, `ClientsByGroupSearchRequest`
- `UsersByRoleSearchRequest`, `ClientsByRoleSearchRequest`, `GroupsByRoleSearchRequest`
- `UsersByTenantSearchRequest`, `ClientsByTenantSearchRequest`, `GroupsByTenantSearchRequest`

### Deliberately left untouched (reuse a filterable top-level schema → keep `filter`)
- `mapping-rules-by-{group,role,tenant}` (reuse `MappingRuleSearchQueryRequest`)
- `roles-by-{group,tenant}` (reuse `RoleSearchQueryRequest`)

## Changes
- Interfaces: replace `TypedSearchRequest<F, S, AnyPage, SELF>` with
  `TypedSortableRequest<S, SELF>` + `TypedPageableRequest<AnyPage, SELF>`.
- Impls: remove the two `filter(...)` overrides that threw
  `UnsupportedOperationException`, and the now-unused filter imports.
- `revapi.json`: add breaking-change justifications for the removed
  `filter(...)` methods (breaking API change).
- Tests: add `FilterTypeSafetyTest` verifying the split (non-filterable
  requests don't expose `filter(...)` / don't extend `TypedFilterableRequest`,
  while the filterable siblings keep it); remove the now-uncompilable runtime
  "filtering throws" tests.
- `qa/util` `EntityManager`: relax the `wrap(...)` generic bound from
  `TypedSearchRequest` to `TypedPageableRequest` (it only calls `page(...)`).

## Verification
- `clients/java` unit tests pass (incl. new `FilterTypeSafetyTest`).
- `revapi:check` passes with the added justifications.
- `spotless:check` passes; `qa/util` compiles.

Closes #36164
