### PR TITLE
fix: align every analytics exporter event name with the contract

### DIFF
--- a/zeebe/exporters/analytics-exporter/AGENTS.md
+++ b/zeebe/exporters/analytics-exporter/AGENTS.md
@@ -68,7 +68,7 @@ Replicated log
 |      ValueType      |      Intent       |                Handler                 |              event.name               |                         Extra filter                         |
 |---------------------|-------------------|----------------------------------------|---------------------------------------|--------------------------------------------------------------|
 | PROCESS_INSTANCE    | ELEMENT_ACTIVATED | ProcessInstanceElementActivatedHandler | `camunda.process.instance.activated`  | bpmnElementType == PROCESS && parentProcessInstanceKey == -1 |
-| USER_TASK           | CREATED           | UserTaskCreatedHandler                 | `user_task_created`                   | —                                                            |
+| USER_TASK           | CREATED           | UserTaskCreatedHandler                 | `camunda.user_task.created`           | —                                                            |
 | USER_TASK           | ASSIGNED          | UserTaskAssignedHandler                | `camunda.user_task.assigned`          | skips empty assignee                                         |
 | TENANT              | CREATED           | TenantCreatedHandler                   | `camunda.tenant.created`              | —                                                            |
 | TENANT              | DELETED           | TenantDeletedHandler                   | `camunda.tenant.deleted`              | —                                                            |
@@ -83,7 +83,7 @@ Replicated log
 | AGENT_INSTANCE      | CREATED           | AgentInstanceCreatedHandler            | `camunda.agent.instance.created`      | —                                                            |
 | AGENT_INSTANCE      | COMPLETED         | AgentInstanceCompletedHandler          | `camunda.agent.instance.completed`    | —                                                            |
 | DECISION_EVALUATION | EVALUATED         | DecisionInstanceEvaluatedHandler       | (counter only, no event)              | —                                                            |
-| —                   | —                 | (scheduled)                            | `heartbeat`                           | every heartbeatInterval, carries broker/exporter versions    |
+| —                   | —                 | (scheduled)                            | `camunda.telemetry.heartbeat`         | every heartbeatInterval, carries broker/exporter versions    |
 
 ### Adding a New Event Handler
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -156,7 +156,7 @@ variables, or any other end-user data.
 |   Source record    |       Intent        |              Event name               |                                               Notes                                                |
 |--------------------|---------------------|---------------------------------------|----------------------------------------------------------------------------------------------------|
 | `PROCESS_INSTANCE` | `ELEMENT_ACTIVATED` | `camunda.process.instance.activated`  | Emitted when a root process element is activated, so it covers every start type.                   |
-| `USER_TASK`        | `CREATED`           | `user_task_created`                   | Emitted for every new user task.                                                                   |
+| `USER_TASK`        | `CREATED`           | `camunda.user_task.created`           | Emitted for every new user task.                                                                   |
 | `USER_TASK`        | `ASSIGNED`          | `camunda.user_task.assigned`          | Emitted for every user task assignment with a non-empty assignee.                                  |
 | `TENANT`           | `CREATED`           | `camunda.tenant.created`              | Emitted for every new tenant.                                                                      |
 | `TENANT`           | `DELETED`           | `camunda.tenant.deleted`              | Emitted for every deleted tenant.                                                                  |
@@ -170,10 +170,11 @@ variables, or any other end-user data.
 | `FORM`             | `DELETED`           | `camunda.form.definition.deleted`     | Emitted once per deleted form definition.                                                          |
 | `AGENT_INSTANCE`   | `CREATED`           | `camunda.agent.instance.created`      | Emitted for every created agent instance.                                                          |
 | `AGENT_INSTANCE`   | `COMPLETED`         | `camunda.agent.instance.completed`    | Emitted for every completed agent instance.                                                        |
-| —                  | —                   | `heartbeat`                           | Emitted periodically by the partition leader (see `heartbeat-interval`).                           |
+| —                  | —                   | `camunda.telemetry.heartbeat`         | Emitted periodically by the partition leader (see `heartbeat-interval`).                           |
 
-`user_task_created` and `heartbeat` predate the analytics data contract and still carry flat
-snake_case names. Every other signal uses the canonical dotted contract name.
+Every signal uses the canonical `camunda.<namespace>.<action>` contract name. `user_task_created`
+and `heartbeat` carried flat pre-contract names until 8.10 and were renamed to
+`camunda.user_task.created` and `camunda.telemetry.heartbeat`.
 
 ### Common log record attributes
 
@@ -205,7 +206,7 @@ process instance passes through however it was started: the client API, or a mes
 or conditional start event. Process instances started by a call activity are excluded, so the event
 counts root instances only.
 
-**`user_task_created`**
+**`camunda.user_task.created`**
 
 |            Attribute             |  Type  |            Description            |
 |----------------------------------|--------|-----------------------------------|
@@ -329,14 +330,14 @@ two agree.
 
 ### Heartbeat attributes
 
-The `heartbeat` event carries static cluster metadata instead of the common log/sequence
+The `camunda.telemetry.heartbeat` event carries static cluster metadata instead of the common log/sequence
 attributes (heartbeats are not tied to the log stream):
 
-|              Attribute               |  Type  |                               Description                                |
-|--------------------------------------|--------|--------------------------------------------------------------------------|
-| `event.name`                         | string | Always `heartbeat`.                                                      |
-| `camunda.heartbeat.broker_version`   | string | Broker version (matches `io.camunda.zeebe.util.VersionUtil#getVersion`). |
-| `camunda.heartbeat.exporter_version` | string | Analytics exporter version.                                              |
+|                   Attribute                    |  Type  |                               Description                                |
+|------------------------------------------------|--------|--------------------------------------------------------------------------|
+| `event.name`                                   | string | Always `camunda.telemetry.heartbeat`.                                    |
+| `camunda.telemetry.heartbeat.broker_version`   | string | Broker version (matches `io.camunda.zeebe.util.VersionUtil#getVersion`). |
+| `camunda.telemetry.heartbeat.exporter_version` | string | Analytics exporter version.                                              |
 
 The analytics schema URL (`https://camunda.io/schemas/analytics/v1`) is delivered automatically via
 the OTel instrumentation scope on every record, not as a per-record attribute.

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -42,8 +42,8 @@ public final class AnalyticsAttributes {
     // Event name values
 
     public static final String PROCESS_INSTANCE_ACTIVATED = "camunda.process.instance.activated";
-    public static final String HEARTBEAT = "heartbeat";
-    public static final String USER_TASK_CREATED = "user_task_created";
+    public static final String HEARTBEAT = "camunda.telemetry.heartbeat";
+    public static final String USER_TASK_CREATED = "camunda.user_task.created";
     public static final String TENANT_CREATED = "camunda.tenant.created";
     public static final String TENANT_DELETED = "camunda.tenant.deleted";
     public static final String PROCESS_INCIDENT_CREATED = "camunda.process.incident.created";
@@ -160,9 +160,9 @@ public final class AnalyticsAttributes {
 
   public static final class Heartbeat {
     public static final AttributeKey<String> BROKER_VERSION =
-        AttributeKey.stringKey("camunda.heartbeat.broker_version");
+        AttributeKey.stringKey("camunda.telemetry.heartbeat.broker_version");
     public static final AttributeKey<String> EXPORTER_VERSION =
-        AttributeKey.stringKey("camunda.heartbeat.exporter_version");
+        AttributeKey.stringKey("camunda.telemetry.heartbeat.exporter_version");
 
     private Heartbeat() {}
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Emits a {@code user_task_created} OTel event for each user task creation. Emits only safe
+ * Emits a {@code camunda.user_task.created} OTel event for each user task creation. Emits only safe
  * process-metadata attributes — never assignee, candidate users, candidate groups, or variables.
  */
 public final class UserTaskCreatedHandler implements AnalyticsHandler<UserTaskRecordValue> {

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsEventNamesTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsEventNamesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the wire value of every analytics event name.
+ *
+ * <p>Event names are a published contract: the analytics backend keys on {@code event.name}, so
+ * renaming one splits the series for every existing record. The rest of the suite asserts against
+ * the {@link AnalyticsAttributes.Event} constants rather than their values, which means a rename
+ * would otherwise pass unnoticed.
+ *
+ * <p>If this test fails you have changed or added a published event name. That is allowed, but it
+ * is a contract change: update the expectations here, the README event table, and coordinate the
+ * migration with the analytics backend before merging.
+ */
+final class AnalyticsEventNamesTest {
+
+  private static final Map<String, String> EXPECTED_EVENT_NAMES =
+      Map.ofEntries(
+          Map.entry("PROCESS_INSTANCE_ACTIVATED", "camunda.process.instance.activated"),
+          Map.entry("HEARTBEAT", "camunda.telemetry.heartbeat"),
+          Map.entry("USER_TASK_CREATED", "camunda.user_task.created"),
+          Map.entry("USER_TASK_ASSIGNED", "camunda.user_task.assigned"),
+          Map.entry("TENANT_CREATED", "camunda.tenant.created"),
+          Map.entry("TENANT_DELETED", "camunda.tenant.deleted"),
+          Map.entry("PROCESS_INCIDENT_CREATED", "camunda.process.incident.created"),
+          Map.entry("PROCESS_INCIDENT_RESOLVED", "camunda.process.incident.resolved"),
+          Map.entry("PROCESS_DEFINITION_CREATED", "camunda.process.definition.created"),
+          Map.entry("PROCESS_DEFINITION_DELETED", "camunda.process.definition.deleted"),
+          Map.entry("DECISION_DEFINITION_CREATED", "camunda.decision.definition.created"),
+          Map.entry("DECISION_DEFINITION_DELETED", "camunda.decision.definition.deleted"),
+          Map.entry("FORM_DEFINITION_CREATED", "camunda.form.definition.created"),
+          Map.entry("FORM_DEFINITION_DELETED", "camunda.form.definition.deleted"),
+          Map.entry("AGENT_INSTANCE_CREATED", "camunda.agent.instance.created"),
+          Map.entry("AGENT_INSTANCE_COMPLETED", "camunda.agent.instance.completed"));
+
+  @Test
+  void shouldNotChangePublishedEventNames() throws IllegalAccessException {
+    // when
+    final Map<String, String> declared = declaredEventNames();
+
+    // then
+    assertThat(declared).containsExactlyInAnyOrderEntriesOf(EXPECTED_EVENT_NAMES);
+  }
+
+  private static Map<String, String> declaredEventNames() throws IllegalAccessException {
+    final Map<String, String> names = new TreeMap<>();
+    for (final Field field : AnalyticsAttributes.Event.class.getDeclaredFields()) {
+      final int modifiers = field.getModifiers();
+      if (field.getType() == String.class
+          && Modifier.isPublic(modifiers)
+          && Modifier.isStatic(modifiers)) {
+        names.put(field.getName(), (String) field.get(null));
+      }
+    }
+    return names;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -112,7 +112,7 @@ dots become underscores), not as log line text — use `|` (structured-metadata 
 |-------------------------------------------------------------------------------------|------------------------------|
 | `{service_name="camunda-zeebe"}`                                                    | All raw analytics events     |
 | `{service_name="camunda-zeebe"} \| event_name="camunda.process.instance.activated"` | Process instance events only |
-| `{service_name="camunda-zeebe"} \| event_name="user_task_created"`                  | User task events only        |
+| `{service_name="camunda-zeebe"} \| event_name="camunda.user_task.created"`          | User task events only        |
 
 ## 5. Tear down
 


### PR DESCRIPTION
## Description

Ten of the twelve analytics-exporter signals use the canonical `camunda.<namespace>.<action>` event name. Two predate that convention and carry flat pre-contract names:

| Before              | After                         |
| ------------------- | ----------------------------- |
| `user_task_created` | `camunda.user_task.created`   |
| `heartbeat`         | `camunda.telemetry.heartbeat` |

The inconsistency is visible rather than theoretical: `camunda.user_task.assigned` and `user_task_created` come from sibling handlers off the same `USER_TASK` record type and sit next to each other in the event table, named differently. It was raised in review of the public documentation for these signals (camunda/camunda-docs#9697), where the choice is to explain the exception on a customer-facing page or to remove it.

## Why now

These names are a public contract from 8.10 onward. Today the only consumer is our own analytics backend, because customers emit these events but do not query them. Once 8.10 GA ships with the names published in the docs, the same rename costs a documentation change on top of the same downstream migration. This is the cheapest week it will ever be.

## Why `camunda.telemetry.heartbeat` and not `camunda.heartbeat`

`camunda.heartbeat` would have been the smaller change, and its existing attributes were already namespaced that way. But it is `camunda.<namespace>` with no `<action>`, so it would have left the README documenting a naming rule that one signal still broke, in the PR whose entire purpose is that every name follows it. Raised in review by Copilot, which was right.

`camunda.telemetry.heartbeat` makes the rule hold without exception and groups the heartbeat with `camunda.telemetry.export_window`, the other always-on signal. Its attributes move with it, so nothing is left stranded under the old namespace:

- `camunda.heartbeat.broker_version` -> `camunda.telemetry.heartbeat.broker_version`
- `camunda.heartbeat.exporter_version` -> `camunda.telemetry.heartbeat.exporter_version`

## Scope

Event names are plain `String` constants in `AnalyticsAttributes.Event`, and the attributes are `AttributeKey` constants, so the code change is those five values. The rest is documentation that quotes them.

- `AnalyticsAttributes.java` - two event name values, two attribute keys.
- `UserTaskCreatedHandler.java` - class Javadoc.
- `README.md` - event table, per-event heading, heartbeat attribute table, and the note that previously explained the exception.
- `AGENTS.md` - handler table rows.
- `src/test/resources/local-test/README.md` - a Loki query example.
- `AnalyticsEventNamesTest.java` - new, see below.

Full module suite passes locally: 312 tests, 0 failures.

## New: the wire names are now pinned by a test

Raised in review, and it was the right call to include it here rather than defer it. Every existing test asserts against the `AnalyticsAttributes.Event` constants rather than their values, so this rename passed the suite unchanged, and so would an accidental one.

`AnalyticsEventNamesTest` pins the literal value of every event name. It reflects over the declared constants rather than listing only the two renamed here, so adding a new event without pinning it fails as well. The failure message says what a legitimate change requires: update the expectations, update the README event table, and coordinate the migration with the analytics backend.

## Downstream impact, and what this needs from reviewers

**This breaks four wire keys in the analytics backend**: two event names and two heartbeat attributes. Both event names are already flowing. Per the 30 June update in the Apollo channel, `user_task_created` and `heartbeat` were among the events validated on a live 1.4M-event window, so `camunda_product_telemetry.events` holds data under the old names. Anything filtering on `event.name`, or reading the heartbeat version attributes, needs a union across both spellings or a backfill.

The exporter also re-sends historical events, which is worth thinking through before this merges: a rename mid-flight means the same underlying records can arrive under two different names depending on when they were exported.

So this needs a migration owner on the data side, not just a code review.

## Backport

Needs `stable/8.10` to be worth doing at all. If it does not land in 8.10, the old names ship publicly and this should be closed rather than deferred.
