### PR TITLE
fix: refresh role memberships after assignment changes

### DIFF
--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -25,7 +25,10 @@ type UseEnrichedGroupsResult = {
   groups: GroupWithId[];
   loading: boolean;
   success: boolean;
-  reload: () => void;
+  reload: () => Promise<{
+    data?: QueryGroupsResponseBody | QueryGroupsByRoleResponseBody;
+    isSuccess: boolean;
+  }>;
   paginationProps: {
     page: { pageNumber: number; pageSize: number; totalItems?: number };
     setPageNumber: (page: number) => void;
@@ -106,9 +109,7 @@ export function useEnrichedGroups<P>(
     groups,
     loading,
     success,
-    reload: () => {
-      void membersQuery.refetch();
-    },
+    reload: membersQuery.refetch,
     paginationProps: {
       page: { ...page, ...membersQuery.data?.page },
       setPageNumber,

--- a/identity/client/src/components/global/useEnrichGroups.tsx
+++ b/identity/client/src/components/global/useEnrichGroups.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type QueryObserverBaseResult } from "@tanstack/react-query";
 import { ApiDefinition, unwrap } from "src/utility/api/request";
 import { searchGroups } from "src/utility/api/groups";
 import { usePagination } from "src/utility/api";
@@ -25,10 +25,9 @@ type UseEnrichedGroupsResult = {
   groups: GroupWithId[];
   loading: boolean;
   success: boolean;
-  reload: () => Promise<{
-    data?: QueryGroupsResponseBody | QueryGroupsByRoleResponseBody;
-    isSuccess: boolean;
-  }>;
+  reload: QueryObserverBaseResult<
+    QueryGroupsResponseBody | QueryGroupsByRoleResponseBody
+  >["refetch"];
   paginationProps: {
     page: { pageNumber: number; pageSize: number; totalItems?: number };
     setPageNumber: (page: number) => void;

--- a/identity/client/src/components/global/useEnrichUsers.tsx
+++ b/identity/client/src/components/global/useEnrichUsers.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type QueryObserverBaseResult } from "@tanstack/react-query";
 import type {
   User,
   QueryUsersResponseBody,
@@ -25,10 +25,9 @@ type UseEnrichedUsersResult = {
   users: UserWithId[];
   loading: boolean;
   success: boolean;
-  reload: () => Promise<{
-    data?: QueryUsersResponseBody | QueryUsersByGroupResponseBody;
-    isSuccess: boolean;
-  }>;
+  reload: QueryObserverBaseResult<
+    QueryUsersResponseBody | QueryUsersByGroupResponseBody
+  >["refetch"];
   paginationProps: {
     page: { pageNumber: number; pageSize: number; totalItems?: number };
     setPageNumber: (page: number) => void;

--- a/identity/client/src/components/global/useEnrichUsers.tsx
+++ b/identity/client/src/components/global/useEnrichUsers.tsx
@@ -25,7 +25,10 @@ type UseEnrichedUsersResult = {
   users: UserWithId[];
   loading: boolean;
   success: boolean;
-  reload: () => void;
+  reload: () => Promise<{
+    data?: QueryUsersResponseBody | QueryUsersByGroupResponseBody;
+    isSuccess: boolean;
+  }>;
   paginationProps: {
     page: { pageNumber: number; pageSize: number; totalItems?: number };
     setPageNumber: (page: number) => void;
@@ -105,9 +108,7 @@ export function useEnrichedUsers<P>(
     users,
     loading,
     success,
-    reload: () => {
-      void membersQuery.refetch();
-    },
+    reload: membersQuery.refetch,
     paginationProps: {
       page: { ...page, ...membersQuery.data?.page },
       setPageNumber,

--- a/identity/client/src/pages/roles/detail/clients/index.tsx
+++ b/identity/client/src/pages/roles/detail/clients/index.tsx
@@ -18,6 +18,7 @@ import { useEntityModal } from "src/components/modal";
 import DeleteModal from "src/pages/roles/detail/clients/DeleteModal";
 import AssignClientsModal from "src/pages/roles/detail/clients/AssignClientsModal";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
 
 type ClientsProps = {
@@ -26,7 +27,6 @@ type ClientsProps = {
 
 const Clients: FC<ClientsProps> = ({ roleId }) => {
   const { t } = useTranslate("roles");
-  const noop = () => {};
 
   const { pageParams, page, ...paginationCallbacks } = usePagination();
   const {
@@ -38,15 +38,21 @@ const Clients: FC<ClientsProps> = ({ roleId }) => {
 
   const assignedClients =
     clients && Array.isArray(clients.items) ? clients.items : [];
+  const { startPolling } = useListPollingReload(
+    reload,
+    assignedClients,
+    "clientId",
+    clients?.page.totalItems,
+  );
 
   const [assignClient, assignClientModal] = useEntityModal(
     AssignClientsModal,
-    noop,
+    () => startPolling(1),
   );
   const openAssignModal = () => assignClient(roleId);
   const [unassignClient, unassignClientModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     { roleId },
   );
 

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupModal.tsx
@@ -18,9 +18,12 @@ import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignGroupModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedGroups: Group[] }
+    {
+      assignedGroups: Group[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+> = ({ entity: { roleId }, onSuccess, onItemsAssigned, open, onClose }) => {
   const { t } = useTranslate("roles");
   const [groupId, setGroupId] = useState("");
   const qc = useQueryClient();
@@ -32,7 +35,15 @@ const AssignGroupModal: FC<
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    mutate({ groupId, roleId }, { onSuccess });
+    mutate(
+      { groupId, roleId },
+      {
+        onSuccess: () => {
+          onItemsAssigned(1);
+          onSuccess();
+        },
+      },
+    );
   };
 
   useEffect(() => {

--- a/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detail/groups/AssignGroupsModal.tsx
@@ -18,9 +18,19 @@ import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignGroupsModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedGroups: Group[] }
+    {
+      assignedGroups: Group[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, assignedGroups, onSuccess, open, onClose }) => {
+> = ({
+  entity: { roleId },
+  assignedGroups,
+  onSuccess,
+  onItemsAssigned,
+  open,
+  onClose,
+}) => {
   const { t } = useTranslate("roles");
   const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
   const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
@@ -42,6 +52,7 @@ const AssignGroupsModal: FC<
           callAssignGroup({ groupId, roleId }),
         ),
       );
+      onItemsAssigned(selectedGroups.length);
       onSuccess();
     } catch {
       // error handled globally

--- a/identity/client/src/pages/roles/detail/groups/index.tsx
+++ b/identity/client/src/pages/roles/detail/groups/index.tsx
@@ -19,6 +19,7 @@ import DeleteModal from "src/pages/roles/detail/groups/DeleteModal";
 import { GroupKeys } from "src/utility/api/groups";
 import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 
 type GroupsProps = {
   roleId: string;
@@ -39,18 +40,24 @@ const Groups: FC<GroupsProps> = ({ roleId, isCamundaGroupsEnabled }) => {
     );
 
   const isGroupsEmpty = !groups || groups.length === 0;
-  const noop = () => {};
+  const { startPolling } = useListPollingReload(
+    reload,
+    groups,
+    "groupId",
+    paginationProps.page.totalItems,
+  );
   const [assignGroups, assignGroupsModal] = useEntityModal(
     isCamundaGroupsEnabled ? AssignGroupsModal : AssignGroupModal,
-    noop,
+    () => {},
     {
       assignedGroups: groups,
+      onItemsAssigned: startPolling,
     },
   );
   const openAssignModal = () => assignGroups({ roleId });
   const [unassignGroup, unassignGroupModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     {
       role: roleId,
     },

--- a/identity/client/src/pages/roles/detail/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/AssignMappingRulesModal.tsx
@@ -18,9 +18,19 @@ import type { MappingRule, Role } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignMappingRulesModal: FC<
   UseEntityModalCustomProps<
     { id: Role["roleId"] },
-    { assignedMappingRules: MappingRule[] }
+    {
+      assignedMappingRules: MappingRule[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: role, assignedMappingRules, onSuccess, open, onClose }) => {
+> = ({
+  entity: role,
+  assignedMappingRules,
+  onSuccess,
+  onItemsAssigned,
+  open,
+  onClose,
+}) => {
   const { t, Translate } = useTranslate("roles");
   const [selectedMappingRules, setSelectedMappingRules] = useState<
     MappingRule[]
@@ -48,6 +58,7 @@ const AssignMappingRulesModal: FC<
           }),
         ),
       );
+      onItemsAssigned(selectedMappingRules.length);
       onSuccess();
     } catch {
       // error handled globally

--- a/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detail/mapping-rules/index.tsx
@@ -18,6 +18,7 @@ import { useEntityModal } from "src/components/modal";
 import DeleteModal from "src/pages/roles/detail/mapping-rules/DeleteModal";
 import AssignMappingRulesModal from "src/pages/roles/detail/mapping-rules/AssignMappingRulesModal.tsx";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 
 type MappingRulesProps = {
   roleId: string;
@@ -25,7 +26,6 @@ type MappingRulesProps = {
 
 const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
   const { t } = useTranslate("roles");
-  const noop = () => {};
 
   const { pageParams, page, ...paginationCallbacks } = usePagination();
   const {
@@ -37,18 +37,25 @@ const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
 
   const isMappingRulesListEmpty =
     !mappingRules || mappingRules.items?.length === 0;
+  const { startPolling } = useListPollingReload(
+    reload,
+    mappingRules?.items ?? [],
+    "mappingRuleId",
+    mappingRules?.page.totalItems,
+  );
 
   const [assignMappingRules, assignMappingRulesModal] = useEntityModal(
     AssignMappingRulesModal,
-    noop,
+    () => {},
     {
       assignedMappingRules: mappingRules?.items || [],
+      onItemsAssigned: startPolling,
     },
   );
   const openAssignModal = () => assignMappingRules({ id: roleId });
   const [unassignMappingRule, unassignMappingRuleModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     {
       roleId,
     },

--- a/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMemberModal.tsx
@@ -20,9 +20,12 @@ import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignMemberModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedUsers: User[] }
+    {
+      assignedUsers: User[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+> = ({ entity: { roleId }, onSuccess, onItemsAssigned, open, onClose }) => {
   const { t, Translate } = useTranslate("roles");
   const [username, setUsername] = useState("");
   const qc = useQueryClient();
@@ -38,6 +41,7 @@ const AssignMemberModal: FC<
       { username, roleId },
       {
         onSuccess: () => {
+          onItemsAssigned(1);
           onSuccess();
         },
       },

--- a/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detail/members/AssignMembersModal.tsx
@@ -18,9 +18,19 @@ import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignMembersModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedUsers: User[] }
+    {
+      assignedUsers: User[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, assignedUsers, onSuccess, open, onClose }) => {
+> = ({
+  entity: { roleId },
+  assignedUsers,
+  onSuccess,
+  onItemsAssigned,
+  open,
+  onClose,
+}) => {
   const { t } = useTranslate("roles");
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [loadingAssignUser, setLoadingAssignUser] = useState(false);
@@ -42,6 +52,7 @@ const AssignMembersModal: FC<
           callAssignUser({ username, roleId }),
         ),
       );
+      onItemsAssigned(selectedUsers.length);
       onSuccess();
     } catch {
       // error handled globally

--- a/identity/client/src/pages/roles/detail/members/index.tsx
+++ b/identity/client/src/pages/roles/detail/members/index.tsx
@@ -19,6 +19,7 @@ import DeleteModal from "src/pages/roles/detail/members/DeleteModal";
 import { UserKeys } from "src/utility/api/users";
 import { useEnrichedUsers } from "src/components/global/useEnrichUsers";
 import TabEmptyState from "src/components/layout/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 
 type MembersProps = {
   roleId: string;
@@ -36,18 +37,23 @@ const Members: FC<MembersProps> = ({ roleId, isOIDC }) => {
     },
     isOIDC,
   );
-  const noop = () => {};
+  const { startPolling } = useListPollingReload(
+    reload,
+    users,
+    "username",
+    paginationProps.page.totalItems,
+  );
 
   const isUsersListEmpty = !users || users?.length === 0;
   const [assignUsers, assignUsersModal] = useEntityModal(
     isOIDC ? AssignMemberModal : AssignMembersModal,
-    noop,
-    { assignedUsers: users },
+    () => {},
+    { assignedUsers: users, onItemsAssigned: startPolling },
   );
   const openAssignModal = () => assignUsers({ roleId });
   const [unassignMember, unassignMemberModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     {
       roleId,
     },

--- a/identity/client/src/pages/roles/detailV2/clients/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/clients/index.tsx
@@ -18,6 +18,7 @@ import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNo
 import DeleteModal from "src/pages/roles/detailV2/clients/DeleteModal";
 import AssignClientsModal from "src/pages/roles/detailV2/clients/AssignClientsModal";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 import type { Role } from "@camunda/camunda-api-zod-schemas/8.10";
 
 type ClientsProps = {
@@ -26,7 +27,6 @@ type ClientsProps = {
 
 const Clients: FC<ClientsProps> = ({ roleId }) => {
   const { t } = useTranslate("roles");
-  const noop = () => {};
 
   const { pageParams, page, ...paginationCallbacks } = usePagination();
   const {
@@ -44,15 +44,21 @@ const Clients: FC<ClientsProps> = ({ roleId }) => {
 
   const assignedClients =
     clients && Array.isArray(clients.items) ? clients.items : [];
+  const { startPolling } = useListPollingReload(
+    reload,
+    assignedClients,
+    "clientId",
+    clients?.page.totalItems,
+  );
 
   const [assignClient, assignClientModal] = useEntityModal(
     AssignClientsModal,
-    noop,
+    () => startPolling(1),
   );
   const openAssignModal = () => assignClient(roleId);
   const [unassignClient, unassignClientModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     { roleId },
   );
 

--- a/identity/client/src/pages/roles/detailV2/groups/AssignGroupModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/AssignGroupModal.tsx
@@ -18,9 +18,12 @@ import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignGroupModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedGroups: Group[] }
+    {
+      assignedGroups: Group[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+> = ({ entity: { roleId }, onSuccess, onItemsAssigned, open, onClose }) => {
   const { t } = useTranslate("roles");
   const [groupId, setGroupId] = useState("");
   const qc = useQueryClient();
@@ -32,7 +35,15 @@ const AssignGroupModal: FC<
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    mutate({ groupId, roleId }, { onSuccess });
+    mutate(
+      { groupId, roleId },
+      {
+        onSuccess: () => {
+          onItemsAssigned(1);
+          onSuccess();
+        },
+      },
+    );
   };
 
   useEffect(() => {

--- a/identity/client/src/pages/roles/detailV2/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/AssignGroupsModal.tsx
@@ -18,9 +18,19 @@ import type { Group, Role } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignGroupsModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedGroups: Group[] }
+    {
+      assignedGroups: Group[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, assignedGroups, onSuccess, open, onClose }) => {
+> = ({
+  entity: { roleId },
+  assignedGroups,
+  onSuccess,
+  onItemsAssigned,
+  open,
+  onClose,
+}) => {
   const { t } = useTranslate("roles");
   const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
   const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
@@ -42,6 +52,7 @@ const AssignGroupsModal: FC<
           callAssignGroup({ groupId, roleId }),
         ),
       );
+      onItemsAssigned(selectedGroups.length);
       onSuccess();
     } catch {
       // error handled globally

--- a/identity/client/src/pages/roles/detailV2/groups/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/groups/index.tsx
@@ -19,6 +19,7 @@ import DeleteModal from "src/pages/roles/detailV2/groups/DeleteModal";
 import { GroupKeys } from "src/utility/api/groups";
 import { useEnrichedGroups } from "src/components/global/useEnrichGroups";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 
 type GroupsProps = {
   roleId: string;
@@ -39,18 +40,24 @@ const Groups: FC<GroupsProps> = ({ roleId, isCamundaGroupsEnabled }) => {
     );
 
   const isGroupsEmpty = !groups || groups.length === 0;
-  const noop = () => {};
+  const { startPolling } = useListPollingReload(
+    reload,
+    groups,
+    "groupId",
+    paginationProps.page.totalItems,
+  );
   const [assignGroups, assignGroupsModal] = useEntityModal(
     isCamundaGroupsEnabled ? AssignGroupsModal : AssignGroupModal,
-    noop,
+    () => {},
     {
       assignedGroups: groups,
+      onItemsAssigned: startPolling,
     },
   );
   const openAssignModal = () => assignGroups({ roleId });
   const [unassignGroup, unassignGroupModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     {
       role: roleId,
     },

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx
@@ -18,9 +18,19 @@ import type { MappingRule, Role } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignMappingRulesModal: FC<
   UseEntityModalCustomProps<
     { id: Role["roleId"] },
-    { assignedMappingRules: MappingRule[] }
+    {
+      assignedMappingRules: MappingRule[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: role, assignedMappingRules, onSuccess, open, onClose }) => {
+> = ({
+  entity: role,
+  assignedMappingRules,
+  onSuccess,
+  onItemsAssigned,
+  open,
+  onClose,
+}) => {
   const { t, Translate } = useTranslate("roles");
   const [selectedMappingRules, setSelectedMappingRules] = useState<
     MappingRule[]
@@ -48,6 +58,7 @@ const AssignMappingRulesModal: FC<
           }),
         ),
       );
+      onItemsAssigned(selectedMappingRules.length);
       onSuccess();
     } catch {
       // error handled globally

--- a/identity/client/src/pages/roles/detailV2/mapping-rules/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/mapping-rules/index.tsx
@@ -18,6 +18,7 @@ import { ErrorInlineNotification } from "src/components/notificationsV2/InlineNo
 import DeleteModal from "src/pages/roles/detailV2/mapping-rules/DeleteModal";
 import AssignMappingRulesModal from "src/pages/roles/detailV2/mapping-rules/AssignMappingRulesModal.tsx";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 
 type MappingRulesProps = {
   roleId: string;
@@ -25,7 +26,6 @@ type MappingRulesProps = {
 
 const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
   const { t } = useTranslate("roles");
-  const noop = () => {};
 
   const { pageParams, page, ...paginationCallbacks } = usePagination();
   const {
@@ -43,18 +43,25 @@ const MappingRules: FC<MappingRulesProps> = ({ roleId }) => {
 
   const isMappingRulesListEmpty =
     !mappingRules || mappingRules.items?.length === 0;
+  const { startPolling } = useListPollingReload(
+    reload,
+    mappingRules?.items ?? [],
+    "mappingRuleId",
+    mappingRules?.page.totalItems,
+  );
 
   const [assignMappingRules, assignMappingRulesModal] = useEntityModal(
     AssignMappingRulesModal,
-    noop,
+    () => {},
     {
       assignedMappingRules: mappingRules?.items || [],
+      onItemsAssigned: startPolling,
     },
   );
   const openAssignModal = () => assignMappingRules({ id: roleId });
   const [unassignMappingRule, unassignMappingRuleModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     {
       roleId,
     },

--- a/identity/client/src/pages/roles/detailV2/members/AssignMemberModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMemberModal.tsx
@@ -19,9 +19,12 @@ import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignMemberModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedUsers: User[] }
+    {
+      assignedUsers: User[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, onSuccess, open, onClose }) => {
+> = ({ entity: { roleId }, onSuccess, onItemsAssigned, open, onClose }) => {
   const { t, Translate } = useTranslate("roles");
   const [username, setUsername] = useState("");
   const qc = useQueryClient();
@@ -37,6 +40,7 @@ const AssignMemberModal: FC<
       { username, roleId },
       {
         onSuccess: () => {
+          onItemsAssigned(1);
           onSuccess();
         },
       },

--- a/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/AssignMembersModal.tsx
@@ -18,9 +18,19 @@ import type { Role, User } from "@camunda/camunda-api-zod-schemas/8.10";
 const AssignMembersModal: FC<
   UseEntityModalCustomProps<
     { roleId: Role["roleId"] },
-    { assignedUsers: User[] }
+    {
+      assignedUsers: User[];
+      onItemsAssigned: (count: number) => void;
+    }
   >
-> = ({ entity: { roleId }, assignedUsers, onSuccess, open, onClose }) => {
+> = ({
+  entity: { roleId },
+  assignedUsers,
+  onSuccess,
+  onItemsAssigned,
+  open,
+  onClose,
+}) => {
   const { t } = useTranslate("roles");
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [loadingAssignUser, setLoadingAssignUser] = useState(false);
@@ -42,6 +52,7 @@ const AssignMembersModal: FC<
           callAssignUser({ username, roleId }),
         ),
       );
+      onItemsAssigned(selectedUsers.length);
       onSuccess();
     } catch {
       // error handled globally

--- a/identity/client/src/pages/roles/detailV2/members/index.tsx
+++ b/identity/client/src/pages/roles/detailV2/members/index.tsx
@@ -19,6 +19,7 @@ import DeleteModal from "src/pages/roles/detailV2/members/DeleteModal";
 import { UserKeys } from "src/utility/api/users";
 import { useEnrichedUsers } from "src/components/global/useEnrichUsers";
 import TabEmptyState from "src/components/layoutV2/TabEmptyState";
+import { useListPollingReload } from "src/utility/hooks/useListPollingReload";
 
 type MembersProps = {
   roleId: string;
@@ -36,18 +37,23 @@ const Members: FC<MembersProps> = ({ roleId, isOIDC }) => {
     },
     isOIDC,
   );
-  const noop = () => {};
+  const { startPolling } = useListPollingReload(
+    reload,
+    users,
+    "username",
+    paginationProps.page.totalItems,
+  );
 
   const isUsersListEmpty = !users || users?.length === 0;
   const [assignUsers, assignUsersModal] = useEntityModal(
     isOIDC ? AssignMemberModal : AssignMembersModal,
-    noop,
-    { assignedUsers: users },
+    () => {},
+    { assignedUsers: users, onItemsAssigned: startPolling },
   );
   const openAssignModal = () => assignUsers({ roleId });
   const [unassignMember, unassignMemberModal] = useEntityModal(
     DeleteModal,
-    noop,
+    () => startPolling(-1),
     {
       roleId,
     },

--- a/identity/client/src/utility/hooks/useListPollingReload.ts
+++ b/identity/client/src/utility/hooks/useListPollingReload.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useCallback, useRef } from "react";
+import { usePollingReload } from "./usePollingReload";
+
+type ListResponse<T> = {
+  items: T[];
+  page?: {
+    totalItems: number;
+  };
+};
+
+type RefetchResult<T> = {
+  data?: ListResponse<T>;
+  isSuccess: boolean;
+};
+
+const useListPollingReload = <T extends object>(
+  reload: () => Promise<RefetchResult<T>>,
+  items: T[],
+  itemKey: keyof T,
+  totalItems?: number,
+) => {
+  const expectedTotalItems = useRef<
+    { count: number; direction: 1 | -1 } | undefined
+  >(undefined);
+
+  const hasListChanged = useCallback(
+    (current: ListResponse<T>) => {
+      const expected = expectedTotalItems.current;
+      if (expected && current.page) {
+        const hasReachedExpectedCount =
+          expected.direction === 1
+            ? current.page.totalItems >= expected.count
+            : current.page.totalItems <= expected.count;
+
+        if (hasReachedExpectedCount) {
+          return true;
+        }
+      }
+
+      if (items.length !== current.items.length) {
+        return true;
+      }
+
+      return items.some(
+        (previousItem) =>
+          !current.items.some(
+            (currentItem) => currentItem[itemKey] === previousItem[itemKey],
+          ),
+      );
+    },
+    [itemKey, items],
+  );
+
+  const { startPolling: startBasePolling, ...pollingState } = usePollingReload(
+    reload,
+    hasListChanged,
+  );
+  const startPolling = useCallback(
+    (itemCountDelta: number) => {
+      expectedTotalItems.current =
+        totalItems === undefined
+          ? undefined
+          : {
+              count: totalItems + itemCountDelta,
+              direction: itemCountDelta > 0 ? 1 : -1,
+            };
+      startBasePolling();
+    },
+    [startBasePolling, totalItems],
+  );
+
+  return { ...pollingState, startPolling };
+};
+
+export { useListPollingReload };


### PR DESCRIPTION
## Description

Role membership mutations are immediately followed by a query invalidation, but secondary storage can still return the pre-mutation state. The affected Role tabs therefore remain stale until a later browser refresh.

This PR reuses the existing bounded polling behavior to refetch Clients, Users, Groups, and Mapping rules after successful assignment changes. A list-specific hook waits for the expected membership count or identifier change, including bulk assignments and paginated results, in both Role detail variants.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #59821