### PR TITLE
fix: name process id expression and call activity in incident message

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn.container;
 
 import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
@@ -259,10 +260,36 @@ public final class CallActivityProcessor
   private Either<Failure, DirectBuffer> evaluateProcessId(
       final BpmnElementContext context, final ExecutableCallActivity element) {
     final var processIdExpression = element.getCalledElementProcessId();
-    final var scopeKey = context.getElementInstanceKey();
-    final var tenantId = context.getTenantId();
-    return expressionProcessor.evaluateStringExpressionAsDirectBuffer(
-        processIdExpression, scopeKey, tenantId);
+    return expressionProcessor
+        .evaluateAnyExpression(
+            processIdExpression, context.getElementInstanceKey(), context.getTenantId())
+        .flatMap(result -> resolveProcessIdFromResult(result, element, context));
+  }
+
+  private Either<Failure, DirectBuffer> resolveProcessIdFromResult(
+      final EvaluationResult result,
+      final ExecutableCallActivity element,
+      final BpmnElementContext context) {
+    if (result.getType() != ResultType.STRING) {
+      return Either.left(nonStringProcessIdFailure(result, element, context));
+    }
+    return Either.right(BufferUtil.wrapString(result.getString()));
+  }
+
+  private Failure nonStringProcessIdFailure(
+      final EvaluationResult result,
+      final ExecutableCallActivity element,
+      final BpmnElementContext context) {
+    return new Failure(
+        "Expected the process id expression '%s' on call activity '%s' to be %s, but was %s.%s"
+            .formatted(
+                result.getExpression(),
+                BufferUtil.bufferAsString(element.getId()),
+                ResultType.STRING,
+                result.getType(),
+                formatWarnings(result)),
+        ErrorType.EXTRACT_VALUE_ERROR,
+        context.getElementInstanceKey());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -29,9 +29,11 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.StringUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class CallActivityProcessor
     implements BpmnElementContainerProcessor<ExecutableCallActivity> {
@@ -57,6 +59,9 @@ public final class CallActivityProcessor
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
   private final BpmnJobBehavior jobBehavior;
   private final int maxProcessDepth;
+
+  // Reused per activation; must not outlive the lookup in getCalledProcess.
+  private final DirectBuffer processIdView = new UnsafeBuffer();
 
   public CallActivityProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -273,7 +278,12 @@ public final class CallActivityProcessor
     if (result.getType() != ResultType.STRING) {
       return Either.left(nonStringProcessIdFailure(result, element, context));
     }
-    return Either.right(BufferUtil.wrapString(result.getString()));
+    return Either.right(wrapProcessId(result.getString()));
+  }
+
+  private DirectBuffer wrapProcessId(final String processId) {
+    processIdView.wrap(StringUtil.getBytes(processId));
+    return processIdView;
   }
 
   private Failure nonStringProcessIdFailure(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -228,7 +228,7 @@ public final class CallActivityIncidentTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """
-            Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'. \
+            Expected the process id expression 'wfChild' on call activity 'call' to be STRING, but was NULL. \
             The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }
@@ -257,9 +257,55 @@ public final class CallActivityIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
-            "Expected result of the expression '"
+            "Expected the process id expression '"
                 + PROCESS_ID_VARIABLE
-                + "' to be 'STRING', but was 'NUMBER'.");
+                + "' on call activity 'call' to be STRING, but was NUMBER.");
+  }
+
+  @Test
+  public void shouldIncludeCallActivityElementIdInIncidentMessageWithMultipleCallActivities() {
+    // given
+    final String brokenCallActivityId = "brokenCall";
+    final String workingCallActivityId = "workingCall";
+    final String workingChildProcessId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            "wf-child-working.bpmn",
+            Bpmn.createExecutableProcess(workingChildProcessId).startEvent().done())
+        .withXmlResource(
+            "wf-parent-multi-call-activity.bpmn",
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .parallelGateway("fork")
+                .callActivity(
+                    brokenCallActivityId, c -> c.zeebeProcessIdExpression(PROCESS_ID_VARIABLE))
+                .endEvent()
+                .moveToNode("fork")
+                .callActivity(workingCallActivityId, c -> c.zeebeProcessId(workingChildProcessId))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+
+    // then
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(brokenCallActivityId)
+            .getFirst();
+
+    assertIncidentCreated(incident, elementInstance)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+            Expected the process id expression 'wfChild' on call activity 'brokenCall' to be STRING, but was NULL. \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }
 
   @Test
@@ -288,7 +334,7 @@ public final class CallActivityIncidentTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """
-            Expected result of the expression 'wfChild' to be 'STRING', but was 'NULL'. \
+            Expected the process id expression 'wfChild' on call activity 'call' to be STRING, but was NULL. \
             The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -303,9 +303,10 @@ public final class CallActivityIncidentTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """
-            Expected the process id expression 'wfChild' on call activity 'brokenCall' to be STRING, but was NULL. \
+            Expected the process id expression '%s' on call activity 'brokenCall' to be STRING, but was NULL. \
             The evaluation reported the following warnings:
-            [NO_VARIABLE_FOUND] No variable found with name 'wfChild'""");
+            [NO_VARIABLE_FOUND] No variable found with name '%s'"""
+                .formatted(PROCESS_ID_VARIABLE, PROCESS_ID_VARIABLE));
   }
 
   @Test


### PR DESCRIPTION
## Description

Closes #59551, first of nine sub-issues under epic #59543 (expression-evaluation failure messages don't say what's failing or what it targets).

A call activity's `calledElementProcessId` expression evaluated through the shared string type-check, so a bad process id expression produced a generic message:

> Expected result of the expression '=processId' to be 'STRING', but was 'NUMBER'.

Never said "process id", never named the call activity. With multiple call activities in one process, no way to tell which one broke from the message alone.

**After:**

> Expected the process id expression '=processId' on call activity 'CallActivity_1' to be STRING, but was NUMBER.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #59551
