### PR TITLE
test: add engine acceptance tests for suspend/resume coverage

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -348,6 +348,102 @@ public class ProcessInstanceSuspendResumeIT {
   }
 
   @Test
+  void shouldSuspendAndResumeWithAdHocSubProcessAsIfNeverSuspended() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobTypeA = Strings.newRandomValidBpmnId();
+    final var jobTypeB = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(
+                "ad-hoc",
+                adHoc -> {
+                  adHoc.serviceTask("taskA", t -> t.zeebeJobType(jobTypeA));
+                  adHoc.serviceTask("taskB", t -> t.zeebeJobType(jobTypeB));
+                })
+            .endEvent()
+            .done();
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+    waitForProcessesToBeDeployed(camundaClient, f -> f.processDefinitionId(processId), 1);
+
+    final long suspendedKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    final long controlKey = startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForProcessInstancesToStart(
+        camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, controlKey)), 2);
+
+    waitForElementInstances(
+        camundaClient, f -> f.processInstanceKey(suspendedKey).elementId("ad-hoc"), 1);
+    waitForElementInstances(
+        camundaClient, f -> f.processInstanceKey(controlKey).elementId("ad-hoc"), 1);
+    final long suspendedAdHocInstanceKey = adHocSubProcessInstanceKey(suspendedKey);
+    final long controlAdHocInstanceKey = adHocSubProcessInstanceKey(controlKey);
+
+    camundaClient
+        .newActivateAdHocSubProcessActivitiesCommand(Long.toString(suspendedAdHocInstanceKey))
+        .activateElement("taskA")
+        .activateElements("taskB")
+        .send()
+        .join();
+    camundaClient
+        .newActivateAdHocSubProcessActivitiesCommand(Long.toString(controlAdHocInstanceKey))
+        .activateElement("taskA")
+        .activateElements("taskB")
+        .send()
+        .join();
+
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(suspendedKey)
+                .elementId(b -> b.in("taskA", "taskB"))
+                .state(ElementInstanceState.ACTIVE),
+        2);
+
+    // when
+    camundaClient.newSuspendProcessInstanceCommand(suspendedKey).send().join();
+    waitForProcessInstancesToBeSuspended(camundaClient, f -> f.processInstanceKey(suspendedKey), 1);
+
+    camundaClient.newResumeProcessInstanceCommand(suspendedKey).send().join();
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(suspendedKey),
+        instances ->
+            assertThat(instances)
+                .singleElement()
+                .extracting(ProcessInstance::getState)
+                .isEqualTo(ProcessInstanceState.ACTIVE));
+
+    activateAndCompleteJobs(jobTypeA, 2);
+    activateAndCompleteJobs(jobTypeB, 2);
+
+    // then
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, controlKey)), 2);
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var suspendedElements = elementIdsAndStates(suspendedKey);
+              final var controlElements = elementIdsAndStates(controlKey);
+              assertThat(suspendedElements).hasSize(7);
+              assertThat(suspendedElements)
+                  .extracting(t -> t.toList().get(0))
+                  .contains("ad-hoc", "taskA", "taskB");
+              assertThat(suspendedElements)
+                  .extracting(t -> t.toList().get(1))
+                  .containsOnly(ElementInstanceState.COMPLETED);
+              assertThat(suspendedElements).containsExactlyInAnyOrderElementsOf(controlElements);
+            });
+  }
+
+  @Test
   void shouldRejectUserTaskCompleteWhileSuspendedAndAcceptAfterResume() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
@@ -521,6 +617,17 @@ public class ProcessInstanceSuspendResumeIT {
               jobs[0] = activated.getFirst().getKey();
             });
     return jobs[0];
+  }
+
+  private static long adHocSubProcessInstanceKey(final long processInstanceKey) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.processInstanceKey(processInstanceKey).elementId("ad-hoc"))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getElementInstanceKey();
   }
 
   private static List<Tuple> elementIdsAndStates(final long processInstanceKey) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -9,11 +9,13 @@ package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForMessageSubscriptions;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForUserTask;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasVariable;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +26,7 @@ import static org.awaitility.Awaitility.await;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.MessageSubscriptionState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -265,6 +268,209 @@ public class ProcessInstanceSuspendResumeIT {
                 .state(ElementInstanceState.ACTIVE),
         1);
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+  }
+
+  @Test
+  void shouldSuspendAndResumeWithParallelGatewayAsIfNeverSuspended() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobTypeA = Strings.newRandomValidBpmnId();
+    final var jobTypeB = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .parallelGateway("fork")
+            .serviceTask("taskA", t -> t.zeebeJobType(jobTypeA))
+            .parallelGateway("join")
+            .moveToNode("fork")
+            .serviceTask("taskB", t -> t.zeebeJobType(jobTypeB))
+            .connectTo("join")
+            .endEvent()
+            .done();
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+    waitForProcessesToBeDeployed(camundaClient, f -> f.processDefinitionId(processId), 1);
+
+    final long suspendedKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    final long controlKey = startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForProcessInstancesToStart(
+        camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, controlKey)), 2);
+
+    // both branches must be active before suspending, otherwise suspend can race the fork
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(suspendedKey)
+                .elementId(b -> b.in("taskA", "taskB"))
+                .state(ElementInstanceState.ACTIVE),
+        2);
+
+    // when
+    camundaClient.newSuspendProcessInstanceCommand(suspendedKey).send().join();
+    waitForProcessInstancesToBeSuspended(camundaClient, f -> f.processInstanceKey(suspendedKey), 1);
+
+    camundaClient.newResumeProcessInstanceCommand(suspendedKey).send().join();
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(suspendedKey),
+        instances ->
+            assertThat(instances)
+                .singleElement()
+                .extracting(ProcessInstance::getState)
+                .isEqualTo(ProcessInstanceState.ACTIVE));
+
+    activateAndCompleteJobs(jobTypeA, 2);
+    activateAndCompleteJobs(jobTypeB, 2);
+
+    // then
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(b -> b.in(suspendedKey, controlKey)), 2);
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var suspendedElements = elementIdsAndStates(suspendedKey);
+              final var controlElements = elementIdsAndStates(controlKey);
+              assertThat(suspendedElements).hasSize(6);
+              assertThat(suspendedElements)
+                  .extracting(t -> t.toList().get(0))
+                  .contains("taskA", "taskB", "fork", "join");
+              assertThat(suspendedElements)
+                  .extracting(t -> t.toList().get(1))
+                  .containsOnly(ElementInstanceState.COMPLETED);
+              assertThat(suspendedElements).containsExactlyInAnyOrderElementsOf(controlElements);
+            });
+  }
+
+  @Test
+  void shouldRejectUserTaskCompleteWhileSuspendedAndAcceptAfterResume() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .userTask("userTask")
+            .zeebeUserTask()
+            .endEvent()
+            .done();
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+    waitForProcessesToBeDeployed(camundaClient, f -> f.processDefinitionId(processId), 1);
+
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    final long userTaskKey =
+        waitForUserTask(camundaClient, f -> f.processInstanceKey(processInstanceKey))
+            .getUserTaskKey();
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when
+    final var problem =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(() -> camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join())
+            .actual();
+    assertThat(problem.details().getDetail()).contains("is suspended");
+
+    // then
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceKey),
+        instances ->
+            assertThat(instances)
+                .singleElement()
+                .extracting(ProcessInstance::getState)
+                .isEqualTo(ProcessInstanceState.ACTIVE));
+
+    camundaClient.newCompleteUserTaskCommand(userTaskKey).send().join();
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+  }
+
+  @Test
+  void shouldCorrelateMessageAfterSuspendAndResume() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobType = Strings.newRandomValidBpmnId();
+    final var messageName = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent(
+                "msgCatch",
+                c ->
+                    c.message(
+                        m -> m.name(messageName).zeebeCorrelationKeyExpression("correlationKey")))
+            .serviceTask("afterMsg", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+    waitForProcessesToBeDeployed(camundaClient, f -> f.processDefinitionId(processId), 1);
+
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId, Map.of("correlationKey", "key1"))
+            .getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("msgCatch")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+    waitForMessageSubscriptions(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .messageSubscriptionState(MessageSubscriptionState.CREATED),
+        1);
+
+    // when - a suspend-driven subscription close isn't observable through this search endpoint
+    // (it re-emits CREATED, not DELETED); that race is covered at the record level instead, by
+    // MessageSuspensionGateTest.
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    camundaClient
+        .newPublishMessageCommand()
+        .messageName(messageName)
+        .correlationKey("key1")
+        .timeToLive(Duration.ofSeconds(120))
+        .send()
+        .join();
+
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("afterMsg")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+
+    activateAndCompleteJobs(jobType, 1);
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
   }
 
   private static void activateAndCompleteJobs(final String jobType, final int count) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeIT.java
@@ -8,11 +8,13 @@
 package io.camunda.it.client;
 
 import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasVariable;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -153,22 +155,13 @@ public class ProcessInstanceSuspendResumeIT {
 
     // then - the same command is now accepted, and the process advances
     camundaClient.newCompleteCommand(jobKey).send().join();
-    await()
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newElementInstanceSearchRequest()
-                            .filter(
-                                f ->
-                                    f.processInstanceKey(processInstanceKey)
-                                        .elementId(ELEMENT_IDS[1])
-                                        .state(ElementInstanceState.ACTIVE))
-                            .send()
-                            .join()
-                            .items())
-                    .isNotEmpty());
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId(ELEMENT_IDS[1])
+                .state(ElementInstanceState.ACTIVE),
+        1);
 
     // leaves an instance active at taskB; cancel it so it doesn't linger on the shared broker
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
@@ -198,31 +191,9 @@ public class ProcessInstanceSuspendResumeIT {
         .doesNotThrowAnyException();
 
     // then - values are exported and the instance stays suspended
-    await()
-        .atMost(Duration.ofSeconds(30))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var variables =
-                  camundaClient
-                      .newVariableSearchRequest()
-                      .filter(f -> f.processInstanceKey(processInstanceKey))
-                      .send()
-                      .join()
-                      .items();
-              assertThat(variables)
-                  .anySatisfy(
-                      v -> {
-                        assertThat(v.getName()).isEqualTo("recoverable");
-                        assertThat(v.getValue()).isEqualTo("\"after\"");
-                      });
-              assertThat(variables)
-                  .anySatisfy(
-                      v -> {
-                        assertThat(v.getName()).isEqualTo("added");
-                        assertThat(v.getValue()).isEqualTo("1");
-                      });
-            });
+    waitUntilProcessInstanceHasVariable(
+        camundaClient, processInstanceKey, "recoverable", "\"after\"");
+    waitUntilProcessInstanceHasVariable(camundaClient, processInstanceKey, "added", "1");
 
     final ProcessInstance stillSuspended =
         camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
@@ -256,22 +227,13 @@ public class ProcessInstanceSuspendResumeIT {
     final long processInstanceKey =
         startProcessInstance(camundaClient, processId, Map.of("x", 1)).getProcessInstanceKey();
     waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
-    await()
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newElementInstanceSearchRequest()
-                            .filter(
-                                f ->
-                                    f.processInstanceKey(processInstanceKey)
-                                        .elementId(catchEventId)
-                                        .state(ElementInstanceState.ACTIVE))
-                            .send()
-                            .join()
-                            .items())
-                    .isNotEmpty());
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId(catchEventId)
+                .state(ElementInstanceState.ACTIVE),
+        1);
 
     camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
     waitForProcessInstancesToBeSuspended(
@@ -285,19 +247,7 @@ public class ProcessInstanceSuspendResumeIT {
         .join();
 
     // then - variable is updated while the instance stays suspended
-    await()
-        .atMost(Duration.ofSeconds(30))
-        .ignoreExceptions()
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newVariableSearchRequest()
-                            .filter(f -> f.processInstanceKey(processInstanceKey).name("x"))
-                            .send()
-                            .join()
-                            .items())
-                    .anySatisfy(v -> assertThat(v.getValue()).isEqualTo("42")));
+    waitUntilProcessInstanceHasVariable(camundaClient, processInstanceKey, "x", "42");
 
     assertThat(
             camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join().getState())
@@ -307,22 +257,13 @@ public class ProcessInstanceSuspendResumeIT {
     camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
 
     // then - token moves past the catch event
-    await()
-        .atMost(Duration.ofSeconds(30))
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newElementInstanceSearchRequest()
-                            .filter(
-                                f ->
-                                    f.processInstanceKey(processInstanceKey)
-                                        .elementId(afterConditionTaskId)
-                                        .state(ElementInstanceState.ACTIVE))
-                            .send()
-                            .join()
-                            .items())
-                    .isNotEmpty());
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId(afterConditionTaskId)
+                .state(ElementInstanceState.ACTIVE),
+        1);
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -619,6 +619,7 @@ public final class TestHelper {
             () -> {
               migratedTask[0] =
                   client.newUserTaskSearchRequest().filter(filter).send().join().singleItem();
+              assertThat(migratedTask[0]).isNotNull();
             });
     return migratedTask[0];
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentSuspensionGateTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class IncidentSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectIncidentResolveWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+
+    ENGINE.job().withKey(job.getKey()).withRetries(0).fail();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when — resolve(username) carries request metadata, so isInternalCommand() is false and the
+    // gate classifies it as REJECT
+    final Record<IncidentRecordValue> rejection =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incident.getKey())
+            .expectRejection()
+            .resolve("some-user");
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(IncidentIntent.RESOLVE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionGateTest.java
@@ -10,13 +10,21 @@ package io.camunda.zeebe.engine.processing.job;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -151,5 +159,77 @@ public final class JobSuspensionGateTest {
         .hasRejectionType(RejectionType.INVALID_STATE);
     assertThat(rejection.getRejectionReason())
         .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldBufferAndDrainJobYieldWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+
+    final Record<JobBatchRecordValue> batch = ENGINE.jobs().withType(jobType).activate();
+    final JobRecordValue activatedJob = batch.getValue().getJobs().getFirst();
+    final long jobKey = batch.getValue().getJobKeys().getFirst();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    ENGINE.writeRecords(RecordToWrite.command().job(JobIntent.YIELD, activatedJob).key(jobKey));
+
+    // then
+    assertThat(bufferedCommandIntent(processInstanceKey)).isEqualTo(JobIntent.YIELD);
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.YIELDED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBufferAndDrainJobRecurAfterBackoffWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+
+    ENGINE.job().withKey(job.getKey()).withRetries(3).withBackOff(Duration.ofSeconds(1)).fail();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    ENGINE.increaseTime(Duration.ofSeconds(2));
+
+    // then
+    assertThat(bufferedCommandIntent(processInstanceKey)).isEqualTo(JobIntent.RECUR_AFTER_BACKOFF);
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.RECURRED_AFTER_BACKOFF)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  private static JobIntent bufferedCommandIntent(final long processInstanceKey) {
+    return (JobIntent)
+        ((BufferedCommandRecordValue) bufferedCommand(processInstanceKey).getValue()).getIntent();
+  }
+
+  private static Record<RecordValue> bufferedCommand(final long processInstanceKey) {
+    return RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(
+            r ->
+                ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                    == processInstanceKey)
+        .getFirst();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSuspensionGateTest.java
@@ -47,4 +47,109 @@ public final class JobSuspensionGateTest {
     assertThat(rejection.getRejectionReason())
         .contains("process instance with key '" + processInstanceKey + "'");
   }
+
+  @Test
+  public void shouldRejectJobFailWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(job.getKey()).withRetries(0).expectRejection().fail();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(JobIntent.FAIL)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectJobThrowErrorWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(job.getKey()).withErrorCode("ERR").expectRejection().throwError();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(JobIntent.THROW_ERROR)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectJobUpdateWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(job.getKey()).expectRejection().update();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(JobIntent.UPDATE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectJobUpdateRetriesWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(job.getKey()).withRetries(5).expectRejection().updateRetries();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(JobIntent.UPDATE_RETRIES)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectJobUpdateTimeoutWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String processId = Strings.newRandomValidBpmnId();
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, processId);
+    final long processInstanceKey = job.getValue().getProcessInstanceKey();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(job.getKey()).withTimeout(60_000L).expectRejection().updateTimeout();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(JobIntent.UPDATE_TIMEOUT)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationSuspensionGateTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ProcessInstanceModificationSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectExternalModifyWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = deployAndStartProcessWithUnreachedElement(processId);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("B")
+            .expectRejection()
+            .modify("test-user");
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+  }
+
+  @Test
+  public void shouldBufferInternalModifyWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final long processInstanceKey = deployAndStartProcessWithUnreachedElement(processId);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var record =
+        new ProcessInstanceModificationRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .addActivateInstruction(
+                new ProcessInstanceModificationActivateInstruction().setElementId("B"));
+
+    ENGINE.writeRecords(RecordToWrite.command().modification(record).key(processInstanceKey));
+
+    // then
+    assertThat(bufferedCommandIntent(processInstanceKey))
+        .isEqualTo(ProcessInstanceModificationIntent.MODIFY);
+  }
+
+  private static ProcessInstanceModificationIntent bufferedCommandIntent(
+      final long processInstanceKey) {
+    return (ProcessInstanceModificationIntent)
+        ((BufferedCommandRecordValue) bufferedCommand(processInstanceKey).getValue()).getIntent();
+  }
+
+  private static Record<RecordValue> bufferedCommand(final long processInstanceKey) {
+    return RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(
+            r ->
+                ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                    == processInstanceKey)
+        .getFirst();
+  }
+
+  private long deployAndStartProcessWithUnreachedElement(final String processId) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .exclusiveGateway("gateway")
+            .sequenceFlowId("toB")
+            .conditionExpression("false")
+            .serviceTask("B", t -> t.zeebeJobType("B"))
+            .endEvent()
+            .moveToLastExclusiveGateway()
+            .defaultFlow()
+            .serviceTask("A", t -> t.zeebeJobType("A"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    return processInstanceKey;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendResumeEquivalenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendResumeEquivalenceTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Each test compares a never-suspended {@code controlKey} instance against a {@code testKey}
+ * instance suspended mid-flight and resumed.
+ */
+public final class SuspendResumeEquivalenceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final Set<ProcessInstanceIntent> ELEMENT_LIFECYCLE_INTENTS =
+      EnumSet.of(
+          ProcessInstanceIntent.ELEMENT_ACTIVATING,
+          ProcessInstanceIntent.ELEMENT_ACTIVATED,
+          ProcessInstanceIntent.ELEMENT_COMPLETING,
+          ProcessInstanceIntent.ELEMENT_COMPLETED,
+          ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN);
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldReachSameStateWithTimerCatchEvent() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobType = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent("timer", c -> c.timerWithDuration("PT1S"))
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    final long controlKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.timerRecords(TimerIntent.CREATED).withProcessInstanceKey(controlKey).await();
+    ENGINE.increaseTime(Duration.ofSeconds(2));
+    ENGINE.job().withType(jobType).ofInstance(controlKey).complete();
+
+    final long testKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.timerRecords(TimerIntent.CREATED).withProcessInstanceKey(testKey).await();
+    ENGINE.processInstance().withInstanceKey(testKey).suspend();
+
+    // when - await the checker's rejected TRIGGER so resume deterministically exercises the
+    // stranded-timer rescan, not a race with the checker's own regular polling
+    ENGINE.increaseTime(Duration.ofSeconds(2));
+    RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+        .onlyCommandRejections()
+        .withProcessInstanceKey(testKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(testKey).resume();
+    ENGINE.job().withType(jobType).ofInstance(testKey).complete();
+
+    // then
+    assertThat(elementLifecycle(testKey))
+        .containsExactlyInAnyOrderElementsOf(elementLifecycle(controlKey));
+  }
+
+  @Test
+  public void shouldReachSameStateWithMessageCatchEvent() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobType = Strings.newRandomValidBpmnId();
+    final var messageName = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent(
+                "msgCatch",
+                c ->
+                    c.message(
+                        m -> m.name(messageName).zeebeCorrelationKeyExpression("correlationKey")))
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    final long controlKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("correlationKey", "control")
+            .create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(controlKey)
+        .await();
+    ENGINE.message().withName(messageName).withCorrelationKey("control").publish();
+    ENGINE.job().withType(jobType).ofInstance(controlKey).complete();
+
+    final long testKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("correlationKey", "test")
+            .create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(testKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(testKey).suspend();
+    // suspending tears down the message-side subscription; await it so publishing below reliably
+    // buffers instead of racing the teardown
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+        .withProcessInstanceKey(testKey)
+        .await();
+
+    // when - the TTL must outlast suspension so resume can re-create the subscription and
+    // correlate it
+    ENGINE
+        .message()
+        .withName(messageName)
+        .withCorrelationKey("test")
+        .withTimeToLive(Duration.ofMinutes(1))
+        .publish();
+    ENGINE.processInstance().withInstanceKey(testKey).resume();
+    ENGINE.job().withType(jobType).ofInstance(testKey).complete();
+
+    // then
+    assertThat(elementLifecycle(testKey))
+        .containsExactlyInAnyOrderElementsOf(elementLifecycle(controlKey));
+  }
+
+  @Test
+  public void shouldReachSameStateWithParallelGateway() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobTypeA = Strings.newRandomValidBpmnId();
+    final var jobTypeB = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .parallelGateway("fork")
+            .serviceTask("taskA", t -> t.zeebeJobType(jobTypeA))
+            .parallelGateway("join")
+            .endEvent()
+            .moveToNode("fork")
+            .serviceTask("taskB", t -> t.zeebeJobType(jobTypeB))
+            .connectTo("join")
+            .done();
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    final long controlKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    ENGINE.job().withType(jobTypeA).ofInstance(controlKey).complete();
+    ENGINE.job().withType(jobTypeB).ofInstance(controlKey).complete();
+
+    final long testKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(testKey)
+        .limit(2)
+        .await();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(testKey).suspend();
+    ENGINE.processInstance().withInstanceKey(testKey).resume();
+    ENGINE.job().withType(jobTypeA).ofInstance(testKey).complete();
+    ENGINE.job().withType(jobTypeB).ofInstance(testKey).complete();
+
+    // then
+    assertThat(elementLifecycle(testKey))
+        .containsExactlyInAnyOrderElementsOf(elementLifecycle(controlKey));
+  }
+
+  @Test
+  public void shouldReachSameStateWithCallActivity() {
+    // given
+    final var childProcessId = Strings.newRandomValidBpmnId();
+    final var childJobType = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance childModel =
+        Bpmn.createExecutableProcess(childProcessId)
+            .startEvent()
+            .serviceTask("childTask", t -> t.zeebeJobType(childJobType))
+            .endEvent()
+            .done();
+
+    final var parentProcessId = Strings.newRandomValidBpmnId();
+    final var parentJobType = Strings.newRandomValidBpmnId();
+    final BpmnModelInstance parentModel =
+        Bpmn.createExecutableProcess(parentProcessId)
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId(childProcessId))
+            .serviceTask("parentTask", t -> t.zeebeJobType(parentJobType))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(childModel).withXmlResource(parentModel).deploy();
+
+    final long controlKey = ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+    final long controlChildKey = awaitChildInstanceKey(controlKey);
+    ENGINE.job().withType(childJobType).ofInstance(controlChildKey).complete();
+    ENGINE.job().withType(parentJobType).ofInstance(controlKey).complete();
+
+    final long testKey = ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+    final long testChildKey = awaitChildInstanceKey(testKey);
+
+    // when - the child's completion signal buffers in the suspended parent scope; await that
+    // before resuming so the drain path is deterministically exercised
+    ENGINE.processInstance().withInstanceKey(testKey).suspend();
+    ENGINE.job().withType(childJobType).ofInstance(testChildKey).complete();
+    RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(r -> ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey() == testKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(testKey).resume();
+    ENGINE.job().withType(parentJobType).ofInstance(testKey).complete();
+
+    // then - the child runs as its own instance, so compare only the parent's lifecycle
+    assertThat(elementLifecycle(testKey))
+        .containsExactlyInAnyOrderElementsOf(elementLifecycle(controlKey));
+  }
+
+  private static long awaitChildInstanceKey(final long parentInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withParentProcessInstanceKey(parentInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst()
+        .getValue()
+        .getProcessInstanceKey();
+  }
+
+  private static List<String> elementLifecycle(final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .limitToProcessInstanceCompleted()
+        .filter(r -> ELEMENT_LIFECYCLE_INTENTS.contains(r.getIntent()))
+        .map(r -> r.getIntent() + ":" + r.getValue().getElementId())
+        .toList();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendResumeReplayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendResumeReplayTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * {@link EngineRule} is a {@code @Rule}, not a {@code @ClassRule}, so each test restarts a fresh
+ * engine instead of leaking state across the restart cycle.
+ */
+public final class SuspendResumeReplayTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRemainSuspendedAfterRestart() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobType = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(model).deploy();
+
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // snapshot before suspending, so recovery must rebuild the marker from the SUSPENDED event
+    engine.snapshot();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    engine.stop();
+    RecordingExporter.reset();
+    engine.start();
+
+    // then - via observable behavior, not by reading SuspensionState directly: state classes
+    // aren't thread-safe against the concurrently running stream processor
+    final var rejection =
+        engine.job().withType(jobType).ofInstance(processInstanceKey).expectRejection().complete();
+    assertThat(rejection.getRejectionType())
+        .describedAs("suspension marker must survive restart")
+        .isEqualTo(RejectionType.INVALID_STATE);
+
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+    engine.job().withType(jobType).ofInstance(processInstanceKey).complete();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(processId)
+        .await();
+  }
+
+  @Test
+  public void shouldDrainBufferedCommandAfterRestart() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobTypeA = Strings.newRandomValidBpmnId();
+    final var jobTypeB = Strings.newRandomValidBpmnId();
+    final var model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .parallelGateway("fork")
+            .serviceTask("taskA", t -> t.zeebeJobType(jobTypeA))
+            .parallelGateway("join")
+            .moveToNode("fork")
+            .serviceTask("taskB", t -> t.zeebeJobType(jobTypeB))
+            .connectTo("join")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(model).deploy();
+
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final Record<ProcessInstanceRecordValue> taskA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("taskA")
+            .getFirst();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(2)
+        .await();
+
+    // activate taskA's job so it's ACTIVATED, not ACTIVATABLE, before suspending - otherwise
+    // suspension parks it, and draining the injected command below removes its owning element
+    // without ever completing it, leaving it dangling (see ResumeProcessInstanceDrainTest)
+    engine.jobs().withType(jobTypeA).withMaxJobsToActivate(1).activate();
+
+    // snapshot before suspending and before the command buffers, so recovery must rebuild both
+    // from the SUSPENDED and BUFFERED events
+    engine.snapshot();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // simulates the internal completion signal a call activity or conditional trigger would send
+    engine.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, taskA.getValue())
+            .key(taskA.getKey()));
+    RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+        .await();
+
+    // when
+    engine.stop();
+    RecordingExporter.reset();
+    engine.start();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withValueType(ValueType.BUFFERED_COMMAND)
+                .withIntent(BufferedCommandIntent.DRAINED)
+                .filter(r -> processInstanceKeyOf(r) == processInstanceKey)
+                .exists())
+        .describedAs("buffered command must survive restart and drain on resume")
+        .isTrue();
+
+    engine.job().withType(jobTypeB).ofInstance(processInstanceKey).complete();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  private static long processInstanceKeyOf(final Record<?> record) {
+    return ((BufferedCommandRecordValue) record.getValue()).getProcessInstanceKey();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationSuspensionGateTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ProcessInstanceMigrationSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectMigrateWhileSuspended() {
+    // given
+    final String jobType = Strings.newRandomValidBpmnId();
+    final String sourceProcessId = Strings.newRandomValidBpmnId();
+    final String targetProcessId = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(sourceProcessId)
+                .startEvent()
+                .serviceTask("A", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var targetDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType(jobType))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        targetDeployment.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskSuspensionGateTest.java
@@ -14,7 +14,9 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -170,5 +172,75 @@ public final class UserTaskSuspensionGateTest {
         .hasRejectionType(RejectionType.INVALID_STATE);
     assertThat(rejection.getRejectionReason())
         .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldCancelUserTaskWhenInstanceTerminatedWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldRejectTaskListenerJobCompletionWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    final String listenerType = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .zeebeTaskListener(l -> l.completing().type(listenerType))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    final long listenerJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(listenerType)
+            .getFirst()
+            .getKey();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(listenerJobKey).expectRejection().complete();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(JobIntent.COMPLETE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskSuspensionGateTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class UserTaskSuspensionGateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectUserTaskCompleteWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<UserTaskRecordValue> rejection =
+        ENGINE.userTask().ofInstance(processInstanceKey).expectRejection().complete();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(UserTaskIntent.COMPLETE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectUserTaskClaimWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<UserTaskRecordValue> rejection =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAssignee("user")
+            .expectRejection()
+            .claim();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(UserTaskIntent.CLAIM)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectUserTaskAssignWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<UserTaskRecordValue> rejection =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAssignee("user")
+            .expectRejection()
+            .assign();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(UserTaskIntent.ASSIGN)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+
+  @Test
+  public void shouldRejectUserTaskUpdateWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final Record<UserTaskRecordValue> rejection =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAllAttributesChanged()
+            .expectRejection()
+            .update();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(UserTaskIntent.UPDATE)
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("process instance with key '" + processInstanceKey + "'");
+  }
+}


### PR DESCRIPTION
## Description

Closes #57537

Adds 27 new tests (23 engine-level, 4 acceptance-level) covering suspend/resume across the four acceptance criteria in the issue, plus gaps a reviewer identified on top of that. Also refactors the four pre-existing acceptance tests to remove duplicated polling logic.

| AC | What | Tests |
|----|------|-------|
| AC1: Control-vs-suspended terminal states equal | Equivalence tests proving suspend→resume produces the same BPMN lifecycle as a never-suspended run | Timer catch, message catch, parallel gateway, call activity (engine); parallel gateway, ad-hoc subprocess (acceptance) |
| AC2: Restart/replay while suspended is deterministic | Suspension marker and buffered commands survive `snapshot→stop→start` | Job completion still rejected after restart; a buffered command survives restart and drains on resume |
| AC3: All gate scenarios covered | Gate tests for processors with REJECT/BUFFER behavior that lacked coverage | Job fail/throwError/update/updateRetries/updateTimeout/yield/recurAfterBackoff, user task complete/claim/assign/update/cancel-on-terminate/task-listener-completion, incident resolve, process instance migrate/modify (engine); user task reject+resume (acceptance) |
| AC4: Large-buffer chunked drain resumes without error | Already covered by the pre-existing `ResumeProcessInstanceDrainTest`; not newly exercised by this PR — job completion is REJECT, not BUFFER, so the new parallel-gateway tests only prove AC1 equivalence | — |

### Commits

1. **`refactor:`** replaces inline `await().atMost(...).untilAsserted(...)` polling blocks in the four pre-existing acceptance tests with `TestHelper`'s existing `waitForElementInstances()` / `waitUntilProcessInstanceHasVariable()` — no behavior change, no new tests.
2. **`test: add engine-level suspend/resume test coverage`** — 18 new tests:
   - `JobSuspensionGateTest.java` — 5 new (fail/throwError/update/updateRetries/updateTimeout)
   - `UserTaskSuspensionGateTest.java` — new file, 4 tests (complete/claim/assign/update)
   - `IncidentSuspensionGateTest.java` — new file, 1 test (resolve)
   - `SuspendResumeEquivalenceTest.java` — new file, 4 tests (timer/message/parallel gateway/call activity)
   - `SuspendResumeReplayTest.java` — new file, 2 tests (suspension survives restart; buffered command survives restart and drains)
3. **`test: add acceptance tests for parallel gateway, user task, and message suspend/resume`** — 3 new tests in `ProcessInstanceSuspendResumeIT.java` (existing file), reusing the `TestHelper` wait methods from the refactor commit.
4. **`test: cover MIGRATE, MODIFY, job YIELD/RECUR_AFTER_BACKOFF, ad-hoc subprocess, and task listener ITs`** — the gaps a reviewer found on top of the above: 6 new engine tests + 1 new acceptance test:
   - `ProcessInstanceMigrationSuspensionGateTest.java` — new file, 1 test (migrate REJECT)
   - `ProcessInstanceModificationSuspensionGateTest.java` — new file, 2 tests (modify REJECT external / BUFFER internal)
   - `JobSuspensionGateTest.java` — 2 more (yield, recurAfterBackoff BUFFER)
   - `UserTaskSuspensionGateTest.java` — 2 more (cancel-on-terminate while suspended; task-listener job completion REJECT)
   - `ProcessInstanceSuspendResumeIT.java` — 1 more (ad-hoc subprocess equivalence)

### Notable implementation details

- **Incident resolve gate**: `resolve()` without a username is an internal command (gets BUFFERED, not REJECTED); the test uses `resolve("some-user")` to trigger the external-command REJECT path instead.
- **Call activity equivalence**: the child process instance is not itself suspended when the parent is — its job completion succeeds normally, but the completion signal it sends back into the parent scope is an internal command that buffers there until resume drains it.
- **Message catch equivalence**: suspending tears down the message-side subscription; resume re-creates it and correlates a message that was published with a TTL long enough to survive suspension.
- **Message acceptance test**: a suspend-driven subscription close re-emits `CREATED` (kept as a resume manifest), not `DELETED`, so that specific teardown race isn't observable through the public search API — it's covered at the record level by `MessageSuspensionGateTest` instead.
- **Restart tests** use `@Rule` (instance-level) `EngineRule`, not `@ClassRule`, so each test gets a fresh engine and doesn't leak state across the snapshot/stop/start cycle.
- **MIGRATE**: unconditionally rejects while suspended — unlike most other suspendable commands, it has no internal/BUFFER path at all.
- **MODIFY**: splits REJECT/BUFFER the same way ad-hoc subprocess instructions do — external commands are rejected outright rather than buffered, because buffering happens before authorization runs, and a queued external command would replay as internal on drain and skip its authorization check.
- **Job `YIELD` / `RECUR_AFTER_BACKOFF`**: both internal-only commands (job-stream error handling and a periodic backoff checker respectively) that buffer while suspended and drain on resume. `RECUR_AFTER_BACKOFF` needs `retries > 0` in the setup — with `retries == 0`, `JobFailProcessor` raises an incident instead of scheduling a backoff, so the command never fires.
- **Ad-hoc subprocess**: had engine-level gate coverage already (`AdHocSubProcessSuspensionGateTest`) but no acceptance-level equivalence test; each activated ad-hoc task produces its own `#innerInstance` wrapper element, so the completed-element count is 7, not the 5 you'd expect from `start`/`ad-hoc`/`taskA`/`taskB`/`end` alone.
- **User task cancel-on-terminate**: cancelling a process instance has `PROCESS` suspension behavior, so it's never gated by suspension, and the resulting user-task cleanup is written as a follow-up event rather than a command, so it never reaches the gate either. The general behavior was already covered (`CancelProcessInstanceTest.shouldCancelUserTaskForActivity`), just not for a suspended instance specifically.
- **User task listener completion**: a task-listener job completion routes through the same `JobCompleteProcessor` as any other job, which already rejects unconditionally while suspended — there's no separate processor or intent-level gate for it, just no test previously exercised a `JobKind.TASK_LISTENER` job.

## Testing

- All 23 engine-level tests pass locally (`./mvnw verify -pl zeebe/engine`)
- Acceptance tests (4 new, 4 refactored) compile but could not be fully executed locally (sandbox loopback-socket limitation in the multi-db test infrastructure); CI validates them — the ad-hoc subprocess element-count assumption above was in fact caught and fixed via a CI failure, not local testing
- Full-repo compilation verified with `./mvnw install -Dquickly -T1C`
