### PR TITLE
fix: stop losing daily load-test Slack results to secret-output masking

### DIFF
--- a/.github/scripts/post-load-test-results-to-slack.py
+++ b/.github/scripts/post-load-test-results-to-slack.py
@@ -10,18 +10,21 @@ source of truth shared with `loadTestMetrics.sh`), so adding a metric there auto
 row here. Metrics tied to secondary storage (e.g. importer/exporter lag) naturally render as n/a
 for a no-secondary-storage variant.
 
-The table has one column per entry in VARIANTS_JSON — adding a daily variant (a new matrix entry
-in camunda-daily-load-tests.yml) needs no change here.
+The table has one column per entry in the variants manifest (VARIANTS_JSON_FILE, or VARIANTS_JSON
+as a fallback) — adding a daily variant (a new matrix entry in camunda-daily-load-tests.yml) needs
+no change here.
 
 Required environment variables:
-  VARIANTS_JSON       JSON array of {key, label, namespace, soakEndEpoch, results} objects, one
-                      per variant, in display order. `results` is {metric_name: value}.
   BENCHMARK           Benchmark name, e.g. medic-daily-YYYY-MM-DD-<sha>-test.
   SLACK_WEBHOOK_URL   Incoming-webhook URL to post to.
   REPO                GitHub repo slug, e.g. camunda/camunda.
   RUN_ID              GitHub Actions run id (used to link the workflow run).
 
 Optional:
+  VARIANTS_JSON_FILE  Path to the variants manifest JSON file (see aggregate-metrics in
+                      camunda-daily-load-tests.yml). Falls back to the VARIANTS_JSON env var
+                      (a literal JSON string) if unset, for manual/local invocation. Empty or
+                      missing data exits cleanly without posting to Slack.
   QUERIES_YAML        Path to queries.yaml. Default:
                       load-tests/docs/scripts/queries.yaml
   FLAMEGRAPH_LINKS    Pre-rendered Slack mrkdwn links to this run's flamegraph
@@ -34,13 +37,24 @@ Optional:
 import json
 import os
 import socket
+import sys
 import time
 import urllib.error
 import urllib.request
 
 import yaml
 
-variants = json.loads(os.environ.get('VARIANTS_JSON') or '[]')
+variants_json_file = os.environ.get('VARIANTS_JSON_FILE')
+if variants_json_file and os.path.exists(variants_json_file):
+    with open(variants_json_file) as f:
+        variants_raw = f.read().strip() or '[]'
+else:
+    variants_raw = (os.environ.get('VARIANTS_JSON') or '').strip() or '[]'
+variants = json.loads(variants_raw)
+
+if not variants:
+    print('No variant metrics available — skipping Slack post.')
+    sys.exit(0)
 bench    = os.environ['BENCHMARK']
 repo     = os.environ['REPO']
 run_id   = os.environ['RUN_ID']
@@ -116,8 +130,8 @@ blocks = [
 ]
 
 # Slack rejects a section block with empty text — dash_links is empty only when variants is
-# empty, which the calling workflow already gates on, but keep this defensive at the script
-# level too (e.g. against direct/manual invocation with an empty VARIANTS_JSON).
+# empty, and the early exit above already handles that case (see the empty/missing-data check
+# near the top of this file). Kept as a defensive check in case that invariant ever changes.
 if dash_links:
     blocks.append({
         'type': 'section',

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -2,8 +2,9 @@
 #              and REST (both against Elasticsearch), and no-secondary-storage (exporters
 #              disabled). After a 15-minute warmup, profiles the next 30 minutes of each variant
 #              via async-profiler. After a 3-hour soak: snapshots metrics as a GitHub artifact,
-#              posts a side-by-side summary table (with flamegraph links) to Slack, then
-#              immediately deletes the namespaces to reduce cost.
+#              posts a side-by-side summary table (with flamegraph links) to Slack (the scheduled
+#              run always posts; a manual run only when opted in via the post-to-slack input),
+#              then immediately deletes the namespaces to reduce cost.
 #              Naming pattern: medic-daily-YYYY-MM-DD-<sha>
 #              Each variant's full lifecycle (setup, warmup, profile, soak, collect-metrics,
 #              cleanup) is delegated to the reusable stress-load-test.yml workflow via a
@@ -23,6 +24,11 @@ on:
         description: 'Docker image tag, that should be reused for the load tests. Allows to skip the docker image build step, can be used for recreating previous tests.'
         type: string
         default: ""
+        required: false
+      post-to-slack:
+        description: 'Post the results to the reliability-testing Slack channel (useful for an end-to-end test run). Always posts on the scheduled run regardless of this input.'
+        type: boolean
+        default: false
         required: false
   schedule:
     # Runs at 2 am Monday-Friday https://crontab.guru/#0_2_*_*_1-5
@@ -199,10 +205,13 @@ jobs:
     name: Notify Slack with results
     runs-on: ubuntu-latest
     needs: [ benchmark-data, aggregate-metrics ]
-    # Only gated on aggregate-metrics succeeding here — whether there's actually data to post
-    # is now checked inside the script after downloading the artifact (see below), since we no
-    # longer have a safe job-output to gate on (see the comment in aggregate-metrics above).
-    if: always() && needs.aggregate-metrics.result == 'success'
+    # Data-presence is checked inside the script after the manifest download, not here: the
+    # job output that used to gate it is gone (see the comment in aggregate-metrics above).
+    # Manual runs post only when explicitly asked; the scheduled run always posts.
+    if: >
+      always() &&
+      needs.aggregate-metrics.result == 'success' &&
+      (github.event_name != 'workflow_dispatch' || inputs.post-to-slack == true)
     timeout-minutes: 5
     permissions:
       actions: read

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -163,16 +163,12 @@ jobs:
           if [ "$manifest" = '[]' ]; then
             echo "::warning::No variant metrics artifacts found; Slack summary and legacy artifact will be empty"
           fi
-          # Written to a FILE (not $GITHUB_OUTPUT): job outputs in this job are unsafe here — this
-          # job also uses secrets.VAULT_* below (Observe build status), and GitHub Actions silently
-          # drops any $GITHUB_OUTPUT write whose value happens to contain a substring matching a
-          # secret registered anywhere in the job (see
-          # https://github.com/orgs/community/discussions/26636). That bit the 2026-09-01 run: the
-          # manifest was built correctly but the variants-json *output* came back empty, and
-          # notify-results posted a header-only table even though every variant's data was intact
-          # in this job's own artifact. Files aren't subject to output-masking, so the artifact is
-          # the only reliable transport here — same reasoning already applied to
-          # upload-variant-metrics above.
+          # Written to a FILE, not $GITHUB_OUTPUT: this job also uses secrets.VAULT_* below (Observe
+          # build status), and GitHub Actions silently drops any $GITHUB_OUTPUT write whose value
+          # happens to contain a substring matching a secret registered anywhere in the job (see
+          # https://github.com/orgs/community/discussions/26636). Files aren't subject to that
+          # masking, so the artifact is the only reliable transport here — same reasoning already
+          # applied to upload-variant-metrics above.
           echo "$manifest" > variants.json
       - name: Upload combined metrics artifact
         if: always()
@@ -205,9 +201,9 @@ jobs:
     name: Notify Slack with results
     runs-on: ubuntu-latest
     needs: [ benchmark-data, aggregate-metrics ]
-    # Data-presence is checked inside the script after the manifest download, not here: the
-    # job output that used to gate it is gone (see the comment in aggregate-metrics above).
-    # Manual runs post only when explicitly asked; the scheduled run always posts.
+    # Data-presence is checked inside post-load-test-results-to-slack.py after the manifest
+    # download, not here. Manual runs post only when explicitly asked; the scheduled run always
+    # posts.
     if: >
       always() &&
       needs.aggregate-metrics.result == 'success' &&

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -125,8 +125,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    outputs:
-      variants-json: ${{ steps.merge.outputs.variants-json }}
     steps:
       - name: Download variant metrics artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -136,8 +134,7 @@ jobs:
           path: variant-metrics
           # No merge-multiple: every artifact contains a file named stress-result.json, so each
           # needs its own per-artifact-name folder to avoid one variant's file overwriting another's.
-      - name: Merge into the legacy combined artifact + variants-json manifest
-        id: merge
+      - name: Merge into the legacy combined artifact + variants manifest
         env:
           BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
           # Keep in sync with the `run-variant` matrix above (key:label pairs) — this determines
@@ -160,11 +157,17 @@ jobs:
           if [ "$manifest" = '[]' ]; then
             echo "::warning::No variant metrics artifacts found; Slack summary and legacy artifact will be empty"
           fi
-          {
-            echo "variants-json<<__VQ_EOF__"
-            echo "$manifest"
-            echo "__VQ_EOF__"
-          } >> "$GITHUB_OUTPUT"
+          # Written to a FILE (not $GITHUB_OUTPUT): job outputs in this job are unsafe here — this
+          # job also uses secrets.VAULT_* below (Observe build status), and GitHub Actions silently
+          # drops any $GITHUB_OUTPUT write whose value happens to contain a substring matching a
+          # secret registered anywhere in the job (see
+          # https://github.com/orgs/community/discussions/26636). That bit the 2026-09-01 run: the
+          # manifest was built correctly but the variants-json *output* came back empty, and
+          # notify-results posted a header-only table even though every variant's data was intact
+          # in this job's own artifact. Files aren't subject to output-masking, so the artifact is
+          # the only reliable transport here — same reasoning already applied to
+          # upload-variant-metrics above.
+          echo "$manifest" > variants.json
       - name: Upload combined metrics artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -172,7 +175,9 @@ jobs:
           # resolve-daily.py only checks this artifact for existence by name prefix — keep the
           # name stable even though its internal file layout changed.
           name: daily-load-test-metrics-${{ needs.benchmark-data.outputs.benchmark }}
-          path: metrics-*.json
+          path: |
+            metrics-*.json
+            variants.json
           retention-days: 90
           if-no-files-found: ignore
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -194,10 +199,10 @@ jobs:
     name: Notify Slack with results
     runs-on: ubuntu-latest
     needs: [ benchmark-data, aggregate-metrics ]
-    # Post only if aggregate-metrics actually succeeded and at least one variant produced
-    # metrics: a failed aggregate-metrics run yields an empty (still != '[]') output, which
-    # would otherwise post an empty Slack payload.
-    if: always() && needs.aggregate-metrics.result == 'success' && needs.aggregate-metrics.outputs.variants-json != '[]'
+    # Only gated on aggregate-metrics succeeding here — whether there's actually data to post
+    # is now checked inside the script after downloading the artifact (see below), since we no
+    # longer have a safe job-output to gate on (see the comment in aggregate-metrics above).
+    if: always() && needs.aggregate-metrics.result == 'success'
     timeout-minutes: 5
     permissions:
       actions: read
@@ -206,6 +211,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Download variant manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: daily-load-test-metrics-${{ needs.benchmark-data.outputs.benchmark }}
+          path: variant-manifest
       - name: List flamegraph artifacts
         id: flamegraph-artifacts
         # Best-effort enhancement: a failure here shouldn't block the Slack results
@@ -240,7 +250,7 @@ jobs:
         # queries.yaml is the canonical source of metric names/labels/formats;
         # the script reads it directly so the Slack table stays in sync.
         env:
-          VARIANTS_JSON: ${{ needs.aggregate-metrics.outputs.variants-json }}
+          VARIANTS_JSON_FILE: variant-manifest/variants.json
           BENCHMARK: ${{ needs.benchmark-data.outputs.benchmark }}
           SLACK_WEBHOOK_URL: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Description

On 2026-09-01 the daily load test's Slack results post came out header-only (metric names, no values), even though the underlying test data was intact. `aggregate-metrics` builds a correct results manifest and passes it to `notify-results` via a `$GITHUB_OUTPUT` job output (`variants-json`). That job also references `secrets.VAULT_*` later in its own steps, and GitHub Actions silently drops an entire `$GITHUB_OUTPUT` write if its value happens to contain a substring matching any secret registered anywhere in the job - no failed step, no visible error. The failed run's own job log confirms it directly ([job 99750628883](https://github.com/camunda/camunda/actions/runs/33462200213/job/99750628883)): `##[warning]Skip output 'variants-json' since it may contain secret.`

This routes the manifest through a file (`variants.json`) bundled into the artifact `aggregate-metrics` already uploads, the same pattern already used for the per-variant metrics artifacts, instead of a job output. `notify-results` downloads that artifact and reads the file directly. `post-load-test-results-to-slack.py` now exits cleanly with no post if the manifest is ever empty, instead of posting a misleading header-only table.

Also adds an opt-in `post-to-slack` boolean input on `workflow_dispatch` (default `false`), so this fix can be end-to-end tested with a real manual dispatch without posting to the channel on every re-run. Scheduled runs are unaffected.

Missing 2026-08-28, 08-31, and 09-01 results were recovered from the affected runs' own artifacts and republished in [#reliability-testing-alerts](https://camunda.slack.com/archives/C0ANMGS3D4Y) - no re-test needed.

The same class of bug exists in `camunda-load-test-metrics.yaml`'s `collect-metrics` job (Vault-fetched Prometheus credentials rather than repo secrets); tracked separately in #61571 since fixing it touches a public `workflow_call` output used by other callers. #61574 separately proposes persisting results outside Slack/GitHub artifacts entirely.

## Checklist

- [x] Backports not applicable - `camunda-daily-load-tests.yml` only runs on `main`.
- [x] Not applicable - doesn't touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

None - discovered live rather than from a pre-filed issue.