### PR TITLE
feat: add camunda.processing.engine.mappings.output-comparison-mode

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -28,6 +28,16 @@ public class EngineMappings {
    */
   @Nullable private InputMode inputComparisonMode = null;
 
+  /**
+   * When set, evaluates output mappings with both the primary resolver ({@code outputMode}) and
+   * this comparison resolver, then logs a warning if their results differ. Intended for diagnostic
+   * use only: each completion evaluates mappings with both resolvers and compares the result
+   * documents, which adds overhead for large mapping sets.
+   *
+   * <p>Has no effect when null (default) or when set to the same value as {@code outputMode}.
+   */
+  @Nullable private OutputMode outputComparisonMode = null;
+
   public enum InputMode {
     ORDERED,
     COMBINED
@@ -73,6 +83,14 @@ public class EngineMappings {
     this.outputMode = outputMode;
   }
 
+  public @Nullable OutputMode getOutputComparisonMode() {
+    return outputComparisonMode;
+  }
+
+  public void setOutputComparisonMode(final @Nullable OutputMode outputComparisonMode) {
+    this.outputComparisonMode = outputComparisonMode;
+  }
+
   @Override
   public String toString() {
     return "EngineMappings{inputMode="
@@ -81,6 +99,8 @@ public class EngineMappings {
         + inputComparisonMode
         + ", outputMode="
         + outputMode
+        + ", outputComparisonMode="
+        + outputComparisonMode
         + '}';
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -301,6 +301,13 @@ public class BrokerBasedPropertiesOverride {
         .getEngine()
         .setOutputMappingMode(
             toEngineOutputMode(camunda.getProcessing().getEngine().getMappings().getOutputMode()));
+
+    override
+        .getExperimental()
+        .getEngine()
+        .setOutputComparisonMode(
+            toEngineOutputMode(
+                camunda.getProcessing().getEngine().getMappings().getOutputComparisonMode()));
   }
 
   private static InputMappingMode toEngineMode(final @Nullable InputMode mode) {
@@ -310,7 +317,11 @@ public class BrokerBasedPropertiesOverride {
     return mode == InputMode.COMBINED ? InputMappingMode.COMBINED : InputMappingMode.ORDERED;
   }
 
-  private static OutputMappingMode toEngineOutputMode(final OutputMode outputMode) {
+  private static @Nullable OutputMappingMode toEngineOutputMode(
+      final @Nullable OutputMode outputMode) {
+    if (outputMode == null) {
+      return null;
+    }
     return outputMode == OutputMode.COMBINED
         ? OutputMappingMode.COMBINED
         : OutputMappingMode.ORDERED;

--- a/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
@@ -125,4 +125,31 @@ public class EngineMappingsTest {
           .isEqualTo(EngineConfiguration.OutputMappingMode.ORDERED);
     }
   }
+
+  @Nested
+  @DisplayName("Output comparison mode")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    BrokerBasedPropertiesOverride.class,
+    UnifiedConfigurationHelper.class
+  })
+  @ActiveProfiles("broker")
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.mappings.output-mode=COMBINED",
+        "camunda.processing.engine.mappings.output-comparison-mode=ORDERED",
+      })
+  class OutputComparisonMode {
+    final BrokerBasedProperties brokerCfg;
+
+    OutputComparisonMode(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetOutputComparisonMode() {
+      assertThat(brokerCfg.getExperimental().getEngine().getOutputComparisonMode())
+          .isEqualTo(EngineConfiguration.OutputMappingMode.ORDERED);
+    }
+  }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -305,6 +305,7 @@ processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval
 processing.engine.mappings.input-comparison-mode
 processing.engine.mappings.input-mode
+processing.engine.mappings.output-comparison-mode
 processing.engine.mappings.output-mode
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1347,6 +1347,11 @@ camunda: # Type: io.camunda.configuration.Camunda
         # declaration order) or COMBINED (legacy combined-FEEL-context behavior restoring the
         # pre-#59087 single-expression evaluation).
         output-mode: COMBINED # Type: OutputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_OUTPUTMODE
+        # When set, also evaluates output mappings with this second resolver and logs a warning
+        # if the results differ from the primary resolver. Intended for migration diagnostics
+        # only: each completion evaluates mappings with both resolvers and compares the
+        # result documents, which adds overhead for large mapping sets.
+        output-comparison-mode: ~ # Type: OutputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_OUTPUTCOMPARISONMODE
 
     flow-control: # Type: io.camunda.configuration.FlowControl
       request: # Type: io.camunda.configuration.Limit

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
+import io.camunda.zeebe.engine.EngineConfiguration.OutputMappingMode;
 import org.jspecify.annotations.Nullable;
 
 public final class EngineCfg implements ConfigurationEntry {
@@ -30,6 +31,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private @Nullable InputMappingMode inputComparisonMode = null;
   private EngineConfiguration.OutputMappingMode outputMappingMode =
       EngineConfiguration.OutputMappingMode.COMBINED;
+  private @Nullable OutputMappingMode outputComparisonMode = null;
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
@@ -150,6 +152,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.outputMappingMode = outputMappingMode;
   }
 
+  public @Nullable OutputMappingMode getOutputComparisonMode() {
+    return outputComparisonMode;
+  }
+
+  public void setOutputComparisonMode(final @Nullable OutputMappingMode outputComparisonMode) {
+    this.outputComparisonMode = outputComparisonMode;
+  }
+
   public GlobalListenersCfg getGlobalListeners() {
     return globalListeners;
   }
@@ -237,6 +247,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + inputComparisonMode
         + ", outputMappingMode="
         + outputMappingMode
+        + ", outputComparisonMode="
+        + outputComparisonMode
         + '}';
   }
 
@@ -301,6 +313,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setFixedStorageOrdinalKey(storageOrdinals.getFixedStorageOrdinalKey())
         .setInputMappingMode(inputMappingMode)
         .setInputComparisonMode(inputComparisonMode)
-        .setOutputMappingMode(outputMappingMode);
+        .setOutputMappingMode(outputMappingMode)
+        .setOutputComparisonMode(outputComparisonMode);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -175,6 +175,7 @@ public final class EngineConfiguration {
   private InputMappingMode inputMappingMode = InputMappingMode.COMBINED;
   private @Nullable InputMappingMode inputComparisonMode = null;
   private OutputMappingMode outputMappingMode = OutputMappingMode.COMBINED;
+  private @Nullable OutputMappingMode outputComparisonMode = null;
 
   /**
    * Controls uniqueness enforcement of business IDs across active process instances.
@@ -782,6 +783,16 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setOutputMappingMode(final OutputMappingMode outputMappingMode) {
     this.outputMappingMode = outputMappingMode;
+    return this;
+  }
+
+  public @Nullable OutputMappingMode getOutputComparisonMode() {
+    return outputComparisonMode;
+  }
+
+  public EngineConfiguration setOutputComparisonMode(
+      final @Nullable OutputMappingMode outputComparisonMode) {
+    this.outputComparisonMode = outputComparisonMode;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -185,7 +185,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             eventTriggerBehavior,
             InputMappingResolvers.forMode(
                 config.getInputMappingMode(), config.getInputComparisonMode()),
-            OutputMappingResolvers.forMode(config.getOutputMappingMode()));
+            OutputMappingResolvers.forMode(
+                config.getOutputMappingMode(), config.getOutputComparisonMode()));
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolvers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolvers.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.variable;
 import io.camunda.zeebe.engine.EngineConfiguration.OutputMappingMode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** Utility methods for working with {@link MappingResolver} instances for output mappings. */
 @NullMarked
@@ -17,10 +18,24 @@ public final class OutputMappingResolvers {
 
   private OutputMappingResolvers() {}
 
-  /** Returns a resolver for the given output mapping mode. */
-  public static MappingResolver<OutputMappings> forMode(final OutputMappingMode outputMappingMode) {
-    return outputMappingMode == OutputMappingMode.COMBINED
-        ? new CombinedOutputMappingResolver()
-        : new OrderedOutputMappingResolver();
+  /**
+   * Returns a resolver for the given output mode. If {@code comparisonMode} is non-null and
+   * different from {@code outputMode}, wraps both in a {@link ComparingMappingResolver} that logs a
+   * warning when results differ.
+   */
+  public static MappingResolver<OutputMappings> forMode(
+      final OutputMappingMode outputMode, final @Nullable OutputMappingMode comparisonMode) {
+    final var primary = singleResolver(outputMode);
+    if (comparisonMode == null || comparisonMode == outputMode) {
+      return primary;
+    }
+    return new ComparingMappingResolver<>(primary, singleResolver(comparisonMode));
+  }
+
+  private static MappingResolver<OutputMappings> singleResolver(final OutputMappingMode mode) {
+    return switch (mode) {
+      case COMBINED -> new CombinedOutputMappingResolver();
+      case ORDERED -> new OrderedOutputMappingResolver();
+    };
   }
 }


### PR DESCRIPTION
Stacked on #61580.

## Summary

Adds `camunda.processing.engine.mappings.output-comparison-mode` diagnostic flag, mirroring the input-comparison-mode flag from #61350.

When set, evaluates output mappings with both the primary resolver (`output-mode`) and this second resolver, logging a WARN if their results differ. Intended for migration diagnostics when switching between ORDERED and COMBINED output-mapping behavior.

- `EngineConfiguration.outputComparisonMode` field with getter/setter
- `EngineMappings.outputComparisonMode` Spring config field
- `EngineCfg.outputComparisonMode` wiring into `createEngineConfiguration()`
- `BrokerBasedPropertiesOverride` wires the comparison mode
- `OutputMappingResolvers.forMode(outputMode, comparisonMode)` wraps with `ComparingMappingResolver<OutputMappings>` when comparison mode is non-null and different from primary
- `defaults.yaml` entry `output-comparison-mode: ~`

## Test plan

- [ ] Set `output-comparison-mode=ORDERED` with `output-mode=COMBINED` and verify WARN logged on divergent mappings
- [ ] No WARN when results match