### PR TITLE
ci: classify SaaS setup failures by error, not by file name

### DIFF
--- a/.github/scripts/alwaysgreen/classify.py
+++ b/.github/scripts/alwaysgreen/classify.py
@@ -198,18 +198,76 @@ def iter_specs(report: Any) -> Iterator[dict]:
 
 _SETUP_SPEC_RE = re.compile(r"test-setup\.spec\.[jt]s$")
 
+#: Error signatures that mark a failed setup spec as an environment problem the fix
+#: agent has no lever on, matched against the spec's last attempt error.
+#:
+#: The file name alone is not the signal. `tests/8.x/test-setup.spec.ts` mixes two
+#: unrelated families: cluster/org provisioning ("Create Default Cluster"), and
+#: ordinary Playwright UI flows ("Create Project Folder for User N", which drives
+#: `ModelerHomePage.createCrossComponentProjectFolder`). Only the first is reliably
+#: environment. Sampled over the 15 failing SaaS downstream runs to 2026-09-01, the
+#: failing setup specs were 10 cluster-health assertions and 4 locator clicks in the
+#: Modeler flow.
+#:
+#: Those 4 are not one thing, and the message does not separate them: on run
+#: 33483343722 the trace shows the app healthy and the button present, failing on a
+#: retry where the project already existed (a test bug), while run 33463316996 shows
+#: the identical message caused by a Modeler `/api/internal/login` 500 that left the
+#: page on its loading spinner (an outage). Triage sees only the report and cannot
+#: tell those apart; the fix agent reads the trace and can, and its `no-fix` verdict
+#: plus the cooldown bound the cost of guessing wrong. Dropping the whole family on
+#: the file name loses the fixable half silently, and is already inconsistent with
+#: the same failure arriving via `smoke-tests.spec.ts`, which is dispatched.
+_PROVISIONING_ERROR_MARKERS = (
+    # Cluster came up but never reached a healthy status.
+    'Received: "Unhealthy"',
+    # Auth0/identity provider refused the login the whole suite depends on.
+    "AUTH0_RATE_LIMIT",
+    "identity provider returned an error page",
+)
+
+
+def is_provisioning_error(message: str | None) -> bool:
+    """Whether a failed setup spec's error points at the environment, not the test.
+
+    Deliberately narrow: anything unrecognised reads as a test failure and gets an
+    agent. The reverse bias is what let a renamed button sit red across three runs
+    with no dispatch — an agent spent on an environment failure costs one run and a
+    `no-fix` verdict that then suppresses the surface for the cooldown, while a
+    missed test failure is silent until someone reads the nightly by hand.
+
+    A login that failed on a changed selector therefore still dispatches: its
+    message carries the locator, not an identity-provider marker.
+
+    Matched against the ANSI-stripped message. Playwright colours its assertion
+    diff and highlights the differing run *inside* the word, so the raw text of a
+    cluster-health failure carries colour codes both around and within
+    `"Unhealthy"` and no marker matches until they are stripped.
+    """
+    text = clean_error(message, limit=4000)
+    return any(marker in text for marker in _PROVISIONING_ERROR_MARKERS)
+
+
+def _last_error_message(spec: dict) -> str:
+    """The error of a spec's final attempt, which is the one that made it fail."""
+    tests = spec.get("tests") or []
+    first = tests[0] if tests else {}
+    results = (first or {}).get("results") or []
+    last = results[-1] if results else {}
+    return ((last or {}).get("error") or {}).get("message") or ""
+
 
 @dataclass(frozen=True)
 class SpecCounts:
     total: int = 0
     failed: int = 0
     flaky: int = 0
-    setup_failed: int = 0
+    provisioning_failed: int = 0
 
 
 def count_specs(report: Any) -> SpecCounts:
     """Count specs in a report, mirroring the categories the pipeline reports."""
-    total = failed = flaky = setup_failed = 0
+    total = failed = flaky = provisioning_failed = 0
     for spec in iter_specs(report):
         total += 1
         ok = spec.get("ok")
@@ -217,11 +275,13 @@ def count_specs(report: Any) -> SpecCounts:
         retried = any(len((t or {}).get("results") or []) > 1 for t in tests)
         if ok is False:
             failed += 1
-            if _SETUP_SPEC_RE.search(spec.get("file") or ""):
-                setup_failed += 1
+            if _SETUP_SPEC_RE.search(spec.get("file") or "") and is_provisioning_error(
+                _last_error_message(spec)
+            ):
+                provisioning_failed += 1
         elif ok is True and retried:
             flaky += 1
-    return SpecCounts(total, failed, flaky, setup_failed)
+    return SpecCounts(total, failed, flaky, provisioning_failed)
 
 
 def saas_surface_from_counts(counts: SpecCounts, *, has_artifacts: bool) -> str:
@@ -239,12 +299,17 @@ def saas_surface_from_counts(counts: SpecCounts, *, has_artifacts: bool) -> str:
     stays `saas-infra`: there the downstream died before Playwright produced any
     evidence, and the failing job is as likely to be the provisioning API as
     anything in the repository.
+
+    `saas-provisioning` needs every failing spec to be a provisioning failure by
+    its *error* (see `is_provisioning_error`), not merely by living in
+    `test-setup.spec.ts`. A run that trips one recognised environment error and one
+    locator failure is a run with a test bug in it, and goes to the agent.
     """
     if not has_artifacts or counts.total == 0:
         return SURFACE_SAAS_INFRA
     if counts.failed == 0:
         return SURFACE_SAAS_CI
-    if counts.setup_failed == counts.failed:
+    if counts.provisioning_failed == counts.failed:
         return SURFACE_SAAS_PROVISIONING
     return SURFACE_SAAS_E2E
 

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -221,7 +221,7 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
                     counts.total + c.total,
                     counts.failed + c.failed,
                     counts.flaky + c.flaky,
-                    counts.setup_failed + c.setup_failed,
+                    counts.provisioning_failed + c.provisioning_failed,
                 )
                 suite = classify.suite_from_rootdir(
                     ((report.get("config") or {}).get("rootDir"))
@@ -235,7 +235,8 @@ def saas_candidate(run_id: str, base_ref: str, job_name: str, workdir: Path) -> 
     cand.surface = classify.saas_surface_from_counts(counts, has_artifacts=has_reports)
     log(
         f"saas counts total={counts.total} failed={counts.failed} "
-        f"flaky={counts.flaky} setup_failed={counts.setup_failed} -> {cand.surface}"
+        f"flaky={counts.flaky} provisioning_failed={counts.provisioning_failed} "
+        f"-> {cand.surface}"
     )
     if cand.surface == classify.SURFACE_SAAS_CI:
         # Every spec passed, so the report-derived specs describe nothing that

--- a/.github/scripts/alwaysgreen/test_classify.py
+++ b/.github/scripts/alwaysgreen/test_classify.py
@@ -171,19 +171,116 @@ def _nested_report(specs):
     }
 
 
+#: Real errors, trimmed, from the failing SaaS setup specs sampled to 2026-09-01.
+CLUSTER_UNHEALTHY_ERROR = (
+    'Error: expect(received).toBe(expected) // Object.is equality\n'
+    'Expected: "Healthy"\nReceived: "Unhealthy"'
+)
+AUTH0_ERROR = (
+    "Error: Login failed after 5 attempts: Error: AUTH0_RATE_LIMIT: "
+    "identity provider returned an error page"
+)
+NEW_PROJECT_LOCATOR_ERROR = (
+    "Error: Failed to click locator getByRole('button', "
+    "{ name: 'New project' }) after 3 attempts."
+)
+
+
+def _failed_spec(file: str, title: str, message: str) -> dict:
+    return {
+        "file": file,
+        "title": title,
+        "ok": False,
+        "tests": [{"results": [{"status": "failed", "error": {"message": message}}]}],
+    }
+
+
 def test_counting_walks_nested_suites():
     # The pipeline's own one-level walk returns 0 here; that is the bug this
     # guards. Real example: downstream run 30259132560 was 15 specs / 2 failures.
     report = _nested_report(
         [
-            {"file": "test-setup.spec.ts", "title": "a", "ok": False, "tests": [{"results": [{"status": "failed"}]}]},
+            _failed_spec("test-setup.spec.ts", "a", CLUSTER_UNHEALTHY_ERROR),
             {"file": "smoke-tests.spec.ts", "title": "b", "ok": True, "tests": [{"results": [{"status": "passed"}]}]},
         ]
     )
     counts = classify.count_specs(report)
     assert counts.total == 2
     assert counts.failed == 1
-    assert counts.setup_failed == 1
+    assert counts.provisioning_failed == 1
+
+
+def test_setup_spec_with_ui_error_is_not_counted_as_provisioning():
+    # Downstream run 33483343722: "Create Project Folder for User 3" in
+    # test-setup.spec.ts, with the trace showing a healthy app and the button on
+    # screen, failing on a retry where the project already existed. A test bug,
+    # dropped with no dispatch because the count keyed off the file name.
+    report = _nested_report(
+        [
+            _failed_spec(
+                "test-setup.spec.ts",
+                "Create Project Folder for User 1",
+                NEW_PROJECT_LOCATOR_ERROR,
+            )
+        ]
+    )
+    counts = classify.count_specs(report)
+    assert counts.failed == 1
+    assert counts.provisioning_failed == 0
+
+
+def test_setup_spec_with_environment_error_is_counted_as_provisioning():
+    report = _nested_report(
+        [
+            _failed_spec(
+                "test-setup.spec.ts", "Create AWS Cluster", CLUSTER_UNHEALTHY_ERROR
+            ),
+            _failed_spec("test-setup.spec.ts", "Create Default Cluster", AUTH0_ERROR),
+        ]
+    )
+    counts = classify.count_specs(report)
+    assert counts.failed == 2
+    assert counts.provisioning_failed == 2
+
+
+def test_provisioning_error_recognises_only_environment_signatures():
+    assert classify.is_provisioning_error(CLUSTER_UNHEALTHY_ERROR)
+    assert classify.is_provisioning_error(AUTH0_ERROR)
+    assert not classify.is_provisioning_error(NEW_PROJECT_LOCATOR_ERROR)
+    assert not classify.is_provisioning_error("")
+    assert not classify.is_provisioning_error(None)
+
+
+def test_provisioning_error_survives_playwright_colour_codes():
+    # Verbatim from downstream run 33437577072. Playwright colours the assertion
+    # diff and marks the differing run *inside* the word, so the marker only
+    # appears once the ANSI is stripped.
+    raw = (
+        "Error: \x1b[2mexpect(\x1b[22m\x1b[31mreceived\x1b[39m\x1b[2m).\x1b[22m"
+        "toBe\x1b[2m(\x1b[22m\x1b[32mexpected\x1b[39m\x1b[2m) // Object.is "
+        'equality\x1b[22m\n\nExpected: \x1b[32m"\x1b[7mH\x1b[27mealthy"\x1b[39m\n'
+        'Received: \x1b[31m"\x1b[7mUnh\x1b[27mealthy"\x1b[39m\n\nCall Log:'
+    )
+    assert classify.is_provisioning_error(raw)
+
+
+def test_login_failure_on_a_changed_selector_is_not_provisioning():
+    # The login helper wraps whatever broke, so "Login failed after N attempts"
+    # alone must not read as environment: only the identity-provider markers do.
+    message = (
+        "Error: Login failed after 5 attempts: Error: Failed to click locator "
+        "getByRole('button', { name: 'Sign in' }) after 3 attempts."
+    )
+    assert not classify.is_provisioning_error(message)
+
+
+def test_failure_outside_a_setup_spec_is_never_provisioning():
+    # An unhealthy-cluster assertion in a normal spec is still a spec the agent
+    # is allowed to look at; the provisioning carve-out is setup-only.
+    report = _nested_report(
+        [_failed_spec("smoke-tests.spec.ts", "c", CLUSTER_UNHEALTHY_ERROR)]
+    )
+    assert classify.count_specs(report).provisioning_failed == 0
 
 
 def test_flaky_counts_retried_specs_that_passed():
@@ -214,7 +311,7 @@ def test_empty_report_counts_zero():
 def test_setup_only_failures_are_provisioning():
     # Observed shape: every failing spec was in test-setup.spec.ts
     # (Create Default Cluster / Create AWS Cluster).
-    counts = classify.SpecCounts(total=15, failed=2, flaky=0, setup_failed=2)
+    counts = classify.SpecCounts(total=15, failed=2, flaky=0, provisioning_failed=2)
     assert (
         classify.saas_surface_from_counts(counts, has_artifacts=True)
         == classify.SURFACE_SAAS_PROVISIONING
@@ -222,7 +319,17 @@ def test_setup_only_failures_are_provisioning():
 
 
 def test_real_test_failures_are_saas_e2e():
-    counts = classify.SpecCounts(total=15, failed=2, flaky=0, setup_failed=0)
+    counts = classify.SpecCounts(total=15, failed=2, flaky=0, provisioning_failed=0)
+    assert (
+        classify.saas_surface_from_counts(counts, has_artifacts=True)
+        == classify.SURFACE_SAAS_E2E
+    )
+
+
+def test_mixed_environment_and_test_failures_are_saas_e2e():
+    # One recognised environment error alongside a real test failure still leaves
+    # a test to fix, so the run goes to the agent rather than being written off.
+    counts = classify.SpecCounts(total=15, failed=3, flaky=0, provisioning_failed=2)
     assert (
         classify.saas_surface_from_counts(counts, has_artifacts=True)
         == classify.SURFACE_SAAS_E2E


### PR DESCRIPTION
## What

AlwaysGreen counts a failing Playwright spec as "provisioning" whenever it lives in `test-setup.spec.ts`. A SaaS run whose failures are all provisioning classifies as `saas-provisioning`, which is not in `DISPATCHABLE_SURFACES` — so **no fix agent is ever dispatched**.

That file is not a provisioning script. `tests/8.x/test-setup.spec.ts` mixes cluster/org creation with ordinary Playwright UI flows — `Create Project Folder for User N` drives `ModelerHomePage.createCrossComponentProjectFolder`.

This changes the discriminator from the **file name** to the **error**.

## Why

Sampling the 15 failing SaaS downstream runs to 2026-09-01, failing setup specs split into:

| Family | Count | Example error |
|---|---|---|
| Cluster health | 10 | `Expected: "Healthy"` / `Received: "Unhealthy"` |
| Locator click in the Modeler flow | 4 | `Failed to click locator getByRole('button', { name: 'New project' })` |

The first family is environment and stays suppressed. The second is the interesting one, **and it is not a single failure**:

- **Run 33483343722** — trace shows login `200`, projects API `200`, app fully rendered, and the "New project" button **present on screen**; it fails on `retry1` with the project already created. A test bug (retry idempotency), currently dropped with no dispatch.
- **Run 33463316996** — identical error message, but the trace shows `POST /api/internal/login` returning **500**, then a logout→authorize redirect loop; the page never leaves its loading spinner, so the button is genuinely absent. An outage.

Triage sees only the JSON report and cannot separate those two. The fix agent reads the trace and does — on the sibling dispatch for the same outage ([run 33464059381](https://github.com/camunda/camunda/actions/runs/33464059381)) it correctly returned `category: not-determined`, `prs: []`, naming the Modeler 500 and declining to mask it. That verdict then feeds `no-fix-verdict-within-cooldown`, so the cost of dispatching into an outage is bounded at one run.

The current rule loses the fixable half of that family silently. It is also **already inconsistent**: when the same failure arrives via `smoke-tests.spec.ts` it is dispatched; only the `test-setup.spec.ts` path is dropped.

Over the last ~7 days of `docker-build-helm-integration.yml`, 6 of 17 SaaS candidates were excluded this way. SM had 0 of 45 excluded by the same rule.

## How

- `is_provisioning_error()` matches a failed setup spec's last error against a narrow list of environment signatures: cluster-unhealthy, `AUTH0_RATE_LIMIT`, identity-provider error page.
- `count_specs` counts `provisioning_failed` only when the spec is a setup spec **and** its error matches. `SpecCounts.setup_failed` is renamed to `provisioning_failed` so the field name can no longer be read as "is in the setup file" — that conflation is the bug.
- Markers are matched after `clean_error` strips ANSI. Playwright colours its assertion diff and highlights the differing run *inside* the word, so the raw text is `Received: <esc>[31m"<esc>[7mUnh<esc>[27mealthy"` and no plain marker matches. Caught during replay, not review; pinned by a test using the verbatim bytes from run 33437577072.

**The bias is deliberately one-way**: an unrecognised error reads as a test failure and gets an agent. A wasted agent costs one run plus a no-fix verdict that suppresses the surface for the cooldown; a missed test failure is silent until a human reads the nightly. A login that fails on a changed selector still dispatches, because its message carries the locator rather than an identity-provider marker.

## Verification

`pytest .github/scripts` — 171 passed (11 new tests).

Replaying the 13 recoverable downstream reports, old vs new:

```
33368115834  old=saas-provisioning  new=saas-provisioning  (prov=2)
33372870381  old=saas-provisioning  new=saas-provisioning  (prov=2)
33398557319  old=saas-provisioning  new=saas-provisioning  (prov=2)
33437577072  old=saas-provisioning  new=saas-provisioning  (prov=1)
33440417725  old=saas-provisioning  new=saas-provisioning  (prov=1)
33440423586  old=saas-provisioning  new=saas-provisioning  (prov=2)
33463316996  old=saas-provisioning  new=saas-smoke-e2e     (prov=0)  <== CHANGED
33483343722  old=saas-provisioning  new=saas-smoke-e2e     (prov=0)  <== CHANGED
```

All 6 cluster-health runs keep their classification — no new agents spent on those. Of the 2 that flip, 33483343722 is a real test bug that should have had an agent, and 33463316996 is the outage, where the agent will reach no-fix and the cooldown will hold. That 1-for-1 split is the trade this PR is making, stated plainly rather than hidden.

## Not in scope

- `saas-infra` (reports absent entirely) is untouched.
- Separately, the SM path drops failures as `no-failing-specs-extracted` (runs 33369794241, 33371906218) — different root cause, not addressed here.
