### PR TITLE
Add e2e tests for redesigned Agent Instance Command API

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -361,7 +361,7 @@ public class AgentHistoryCommitLifecycleIT {
                     new AgentInstanceHistoryItem()
                         .historyItemId(historyItemId)
                         .loopIteration(1)
-                        .role(AgentInstanceHistoryRole.ASSISTANT)
+                        .role(AgentInstanceHistoryRole.TOOL_RESULT)
                         .content(
                             List.of(
                                 AgentInstanceHistoryContent.text("I can help with many tasks.")))
@@ -419,7 +419,7 @@ public class AgentHistoryCommitLifecycleIT {
                     new AgentInstanceHistoryItem()
                         .historyItemId(historyItemId)
                         .loopIteration(1)
-                        .role(AgentInstanceHistoryRole.ASSISTANT)
+                        .role(AgentInstanceHistoryRole.TOOL_RESULT)
                         .content(
                             List.of(AgentInstanceHistoryContent.text("A different resent answer.")))
                         .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
@@ -451,7 +451,7 @@ public class AgentHistoryCommitLifecycleIT {
               final var response =
                   camundaClient
                       .newAgentInstanceHistorySearchRequest(agentInstanceKey)
-                      .filter(f -> f.role(AgentInstanceHistoryRole.ASSISTANT))
+                      .filter(f -> f.role(AgentInstanceHistoryRole.TOOL_RESULT))
                       .execute();
               assertThat(response.items())
                   .as("exactly one history item persists for the id resent across jobs")
@@ -489,8 +489,8 @@ public class AgentHistoryCommitLifecycleIT {
                   .as("aggregated tokens must count job A's item once, not job B's resend too")
                   .isEqualTo(50L);
               assertThat(aggregatedMetrics.getModelCalls())
-                  .as("deduped resend must not be counted as an extra model call")
-                  .isEqualTo(1);
+                  .as("TOOL_RESULT items never count as model calls, deduped or not")
+                  .isEqualTo(0);
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -708,9 +708,11 @@ public class AgentHistoryCommitLifecycleIT {
             .join()
             .getAgentInstanceKey();
 
-    // This also emits AGENT_HISTORY:DISCARD for the CONFIGURATION item just created above (no
-    // committed snapshot exists yet, so model/provider/systemPrompt roll back to defaults). Tests
-    // using this helper only assert on the non-CONFIGURATION history items they create afterward.
+    // This also emits AGENT_HISTORY:DISCARD for the CONFIGURATION item just created above. That
+    // item's model/provider/systemPrompt were already applied to the AgentInstance optimistically
+    // on CREATE and are NOT rolled back by the discard (see #61391). Tests using this helper only
+    // assert on the non-CONFIGURATION history items they create afterward, so this doesn't matter
+    // here.
     camundaClient.newFailCommand(activatedJob).retries(1).execute();
 
     waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.command.AgentTool;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.assertj.core.groups.Tuple;
 import org.awaitility.Awaitility;
@@ -289,6 +291,206 @@ public class AgentHistoryCommitLifecycleIT {
                         assertThat(item.getMetrics().getOutputTokens()).isEqualTo(50L);
                         assertThat(item.getMetrics().getDurationMs()).isEqualTo(500L);
                       });
+            });
+  }
+
+  @Test
+  void shouldDedupeResendOfSameHistoryItemIdAcrossJobActivations() {
+    // --- setup: a sequential multi-instance AI-agent service task, so a SECOND, independent job
+    // activation (job B, on a brand-new element instance) exists for the SAME agent instance once
+    // the first job (job A) completes ---
+    final var processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID + "CrossJobDedupe")
+            .startEvent()
+            .serviceTask(
+                SERVICE_TASK_ID,
+                t ->
+                    t.zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                        .zeebeAiAgentTaskDefinition()
+                        .multiInstance(
+                            m ->
+                                m.sequential()
+                                    .zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient, processModel, "agent-history-cross-job-dedupe.bpmn");
+    final long processInstanceKey =
+        camundaClient
+            .newCreateInstanceCommand()
+            .processDefinitionKey(process.getProcessDefinitionKey())
+            .variables(Map.of("items", List.of("a", "b")))
+            .execute()
+            .getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.elementId(SERVICE_TASK_ID)
+                .type(ElementInstanceType.SERVICE_TASK)
+                .processInstanceKey(processInstanceKey),
+        1);
+    final long elementInstanceKey1 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(SERVICE_TASK_ID)
+                        .type(ElementInstanceType.SERVICE_TASK)
+                        .processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey1);
+    final var jobA = activateAgenticJob(processInstanceKey, true);
+
+    final String historyItemId = UUID.randomUUID().toString();
+
+    // when — job A submits the item and completes, committing it
+    final var firstResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey1)
+            .jobKey(jobA.getKey())
+            .jobLease(jobA.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(historyItemId)
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.ASSISTANT)
+                        .content(
+                            List.of(
+                                AgentInstanceHistoryContent.text("I can help with many tasks.")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
+                        .metrics(
+                            new AgentInstanceHistoryMetrics()
+                                .inputTokens(100L)
+                                .outputTokens(50L)
+                                .durationMs(500L))))
+            .send()
+            .join();
+    final long originalHistoryItemKey =
+        firstResponse.getCreatedHistory().getFirst().getHistoryItemKey();
+
+    camundaClient.newCompleteCommand(jobA).execute();
+
+    // given — the multi-instance body advances: a second, independent job activation exists for
+    // the SAME agent instance, on a brand-new element instance
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.elementId(SERVICE_TASK_ID)
+                .type(ElementInstanceType.SERVICE_TASK)
+                .processInstanceKey(processInstanceKey),
+        2);
+    final long elementInstanceKey2 =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(SERVICE_TASK_ID)
+                        .type(ElementInstanceType.SERVICE_TASK)
+                        .processInstanceKey(processInstanceKey))
+            .sort(s -> s.elementInstanceKey().asc())
+            .execute()
+            .items()
+            .get(1)
+            .getElementInstanceKey();
+    final var jobB = activateAgenticJob(processInstanceKey, true);
+    assertThat(jobB.getElementInstanceKey())
+        .as("job B must be the job activated for the second element instance")
+        .isEqualTo(elementInstanceKey2);
+
+    // when — job B (a brand-new job, on a brand-new element instance) resends the SAME
+    // historyItemId, with different content/metrics on purpose — dedup keys on historyItemId
+    // alone, and must span job A even though job A already completed and committed.
+    final var secondResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey2)
+            .jobKey(jobB.getKey())
+            .jobLease(jobB.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(historyItemId)
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.ASSISTANT)
+                        .content(
+                            List.of(AgentInstanceHistoryContent.text("A different resent answer.")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
+                        .metrics(
+                            new AgentInstanceHistoryMetrics()
+                                .inputTokens(999L)
+                                .outputTokens(999L)
+                                .durationMs(999L))))
+            .send()
+            .join();
+
+    assertThat(secondResponse.getCreatedHistory())
+        .as("the resent item must be flagged as a duplicate of job A's item, across jobs")
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.isDuplicate()).isTrue();
+              assertThat(item.getHistoryItemKey()).isEqualTo(originalHistoryItemKey);
+            });
+
+    camundaClient.newCompleteCommand(jobB).execute();
+
+    // then
+    Awaitility.await("resent history item deduped across job activations, not double-applied")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response =
+                  camundaClient
+                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                      .filter(f -> f.role(AgentInstanceHistoryRole.ASSISTANT))
+                      .execute();
+              assertThat(response.items())
+                  .as("exactly one history item persists for the id resent across jobs")
+                  .singleElement()
+                  .satisfies(
+                      item -> {
+                        assertThat(item.getContent())
+                            .as(
+                                "persisted content must match job A's submission, not job B's"
+                                    + " resend")
+                            .extracting(c -> ((TextContent) c).getText())
+                            .containsExactly("I can help with many tasks.");
+                        assertThat(item.getMetrics())
+                            .as(
+                                "persisted metrics must match job A's submission, not job B's"
+                                    + " resend")
+                            .isNotNull();
+                        assertThat(item.getMetrics().getInputTokens()).isEqualTo(100L);
+                        assertThat(item.getMetrics().getOutputTokens()).isEqualTo(50L);
+                        assertThat(item.getMetrics().getDurationMs()).isEqualTo(500L);
+                      });
+
+              final var aggregatedMetrics =
+                  camundaClient
+                      .newAgentInstanceSearchRequest()
+                      .filter(f -> f.agentInstanceKey(agentInstanceKey))
+                      .execute()
+                      .items()
+                      .getFirst()
+                      .getMetrics();
+              assertThat(aggregatedMetrics.getInputTokens())
+                  .as("aggregated tokens must count job A's item once, not job B's resend too")
+                  .isEqualTo(100L);
+              assertThat(aggregatedMetrics.getOutputTokens())
+                  .as("aggregated tokens must count job A's item once, not job B's resend too")
+                  .isEqualTo(50L);
+              assertThat(aggregatedMetrics.getModelCalls())
+                  .as("deduped resend must not be counted as an extra model call")
+                  .isEqualTo(1);
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -16,10 +16,15 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
 import io.camunda.client.api.command.AgentInstanceHistoryItem;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
+import io.camunda.client.api.command.AgentInstanceLimits;
+import io.camunda.client.api.command.AgentTool;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -190,6 +195,240 @@ public class AgentHistoryCommitLifecycleIT {
         "winning item COMMITTED, superseded item DISCARDED",
         tuple(winningItemKey, AgentInstanceHistoryCommitStatus.COMMITTED),
         tuple(supersededItemKey, AgentInstanceHistoryCommitStatus.DISCARDED));
+  }
+
+  @Test
+  void shouldDedupeResendOfSameHistoryItemIdWithinSameJobActivation() {
+    // --- setup: an activated agentic job on a fresh agent instance ---
+    final long processInstanceKey = deployAndStartProcessInstance();
+    final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey);
+    final var activatedJob = activateAgenticJob(processInstanceKey, true);
+
+    final String historyItemId = UUID.randomUUID().toString();
+
+    // when — the same historyItemId is submitted twice against the SAME job activation (same
+    // jobKey/lease), e.g. an HTTP client retry. Content/metrics differ on purpose: dedup keys on
+    // historyItemId alone, not on content — only the FIRST submission should stick.
+    camundaClient
+        .newUpdateAgentInstanceCommand(agentInstanceKey)
+        .elementInstanceKey(elementInstanceKey)
+        .jobKey(activatedJob.getKey())
+        .jobLease(activatedJob.getLeaseToken())
+        .history(
+            List.of(
+                new AgentInstanceHistoryItem()
+                    .historyItemId(historyItemId)
+                    .loopIteration(1)
+                    .role(AgentInstanceHistoryRole.ASSISTANT)
+                    .content(
+                        List.of(AgentInstanceHistoryContent.text("I can help with many tasks.")))
+                    .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
+                    .metrics(
+                        new AgentInstanceHistoryMetrics()
+                            .inputTokens(100L)
+                            .outputTokens(50L)
+                            .durationMs(500L))))
+        .send()
+        .join();
+
+    final var secondResponse =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(activatedJob.getKey())
+            .jobLease(activatedJob.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(historyItemId)
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.ASSISTANT)
+                        .content(
+                            List.of(AgentInstanceHistoryContent.text("A different resent answer.")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
+                        .metrics(
+                            new AgentInstanceHistoryMetrics()
+                                .inputTokens(999L)
+                                .outputTokens(999L)
+                                .durationMs(999L))))
+            .send()
+            .join();
+
+    assertThat(secondResponse.getCreatedHistory())
+        .as("the resent item must be flagged as a duplicate, not a new history entry")
+        .singleElement()
+        .satisfies(item -> assertThat(item.isDuplicate()).isTrue());
+
+    camundaClient.newCompleteCommand(activatedJob).execute();
+
+    // then
+    Awaitility.await("resent history item deduped, not double-applied")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response =
+                  camundaClient
+                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                      .filter(f -> f.role(AgentInstanceHistoryRole.ASSISTANT))
+                      .execute();
+              assertThat(response.items())
+                  .as("exactly one history item persists for the resent id")
+                  .singleElement()
+                  .satisfies(
+                      item -> {
+                        assertThat(item.getContent())
+                            .as("persisted content must match the FIRST submission, not the resend")
+                            .extracting(c -> ((TextContent) c).getText())
+                            .containsExactly("I can help with many tasks.");
+                        assertThat(item.getMetrics())
+                            .as("persisted metrics must match the FIRST submission, not the resend")
+                            .isNotNull();
+                        assertThat(item.getMetrics().getInputTokens()).isEqualTo(100L);
+                        assertThat(item.getMetrics().getOutputTokens()).isEqualTo(50L);
+                        assertThat(item.getMetrics().getDurationMs()).isEqualTo(500L);
+                      });
+            });
+  }
+
+  @Test
+  void shouldApplyConfigurationChangeToAgentInstanceOnlyAfterJobCompletion() {
+    // --- setup: a fresh agent instance, plus an activated job to carry the UPDATE below ---
+    final long processInstanceKey = deployAndStartProcessInstance();
+    final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey);
+    final var activatedJob = activateAgenticJob(processInstanceKey, true);
+
+    // captured, not hardcoded — see createAgentInstance() for why.
+    final var baseline =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentInstanceKey(agentInstanceKey))
+            .execute()
+            .items()
+            .getFirst();
+    final String baselineModel = baseline.getDefinition().getModel();
+    final String baselineProvider = baseline.getDefinition().getProvider();
+    final long baselineMaxTokens = baseline.getLimits().getMaxTokens();
+    final int baselineMaxModelCalls = baseline.getLimits().getMaxModelCalls();
+    final int baselineMaxToolCalls = baseline.getLimits().getMaxToolCalls();
+    final int baselineToolCount = baseline.getTools().size();
+
+    // when — WITHOUT completing the job, an UPDATE carries a CONFIGURATION item changing
+    // model/provider/tools/limits.
+    final long configHistoryItemKey =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(activatedJob.getKey())
+            .jobLease(activatedJob.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.CONFIGURATION)
+                        .content(List.of(AgentInstanceHistoryContent.text("configuration change")))
+                        .producedAt(OffsetDateTime.now())
+                        .model("gpt-4o-mini")
+                        .provider("azure-openai")
+                        .tools(List.of(AgentTool.of("calculator")))
+                        .limits(AgentInstanceLimits.of(5000L, 8, 16))))
+            .send()
+            .join()
+            .getCreatedHistory()
+            .getFirst()
+            .getHistoryItemKey();
+
+    // confirm the UPDATE actually landed as PENDING before checking the baseline still holds.
+    // Without this, the baseline check below could pass purely because it ran before the write
+    // was even indexed, not because the CONFIGURATION change is genuinely deferred until commit.
+    Awaitility.await("CONFIGURATION history item indexed as PENDING")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var pendingItems =
+                  camundaClient
+                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                      .filter(
+                          f ->
+                              f.historyItemKey(configHistoryItemKey)
+                                  .commitStatus(AgentInstanceHistoryCommitStatus.PENDING))
+                      .execute()
+                      .items();
+              assertThat(pendingItems)
+                  .as("CONFIGURATION history item must be indexed as PENDING before commit")
+                  .hasSize(1);
+            });
+
+    // the write is confirmed indexed, so a direct assertion (no untilAsserted) is enough to prove
+    // the AgentInstance itself still shows the baseline values.
+    final var beforeCommit =
+        camundaClient
+            .newAgentInstanceSearchRequest()
+            .filter(f -> f.agentInstanceKey(agentInstanceKey))
+            .execute()
+            .items()
+            .getFirst();
+    assertThat(beforeCommit.getDefinition().getModel())
+        .as("model must still be the baseline; the CONFIGURATION change hasn't committed yet")
+        .isEqualTo(baselineModel);
+    assertThat(beforeCommit.getDefinition().getProvider())
+        .as("provider must still be the baseline; the CONFIGURATION change hasn't committed yet")
+        .isEqualTo(baselineProvider);
+    assertThat(beforeCommit.getTools())
+        .as("tools must still be the baseline; the CONFIGURATION change hasn't committed yet")
+        .hasSize(baselineToolCount);
+    assertThat(beforeCommit.getLimits().getMaxTokens())
+        .as("maxTokens must still be the baseline; the CONFIGURATION change hasn't committed yet")
+        .isEqualTo(baselineMaxTokens);
+    assertThat(beforeCommit.getLimits().getMaxModelCalls())
+        .as(
+            "maxModelCalls must still be the baseline; the CONFIGURATION change hasn't committed"
+                + " yet")
+        .isEqualTo(baselineMaxModelCalls);
+    assertThat(beforeCommit.getLimits().getMaxToolCalls())
+        .as(
+            "maxToolCalls must still be the baseline; the CONFIGURATION change hasn't committed"
+                + " yet")
+        .isEqualTo(baselineMaxToolCalls);
+
+    camundaClient.newCompleteCommand(activatedJob).execute();
+
+    Awaitility.await("agent instance definition reflects committed CONFIGURATION change")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var afterCommit =
+                  camundaClient
+                      .newAgentInstanceSearchRequest()
+                      .filter(f -> f.agentInstanceKey(agentInstanceKey))
+                      .execute()
+                      .items()
+                      .getFirst();
+              assertThat(afterCommit.getDefinition().getModel())
+                  .as("model must reflect the committed CONFIGURATION change")
+                  .isEqualTo("gpt-4o-mini");
+              assertThat(afterCommit.getDefinition().getProvider())
+                  .as("provider must reflect the committed CONFIGURATION change")
+                  .isEqualTo("azure-openai");
+              assertThat(afterCommit.getTools())
+                  .as("tools must reflect the committed CONFIGURATION change")
+                  .extracting(AgentInstance.Tool::getName)
+                  .containsExactly("calculator");
+              assertThat(afterCommit.getLimits().getMaxTokens())
+                  .as("maxTokens must reflect the committed CONFIGURATION change")
+                  .isEqualTo(5000L);
+              assertThat(afterCommit.getLimits().getMaxModelCalls())
+                  .as("maxModelCalls must reflect the committed CONFIGURATION change")
+                  .isEqualTo(8);
+              assertThat(afterCommit.getLimits().getMaxToolCalls())
+                  .as("maxToolCalls must reflect the committed CONFIGURATION change")
+                  .isEqualTo(16);
+            });
   }
 
   // --- helpers: each step below is called directly from the test bodies above ---

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -16,9 +16,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.TextContent;
 import io.camunda.client.api.command.AgentInstanceHistoryItem;
 import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -30,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -352,15 +355,239 @@ public class AgentInstanceHistorySearchIT {
             });
   }
 
+  @Test
+  void shouldCreateAgentInstanceWithMultipleHistoryItemsInOneBatch() {
+    // given - an agent job for which we can create an agent instance
+    final var job = startAndActivateAgentJob();
+
+    // when — a CONFIGURATION item and a USER item are submitted together in ONE CREATE call,
+    // proving CREATE can batch more than a single history item at a time.
+    final var createResponse =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(job.elementInstanceKey())
+            .jobKey(job.jobKey())
+            .jobLease(job.jobLease())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.CONFIGURATION)
+                        .content(List.of(AgentInstanceHistoryContent.text("configuration")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T09:59:00Z"))
+                        .model("gpt-4o")
+                        .provider("openai")
+                        .systemPrompt(
+                            List.of(
+                                AgentInstanceHistoryContent.text("You are a helpful assistant."))),
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.USER)
+                        .content(List.of(AgentInstanceHistoryContent.text("Hello there")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))))
+            .send()
+            .join();
+    final long agentInstanceKey = createResponse.getAgentInstanceKey();
+    final long configurationItemKey = createResponse.getCreatedHistory().get(0).getHistoryItemKey();
+    final long userItemKey = createResponse.getCreatedHistory().get(1).getHistoryItemKey();
+
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+
+    camundaClient.newCompleteCommand(job.jobKey()).withLeaseToken(job.jobLease()).execute();
+    waitForHistoryItemsToBeIndexed(camundaClient, agentInstanceKey, 2);
+
+    // then
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .sort(s -> s.producedAt().desc())
+            .execute();
+
+    assertThat(response.items())
+        .as("both items from the single CREATE batch must come back, ordered by producedAt")
+        .extracting(AgentInstanceHistory::getHistoryItemKey)
+        .containsExactly(userItemKey, configurationItemKey);
+    assertThat(response.items())
+        .as("both items from the single CREATE batch must come back, ordered by producedAt")
+        .extracting(AgentInstanceHistory::getRole)
+        .containsExactly(AgentInstanceHistoryRole.USER, AgentInstanceHistoryRole.CONFIGURATION);
+    assertThat(response.items().getFirst().getContent())
+        .as("the USER item's submitted content must be preserved")
+        .extracting(c -> ((TextContent) c).getText())
+        .containsExactly("Hello there");
+  }
+
+  @Test
+  void shouldUpdateAgentInstanceWithMultipleHistoryItemsInOneBatch() {
+    // given - an agent job for which we can create an agent instance
+    final var job = startAndActivateAgentJob();
+
+    final var createResponse =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(job.elementInstanceKey())
+            .jobKey(job.jobKey())
+            .jobLease(job.jobLease())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.CONFIGURATION)
+                        .content(List.of(AgentInstanceHistoryContent.text("configuration")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T09:59:00Z"))
+                        .model("gpt-4o")
+                        .provider("openai")
+                        .systemPrompt(
+                            List.of(
+                                AgentInstanceHistoryContent.text("You are a helpful assistant.")))))
+            .send()
+            .join();
+    final long agentInstanceKey = createResponse.getAgentInstanceKey();
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+
+    // when — three items of different roles are submitted together in ONE UPDATE call.
+    final var updatedHistory =
+        camundaClient
+            .newUpdateAgentInstanceCommand(agentInstanceKey)
+            .elementInstanceKey(job.elementInstanceKey())
+            .jobKey(job.jobKey())
+            .jobLease(job.jobLease())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.USER)
+                        .content(List.of(AgentInstanceHistoryContent.text("What's the weather?")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z")),
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.ASSISTANT)
+                        .content(List.of(AgentInstanceHistoryContent.text("Let me check that.")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:01:00Z"))
+                        .metrics(
+                            new AgentInstanceHistoryMetrics()
+                                .inputTokens(256L)
+                                .outputTokens(64L)
+                                .durationMs(800L)),
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.TOOL_RESULT)
+                        .content(List.of(AgentInstanceHistoryContent.object("sunny, 22C")))
+                        .producedAt(OffsetDateTime.parse("2025-06-01T10:02:00Z"))))
+            .send()
+            .join()
+            .getCreatedHistory();
+    final long userItemKey = updatedHistory.get(0).getHistoryItemKey();
+    final long assistantItemKey = updatedHistory.get(1).getHistoryItemKey();
+    final long toolResultItemKey = updatedHistory.get(2).getHistoryItemKey();
+
+    // Complete the job so all three PENDING items commit and become searchable.
+    camundaClient.newCompleteCommand(job.jobKey()).withLeaseToken(job.jobLease()).execute();
+    waitForHistoryItemsToBeIndexed(
+        camundaClient,
+        agentInstanceKey,
+        f -> f.role(r -> r.neq(AgentInstanceHistoryRole.CONFIGURATION)),
+        3);
+
+    // then
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.role(r -> r.neq(AgentInstanceHistoryRole.CONFIGURATION)))
+            .sort(s -> s.producedAt().asc())
+            .execute();
+
+    assertThat(response.items())
+        .as("all three items from the single UPDATE batch must come back, ordered by producedAt")
+        .extracting(AgentInstanceHistory::getHistoryItemKey)
+        .containsExactly(userItemKey, assistantItemKey, toolResultItemKey);
+    assertThat(response.items())
+        .as("all three items from the single UPDATE batch must come back, ordered by producedAt")
+        .extracting(AgentInstanceHistory::getRole)
+        .containsExactly(
+            AgentInstanceHistoryRole.USER,
+            AgentInstanceHistoryRole.ASSISTANT,
+            AgentInstanceHistoryRole.TOOL_RESULT);
+    final var metrics = response.items().stream().map(AgentInstanceHistory::getMetrics).toList();
+    assertThat(metrics.get(0)).as("USER item must have no metrics").isNull();
+    assertThat(metrics.get(1))
+        .as("ASSISTANT item must return the metrics submitted with it")
+        .isNotNull();
+    assertThat(metrics.get(1).getInputTokens()).isEqualTo(256L);
+    assertThat(metrics.get(1).getOutputTokens()).isEqualTo(64L);
+    assertThat(metrics.get(1).getDurationMs()).isEqualTo(800L);
+    assertThat(metrics.get(2)).as("TOOL_RESULT item must have no metrics").isNull();
+  }
+
+  /**
+   * Starts a new instance of the class's process and activates its agent job — but does not create
+   * the agent instance itself, leaving each caller free to submit its own CREATE batch. Shared by
+   * the two tests above so each can set up its own agent instance without touching the class's
+   * shared {@code agentInstanceKey}/{@code elementInstanceKey} fields, which the other tests in
+   * this class assert on.
+   */
+  private static AgentJob startAndActivateAgentJob() {
+    final var pi = startProcessInstance(camundaClient, PROCESS_ID);
+    final long processInstanceKey = pi.getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey),
+        1);
+
+    final long elementInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(AGENT_ELEMENT_ID).processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    final var activatedJobs =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .maxJobsToActivate(1)
+            .withLease(true)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    assertThat(activatedJobs)
+        .as("expected to activate one agent job for process instance %d", processInstanceKey)
+        .isNotEmpty();
+
+    return new AgentJob(
+        elementInstanceKey, activatedJobs.get(0).getKey(), activatedJobs.get(0).getLeaseToken());
+  }
+
   private static void waitForHistoryItemsToBeIndexed(
       final CamundaClient client, final long agentKey, final int expectedCount) {
+    waitForHistoryItemsToBeIndexed(client, agentKey, f -> {}, expectedCount);
+  }
+
+  private static void waitForHistoryItemsToBeIndexed(
+      final CamundaClient client,
+      final long agentKey,
+      final Consumer<AgentInstanceHistoryFilter> filter,
+      final int expectedCount) {
     Awaitility.await("agent history indexed")
         .atMost(Duration.ofSeconds(30))
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              final var response = client.newAgentInstanceHistorySearchRequest(agentKey).execute();
+              final var response =
+                  client.newAgentInstanceHistorySearchRequest(agentKey).filter(filter).execute();
               assertThat(response.items()).hasSizeGreaterThanOrEqualTo(expectedCount);
             });
   }
+
+  private record AgentJob(long elementInstanceKey, long jobKey, String jobLease) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -3177,4 +3177,109 @@ public class AgentInstanceHistoryBatchProcessingTest {
                 + " from this resend")
         .hasSize(2);
   }
+
+  @Test
+  public void shouldRejectResendAfterJobHasCompleted() {
+    // given — a sequential multi-instance AI-agent service task. A plain single-service-task
+    // process won't do here: completing EI1's job also completes EI1, and with a single task that
+    // completes the whole process (and the agent instance with it), leaving nothing left to
+    // reject a resend against. Routing the resend through EI2 — still active — isolates the one
+    // thing this test is about: job1 itself is no longer ACTIVATED.
+    final var multiInstanceProcessId = "dedup-sequential-multi-instance-resend-after-completion";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(multiInstanceProcessId)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t ->
+                        t.zeebeJobType(helper.getJobType())
+                            .zeebeAiAgentTaskDefinition()
+                            .multiInstance(
+                                m ->
+                                    m.sequential()
+                                        .zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(multiInstanceProcessId)
+            .withVariables(Map.of("items", List.of("a", "b")))
+            .create();
+    final var ei1 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(ei1)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    ENGINE.job().ofInstance(processInstanceKey).withType(helper.getJobType()).complete();
+
+    final var ei2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .limit(2)
+            .toList()
+            .get(1)
+            .getKey();
+
+    // when — a resend reuses job1 (EI1's own, now-completed job) but targets EI2 (still active),
+    // so the rejection reflects job1's own state, not EI2's — which is otherwise valid.
+    final var job1Key =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .filter(r -> r.getValue().getElementInstanceKey() == ei1)
+            .getFirst()
+            .getKey();
+
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(ei2)
+            .withJobKey(job1Key)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-after-completion")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("resend after completion"))))
+            .expectRejection()
+            .update();
+
+    // then
+    assertThat(rejection.getRecordType())
+        .as("job1 is no longer ACTIVATED, so the resend must be rejected")
+        .isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType())
+        .as("job1 is no longer ACTIVATED, so the resend must be rejected")
+        .isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .as("job1 is no longer ACTIVATED, so the resend must be rejected")
+        .contains(
+            ("Expected to update agent instance related to job with key '%d', but job was not "
+                    + "active.")
+                .formatted(job1Key));
+  }
 }


### PR DESCRIPTION
## Description

This PR adds end-to-end confidence for the redesigned Agent Instance Command API. Several behaviors were implemented but never tested through the client: batched history writes, historyItemId dedup, and deferred `CONFIGURATION` commits.

**Covered**: Six new tests cover these gaps:
- Batching multiple history items into one `CREATE` or `UPDATE` call
- Deduping a resent historyItemId, within a job activation and across job activations
- A `CONFIGURATION` change via `UPDATE` staying uncommitted until the job completes
- A resend being rejected once its job has already completed

Five tests are new methods on existing `@MultiDbTest` IT classes (no new test classes, no added CI cost). One is an engine unit test.

**Drive-by**: fixed a comment in `AgentHistoryCommitLifecycleIT` that wrongly claimed discarding a `CONFIGURATION` item rolls it back to defaults. It doesn't — that's a real bug, filed separately as camunda/camunda#61391 (no fix here; test-coverage PR only).

**Not covered**: reasoning/cache token metrics (#59320, not wired to REST yet) and a regression test for #61391 (still unsettled whether it's a bug).

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #60154
