### PR TITLE
fix: validate OpenSearch minimum age configuration

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -21,10 +21,23 @@ import io.camunda.zeebe.util.SemanticVersion;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OpensearchExporter implements Exporter {
+
+  /**
+   * Supported pattern for the ISM {@code min_index_age} property. Retention periods smaller than a
+   * second are not useful here, so only days, hours, minutes, and seconds are supported.
+   *
+   * <p>See https://docs.opensearch.org/latest/api-reference/units/
+   */
+  private static final String PATTERN_MIN_AGE_FORMAT = "^[0-9]+[dhms]$";
+
+  private static final Predicate<String> CHECKER_MIN_AGE =
+      Pattern.compile(PATTERN_MIN_AGE_FORMAT).asPredicate();
 
   // by default, the bulk request may not be bigger than 100MB
   private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
@@ -195,6 +208,14 @@ public class OpensearchExporter implements Exporter {
     if (priority < 0) {
       throw new ExporterException(
           "Opensearch index template priority must be >= 0. Current value: %d".formatted(priority));
+    }
+
+    final String minimumAge = configuration.retention.getMinimumAge();
+    if (minimumAge != null && !CHECKER_MIN_AGE.test(minimumAge)) {
+      throw new ExporterException(
+          String.format(
+              "Opensearch minimumAge '%s' must match pattern '%s', but didn't.",
+              minimumAge, PATTERN_MIN_AGE_FORMAT));
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -211,7 +211,10 @@ public class OpensearchExporter implements Exporter {
     }
 
     final String minimumAge = configuration.retention.getMinimumAge();
-    if (minimumAge != null && !CHECKER_MIN_AGE.test(minimumAge)) {
+    if (minimumAge == null || minimumAge.isBlank()) {
+      throw new ExporterException("Opensearch minimumAge must not be null or blank.");
+    }
+    if (!CHECKER_MIN_AGE.test(minimumAge)) {
       throw new ExporterException(
           String.format(
               "Opensearch minimumAge '%s' must match pattern '%s', but didn't.",

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -576,6 +576,29 @@ final class OpensearchExporterTest {
       assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
     }
 
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"1", "-1", "1ms"})
+    void shouldNotAllowInvalidMinimumAge(final String invalidMinimumAge) {
+      // given
+      config.retention.setMinimumAge(invalidMinimumAge);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context))
+          .isInstanceOf(ExporterException.class)
+          .hasMessageContaining("must match pattern '^[0-9]+[dhms]$'")
+          .hasMessageContaining("minimumAge '" + invalidMinimumAge + "'");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"1s", "5m", "2h", "30d"})
+    void shouldAllowValidMinimumAge(final String validMinimumAge) {
+      // given
+      config.retention.setMinimumAge(validMinimumAge);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context)).doesNotThrowAnyException();
+    }
+
     @Test
     void shouldForbidNegativeNumberOfReplicas() {
       // given

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
@@ -587,6 +588,19 @@ final class OpensearchExporterTest {
           .isInstanceOf(ExporterException.class)
           .hasMessageContaining("must match pattern '^[0-9]+[dhms]$'")
           .hasMessageContaining("minimumAge '" + invalidMinimumAge + "'");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" "})
+    void shouldNotAllowNullOrBlankMinimumAge(final String invalidMinimumAge) {
+      // given
+      config.retention.setMinimumAge(invalidMinimumAge);
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context))
+          .isInstanceOf(ExporterException.class)
+          .hasMessageContaining("must not be null or blank");
     }
 
     @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
## Summary
Cherry-pick of #60840 by @Hardikraja, run through CI (external contributor PRs don't trigger CI runs automatically).

Invalid retention minimum-age values were accepted during exporter configuration and failed only when OpenSearch applied the ISM policy. This validates the value during configuration using the supported day, hour, minute, and second units, matching the Elasticsearch exporter behavior.

Additionally rejects a null/blank `minimumAge` (raised in review): an explicit null bypassed the pattern check and would reach OpenSearch as `min_index_age: null`, causing the same runtime failure this PR fixes.

Closes #15987 

## Test plan
- [x] `OpensearchExporterTest` passes locally (321 tests)
- [ ] CI passes