### PR TITLE
fix: pin AlwaysGreen SaaS component versions to 8.10-SNAPSHOT

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -826,10 +826,10 @@ jobs:
                       "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.10",
                       "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
-                      "operateVersion": "SNAPSHOT",
-                      "tasklistVersion": "SNAPSHOT",
-                      "connectorsVersion": "SNAPSHOT",
-                      "optimizeVersion": "SNAPSHOT"
+                      "operateVersion": "8.10-SNAPSHOT",
+                      "tasklistVersion": "8.10-SNAPSHOT",
+                      "connectorsVersion": "8.10-SNAPSHOT",
+                      "optimizeVersion": "8.10-SNAPSHOT"
                   }
                 }'
 


### PR DESCRIPTION
## Summary
- The AlwaysGreen `repository_dispatch` payload to `camunda/c8-cross-component-e2e-tests` (`docker-build-helm-integration.yml`, job `trigger-saas-e2e`) hardcoded `operateVersion`, `tasklistVersion`, `connectorsVersion`, and `optimizeVersion` to plain `SNAPSHOT`.
- On `stable/8.10` that resolves to each component's latest main-line snapshot, not the 8.10 release line's own snapshot build — the wrong artifacts to test against a stable branch.
- `c8Version` (`"8.10"`) and `zeebeVersion` (the build's own image tag) were already correctly branch-specific; aligned the other four to `8.10-SNAPSHOT`.

## Test plan
- [ ] Confirm the next AlwaysGreen SaaS dispatch on this branch pulls `*:8.10-SNAPSHOT` images for Operate/Tasklist/Connectors/Optimize instead of `*:SNAPSHOT`