### PR TITLE
ci: let the SaaS E2E wait loop outlive a failing downstream run

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -793,7 +793,11 @@ jobs:
     # zeebeVersion. success() keeps the implicit needs-succeeded gate that a
     # custom `if` would otherwise drop.
     if: success() && needs.build-and-push.outputs.image-tag != ''
-    timeout-minutes: 30
+    # Must stay above the wait-downstream poll budget (70m) so that loop, not the
+    # runner, ends the wait: a job-level timeout cancels the step before it can
+    # write downstream_conclusion, and `cancelled` does not match the
+    # `contains(needs.*.result, 'failure')` gate on alwaysgreen-triage.
+    timeout-minutes: 75
     permissions: { }
     steps:
       - name: Checkout repository
@@ -887,7 +891,10 @@ jobs:
 
           RUN_ID=""
 
-          for _ in {1..80}; do
+          # 140 ticks x 30s = 70m. A downstream run that fails takes far longer
+          # than one that passes (~20m), because every failing spec burns its
+          # retries and per-test timeout; the observed worst case is ~57m.
+          for _ in {1..140}; do
             if [[ -z "$RUN_ID" ]]; then
               # A retry-exhausted poll must not end the wait: this loop is the
               # timeout mechanism, so fall through to the next tick. Only a


### PR DESCRIPTION
## What went wrong

Run [33439622089](https://github.com/camunda/camunda/actions/runs/33439622089) (`stable/8.8`, `d91e717`) went red on **Trigger SaaS E2E tests** with `The job has exceeded the maximum execution time of 30m0s`. Every other job in the run succeeded or was skipped.

The downstream run it was waiting on — [c8-cross-component-e2e-tests 33440423586](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/33440423586) — ran `21:15:43Z → 22:12:03Z` (**56m**). The upstream waiter was killed at `21:45:46Z`, 26 minutes before the downstream produced a verdict.

### The failure chain

1. `trigger-saas-e2e` sets `timeout-minutes: 30`, while its own poll loop budgets `80 × sleep 30` = **40m**. The runner cap is the smaller of the two, so the loop's graceful exit was unreachable dead code.
2. Both budgets are undersized. Over the last **298** runs of `playwright_saas_pr_trigger_monorepo.yml` the longest run took **62.3m**:

   | Conclusion | n | median | max | > 30m | > 35m | > 40m | > 70m |
   |---|---|---|---|---|---|---|---|
   | success | 265 | 17.8m | 58.5m | 9 (3%) | 4 (2%) | 4 (2%) | 0 |
   | failure | 33 | 22.4m | 62.3m | 13 (39%) | 12 (36%) | 12 (36%) | 0 |

   Long runs skew heavily toward failures, but **successes overrun too** — 4 green downstream runs exceeded 40m. So the cap yields both lost failure signal *and* false reds on genuinely green runs.
3. The runner cancellation kills the step before it reaches `echo "downstream_conclusion=..."`, so the category artifact fell back to `unknown`:
   ```json
   {"downstream_conclusion": "unknown", "downstream_category": "unknown"}
   ```
4. A timed-out job reports `cancelled`, not `failure`. The `alwaysgreen-triage` gate is `contains(needs.*.result, 'failure')`, so **AlwaysGreen triage and fix dispatch was skipped** (confirmed: `"conclusion": "skipped"`).

Net effect: the runs most worth triaging — the long ones — are exactly the runs whose signal is discarded.

### What actually failed downstream

The only failing spec in this run, in **both** the v1 and v2 reports (4 passed, 9 skipped, 1 failed each), was `test-setup.spec.ts` › `Create AWS Cluster`:

```
Expected: "Healthy"
Received: "Unhealthy"
Timeout 1500000ms exceeded while waiting on the predicate
```

The INT AWS cluster did not reach `Healthy` within the test's own 25-minute wait (the test already carries the comment *"AWS clusters on SaaS INT routinely need 10+ min to reach Healthy"*). That 2 × 25m wait is also what makes these runs ~56m long.

This is **not** a one-off: across the last 33 failing downstream runs, `Create AWS Cluster` is the second most frequent failing spec (18 occurrences), behind `smoke-tests.spec.ts › Most Common Flow User Flow With All Apps` (19). I could not find an existing tracking issue for it.

**This PR does not fix that failure** — it fixes the plumbing that throws the failure away. The two need separate changes.

## The change

- Poll loop `{1..80}` → `{1..140}` (40m → **70m**).
- Job `timeout-minutes` `30` → **75**.

The ordering is the point: the loop must stay the binding timeout so a genuinely stuck downstream exits through `downstream_conclusion=timeout` as a step *failure*, which both records a real category and satisfies the triage gate. 75m > 70m leaves headroom for checkout, token generation, and the post steps. 70m sits above the 62.3m worst case observed across 298 runs.

No assertion is weakened and no failure is masked — a red downstream still fails this job, now with the real reason attached.

## Other branches affected

The same defect exists everywhere; `stable/8.8` was only the branch that surfaced it.

| Branch | `timeout-minutes` | Loop budget | Job cap < loop budget | Below 62.3m worst case |
|---|---|---|---|---|
| `stable/8.8` | 30 | 40m | yes | yes |
| `stable/8.9` | 35 | 40m | yes | yes |
| `stable/8.10` | 35 | 40m | yes | yes |
| `main` | 35 | 40m | yes | yes |

Raising the cap to 35 on the other three did not fix it — 35m is still under both the 40m loop budget and the observed worst case. They need the same change; this PR is kept branch-scoped to the branch that failed.

## Verification

- `docker-build-helm-integration.yml` parses; `jobs.trigger-saas-e2e.timeout-minutes == 75`.
- Timings, artifacts, and the skipped-triage conclusion are read directly from run `33439622089` and downstream run `33440423586`; the duration table is computed over 298 downstream runs.
- End-to-end confirmation needs a downstream run that exceeds 40m, which cannot be forced locally.

Nightly run: https://github.com/camunda/camunda/actions/runs/33439622089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
