### PR TITLE
fix: groups edit-modal v2 passes errors array with translated values

### DIFF
--- a/identity/client/src/pages/groups/modals/EditModal.tsx
+++ b/identity/client/src/pages/groups/modals/EditModal.tsx
@@ -13,7 +13,7 @@ import useTranslate from "src/utility/localization";
 import { useNotifications } from "src/components/notifications";
 import { groupMutations } from "src/utility/api/groups/mutations";
 import TextField from "src/components/form/TextField";
-import { isValidId } from "src/utility/validate.ts";
+import { getIdPattern, isValidId } from "src/utility/validate.ts";
 import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
 
 const EditModal: FC<UseEntityModalProps<Group>> = ({
@@ -81,7 +81,13 @@ const EditModal: FC<UseEntityModalProps<Group>> = ({
           validateGroupId(value);
           setGroupId(value);
         }}
-        errors={!isGroupIdValid ? t("pleaseEnterValidGroupId") : undefined}
+        errors={
+          !isGroupIdValid
+            ? t("pleaseEnterValidGroupId", {
+                pattern: getIdPattern(),
+              })
+            : undefined
+        }
         readOnly
       />
       <TextField

--- a/identity/client/src/pages/groups/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/groups/modalsV2/EditModal.tsx
@@ -13,7 +13,7 @@ import useTranslate from "src/utility/localization";
 import { useNotifications } from "src/components/notifications";
 import { groupMutations } from "src/utility/api/groups/mutations";
 import TextField from "src/components/formV2/TextField";
-import { isValidId } from "src/utility/validate.ts";
+import { getIdPattern, isValidId } from "src/utility/validate.ts";
 import type { Group } from "@camunda/camunda-api-zod-schemas/8.10";
 
 const EditModal: FC<UseEntityModalProps<Group>> = ({
@@ -80,7 +80,13 @@ const EditModal: FC<UseEntityModalProps<Group>> = ({
           validateGroupId(value);
           setGroupId(value);
         }}
-        errors={!isGroupIdValid ? t("pleaseEnterValidGroupId") : []}
+        errors={
+          !isGroupIdValid
+            ? t("pleaseEnterValidGroupId", {
+                pattern: getIdPattern(),
+              })
+            : []
+        }
         readOnly
       />
       <TextField

--- a/identity/client/src/pages/groups/modalsV2/EditModal.tsx
+++ b/identity/client/src/pages/groups/modalsV2/EditModal.tsx
@@ -80,7 +80,7 @@ const EditModal: FC<UseEntityModalProps<Group>> = ({
           validateGroupId(value);
           setGroupId(value);
         }}
-        errors={!isGroupIdValid ? [t("pleaseEnterValidGroupId")] : []}
+        errors={!isGroupIdValid ? t("pleaseEnterValidGroupId") : []}
         readOnly
       />
       <TextField


### PR DESCRIPTION
## Description

This problem had been [reported by Copilot](https://github.com/camunda/camunda/pull/61438#discussion_r3893084846) during the Admin groups migration in #61438. I got suspicious when Copilot reported it again on the 8.10 backport PR. Turns out, I applied the fix the v1 version of the `EditModal` not the v2 version 🤦‍♂️. This PR applies it the v2 version as well. An app-wide search for `[t(` returns zero results, so the problem should not exist in other places.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related #60633
