### PR TITLE
feat: report per-instance batch operation state in the Processes list

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/batch-operations.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/batch-operations.ts
@@ -6,7 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {BatchOperation, QueryBatchOperationsResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+	BatchOperation,
+	BatchOperationItem,
+	QueryBatchOperationItemsResponseBody,
+	QueryBatchOperationsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 
 function createBatchOperation(overrides?: Partial<BatchOperation>): BatchOperation {
 	return {
@@ -35,4 +40,40 @@ function createQueryBatchOperationsResponse(
 	};
 }
 
-export {createBatchOperation, createQueryBatchOperationsResponse};
+function createBatchOperationItem(overrides?: Partial<BatchOperationItem>): BatchOperationItem {
+	return {
+		batchOperationKey: 'batch-op-1',
+		itemKey: 'item-1',
+		processInstanceKey: '2251799813685280',
+		rootProcessInstanceKey: null,
+		state: 'COMPLETED',
+		processedDate: '2024-01-01T10:05:00.000Z',
+		errorMessage: null,
+		operationType: 'CANCEL_PROCESS_INSTANCE',
+		...overrides,
+	};
+}
+
+function createQueryBatchOperationItemsResponse(overrides?: {
+	items?: BatchOperationItem[];
+	page?: Partial<QueryBatchOperationItemsResponseBody['page']>;
+}): QueryBatchOperationItemsResponseBody {
+	const items = overrides?.items ?? [];
+	return {
+		items,
+		page: {
+			totalItems: items.length,
+			startCursor: null,
+			endCursor: null,
+			hasMoreTotalItems: false,
+			...overrides?.page,
+		},
+	};
+}
+
+export {
+	createBatchOperation,
+	createQueryBatchOperationsResponse,
+	createBatchOperationItem,
+	createQueryBatchOperationItemsResponse,
+};

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -64,6 +64,11 @@ const mockQueryBatchOperationsEndpoint = createEndpointMock({
 	method: endpoints.queryBatchOperations.method,
 });
 
+const mockQueryBatchOperationItemsEndpoint = createEndpointMock({
+	endpoint: endpoints.queryBatchOperationItems.getUrl(),
+	method: endpoints.queryBatchOperationItems.method,
+});
+
 const mockQueryProcessInstancesEndpoint = createEndpointMock({
 	endpoint: endpoints.queryProcessInstances.getUrl(),
 	method: endpoints.queryProcessInstances.method,
@@ -216,6 +221,7 @@ export {
 	mockGetIncidentProcessInstanceStatisticsByDefinitionEndpoint,
 	mockQueryBatchOperationsEndpoint,
 	mockQueryProcessInstancesEndpoint,
+	mockQueryBatchOperationItemsEndpoint,
 	mockGetDecisionInstanceEndpoint,
 	mockQueryDecisionDefinitionsEndpoint,
 	mockQueryDecisionInstancesEndpoint,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {afterEach, beforeEach, describe, expect} from 'vitest';
+import {afterEach, beforeEach, describe, expect, vi} from 'vitest';
 import {HttpResponse} from 'msw';
 import {it} from '#/vitest-modules/test-extend';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
@@ -67,6 +67,7 @@ describe('<InstancesTable />', () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		sessionStorage.clear();
 	});
 
@@ -268,6 +269,109 @@ describe('<InstancesTable />', () => {
 		await expect.element(screen.getByRole('columnheader', {name: 'Operation State'})).toBeVisible();
 		await expect.element(screen.getByText('COMPLETED')).toBeVisible();
 		await expect.element(screen.getByText('FAILED')).toBeVisible();
+	});
+
+	it('should report all operation item states for the same process instance', async ({worker}) => {
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({
+						items: [createProcessInstance({processInstanceKey: '1'})],
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [
+							createBatchOperationItem({itemKey: 'item-1', processInstanceKey: '1', state: 'COMPLETED'}),
+							createBatchOperationItem({itemKey: 'item-2', processInstanceKey: '1', state: 'FAILED'}),
+						],
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderInstancesTable({...BASE_SEARCH, batchOperationKey: 'batch-op-1'});
+
+		await expect.element(screen.getByText('FAILED, COMPLETED')).toBeVisible();
+	});
+
+	it('should refresh active operation item states until they finish', async ({worker}) => {
+		vi.useFakeTimers({shouldAdvanceTime: true});
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({
+						items: [createProcessInstance({processInstanceKey: '1'})],
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [createBatchOperationItem({processInstanceKey: '1', state: 'ACTIVE'})],
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderInstancesTable({...BASE_SEARCH, batchOperationKey: 'batch-op-1'});
+		await expect.element(screen.getByText('ACTIVE')).toBeVisible();
+
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [createBatchOperationItem({processInstanceKey: '1', state: 'COMPLETED'})],
+					}),
+				),
+			}),
+		);
+		await vi.advanceTimersByTimeAsync(5000);
+
+		await expect.element(screen.getByText('COMPLETED')).toBeVisible();
+	});
+
+	it('should report an operation item request failure instead of an empty state', async ({worker}) => {
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({
+						items: [createProcessInstance({processInstanceKey: '1'})],
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json({}, {status: 403}),
+			}),
+		);
+
+		const screen = await renderInstancesTable({...BASE_SEARCH, batchOperationKey: 'batch-op-1'});
+
+		await expect.element(screen.getByText('Data could not be fetched')).toBeVisible();
+	});
+
+	it('should announce operation state loading once without assertive cell announcements', async ({worker}) => {
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({
+						items: [createProcessInstance({processInstanceKey: '1'}), createProcessInstance({processInstanceKey: '2'})],
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(createQueryBatchOperationItemsResponse()),
+				delay: 'infinite',
+			}),
+		);
+
+		const screen = await renderInstancesTable({...BASE_SEARCH, batchOperationKey: 'batch-op-1'});
+		await expect.element(screen.getByRole('columnheader', {name: 'Operation State'})).toBeVisible();
+
+		expect(document.querySelectorAll('[aria-live="assertive"]')).toHaveLength(0);
+		await expect.element(screen.getByText('Loading...')).toHaveAttribute('aria-live', 'polite');
 	});
 
 	it('should fall back to a placeholder for an instance with no matching operation item', async ({worker}) => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.test.tsx
@@ -10,11 +10,18 @@ import {afterEach, beforeEach, describe, expect} from 'vitest';
 import {HttpResponse} from 'msw';
 import {it} from '#/vitest-modules/test-extend';
 import {renderWithRouter} from '#/vitest-modules/render-with-router';
-import {mockQueryProcessInstancesEndpoint} from '#/shared-test-modules/mock-handlers';
+import {
+	mockQueryBatchOperationItemsEndpoint,
+	mockQueryProcessInstancesEndpoint,
+} from '#/shared-test-modules/mock-handlers';
 import {
 	createProcessInstance,
 	createQueryProcessInstancesResponse,
 } from '#/shared-test-modules/api-mocks/process-instances';
+import {
+	createBatchOperationItem,
+	createQueryBatchOperationItemsResponse,
+} from '#/shared-test-modules/api-mocks/batch-operations';
 import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
 import {useState} from 'react';
 import {userEvent} from 'vitest/browser';
@@ -219,6 +226,75 @@ describe('<InstancesTable />', () => {
 
 		await expect.element(screen.getByText('Order Process')).not.toBeInTheDocument();
 		await expect.element(screen.getByText('There are no Instances matching this filter set')).toBeVisible();
+	});
+
+	it('should not show the operation state column outside a batch operation filter', async ({worker}) => {
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({items: [createProcessInstance({processInstanceKey: '1'})]}),
+				),
+			}),
+		);
+
+		const screen = await renderInstancesTable();
+
+		await expect.element(screen.getByRole('columnheader', {name: 'Operation State'})).not.toBeInTheDocument();
+	});
+
+	it('should report each instance operation state when filtering by a batch operation', async ({worker}) => {
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({
+						items: [createProcessInstance({processInstanceKey: '1'}), createProcessInstance({processInstanceKey: '2'})],
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [
+							createBatchOperationItem({processInstanceKey: '1', state: 'COMPLETED'}),
+							createBatchOperationItem({processInstanceKey: '2', state: 'FAILED', errorMessage: 'boom'}),
+						],
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderInstancesTable({...BASE_SEARCH, batchOperationKey: 'batch-op-1'});
+
+		await expect.element(screen.getByRole('columnheader', {name: 'Operation State'})).toBeVisible();
+		await expect.element(screen.getByText('COMPLETED')).toBeVisible();
+		await expect.element(screen.getByText('FAILED')).toBeVisible();
+	});
+
+	it('should fall back to a placeholder for an instance with no matching operation item', async ({worker}) => {
+		worker.use(
+			mockQueryProcessInstancesEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryProcessInstancesResponse({
+						// An end date keeps `--` unique to the operation-state cell.
+						items: [
+							createProcessInstance({
+								processInstanceKey: '1',
+								state: 'COMPLETED',
+								endDate: '2026-01-15T11:00:00.000Z',
+							}),
+						],
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(createQueryBatchOperationItemsResponse({items: []})),
+			}),
+		);
+
+		const screen = await renderInstancesTable({...BASE_SEARCH, batchOperationKey: 'batch-op-1'});
+
+		await expect.element(screen.getByRole('columnheader', {name: 'Operation State'})).toBeVisible();
+		await expect.element(screen.getByText('--')).toBeVisible();
 	});
 
 	it('should show the parent instance link only when the instance has a parent', async ({worker}) => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.tsx
@@ -8,8 +8,13 @@
 
 import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
-import {DataTableSkeleton, InlineLoading} from '@carbon/react';
-import type {BatchOperationItem, ProcessInstance, ProcessInstanceState} from '@camunda/camunda-api-zod-schemas/8.10';
+import {DataTableSkeleton, SkeletonText} from '@carbon/react';
+import type {
+	BatchOperationItem,
+	BatchOperationItemState,
+	ProcessInstance,
+	ProcessInstanceState,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {PanelHeader} from '#/operate/shared/PanelHeader/PanelHeader';
 import {PaginatedSortableTable} from '#/operate/shared/PaginatedSortableTable/PaginatedSortableTable';
 import {StateIcon} from '#/operate/shared/StateIcon/StateIcon';
@@ -21,7 +26,7 @@ import {formatTimestamp} from '#/operate/shared/utils/formatTimestamp';
 import {useProcessInstancesSearch} from './useProcessInstancesSearch';
 import {useOperationItemsForInstances} from './batchOperationItems.queries';
 import type {ProcessesSearch} from './processesFilter';
-import {InstancesTableContainer, ProcessName, InstanceLink} from './styled';
+import {InstancesTableContainer, ProcessName, InstanceLink, VisuallyHiddenStatus} from './styled';
 
 type Props = {
 	search: ProcessesSearch;
@@ -32,6 +37,24 @@ function getDisplayState(instance: ProcessInstance): ProcessInstanceState | 'INC
 		return 'SUSPENDED';
 	}
 	return instance.hasIncident ? 'INCIDENT' : instance.state;
+}
+
+const OPERATION_STATE_ORDER: BatchOperationItemState[] = ['FAILED', 'ACTIVE', 'CANCELED', 'SKIPPED', 'COMPLETED'];
+
+function getOperationStatesByInstance(items: BatchOperationItem[] | undefined) {
+	const statesByInstance = new Map<string, Set<BatchOperationItemState>>();
+	for (const item of items ?? []) {
+		const states = statesByInstance.get(item.processInstanceKey) ?? new Set<BatchOperationItemState>();
+		states.add(item.state);
+		statesByInstance.set(item.processInstanceKey, states);
+	}
+
+	return new Map(
+		[...statesByInstance].map(([processInstanceKey, states]) => [
+			processInstanceKey,
+			OPERATION_STATE_ORDER.filter((state) => states.has(state)).join(', '),
+		]),
+	);
 }
 
 const InstancesTable: React.FC<Props> = ({search}) => {
@@ -57,14 +80,12 @@ const InstancesTable: React.FC<Props> = ({search}) => {
 	const batchOperationKey = search.batchOperationKey || undefined;
 	const isOperationStateColumnVisible = batchOperationKey !== undefined;
 	const processInstanceKeys = processInstances.map((instance) => instance.processInstanceKey);
-	const {data: operationItemsData, isLoading: isLoadingOperationItems} = useOperationItemsForInstances(
-		batchOperationKey,
-		processInstanceKeys,
-	);
-	const operationItemsByInstance = useMemo(
-		() => new Map<string, BatchOperationItem>(operationItemsData?.items.map((item) => [item.processInstanceKey, item])),
-		[operationItemsData],
-	);
+	const {
+		data: operationItems,
+		isLoading: isLoadingOperationItems,
+		isError: isOperationItemsError,
+	} = useOperationItemsForInstances(batchOperationKey, processInstanceKeys);
+	const operationItemsByInstance = useMemo(() => getOperationStatesByInstance(operationItems), [operationItems]);
 	const isTenantColumnVisible =
 		getClientConfig().deployment.isMultiTenancyEnabled && !isSpecificTenant(search.tenantId);
 	const hasVersionTags = processInstances.some(({processDefinitionVersionTag}) => Boolean(processDefinitionVersionTag));
@@ -92,9 +113,11 @@ const InstancesTable: React.FC<Props> = ({search}) => {
 						label: t('operate.processes.instancesTable.operationState'),
 						render: (row: ProcessInstance) =>
 							isLoadingOperationItems ? (
-								<InlineLoading description={t('operate.processes.instancesTable.operationStateLoading')} />
+								<SkeletonText width="6rem" />
+							) : isOperationItemsError ? (
+								t('operate.shared.errorMessage.message')
 							) : (
-								(operationItemsByInstance.get(row.processInstanceKey)?.state ?? '--')
+								(operationItemsByInstance.get(row.processInstanceKey) ?? '--')
 							),
 					},
 				]
@@ -204,6 +227,11 @@ const InstancesTable: React.FC<Props> = ({search}) => {
 				count={totalCount}
 				hasMoreTotalItems={hasMoreTotalItems}
 			/>
+			{isLoadingOperationItems && (
+				<VisuallyHiddenStatus role="status" aria-live="polite">
+					{t('operate.processes.instancesTable.operationStateLoading')}
+				</VisuallyHiddenStatus>
+			)}
 			{status === 'pending' && isFetching ? (
 				<DataTableSkeleton columnCount={columns.length} rowCount={5} showHeader={false} showToolbar={false} />
 			) : (

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/InstancesTable.tsx
@@ -6,9 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
-import type {ProcessInstance, ProcessInstanceState} from '@camunda/camunda-api-zod-schemas/8.10';
-import {DataTableSkeleton} from '@carbon/react';
+import {DataTableSkeleton, InlineLoading} from '@carbon/react';
+import type {BatchOperationItem, ProcessInstance, ProcessInstanceState} from '@camunda/camunda-api-zod-schemas/8.10';
 import {PanelHeader} from '#/operate/shared/PanelHeader/PanelHeader';
 import {PaginatedSortableTable} from '#/operate/shared/PaginatedSortableTable/PaginatedSortableTable';
 import {StateIcon} from '#/operate/shared/StateIcon/StateIcon';
@@ -18,6 +19,7 @@ import {getClientConfig} from '#/shared/config/getClientConfig';
 import {isSpecificTenant} from '#/operate/shared/utils/isSpecificTenant';
 import {formatTimestamp} from '#/operate/shared/utils/formatTimestamp';
 import {useProcessInstancesSearch} from './useProcessInstancesSearch';
+import {useOperationItemsForInstances} from './batchOperationItems.queries';
 import type {ProcessesSearch} from './processesFilter';
 import {InstancesTableContainer, ProcessName, InstanceLink} from './styled';
 
@@ -49,6 +51,20 @@ const InstancesTable: React.FC<Props> = ({search}) => {
 		fetchNextPage,
 	} = useProcessInstancesSearch(search);
 
+	// The operation-state column only exists while the list is filtered by a batch operation —
+	// outside that filter there is no operation for a row to report on. Truthiness, as in legacy,
+	// so an empty key from a hand-edited URL behaves like no filter at all.
+	const batchOperationKey = search.batchOperationKey || undefined;
+	const isOperationStateColumnVisible = batchOperationKey !== undefined;
+	const processInstanceKeys = processInstances.map((instance) => instance.processInstanceKey);
+	const {data: operationItemsData, isLoading: isLoadingOperationItems} = useOperationItemsForInstances(
+		batchOperationKey,
+		processInstanceKeys,
+	);
+	const operationItemsByInstance = useMemo(
+		() => new Map<string, BatchOperationItem>(operationItemsData?.items.map((item) => [item.processInstanceKey, item])),
+		[operationItemsData],
+	);
 	const isTenantColumnVisible =
 		getClientConfig().deployment.isMultiTenancyEnabled && !isSpecificTenant(search.tenantId);
 	const hasVersionTags = processInstances.some(({processDefinitionVersionTag}) => Boolean(processDefinitionVersionTag));
@@ -69,6 +85,20 @@ const InstancesTable: React.FC<Props> = ({search}) => {
 				</ProcessName>
 			),
 		},
+		...(isOperationStateColumnVisible
+			? [
+					{
+						key: 'instanceOperationState',
+						label: t('operate.processes.instancesTable.operationState'),
+						render: (row: ProcessInstance) =>
+							isLoadingOperationItems ? (
+								<InlineLoading description={t('operate.processes.instancesTable.operationStateLoading')} />
+							) : (
+								(operationItemsByInstance.get(row.processInstanceKey)?.state ?? '--')
+							),
+					},
+				]
+			: []),
 		{
 			key: 'processInstanceKey',
 			sortKey: 'processInstanceKey',

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
@@ -30,8 +30,9 @@ async function queryBatchOperationItems(
 }
 
 /**
- * Fetches all batch-operation items for the visible instances, so the list can report every item
- * produced by operations such as resolving multiple incidents in one process instance.
+ * Fetches all batch-operation items for the currently loaded process-instance rows, so the list
+ * can report every item produced by operations such as resolving multiple incidents in one
+ * process instance.
  */
 function useOperationItemsForInstances(batchOperationKey: string | undefined, processInstanceKeys: string[]) {
 	const filter = {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
@@ -67,13 +67,7 @@ function useOperationItemsForInstances(batchOperationKey: string | undefined, pr
 		enabled: batchOperationKey !== undefined && processInstanceKeys.length > 0,
 		refetchInterval: (query) => {
 			const items = query.state.data;
-			if (items === undefined) {
-				return false;
-			}
-
-			const instancesWithItems = new Set(items.map(({processInstanceKey}) => processInstanceKey));
-			const hasMissingItems = processInstanceKeys.some((key) => !instancesWithItems.has(key));
-			return items.some(({state}) => state === 'ACTIVE') || hasMissingItems ? ACTIVE_ITEMS_REFETCH_INTERVAL_MS : false;
+			return items?.some(({state}) => state === 'ACTIVE') ? ACTIVE_ITEMS_REFETCH_INTERVAL_MS : false;
 		},
 	});
 }

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {queryOptions, useQuery} from '@tanstack/react-query';
+import type {
+	QueryBatchOperationItemsRequestBody,
+	QueryBatchOperationItemsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request} from '#/shared/http/request';
+import {mapQueryError} from '#/shared/http/mapQueryError';
+import {endpoints} from '#/shared/http/endpoints';
+
+function batchOperationItemsOptions(body: QueryBatchOperationItemsRequestBody) {
+	return queryOptions({
+		queryKey: ['batchOperationItems', body] as const,
+		queryFn: async (): Promise<QueryBatchOperationItemsResponseBody> => {
+			const {response, error} = await request(endpoints.queryBatchOperationItems(body));
+			if (error !== null) {
+				throw mapQueryError(error);
+			}
+			return response.json();
+		},
+	});
+}
+
+/**
+ * Fetches the batch-operation item for each visible instance, so the list can show how that
+ * instance fared in the batch operation it is filtered by. One item per instance, so the page
+ * limit is the number of rows on screen.
+ */
+function useOperationItemsForInstances(batchOperationKey: string | undefined, processInstanceKeys: string[]) {
+	return useQuery({
+		...batchOperationItemsOptions({
+			filter: {
+				batchOperationKey: {$eq: batchOperationKey!},
+				processInstanceKey: {$in: processInstanceKeys},
+			},
+			page: {limit: processInstanceKeys.length},
+		}),
+		enabled: batchOperationKey !== undefined && processInstanceKeys.length > 0,
+	});
+}
+
+export {useOperationItemsForInstances};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
@@ -6,8 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {queryOptions, useQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 import type {
+	BatchOperationItem,
 	QueryBatchOperationItemsRequestBody,
 	QueryBatchOperationItemsResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
@@ -15,34 +16,65 @@ import {request} from '#/shared/http/request';
 import {mapQueryError} from '#/shared/http/mapQueryError';
 import {endpoints} from '#/shared/http/endpoints';
 
-function batchOperationItemsOptions(body: QueryBatchOperationItemsRequestBody) {
-	return queryOptions({
-		queryKey: ['batchOperationItems', body] as const,
-		queryFn: async (): Promise<QueryBatchOperationItemsResponseBody> => {
-			const {response, error} = await request(endpoints.queryBatchOperationItems(body));
-			if (error !== null) {
-				throw mapQueryError(error);
-			}
-			return response.json();
-		},
-	});
+const PAGE_LIMIT = 100;
+const ACTIVE_ITEMS_REFETCH_INTERVAL_MS = 5000;
+
+async function queryBatchOperationItems(
+	body: QueryBatchOperationItemsRequestBody,
+): Promise<QueryBatchOperationItemsResponseBody> {
+	const {response, error} = await request(endpoints.queryBatchOperationItems(body));
+	if (error !== null) {
+		throw mapQueryError(error);
+	}
+	return response.json();
 }
 
 /**
- * Fetches the batch-operation item for each visible instance, so the list can show how that
- * instance fared in the batch operation it is filtered by. One item per instance, so the page
- * limit is the number of rows on screen.
+ * Fetches all batch-operation items for the visible instances, so the list can report every item
+ * produced by operations such as resolving multiple incidents in one process instance.
  */
 function useOperationItemsForInstances(batchOperationKey: string | undefined, processInstanceKeys: string[]) {
+	const filter = {
+		batchOperationKey: batchOperationKey === undefined ? undefined : {$eq: batchOperationKey},
+		processInstanceKey: {$in: processInstanceKeys},
+	} satisfies QueryBatchOperationItemsRequestBody['filter'];
+
 	return useQuery({
-		...batchOperationItemsOptions({
-			filter: {
-				batchOperationKey: batchOperationKey === undefined ? undefined : {$eq: batchOperationKey},
-				processInstanceKey: {$in: processInstanceKeys},
-			},
-			page: {limit: processInstanceKeys.length},
-		}),
+		queryKey: ['batchOperationItems', filter] as const,
+		queryFn: async (): Promise<BatchOperationItem[]> => {
+			const items: BatchOperationItem[] = [];
+			let after: string | undefined;
+
+			do {
+				const result = await queryBatchOperationItems({
+					filter,
+					page: {limit: PAGE_LIMIT, ...(after === undefined ? {} : {after})},
+				});
+				items.push(...result.items);
+
+				if (
+					result.items.length === 0 ||
+					result.page.endCursor === null ||
+					(!result.page.hasMoreTotalItems && items.length >= result.page.totalItems)
+				) {
+					break;
+				}
+				after = result.page.endCursor;
+			} while (after !== undefined);
+
+			return items;
+		},
 		enabled: batchOperationKey !== undefined && processInstanceKeys.length > 0,
+		refetchInterval: (query) => {
+			const items = query.state.data;
+			if (items === undefined) {
+				return false;
+			}
+
+			const instancesWithItems = new Set(items.map(({processInstanceKey}) => processInstanceKey));
+			const hasMissingItems = processInstanceKeys.some((key) => !instancesWithItems.has(key));
+			return items.some(({state}) => state === 'ACTIVE') || hasMissingItems ? ACTIVE_ITEMS_REFETCH_INTERVAL_MS : false;
+		},
 	});
 }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
@@ -37,7 +37,7 @@ function useOperationItemsForInstances(batchOperationKey: string | undefined, pr
 	return useQuery({
 		...batchOperationItemsOptions({
 			filter: {
-				batchOperationKey: {$eq: batchOperationKey!},
+				batchOperationKey: batchOperationKey === undefined ? undefined : {$eq: batchOperationKey},
 				processInstanceKey: {$in: processInstanceKeys},
 			},
 			page: {limit: processInstanceKeys.length},

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/batchOperationItems.queries.ts
@@ -16,7 +16,6 @@ import {request} from '#/shared/http/request';
 import {mapQueryError} from '#/shared/http/mapQueryError';
 import {endpoints} from '#/shared/http/endpoints';
 
-const PAGE_LIMIT = 100;
 const ACTIVE_ITEMS_REFETCH_INTERVAL_MS = 5000;
 
 async function queryBatchOperationItems(
@@ -29,41 +28,20 @@ async function queryBatchOperationItems(
 	return response.json();
 }
 
-/**
- * Fetches all batch-operation items for the currently loaded process-instance rows, so the list
- * can report every item produced by operations such as resolving multiple incidents in one
- * process instance.
- */
 function useOperationItemsForInstances(batchOperationKey: string | undefined, processInstanceKeys: string[]) {
-	const filter = {
-		batchOperationKey: batchOperationKey === undefined ? undefined : {$eq: batchOperationKey},
-		processInstanceKey: {$in: processInstanceKeys},
-	} satisfies QueryBatchOperationItemsRequestBody['filter'];
+	const requestBody = {
+		filter: {
+			batchOperationKey: batchOperationKey === undefined ? undefined : {$eq: batchOperationKey},
+			processInstanceKey: {$in: processInstanceKeys},
+		},
+		page: {limit: processInstanceKeys.length},
+	} satisfies QueryBatchOperationItemsRequestBody;
 
 	return useQuery({
-		queryKey: ['batchOperationItems', filter] as const,
+		queryKey: ['batchOperationItems', requestBody] as const,
 		queryFn: async (): Promise<BatchOperationItem[]> => {
-			const items: BatchOperationItem[] = [];
-			let after: string | undefined;
-
-			do {
-				const result = await queryBatchOperationItems({
-					filter,
-					page: {limit: PAGE_LIMIT, ...(after === undefined ? {} : {after})},
-				});
-				items.push(...result.items);
-
-				if (
-					result.items.length === 0 ||
-					result.page.endCursor === null ||
-					(!result.page.hasMoreTotalItems && items.length >= result.page.totalItems)
-				) {
-					break;
-				}
-				after = result.page.endCursor;
-			} while (after !== undefined);
-
-			return items;
+			const result = await queryBatchOperationItems(requestBody);
+			return result.items;
 		},
 		enabled: batchOperationKey !== undefined && processInstanceKeys.length > 0,
 		refetchInterval: (query) => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Processes/styled.ts
@@ -72,6 +72,18 @@ const InstanceLink = styled(Link)`
 	}
 `;
 
+const VisuallyHiddenStatus = styled.span`
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+`;
+
 export {
 	IndentedGroup,
 	CanceledIcon,
@@ -83,4 +95,5 @@ export {
 	InstancesTableContainer,
 	ProcessName,
 	InstanceLink,
+	VisuallyHiddenStatus,
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -18,6 +18,7 @@ import {
 	type GetIncidentProcessInstanceStatisticsByDefinitionRequestBody,
 	type QueryProcessInstancesRequestBody,
 	type QueryBatchOperationsRequestBody,
+	type QueryBatchOperationItemsRequestBody,
 	type QueryDecisionDefinitionsRequestBody,
 	type QueryDecisionInstancesRequestBody,
 	type CreateDecisionInstancesDeletionBatchOperationRequestBody,
@@ -226,6 +227,14 @@ const endpoints = {
 		new Request(getFullURL(unifiedAPIEndpoints.queryBatchOperations.getUrl()), {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.queryBatchOperations.method,
+			body: JSON.stringify(body),
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	queryBatchOperationItems: (body: QueryBatchOperationItemsRequestBody) =>
+		new Request(getFullURL(unifiedAPIEndpoints.queryBatchOperationItems.getUrl()), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.queryBatchOperationItems.method,
 			body: JSON.stringify(body),
 			headers: {'Content-Type': 'application/json'},
 		}),

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -501,6 +501,8 @@
 					"tenant": "Mandant",
 					"startDate": "Startdatum",
 					"endDate": "Enddatum",
+					"operationState": "Vorgangsstatus",
+					"operationStateLoading": "Wird geladen...",
 					"parentProcessInstanceKey": "Übergeordneter Prozessinstanz-Schlüssel",
 					"viewInstance": "Instanz {{key}} anzeigen",
 					"viewParentInstance": "Übergeordnete Instanz {{key}} anzeigen",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -515,6 +515,8 @@
 					"tenant": "Tenant",
 					"startDate": "Start Date",
 					"endDate": "End Date",
+					"operationState": "Operation State",
+					"operationStateLoading": "Loading...",
 					"parentProcessInstanceKey": "Parent Process Instance Key",
 					"viewInstance": "View instance {{key}}",
 					"viewParentInstance": "View parent instance {{key}}",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -501,6 +501,8 @@
 					"tenant": "Inquilino",
 					"startDate": "Fecha de inicio",
 					"endDate": "Fecha de fin",
+					"operationState": "Estado de la operación",
+					"operationStateLoading": "Cargando...",
 					"parentProcessInstanceKey": "Clave de instancia de proceso principal",
 					"viewInstance": "Ver instancia {{key}}",
 					"viewParentInstance": "Ver instancia principal {{key}}",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -504,6 +504,8 @@
 					"tenant": "Locataire",
 					"startDate": "Date de début",
 					"endDate": "Date de fin",
+					"operationState": "État de l'opération",
+					"operationStateLoading": "Chargement...",
 					"parentProcessInstanceKey": "Clé d'instance de processus parente",
 					"viewInstance": "Afficher l'instance {{key}}",
 					"viewParentInstance": "Afficher l'instance parente {{key}}",

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/operate/operate-processes.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/operate/operate-processes.test.ts
@@ -13,6 +13,7 @@ import {
 	mockGetIncidentProcessInstanceStatisticsByErrorEndpoint,
 	mockGetProcessDefinitionInstanceStatisticsEndpoint,
 	mockLicenseEndpoint,
+	mockQueryBatchOperationItemsEndpoint,
 	mockQueryProcessDefinitionsEndpoint,
 	mockQueryProcessInstancesEndpoint,
 	mockSystemConfigurationEndpoint,
@@ -28,6 +29,10 @@ import {
 	createProcessInstance,
 	createQueryProcessInstancesResponse,
 } from '#/shared-test-modules/api-mocks/process-instances';
+import {
+	createBatchOperationItem,
+	createQueryBatchOperationItemsResponse,
+} from '#/shared-test-modules/api-mocks/batch-operations';
 import {createPaginatedResponse} from '#/shared-test-modules/api-mocks/shared';
 
 test.beforeEach(({network}) => {
@@ -89,5 +94,22 @@ test.describe('Operate processes page', () => {
 		await expect(operateProcessesPage.instancesTable).toBeVisible();
 		await expect(operateProcessesPage.instanceLink('1001')).toHaveAttribute('href', '/operate/processes/1001');
 		await expect(operateProcessesPage.instanceLink('1002')).toHaveAttribute('href', '/operate/processes/1002');
+	});
+
+	test('should show operation states when filtering by a batch operation', async ({network, operateProcessesPage}) => {
+		network.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [createBatchOperationItem({processInstanceKey: '1001', state: 'ACTIVE'})],
+					}),
+				),
+			}),
+		);
+
+		await operateProcessesPage.goto('?batchOperationKey=2f5b1beb-cbeb-41c8-a2f0-4c0bcf76c4ee');
+
+		await expect(operateProcessesPage.operationStateColumn).toBeVisible();
+		await expect(operateProcessesPage.operationState('ACTIVE')).toBeVisible();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/OperateProcesses.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/OperateProcesses.page.ts
@@ -18,8 +18,8 @@ class OperateProcessesPage extends BasePage {
 		this.header = new Header(page, 'Camunda Operate');
 	}
 
-	async goto() {
-		return this.page.goto('/operate/processes');
+	async goto(search = '') {
+		return this.page.goto(`/operate/processes${search}`);
 	}
 
 	get filtersPanel() {
@@ -36,6 +36,14 @@ class OperateProcessesPage extends BasePage {
 
 	get instancesTable() {
 		return this.page.getByTestId('process-instances-table');
+	}
+
+	get operationStateColumn() {
+		return this.instancesTable.getByRole('columnheader', {name: 'Operation State'});
+	}
+
+	operationState(state: string) {
+		return this.instancesTable.getByRole('cell', {name: state});
 	}
 
 	instanceLink(processInstanceKey: string) {


### PR DESCRIPTION
## Description

Stacked on #61561.

Filtering the list by a batch operation key showed which instances it touched but not how each fared — a failed item looked identical to a completed one. Adds an Operation State column, shown only under that filter.

Legacy's `batchOperationKey` prop to `SortableTable` also drove per-row success/error tinting, the leading expand column, and the expandable error message. The unified table has no equivalent for any of it; all three follow separately and will close the issue.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Part of #55986
