### PR TITLE
refactor: extract OutputMappingResolver interface with ORDERED and COMBINED implementations

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -39,7 +39,8 @@ import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionSchedu
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
-import io.camunda.zeebe.engine.processing.variable.MappingResolvers;
+import io.camunda.zeebe.engine.processing.variable.InputMappingResolvers;
+import io.camunda.zeebe.engine.processing.variable.OutputMappingResolvers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -184,8 +185,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState,
             variableBehavior,
             eventTriggerBehavior,
-            MappingResolvers.forMode(config.getInputMappingMode(), config.getInputComparisonMode()),
-            config.getOutputMappingMode());
+            InputMappingResolvers.forMode(
+                config.getInputMappingMode(), config.getInputComparisonMode()),
+            OutputMappingResolvers.forMode(config.getOutputMappingMode()));
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import io.camunda.zeebe.engine.EngineConfiguration.OutputMappingMode;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -20,8 +19,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping
 import io.camunda.zeebe.engine.processing.variable.MappingContext;
 import io.camunda.zeebe.engine.processing.variable.MappingExpressionProcessor;
 import io.camunda.zeebe.engine.processing.variable.MappingResolver;
-import io.camunda.zeebe.engine.processing.variable.MsgPackPath;
-import io.camunda.zeebe.engine.processing.variable.OutputMappingResultBuilder;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -32,7 +29,6 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NonNull;
@@ -48,16 +44,16 @@ public final class BpmnVariableMappingBehavior {
   private final EventScopeInstanceState eventScopeInstanceState;
 
   private final EventTriggerBehavior eventTriggerBehavior;
-  private final OutputMappingMode outputMappingMode;
-  private final MappingResolver inputMappingResolver;
+  private final MappingResolver<InputMappings> inputMappingResolver;
+  private final MappingResolver<OutputMappings> outputMappingResolver;
 
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final MappingResolver inputMappingResolver,
-      final OutputMappingMode outputMappingMode) {
+      final MappingResolver<InputMappings> inputMappingResolver,
+      final MappingResolver<OutputMappings> outputMappingResolver) {
     this.expressionProcessor = expressionProcessor;
     inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
@@ -66,7 +62,7 @@ public final class BpmnVariableMappingBehavior {
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.inputMappingResolver = inputMappingResolver;
-    this.outputMappingMode = outputMappingMode;
+    this.outputMappingResolver = outputMappingResolver;
   }
 
   /**
@@ -101,7 +97,7 @@ public final class BpmnVariableMappingBehavior {
             context.getProcessDefinitionKey(),
             context.getTenantId());
     final var result =
-        inputMappingResolver.resolveInputMappings(
+        inputMappingResolver.resolve(
             inputMappings.get(),
             new MappingExpressionProcessor(inputMappingExpressionProcessor, mappingContext));
     if (result.isLeft()) {
@@ -164,49 +160,22 @@ public final class BpmnVariableMappingBehavior {
         }
       }
 
-      final Either<Failure, DirectBuffer> result;
-      if (outputMappingMode == OutputMappingMode.COMBINED) {
-        // evaluate the single pre-built FEEL context expression against the outer scope
-        result =
-            expressionProcessor.evaluateVariableMappingExpression(
-                outputMappings.get().combinedExpression(), elementInstanceKey, tenantId);
-      } else {
-        // ORDERED: evaluate each mapping in turn; each sees results of earlier ones
-        // Resolves the current scope value at a nested target's path so the builder can merge into
-        // it and keep the existing sibling properties: look up the top-level variable in the
-        // element
-        // scope, then navigate into it along the remaining path segments (null when absent).
-        final var resultBuilder =
-            new OutputMappingResultBuilder(
-                path ->
-                    Optional.ofNullable(
-                            variablesState.getVariable(
-                                elementInstanceKey, BufferUtil.wrapString(path.getFirst())))
-                        .map(rootValue -> MsgPackPath.navigate(rootValue, path, 1))
-                        .orElse(null));
-        // crosses from Zeebe's Either<Failure, T> world into FEEL's Either<DirectBuffer,
-        // EvaluationContext> convention (Left = terminal value or absence) for this one lambda
-        final var processor =
-            expressionProcessor.prependContext(name -> Either.left(resultBuilder.get(name)));
-
-        Either<Failure, DirectBuffer> loopResult = null;
-        for (final var mapping : outputMappings.get().mappings()) {
-          final var r =
-              processor.evaluateVariableMappingExpression(
-                  mapping.source(), elementInstanceKey, tenantId);
-          if (r.isLeft()) {
-            loopResult = Either.left(r.getLeft());
-            break;
-          }
-          resultBuilder.put(mapping.targetPath(), r.get());
-        }
-        result = loopResult != null ? loopResult : Either.right(resultBuilder.toDocument());
+      final var mappingContext =
+          new MappingContext(
+              element.getId(),
+              elementInstanceKey,
+              processInstanceKey,
+              processDefinitionKey,
+              tenantId);
+      final var resolveResult =
+          outputMappingResolver.resolve(
+              outputMappings.get(),
+              new MappingExpressionProcessor(expressionProcessor, mappingContext));
+      if (resolveResult.isLeft()) {
+        return Either.left(resolveResult.getLeft());
       }
-
-      if (result.isLeft()) {
-        return Either.left(result.getLeft());
-      }
-      return propagateVariables(context, element, getVariableScopeKey(context), result.get());
+      return propagateVariables(
+          context, element, getVariableScopeKey(context), resolveResult.get());
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.NullMarked;
  * same RFC-6901 leaf JSON pointer; empty when no input mapping references a cluster variable.
  *
  * <p>{@code combinedExpression} is the pre-parsed FEEL context literal built from all mappings at
- * deploy/load time for {@code CombinedMappingResolver} to evaluate on each activation without
+ * deploy/load time for {@code CombinedInputMappingResolver} to evaluate on each activation without
  * rebuilding it. Deploy-time parsing rejects invalid FEEL by throwing, so by the time this record
  * exists the field is always a valid expression.
  */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/CombinedInputMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/CombinedInputMappingResolver.java
@@ -37,11 +37,11 @@ import org.jspecify.annotations.NullMarked;
  * {@code "1"} rather than being reparsed as a number by FEEL.
  */
 @NullMarked
-public final class CombinedMappingResolver implements MappingResolver {
+public final class CombinedInputMappingResolver implements MappingResolver<InputMappings> {
 
   @Override
-  public Either<Failure, DirectBuffer> resolveInputMappings(
-      final InputMappings inputMappings, final MappingExpressionProcessor processor) {
-    return processor.evaluateVariableMappingExpression(inputMappings.combinedExpression());
+  public Either<Failure, DirectBuffer> resolve(
+      final InputMappings mappings, final MappingExpressionProcessor processor) {
+    return processor.evaluateVariableMappingExpression(mappings.combinedExpression());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/CombinedOutputMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/CombinedOutputMappingResolver.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
+import io.camunda.zeebe.util.Either;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Resolves output mappings by evaluating a single pre-built FEEL context literal against the outer
+ * scope. This restores the pre-{@code #59087} behavior where all mappings were combined into one
+ * expression at deploy time.
+ *
+ * <p>The combined expression is precomputed by {@link VariableMappingTransformer} and stored on
+ * {@link OutputMappings}, so each completion only pays for evaluation.
+ */
+@NullMarked
+public final class CombinedOutputMappingResolver implements MappingResolver<OutputMappings> {
+
+  @Override
+  public Either<Failure, DirectBuffer> resolve(
+      final OutputMappings mappings, final MappingExpressionProcessor processor) {
+    return processor.evaluateVariableMappingExpression(mappings.combinedExpression());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.variable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
@@ -26,9 +25,12 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Both resolvers are always run — even when the primary fails — so that divergences between
  * failure and success outcomes are also detected and logged.
+ *
+ * @param <M> the type of mappings record (e.g. {@link
+ *     io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings})
  */
 @NullMarked
-public final class ComparingMappingResolver implements MappingResolver {
+public final class ComparingMappingResolver<M> implements MappingResolver<M> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ComparingMappingResolver.class);
   private static final ObjectMapper MSGPACK_MAPPER = new ObjectMapper(new MessagePackFactory());
@@ -36,30 +38,31 @@ public final class ComparingMappingResolver implements MappingResolver {
   // 1/s throttle per instance; one engine instance → one resolver → effective global rate limit
   private final Logger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(1));
 
-  private final MappingResolver primary;
-  private final MappingResolver comparison;
+  private final MappingResolver<M> primary;
+  private final MappingResolver<M> comparison;
 
-  public ComparingMappingResolver(final MappingResolver primary, final MappingResolver comparison) {
+  public ComparingMappingResolver(
+      final MappingResolver<M> primary, final MappingResolver<M> comparison) {
     this.primary = primary;
     this.comparison = comparison;
   }
 
   @Override
-  public Either<Failure, DirectBuffer> resolveInputMappings(
-      final InputMappings inputMappings, final MappingExpressionProcessor processor) {
-    final var primaryResult = primary.resolveInputMappings(inputMappings, processor);
+  public Either<Failure, DirectBuffer> resolve(
+      final M mappings, final MappingExpressionProcessor processor) {
+    final var primaryResult = primary.resolve(mappings, processor);
 
-    // Snapshot before the comparison run: CombinedMappingResolver returns a view into a shared
+    // Snapshot before the comparison run: CombinedInputMappingResolver returns a view into a shared
     // evaluation buffer that the comparison resolver will overwrite on its own evaluation pass.
     // Returning the snapshot (a clone) instead of primaryResult shields the caller from corruption.
     final var snapshot = snapshot(primaryResult);
 
     try {
-      final var comparisonResult = comparison.resolveInputMappings(inputMappings, processor);
+      final var comparisonResult = comparison.resolve(mappings, processor);
 
       if (!equivalent(snapshot, comparisonResult)) {
         throttledLog.warn(
-            "Input mapping results differ between {} and {} resolvers [{}].",
+            "Mapping results differ between {} and {} resolvers [{}].",
             primary.getClass().getSimpleName(),
             comparison.getClass().getSimpleName(),
             processor.getMappingContext());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolvers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolvers.java
@@ -8,33 +8,34 @@
 package io.camunda.zeebe.engine.processing.variable;
 
 import io.camunda.zeebe.engine.EngineConfiguration.InputMappingMode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-/** Utility methods for working with {@link MappingResolver} instances. */
+/** Utility methods for working with {@link MappingResolver} instances for input mappings. */
 @NullMarked
-public final class MappingResolvers {
+public final class InputMappingResolvers {
 
-  private MappingResolvers() {}
+  private InputMappingResolvers() {}
 
   /**
    * Returns a resolver for the given input mode. If {@code comparisonMode} is non-null and
    * different from {@code inputMode}, wraps both in a {@link ComparingMappingResolver} that logs a
    * warning when results differ.
    */
-  public static MappingResolver forMode(
+  public static MappingResolver<InputMappings> forMode(
       final InputMappingMode inputMode, final @Nullable InputMappingMode comparisonMode) {
     final var primary = singleResolver(inputMode);
     if (comparisonMode == null || comparisonMode == inputMode) {
       return primary;
     }
-    return new ComparingMappingResolver(primary, singleResolver(comparisonMode));
+    return new ComparingMappingResolver<>(primary, singleResolver(comparisonMode));
   }
 
-  private static MappingResolver singleResolver(final InputMappingMode mode) {
+  private static MappingResolver<InputMappings> singleResolver(final InputMappingMode mode) {
     return switch (mode) {
-      case COMBINED -> new CombinedMappingResolver();
-      case ORDERED -> new OrderedMappingResolver();
+      case COMBINED -> new CombinedInputMappingResolver();
+      case ORDERED -> new OrderedInputMappingResolver();
     };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/MappingResolver.java
@@ -8,25 +8,28 @@
 package io.camunda.zeebe.engine.processing.variable;
 
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.util.Either;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A swappable strategy for resolving an element's input mappings into a single MsgPack result
- * document. Implementations differ in how (and whether) earlier mappings' results are visible to
- * later ones, but never apply the result to variable scope themselves — the caller keeps ownership
- * of doing that, so a future shadow/comparison mode can run multiple resolvers and diff their
- * documents without touching this interface again.
+ * A swappable strategy for resolving an element's mappings into a single MsgPack result document.
+ * Implementations differ in how (and whether) earlier mappings' results are visible to later ones,
+ * but never apply the result to variable scope themselves — the caller keeps ownership of doing
+ * that, so a future shadow/comparison mode can run multiple resolvers and diff their documents
+ * without touching this interface again.
+ *
+ * @param <M> the type of mappings record to resolve (e.g. {@link
+ *     io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings} or {@link
+ *     io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings})
  */
 @NullMarked
-public interface MappingResolver {
+public interface MappingResolver<M> {
 
   /**
-   * Resolves the given input mappings into a single MsgPack result document.
+   * Resolves the given mappings into a single MsgPack result document.
    *
-   * @param inputMappings the element's input mappings, in modeling order
+   * @param mappings the element's mappings, in modeling order
    * @param processor the pre-scoped expression processor; its evaluation context is already scoped
    *     to the element instance, and carries {@link MappingExpressionProcessor#getMappingContext()}
    *     with element identity (element ID, scope key, process instance key, process definition key,
@@ -34,6 +37,5 @@ public interface MappingResolver {
    * @return either the resolved result document, or the failure of the first mapping that failed to
    *     evaluate
    */
-  Either<Failure, DirectBuffer> resolveInputMappings(
-      InputMappings inputMappings, MappingExpressionProcessor processor);
+  Either<Failure, DirectBuffer> resolve(M mappings, MappingExpressionProcessor processor);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedInputMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedInputMappingResolver.java
@@ -22,10 +22,10 @@ import org.jspecify.annotations.NullMarked;
  * name shadows it totally. Resolution stops at the first failing mapping.
  */
 @NullMarked
-public final class OrderedMappingResolver implements MappingResolver {
+public final class OrderedInputMappingResolver implements MappingResolver<InputMappings> {
 
   @Override
-  public Either<Failure, DirectBuffer> resolveInputMappings(
+  public Either<Failure, DirectBuffer> resolve(
       final InputMappings inputMappings, final MappingExpressionProcessor processor) {
     final var resultBuilder =
         new InputMappingResultBuilder(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedOutputMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OrderedOutputMappingResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
+import io.camunda.zeebe.util.Either;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Resolves output mappings one by one in modeling order. Each mapping's source expression sees the
+ * results of the earlier mappings (they take priority over same-named scope variables) and falls
+ * back to the element's variable scope otherwise. A nested target merges with the existing scope
+ * value at every path level. Resolution stops at the first failing mapping.
+ *
+ * <p>The scope value for nested-target merges is obtained from the pre-scoped evaluation context
+ * carried by the {@link MappingExpressionProcessor}: the top-level variable is looked up there,
+ * then navigated along the remaining path segments via {@link MsgPackPath}.
+ */
+@NullMarked
+public final class OrderedOutputMappingResolver implements MappingResolver<OutputMappings> {
+
+  @Override
+  public Either<Failure, DirectBuffer> resolve(
+      final OutputMappings outputMappings, final MappingExpressionProcessor processor) {
+    final var resultBuilder =
+        new OutputMappingResultBuilder(
+            path -> {
+              final var value = processor.getEvaluationContext().getVariable(path.getFirst());
+              final var rootValue = value.isLeft() ? value.getLeft() : null;
+              return rootValue == null ? null : MsgPackPath.navigate(rootValue, path, 1);
+            });
+    final var boundProcessor = processor.prependContext(resultBuilder::get);
+
+    for (final OutputMapping mapping : outputMappings.mappings()) {
+      final var result = boundProcessor.evaluateVariableMappingExpression(mapping.source());
+      if (result.isLeft()) {
+        return Either.left(result.getLeft());
+      }
+      resultBuilder.put(mapping.targetPath(), result.get());
+    }
+    return Either.right(resultBuilder.toDocument());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolvers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolvers.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import io.camunda.zeebe.engine.EngineConfiguration.OutputMappingMode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
+import org.jspecify.annotations.NullMarked;
+
+/** Utility methods for working with {@link MappingResolver} instances for output mappings. */
+@NullMarked
+public final class OutputMappingResolvers {
+
+  private OutputMappingResolvers() {}
+
+  /** Returns a resolver for the given output mapping mode. */
+  public static MappingResolver<OutputMappings> forMode(final OutputMappingMode outputMappingMode) {
+    return switch (outputMappingMode) {
+      case COMBINED -> new CombinedOutputMappingResolver();
+      case ORDERED -> new OrderedOutputMappingResolver();
+    };
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -70,11 +70,11 @@ final class ComparingMappingResolverTest {
   @Test
   void shouldReturnPrimaryResultWhenBothSucceedWithEqualBytes() {
     final var buf = bufferOf("same");
-    final MappingResolver primary = (m, p) -> Either.right(buf);
-    final MappingResolver comparison = (m, p) -> Either.right(buf);
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(buf);
+    final MappingResolver<InputMappings> comparison = (m, p) -> Either.right(buf);
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(result.get()).isEqualTo(buf);
@@ -84,11 +84,12 @@ final class ComparingMappingResolverTest {
   @Test
   void shouldLogWarnWhenPrimarySucceedsButComparisonFails() {
     final var buf = bufferOf("value");
-    final MappingResolver primary = (m, p) -> Either.right(buf);
-    final MappingResolver comparison = (m, p) -> Either.left(new Failure("comparison failed"));
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(buf);
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.left(new Failure("comparison failed"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(result.get()).isEqualTo(buf);
@@ -99,19 +100,19 @@ final class ComparingMappingResolverTest {
         .satisfies(
             e -> {
               assertThat(e.getLevel()).isEqualTo(Level.WARN);
-              assertThat(e.getMessage().getFormattedMessage())
-                  .contains("Input mapping results differ");
+              assertThat(e.getMessage().getFormattedMessage()).contains("Mapping results differ");
             });
   }
 
   @Test
   void shouldLogWarnWhenPrimaryFailsAndComparisonSucceeds() {
     final var buf = bufferOf("value");
-    final MappingResolver primary = (m, p) -> Either.left(new Failure("primary failed"));
-    final MappingResolver comparison = (m, p) -> Either.right(buf);
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary =
+        (m, p) -> Either.left(new Failure("primary failed"));
+    final MappingResolver<InputMappings> comparison = (m, p) -> Either.right(buf);
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isLeft()).isTrue();
     assertThat(result.getLeft().getMessage()).isEqualTo("primary failed");
@@ -122,18 +123,18 @@ final class ComparingMappingResolverTest {
         .satisfies(
             e -> {
               assertThat(e.getLevel()).isEqualTo(Level.WARN);
-              assertThat(e.getMessage().getFormattedMessage())
-                  .contains("Input mapping results differ");
+              assertThat(e.getMessage().getFormattedMessage()).contains("Mapping results differ");
             });
   }
 
   @Test
   void shouldNotLogWarnWhenBothFailWithSameFailure() {
-    final MappingResolver primary = (m, p) -> Either.left(new Failure("same error"));
-    final MappingResolver comparison = (m, p) -> Either.left(new Failure("same error"));
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.left(new Failure("same error"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.left(new Failure("same error"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isLeft()).isTrue();
     assertThat(result.getLeft().getMessage()).isEqualTo("same error");
@@ -143,11 +144,11 @@ final class ComparingMappingResolverTest {
 
   @Test
   void shouldLogWarnWhenBothFailWithDifferentMessages() {
-    final MappingResolver primary = (m, p) -> Either.left(new Failure("error A"));
-    final MappingResolver comparison = (m, p) -> Either.left(new Failure("error B"));
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.left(new Failure("error A"));
+    final MappingResolver<InputMappings> comparison = (m, p) -> Either.left(new Failure("error B"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isLeft()).isTrue();
     assertThat(result.getLeft().getMessage()).isEqualTo("error A");
@@ -160,11 +161,12 @@ final class ComparingMappingResolverTest {
 
   @Test
   void shouldLogWarnWhenBothSucceedWithDifferentDocuments() {
-    final MappingResolver primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
-    final MappingResolver comparison = (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(recorder.getAppendedEvents()).hasSize(1);
@@ -173,11 +175,11 @@ final class ComparingMappingResolverTest {
   @Test
   void shouldNotLogWarnWhenBothSucceedWithEqualNestedDocuments() {
     final var buf = msgPackOf("{\"a\":{\"b\":1,\"c\":2},\"d\":3}");
-    final MappingResolver primary = (m, p) -> Either.right(buf);
-    final MappingResolver comparison = (m, p) -> Either.right(buf);
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(buf);
+    final MappingResolver<InputMappings> comparison = (m, p) -> Either.right(buf);
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(recorder.getAppendedEvents()).isEmpty();
@@ -185,11 +187,13 @@ final class ComparingMappingResolverTest {
 
   @Test
   void shouldLogWarnWhenBothSucceedWithDifferentNestedValues() {
-    final MappingResolver primary = (m, p) -> Either.right(msgPackOf("{\"a\":{\"b\":1}}"));
-    final MappingResolver comparison = (m, p) -> Either.right(msgPackOf("{\"a\":{\"b\":99}}"));
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary =
+        (m, p) -> Either.right(msgPackOf("{\"a\":{\"b\":1}}"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"a\":{\"b\":99}}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(recorder.getAppendedEvents()).hasSize(1);
@@ -199,11 +203,13 @@ final class ComparingMappingResolverTest {
   void shouldNotLogWarnWhenDocumentsHaveSameContentButDifferentKeyOrder() {
     // Tests the deep (order-insensitive) comparison path — same key-value pairs,
     // different insertion order → different bytes but semantically equal
-    final MappingResolver primary = (m, p) -> Either.right(msgPackOf("{\"a\":1,\"b\":2}"));
-    final MappingResolver comparison = (m, p) -> Either.right(msgPackOf("{\"b\":2,\"a\":1}"));
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final MappingResolver<InputMappings> primary =
+        (m, p) -> Either.right(msgPackOf("{\"a\":1,\"b\":2}"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"b\":2,\"a\":1}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(recorder.getAppendedEvents()).isEmpty();
@@ -220,16 +226,16 @@ final class ComparingMappingResolverTest {
     // Use a mutable UnsafeBuffer wrapping original's bytes
     final var sharedView = new UnsafeBuffer(BufferUtil.cloneBuffer(original));
 
-    final MappingResolver primary = (m, p) -> Either.right(sharedView);
-    final MappingResolver comparison =
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(sharedView);
+    final MappingResolver<InputMappings> comparison =
         (m, p) -> {
           // Overwrite the shared buffer's backing bytes in-place, as the FEEL engine does
           sharedView.putBytes(0, BufferUtil.bufferAsArray(different), 0, different.capacity());
           return Either.right(different);
         };
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     // The returned buffer must contain the snapshot (original), not the overwritten bytes
@@ -243,14 +249,14 @@ final class ComparingMappingResolverTest {
   @Test
   void shouldReturnPrimaryResultAndLogWarnWhenComparisonThrows() {
     final var buf = bufferOf("value");
-    final MappingResolver primary = (m, p) -> Either.right(buf);
-    final MappingResolver comparison =
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(buf);
+    final MappingResolver<InputMappings> comparison =
         (m, p) -> {
           throw new RuntimeException("unexpected comparison failure");
         };
-    final var resolver = new ComparingMappingResolver(primary, comparison);
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
 
-    final var result = resolver.resolveInputMappings(INPUT_MAPPINGS, PROCESSOR);
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
 
     assertThat(result.isRight()).isTrue();
     assertThat(recorder.getAppendedEvents())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -38,9 +38,10 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Runs input-mapping scenarios through both {@link MappingResolver} implementations side by side,
- * so each test documents where {@link OrderedMappingResolver} (the current per-mapping behavior,
- * "Today") and {@link CombinedMappingResolver} (the resurrected pre-{@code baddd911435}
- * combined-FEEL-context behavior, "8.9.0") agree, and precisely why they diverge where they don't.
+ * so each test documents where {@link OrderedInputMappingResolver} (the current per-mapping
+ * behavior, "Today") and {@link CombinedInputMappingResolver} (the resurrected pre-{@code
+ * baddd911435} combined-FEEL-context behavior, "8.9.0") agree, and precisely why they diverge where
+ * they don't.
  *
  * <p>Tests are grouped into {@code @Nested} classes mirroring the eight numbered rules of the
  * internal "Rules that input mappings adhere to" reference doc, one class per rule, with each
@@ -49,8 +50,8 @@ import org.junit.jupiter.api.Test;
  * camunda/camunda#60011 -- that test intentionally asserts today's actual, non-ideal output, not
  * the proposed fix, and will need deliberate updating once that issue is fixed. Rule 7 (partial
  * shadowing) turned out, once this test exercised a real ancestor-scope hierarchy instead of a flat
- * in-memory stand-in, to already be correctly implemented by {@link OrderedMappingResolver} for
- * every scenario here -- the actual gap sits in {@link CombinedMappingResolver}'s single
+ * in-memory stand-in, to already be correctly implemented by {@link OrderedInputMappingResolver}
+ * for every scenario here -- the actual gap sits in {@link CombinedInputMappingResolver}'s single
  * combined-FEEL-context evaluation, which loses an ancestor's untouched sibling once that object's
  * root has been partially mapped (see 7.3-7.5). Two further groups cover scenarios the doc doesn't
  * address: the qualified/bare-name self-reference cases from issue #60551 that motivated this whole
@@ -67,7 +68,7 @@ import org.junit.jupiter.api.Test;
  * by {@link Helpers#buildProcessor}, which walks the provided scope chain from innermost to
  * outermost -- no embedded database required.
  */
-class MappingResolverComparisonTest {
+class InputMappingResolverComparisonTest {
 
   private static final ExpressionLanguage EXPRESSION_LANGUAGE =
       ExpressionLanguageFactory.createExpressionLanguage(
@@ -75,8 +76,8 @@ class MappingResolverComparisonTest {
   private static final Duration DEFAULT_TIMEOUT =
       EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
 
-  private static final OrderedMappingResolver ORDERED = new OrderedMappingResolver();
-  private static final CombinedMappingResolver LEGACY = new CombinedMappingResolver();
+  private static final OrderedInputMappingResolver ORDERED = new OrderedInputMappingResolver();
+  private static final CombinedInputMappingResolver LEGACY = new CombinedInputMappingResolver();
 
   @Nested
   @DisplayName("Rule 1: an input mapping creates a local variable")
@@ -345,8 +346,8 @@ class MappingResolverComparisonTest {
   @Nested
   @DisplayName(
       "Rule 7: variables from a higher scope are partially shadowed by input mappings"
-          + " (OrderedMappingResolver already implements this correctly; the gap is in"
-          + " CombinedMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
+          + " (OrderedInputMappingResolver already implements this correctly; the gap is in"
+          + " CombinedInputMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
           + " ancestor's untouched sibling once that object's root has been partially mapped)")
   class Rule7PartiallyShadowsHigherScope {
 
@@ -455,9 +456,9 @@ class MappingResolverComparisonTest {
   @Nested
   @DisplayName(
       "Rule 8: types survive across input mappings within one resolver context, but not when"
-          + " written through MsgPack (confirmed bug camunda/camunda#60011). OrderedMappingResolver"
+          + " written through MsgPack (confirmed bug camunda/camunda#60011). OrderedInputMappingResolver"
           + " is the broken party here: it loses the FEEL type at every mapping boundary via the"
-          + " MsgPack round-trip. CombinedMappingResolver evaluates all mappings in one FEEL"
+          + " MsgPack round-trip. CombinedInputMappingResolver evaluates all mappings in one FEEL"
           + " context expression, so the type survives. When input-comparison-mode=ORDERED is used"
           + " with the COMBINED default, any mapping that reads a FEEL-typed value set by an"
           + " earlier mapping WILL trigger comparison warnings -- that is expected and correct."
@@ -466,8 +467,8 @@ class MappingResolverComparisonTest {
 
     @Test
     @DisplayName(
-        "8.1 OrderedMappingResolver loses the FEEL type at the mapping boundary (bug #60011);"
-            + " CombinedMappingResolver preserves it within the single FEEL context")
+        "8.1 OrderedInputMappingResolver loses the FEEL type at the mapping boundary (bug #60011);"
+            + " CombinedInputMappingResolver preserves it within the single FEEL context")
     void shouldLoseTheFeelTypeAcrossMappingsInOrderedButNotInCombined() {
       final var mappings =
           List.of(Helpers.mapping("=duration(\"P1DT2H\")", "x"), Helpers.mapping("=x.days", "y"));
@@ -667,8 +668,7 @@ class MappingResolverComparisonTest {
       final var inputMappings =
           new VariableMappingTransformer().transformInputMappings(mappings, EXPRESSION_LANGUAGE);
       return new ResolverResults(
-          ORDERED.resolveInputMappings(inputMappings, processor),
-          LEGACY.resolveInputMappings(inputMappings, processor));
+          ORDERED.resolve(inputMappings, processor), LEGACY.resolve(inputMappings, processor));
     }
 
     /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolverComparisonTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
+import io.camunda.zeebe.engine.processing.expression.ScopedEvaluationContext;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OutputMappingResolverComparisonTest {
+
+  private static final ExpressionLanguage EXPRESSION_LANGUAGE =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private static final Duration DEFAULT_TIMEOUT =
+      io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
+
+  private static final OrderedOutputMappingResolver ORDERED = new OrderedOutputMappingResolver();
+  private static final CombinedOutputMappingResolver COMBINED = new CombinedOutputMappingResolver();
+
+  @Nested
+  @DisplayName("Non-overlapping targets")
+  class NonOverlappingTargets {
+    @Test
+    void shouldProduceSameResultForDistinctTargets() {
+      final var r =
+          Helpers.resolve(
+              List.of(Helpers.mapping("=x", "a"), Helpers.mapping("=y", "b")),
+              Map.of("x", 1, "y", 2));
+      Helpers.assertSame(r, "{'a':1,'b':2}");
+    }
+  }
+
+  @Nested
+  @DisplayName("Duplicate target with intermediate read")
+  class DuplicateTargetWithIntermediateRead {
+    @Test
+    void shouldDifferOnIntermediateValueVisibility() {
+      final var r =
+          Helpers.resolve(
+              List.of(
+                  Helpers.mapping("=1", "x"),
+                  Helpers.mapping("=x", "y"),
+                  Helpers.mapping("=2", "x")),
+              Map.of());
+      Helpers.assertDiffers(r, "{'x':2,'y':1}", "{'x':2,'y':2}");
+    }
+  }
+
+  @Nested
+  @DisplayName("Nested target scope seeding")
+  class NestedTargetScopeSeeding {
+    @Test
+    void shouldPreserveSiblingKeysForNestedTarget() {
+      final var scope = Map.<String, Object>of("a", Map.of("b", "old", "c", "kept"));
+      final var r = Helpers.resolve(List.of(Helpers.mapping("=x", "a.b")), Map.of("x", 42), scope);
+      Helpers.assertSame(r, "{'a':{'b':42,'c':'kept'}}");
+    }
+  }
+
+  static final class Helpers {
+
+    static ResolverResults resolve(final List<ZeebeMapping> m, final Map<String, Object> jobVars) {
+      return resolve(m, jobVars, Map.of());
+    }
+
+    static ResolverResults resolve(
+        final List<ZeebeMapping> m,
+        final Map<String, Object> jobVars,
+        final Map<String, Object> elementScope) {
+      final var outputMappings =
+          new VariableMappingTransformer().transformOutputMappings(m, EXPRESSION_LANGUAGE);
+      final var processor = buildProcessor(jobVars, elementScope);
+      return new ResolverResults(
+          ORDERED.resolve(outputMappings, processor), COMBINED.resolve(outputMappings, processor));
+    }
+
+    private static MappingExpressionProcessor buildProcessor(
+        final Map<String, Object> jobVars, final Map<String, Object> elementScope) {
+      final var ej = encode(jobVars);
+      final var ee = encode(elementScope);
+      final ScopedEvaluationContext ctx = name -> Either.left(ee.getOrDefault(name, ej.get(name)));
+      final var ctx2 = new MappingContext(BufferUtil.wrapString("t"), -1L, -1L, -1L, "");
+      return new MappingExpressionProcessor(
+          new ExpressionProcessor(EXPRESSION_LANGUAGE, ctx, DEFAULT_TIMEOUT), ctx2);
+    }
+
+    private static Map<String, DirectBuffer> encode(final Map<String, Object> vars) {
+      return vars.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  Map.Entry::getKey,
+                  e -> new UnsafeBuffer(MsgPackConverter.convertToMsgPack(e.getValue()))));
+    }
+
+    static void assertSame(final ResolverResults r, final String expected) {
+      assertThat(r.ordered()).isRight();
+      assertThat(r.combined()).isRight();
+      MsgPackUtil.assertEquality(r.ordered().get(), expected);
+      MsgPackUtil.assertEquality(r.combined().get(), expected);
+    }
+
+    static void assertDiffers(
+        final ResolverResults r, final String expectedOrdered, final String expectedCombined) {
+      assertThat(r.ordered()).isRight();
+      assertThat(r.combined()).isRight();
+      MsgPackUtil.assertEquality(r.ordered().get(), expectedOrdered);
+      MsgPackUtil.assertEquality(r.combined().get(), expectedCombined);
+    }
+
+    static ZeebeMapping mapping(final String source, final String target) {
+      return new ZeebeMapping() {
+        @Override
+        public String getSource() {
+          return source;
+        }
+
+        @Override
+        public String getTarget() {
+          return target;
+        }
+
+        @Override
+        public String toString() {
+          return source + " -> " + target;
+        }
+      };
+    }
+  }
+
+  record ResolverResults(
+      Either<Failure, DirectBuffer> ordered, Either<Failure, DirectBuffer> combined) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -330,6 +332,66 @@ public final class VariableOutputMappingTransformerTest {
 
     // then
     MsgPackUtil.assertEquality(resultBuilder.toDocument(), "{'a':{'b':1}, 'd':{'p':0}}");
+  }
+
+  // ── combinedExpression tests ──────────────────────────────────────────────
+
+  @Test
+  void shouldBuildValidCombinedExpression() {
+    // given: simple non-overlapping mappings
+    final var mappings = List.of(mapping("x", "a"), mapping("y", "b"));
+
+    // when
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // then: combinedExpression is parseable (transformer would have thrown if not)
+    assertThat(outputMappings.combinedExpression().isValid()).isTrue();
+  }
+
+  @Test
+  void shouldEvaluateCombinedExpressionForSimpleTargets() {
+    // given: [x→a, y→b] with job scope {x:1, y:2}
+    final var mappings = List.of(mapping("x", "a"), mapping("y", "b"));
+    final var scope = Map.of("x", asMsgPack("1"), "y", asMsgPack("2"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when: evaluate combinedExpression against job scope (no accumulated context)
+    final var result =
+        expressionLanguage.evaluateExpression(
+            outputMappings.combinedExpression(), name -> Either.left(scope.get(name)));
+
+    // then: same result as ORDERED for non-overlapping targets
+    assertThat(result.isFailure()).isFalse();
+    MsgPackUtil.assertEquality(new UnsafeBuffer(result.toBuffer()), "{'a':1,'b':2}");
+  }
+
+  @Test
+  void shouldEvaluateCombinedExpressionForDuplicateTargetWithIntermediateRead() {
+    // given: [1→x, x→y, 2→x] — duplicate target x, with y reading x between the two x writes.
+    // CombinedOutputMappingResolver evaluates one expression; duplicate x is resolved at
+    // expression-build time to the last value (2), so y sees x=2, not x=1.
+    final var mappings = List.of(mapping("1", "x"), mapping("x", "y"), mapping("2", "x"));
+    final var outputMappings = transformer.transformOutputMappings(mappings, expressionLanguage);
+
+    // when: no job scope needed — sources are literals
+    final var result =
+        expressionLanguage.evaluateExpression(
+            outputMappings.combinedExpression(), name -> Either.left(null));
+
+    // then: COMBINED gives x=2, y=2 (differs from ORDERED which gives y=1)
+    assertThat(result.isFailure()).isFalse();
+    MsgPackUtil.assertEquality(new UnsafeBuffer(result.toBuffer()), "{'x':2,'y':2}");
+  }
+
+  @Test
+  void shouldThrowWhenTargetCreatesUnparseableCombinedExpression() {
+    // a..b splits to ["a","","b"] — empty segment is not a valid FEEL identifier
+    Assertions.assertThatThrownBy(
+            () ->
+                transformer.transformOutputMappings(
+                    List.of(mapping("x", "a..b")), expressionLanguage))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith("Failed to build variable mapping expression:");
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {


### PR DESCRIPTION
Stacked on #61598. Extracts output-mapping evaluation into `MappingResolver<OutputMappings>`. Generifies `MappingResolver<M>` to cover both input and output. Renames `CombinedMappingResolver` → `CombinedInputMappingResolver`, `OrderedMappingResolver` → `OrderedInputMappingResolver`.

relates to https://github.com/camunda/camunda/issues/60556