### PR TITLE
test: add suspend/resume benchmarks

### DIFF
--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.List;
 import java.util.stream.Stream;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
@@ -31,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class DefaultExecutionQueueTest {
@@ -577,6 +580,67 @@ class DefaultExecutionQueueTest {
     final var inOrder = Mockito.inOrder(session);
     inOrder.verify(session).update(eq("ms.update"), any());
     inOrder.verify(session).update(eq("ms.createIfNotExists"), any());
+  }
+
+  @Test
+  public void shouldFragmentJdbcBatchesWhenPreserveOrderInterleavesStatementIds() {
+    // given - message-correlation-style traffic on a preserveOrder: true context type
+    final int itemCount = 6;
+    for (int i = 0; i < itemCount; i++) {
+      final var statementId = i % 2 == 0 ? "ms.correlate" : "ms.createIfNotExists";
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.MESSAGE_SUBSCRIPTION, // preserveOrder: true
+              WriteStatementType.UPDATE,
+              (long) i,
+              statementId,
+              "parameter" + i));
+    }
+
+    // when
+    executionQueue.flush();
+
+    // then - preserveOrder keeps the alternating order, so every item is its own single-statement
+    // batch
+    final var statementIds = ArgumentCaptor.forClass(String.class);
+    verify(session, times(itemCount)).update(statementIds.capture(), any());
+    assertThat(countBatchFragments(statementIds.getAllValues())).isEqualTo(itemCount);
+  }
+
+  @Test
+  public void shouldNotFragmentJdbcBatchesWhenOrderIsNotPreserved() {
+    // given - the same alternating-statement-ID traffic, but on a preserveOrder: false context
+    // type
+    final int itemCount = 6;
+    for (int i = 0; i < itemCount; i++) {
+      final var statementId = i % 2 == 0 ? "job.a" : "job.b";
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.JOB, // preserveOrder: false
+              WriteStatementType.UPDATE,
+              (long) i,
+              statementId,
+              "parameter" + i));
+    }
+
+    // when
+    executionQueue.flush();
+
+    // then - sorting groups every "job.a" together and every "job.b" together into one batch each
+    final var statementIds = ArgumentCaptor.forClass(String.class);
+    verify(session, times(itemCount)).update(statementIds.capture(), any());
+    assertThat(countBatchFragments(statementIds.getAllValues())).isEqualTo(2);
+  }
+
+  /** Counts maximal runs of consecutive equal statement IDs, i.e. the number of JDBC batches. */
+  private static int countBatchFragments(final List<String> statementIds) {
+    int fragments = 1;
+    for (int i = 1; i < statementIds.size(); i++) {
+      if (!statementIds.get(i).equals(statementIds.get(i - 1))) {
+        fragments++;
+      }
+    }
+    return fragments;
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/JobActivationWithSuspendedJobsBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/JobActivationWithSuspendedJobsBenchmark.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks job activation throughput with and without suspended jobs in state. Suspended jobs are
+ * removed from the activatable-by-priority index, so JobBatchActivateProcessor should not be
+ * affected by their presence. This is a negative benchmark confirming the index design works.
+ */
+@Warmup(iterations = 50, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 25, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class JobActivationWithSuspendedJobsBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(JobActivationWithSuspendedJobsBenchmark.class.getName());
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType("task").done())
+          .endEvent()
+          .done();
+
+  @Param({"0", "10000", "100000"})
+  private int suspendedJobCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long piKey;
+  private Record<JobBatchRecordValue> lastActivation;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    engine.createDeploymentClient().withXmlResource(PROCESS).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+
+    LOG.info("Creating {} PIs to suspend (one job each)...", suspendedJobCount);
+    for (int i = 0; i < suspendedJobCount; i++) {
+      final long suspendedPiKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+      RecordingExporter.jobRecords()
+          .withIntent(JobIntent.CREATED)
+          .withProcessInstanceKey(suspendedPiKey)
+          .getFirst();
+
+      processInstanceClient.withInstanceKey(suspendedPiKey).suspend();
+
+      RecordingExporter.reset();
+      if (i > 0 && i % 10000 == 0) {
+        LOG.info("\t{} PIs suspended.", i);
+        engine.reset();
+      }
+    }
+
+    LOG.info("Setup complete. {} suspended jobs in state.", suspendedJobCount);
+    engine.reset();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    piKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    RecordingExporter.jobRecords()
+        .withIntent(JobIntent.CREATED)
+        .withType("task")
+        .withProcessInstanceKey(piKey)
+        .getFirst();
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // an empty batch (e.g. a regression in the suspended-job index) would otherwise read as
+    // improved throughput instead of failing; check here rather than in the timed benchmark
+    // method so validation doesn't add to the measured section
+    final var activatedJobs = lastActivation.getValue().getJobs();
+    if (activatedJobs.size() != 1) {
+      throw new IllegalStateException(
+          "Expected exactly 1 job to be activated, but got %d".formatted(activatedJobs.size()));
+    }
+    // the count alone can't catch the regression this benchmark targets: if a preloaded suspended
+    // job leaked back into the activatable index, activation could still return exactly one job -
+    // the wrong one - while this PI's job stays queued. Assert the job belongs to this invocation.
+    final long activatedPiKey = activatedJobs.getFirst().getProcessInstanceKey();
+    if (activatedPiKey != piKey) {
+      throw new IllegalStateException(
+          "Expected the activated job to belong to PI %d, but it belonged to %d"
+              .formatted(piKey, activatedPiKey));
+    }
+
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // created PI (and its activated job) first so state doesn't accumulate across the whole trial
+    processInstanceClient.withInstanceKey(piKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public Record<JobBatchRecordValue> measureJobActivationThroughput() {
+    // Timeout must outlast the whole trial (warmup + measurement); otherwise an activated job
+    // times out mid-run, becomes activatable again, and gets mixed into later invocations.
+    lastActivation =
+        engine
+            .createJobActivationClient()
+            .withType("task")
+            .withMaxJobsToActivate(1)
+            .withTimeout(Duration.ofMinutes(10).toMillis())
+            .activate();
+    return lastActivation;
+  }
+
+  @JMHTest("measureJobActivationThroughput")
+  void shouldMeasureJobActivationWith0SuspendedJobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedJobCount", "0")).run();
+  }
+
+  @JMHTest("measureJobActivationThroughput")
+  void shouldMeasureJobActivationWith10kSuspendedJobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedJobCount", "10000")).run();
+  }
+
+  @JMHTest("measureJobActivationThroughput")
+  void shouldMeasureJobActivationWith100kSuspendedJobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedJobCount", "100000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/ResumeBufferDrainBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/ResumeBufferDrainBenchmark.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks how long a large command buffer takes to drain on resume. Resume drains one buffered
+ * command per {@code DRAIN} cycle ({@code BufferedCommandDrainProcessor}) - each its own follow-up
+ * command, log append and RocksDB seek - so latency is expected to scale with the buffered count as
+ * sequential round-trips, not as a single batch operation. This contrasts with {@link
+ * SuspendedBufferDrainBenchmark}, which clears the same kind of buffer in one synchronous
+ * scan-and-delete on cancel.
+ *
+ * <p>The process forks into two parallel timer catch events. Setup suspends the instance, then
+ * injects {@code bufferedCommandCount} {@code COMPLETE_ELEMENT} commands for the first timer
+ * directly into the buffer (mirroring {@code
+ * ResumeProcessInstanceDrainTest#bufferCompleteCommands}) - the only way to populate the buffer,
+ * since real completions are rejected while suspended rather than buffered. The second timer never
+ * fires and keeps the instance alive through the whole drain, so {@code RESUMED} - written once the
+ * buffer is empty - is a clean signal that the drain finished and does not race the instance
+ * completing out from under it.
+ */
+// SingleShotTime with fixed iterations: the @Setup that rebuilds the whole buffer (up to 100k
+// commands) dwarfs the timed drain, and a time-based window would repeat it many times per
+// iteration. One measured op per iteration is enough.
+@Warmup(iterations = 3, batchSize = 1)
+@Measurement(iterations = 5, batchSize = 1)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class ResumeBufferDrainBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ResumeBufferDrainBenchmark.class.getName());
+
+  private static final int WRITE_CHUNK_SIZE = 1000;
+
+  @Param({"1000", "10000", "100000"})
+  private int bufferedCommandCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .parallelGateway("fork")
+            .intermediateCatchEvent("wait", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .moveToNode("fork")
+            .intermediateCatchEvent("keepAlive", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupBufferedCommands() {
+    LOG.info("Creating PI with {} buffered commands...", bufferedCommandCount);
+    // engine.reset() in the previous invocation's teardown restores the 5s default wait, and the
+    // await for up to 100k commands to reach BUFFERED below far exceeds it - raise the ceiling
+    // before that await, not only before the timed resume(). It only bounds how long a wait takes
+    // to fail; it doesn't bias the timed call.
+    RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    final var waitElement =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("wait")
+            .getFirst();
+
+    processInstanceClient.withInstanceKey(processInstanceKey).suspend();
+
+    engine.writeRecordsInChunks(
+        WRITE_CHUNK_SIZE,
+        IntStream.range(0, bufferedCommandCount)
+            .mapToObj(
+                i ->
+                    RecordToWrite.command()
+                        .processInstance(
+                            ProcessInstanceIntent.COMPLETE_ELEMENT, waitElement.getValue())
+                        .key(waitElement.getKey()))
+            .toArray(RecordToWrite[]::new));
+
+    // writeRecordsInChunks only waits for the log append, not for these commands to be processed;
+    // wait for them to actually reach BUFFERED so the benchmark measures resume()'s drain alone.
+    RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(
+            r ->
+                ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                    == processInstanceKey)
+        .limit(bufferedCommandCount)
+        .count();
+
+    LOG.info(
+        "PI {} suspended with {} commands buffered.", processInstanceKey, bufferedCommandCount);
+    RecordingExporter.reset();
+    RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // the "keepAlive" branch is still waiting on its timer after resume - cancel the instance so
+    // its
+    // RocksDB state doesn't accumulate across the whole trial (engine.reset() clears only the
+    // log/exporter).
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureBufferDrainOnResume() {
+    // the "keepAlive" timer keeps the instance active through the drain, so RESUMED is written once
+    // the buffer is empty - onPartition(1) skips resume()'s fallback partition lookup, which would
+    // read back an already-exported record no longer available after RecordingExporter.reset().
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).resume();
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureBufferDrainOnResume")
+  void shouldMeasureBufferDrainOnResumeWith1kBufferedCommands(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("bufferedCommandCount", "1000")).run();
+  }
+
+  @JMHTest("measureBufferDrainOnResume")
+  void shouldMeasureBufferDrainOnResumeWith10kBufferedCommands(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("bufferedCommandCount", "10000")).run();
+  }
+
+  @JMHTest("measureBufferDrainOnResume")
+  void shouldMeasureBufferDrainOnResumeWith100kBufferedCommands(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("bufferedCommandCount", "100000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/ResumeJobsLatencyBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/ResumeJobsLatencyBenchmark.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks the time to resume a process instance with many jobs suspended. This is the reverse of
+ * {@link SuspendJobsBenchmark}: unlike suspend, which walks the whole element tree and appends
+ * {@code Job.SUSPENDED} for every activatable job in a single command, resume drains one job per
+ * {@code RESUME_JOBS} command cycle ({@code ProcessInstanceResumeJobsProcessor}), each its own
+ * follow-up command and log append. Latency is therefore expected to scale with N sequential
+ * round-trips through the stream processor, not with a single O(N) tree walk.
+ */
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class ResumeJobsLatencyBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ResumeJobsLatencyBenchmark.class.getName());
+
+  // capped at 4000: setup suspends a PI with jobCount activatable jobs, and SUSPEND writes
+  // Job.SUSPENDED for all of them in one command - beyond ~4000 that batch exceeds the 4MB
+  // record-size limit and SUSPEND is rejected (see SuspensionBatchLimitTest, 5000 rejected).
+  @Param({"100", "1000", "2000", "4000"})
+  private int jobCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("task")
+                        .multiInstance()
+                        .parallel()
+                        .zeebeInputCollectionExpression(TestEngine.collectionExpression(jobCount))
+                        .multiInstanceDone()
+                        .done())
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupSuspendedProcessInstance() {
+    LOG.info("Creating PI with {} jobs, then suspending...", jobCount);
+    // 2000 jobs' SUSPENDED export can exceed the 5s default under load, same as
+    // SuspendJobsBenchmark; suspend() itself (not just the timed resume() below) needs the
+    // raised ceiling, so it must be set before calling it, not only after
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(60).toMillis());
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    RecordingExporter.jobRecords()
+        .withIntent(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(jobCount)
+        .count();
+
+    processInstanceClient.withInstanceKey(processInstanceKey).suspend();
+
+    LOG.info("PI {} suspended with {} jobs.", processInstanceKey, jobCount);
+    RecordingExporter.reset();
+    // resume drains one job per RESUME_JOBS cycle instead of one batch write, so completion time
+    // scales with jobCount sequential round-trips; this ceiling only bounds how long the timed
+    // resume() call waits to fail, it doesn't bias a successful result
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(60).toMillis());
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // resumed PI (and its N now-activatable jobs) first so state doesn't accumulate across the
+    // whole trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureResumeTime() {
+    // onPartition(1) avoids resume()'s fallback partition lookup, which reads back an already
+    // exported process instance record for this key - a record that no longer exists once
+    // RecordingExporter.reset() has run in setup, above
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).resume();
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureResumeTime")
+  void shouldMeasureResumeLatencyWith100Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "100")).run();
+  }
+
+  @JMHTest("measureResumeTime")
+  void shouldMeasureResumeLatencyWith1000Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "1000")).run();
+  }
+
+  @JMHTest("measureResumeTime")
+  void shouldMeasureResumeLatencyWith2000Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "2000")).run();
+  }
+
+  @JMHTest("measureResumeTime")
+  void shouldMeasureResumeLatencyWith4000Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "4000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendJobsBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendJobsBenchmark.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks the time to suspend a process instance with many active elements. Uses a parallel
+ * multi-instance service task to create PIs with N active jobs. The suspend operation BFS-walks all
+ * element instances and writes Job.SUSPENDED for each activatable job.
+ */
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspendJobsBenchmark {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SuspendJobsBenchmark.class.getName());
+
+  // 4000 is the largest count that still suspends: SUSPEND writes Job.SUSPENDED for every
+  // activatable job in one command, and beyond ~4000 that batch exceeds the 4MB record-size limit
+  // (see SuspensionBatchLimitTest, where 5000 is rejected).
+  @Param({"100", "1000", "2000", "4000"})
+  private int activeElementCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("task")
+                        .multiInstance()
+                        .parallel()
+                        .zeebeInputCollectionExpression(
+                            TestEngine.collectionExpression(activeElementCount))
+                        .multiInstanceDone()
+                        .done())
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    LOG.info("Creating PI with {} active elements...", activeElementCount);
+    // 2000 elements' CREATED and SUSPENDED exports can each exceed the 5s default under load, and
+    // engine.reset() in the previous invocation's teardown restores that default - so the ceiling
+    // must be raised before the CREATED await below, not only before the timed suspend(). It only
+    // bounds how long a wait takes to fail; it doesn't bias the timed call.
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    RecordingExporter.jobRecords()
+        .withIntent(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(activeElementCount)
+        .count();
+
+    LOG.info("PI {} ready with {} jobs.", processInstanceKey, activeElementCount);
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // suspended PI (and its N jobs) first so state doesn't accumulate across the whole trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureSuspendTime() {
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).suspend();
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith100ActiveElements(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("activeElementCount", "100")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith1000ActiveElements(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("activeElementCount", "1000")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith2000ActiveElements(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("activeElementCount", "2000")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith4000ActiveElements(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("activeElementCount", "4000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendResumeToggleBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendResumeToggleBenchmark.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks a full suspend/resume cycle interleaved with job-activation attempts: suspend, try to
+ * activate (expect none), resume, then activate for real (expect all N). Measures this as a
+ * sequential round trip rather than with a multi-threaded {@code @Threads} variant, since the
+ * stream processor is a single actor and serializes command processing per partition regardless.
+ */
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspendResumeToggleBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspendResumeToggleBenchmark.class.getName());
+
+  // capped at 4000: each cycle suspends a PI with jobCount activatable jobs, and SUSPEND writes
+  // Job.SUSPENDED for all of them in one command - beyond ~4000 that batch exceeds the 4MB
+  // record-size limit and SUSPEND is rejected (see SuspensionBatchLimitTest, 5000 rejected).
+  @Param({"10", "1000", "4000"})
+  private int jobCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("task")
+                        .multiInstance()
+                        .parallel()
+                        .zeebeInputCollectionExpression(TestEngine.collectionExpression(jobCount))
+                        .multiInstanceDone()
+                        .done())
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    LOG.info("Creating PI with {} jobs...", jobCount);
+    // engine.reset() in the previous invocation's teardown restores the 5s default wait - raise the
+    // ceiling before the CREATED await below, not only before the timed toggle. It only bounds how
+    // long a wait takes to fail; it doesn't bias the timed call.
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    RecordingExporter.jobRecords()
+        .withIntent(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(jobCount)
+        .count();
+
+    LOG.info("PI {} ready with {} jobs.", processInstanceKey, jobCount);
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // resumed PI (and its N activated jobs) first so state doesn't accumulate across the whole
+    // trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureToggleWithJobActivation() {
+    // onPartition(1) keeps the timed section to engine round trips only: without it the client
+    // scans RecordingExporter to discover the partition before each command, adding harness work.
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).suspend();
+
+    // the default 10s lease is shorter than this trial (5s warmup + 10s measurement);
+    // engine.reset()
+    // doesn't clear engine state, so a job activated here and left uncompleted would time out and
+    // become activatable again mid-trial, letting a later invocation's "whileSuspended" activation
+    // pick up a stale job from an earlier invocation and fail its "no jobs" assertion
+    final var whileSuspended =
+        engine
+            .createJobActivationClient()
+            .withType("task")
+            .withMaxJobsToActivate(jobCount)
+            .withTimeout(Duration.ofMinutes(10).toMillis())
+            .activate();
+    if (!whileSuspended.getValue().getJobKeys().isEmpty()) {
+      throw new IllegalStateException(
+          "Expected no jobs to be activatable while suspended, but got %d"
+              .formatted(whileSuspended.getValue().getJobKeys().size()));
+    }
+
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).resume();
+
+    final var afterResume =
+        engine
+            .createJobActivationClient()
+            .withType("task")
+            .withMaxJobsToActivate(jobCount)
+            .withTimeout(Duration.ofMinutes(10).toMillis())
+            .activate();
+    if (afterResume.getValue().getJobKeys().size() != jobCount) {
+      throw new IllegalStateException(
+          "Expected all %d jobs to be activatable after resume, but got %d"
+              .formatted(jobCount, afterResume.getValue().getJobKeys().size()));
+    }
+
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureToggleWithJobActivation")
+  void shouldMeasureToggleLatencyWith10Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "10")).run();
+  }
+
+  @JMHTest("measureToggleWithJobActivation")
+  void shouldMeasureToggleLatencyWith1000Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "1000")).run();
+  }
+
+  @JMHTest("measureToggleWithJobActivation")
+  void shouldMeasureToggleLatencyWith4000Jobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "4000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendTreeWalkDepthBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendTreeWalkDepthBenchmark.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks the cost of the suspend tree-walk itself, isolated from per-element suspend cost. The
+ * walk ({@code ElementInstanceState#getChildren}) is BFS and visits every element instance,
+ * including subprocess wrappers with nothing to suspend, one RocksDB prefix-scan per level. A wide
+ * tree ({@link SuspendJobsBenchmark}, {@link SuspendWideNonJobTreeBenchmark}) needs only one such
+ * call to reach all N leaves; N levels of nesting need N sequential ones. The innermost subprocess
+ * holds a receive task so the chain stays active long enough to suspend.
+ */
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspendTreeWalkDepthBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspendTreeWalkDepthBenchmark.class.getName());
+
+  @Param({"10", "50", "100", "200"})
+  private int nestingDepth;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .subProcess("nested-" + nestingDepth, nestedSubProcess(nestingDepth))
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  private static Consumer<SubProcessBuilder> nestedSubProcess(final int remainingDepth) {
+    if (remainingDepth <= 1) {
+      return subProcess ->
+          subProcess
+              .embeddedSubProcess()
+              .startEvent()
+              .receiveTask("receive")
+              .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+              .endEvent();
+    }
+    return subProcess ->
+        subProcess
+            .embeddedSubProcess()
+            .startEvent()
+            .subProcess("nested-" + (remainingDepth - 1), nestedSubProcess(remainingDepth - 1))
+            .endEvent();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    LOG.info("Creating PI with {} levels of nested subprocesses...", nestingDepth);
+    processInstanceKey =
+        processInstanceClient.ofBpmnProcessId("process").withVariable("key", "k").create();
+
+    RecordingExporter.processMessageSubscriptionRecords()
+        .withIntent(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+
+    LOG.info("PI {} ready at nesting depth {}.", processInstanceKey, nestingDepth);
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // suspend()'s subscription close is async and later buffers a REOPEN once its ack lands -
+    // wait for that here so it can't bleed into the next invocation's own CREATED wait.
+    TestEngine.awaitReopenBuffered(processInstanceKey, 1);
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // suspended PI (and its nested subprocess/subscription) first so state doesn't accumulate
+    // across the whole trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    // cancel() returns after the root's own termination, but its subscription close is a separate
+    // async round trip - wait for the DELETED ack too, so it can't bleed into the next invocation.
+    RecordingExporter.processMessageSubscriptionRecords()
+        .withIntent(ProcessMessageSubscriptionIntent.DELETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureSuspendTime() {
+    // onPartition(1) keeps the timed section to the engine's tree walk only: without it the client
+    // scans RecordingExporter to discover the partition first, adding harness work that especially
+    // distorts the shallow-depth measurements.
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).suspend();
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyAtDepth10(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("nestingDepth", "10")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyAtDepth50(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("nestingDepth", "50")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyAtDepth100(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("nestingDepth", "100")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyAtDepth200(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("nestingDepth", "200")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendWideNonJobTreeBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendWideNonJobTreeBenchmark.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks the time to suspend a process instance with many active elements that are message
+ * subscriptions rather than jobs, contrasting with {@link SuspendJobsBenchmark}. Suspend runs two
+ * independent BFS walks over the element tree: {@code ProcessInstanceSuspensionJobBehavior}
+ * (suspends activatable jobs) and {@code ProcessInstanceSuspensionMessageSubscriptionBehavior}
+ * (closes {@code OPENED} message subscriptions). A wide tree of parallel receive tasks exercises
+ * only the second walk, isolating the per-element cost of closing a subscription from the
+ * per-element cost of suspending a job. Uses the same shallow, wide (root -&gt; N parallel
+ * receive-task instances) shape as {@link SuspendJobsBenchmark} so the two are directly comparable.
+ */
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspendWideNonJobTreeBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspendWideNonJobTreeBenchmark.class.getName());
+
+  @Param({"100", "500", "1000", "2000"})
+  private int subscriptionCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .receiveTask("receive")
+            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+            .multiInstance()
+            .parallel()
+            .zeebeInputCollectionExpression(TestEngine.collectionExpression(subscriptionCount))
+            .multiInstanceDone()
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    LOG.info("Creating PI with {} open message subscriptions...", subscriptionCount);
+    // 2000 elements' CREATED and SUSPENDED exports can each exceed the 5s default under load, and
+    // engine.reset() in the previous invocation's teardown restores that default - so the ceiling
+    // must be raised before the CREATED await below, not only before the timed suspend(). It only
+    // bounds how long a wait takes to fail; it doesn't bias the timed call.
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
+    processInstanceKey =
+        processInstanceClient.ofBpmnProcessId("process").withVariable("key", "k").create();
+
+    RecordingExporter.processMessageSubscriptionRecords()
+        .withIntent(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(subscriptionCount)
+        .count();
+
+    LOG.info("PI {} ready with {} subscriptions.", processInstanceKey, subscriptionCount);
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // each suspend()'s close buffers a REOPEN once its async ack lands - wait for all of them so
+    // that trailing work can't race the next invocation's own subscription-CREATED wait.
+    TestEngine.awaitReopenBuffered(processInstanceKey, subscriptionCount);
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // suspended PI (and its N subscriptions) first so state doesn't accumulate across the whole
+    // trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    // cancel() returns after the root's own termination, but each subscription's close is a
+    // separate async round trip - wait for all N DELETED acks too before resetting.
+    RecordingExporter.processMessageSubscriptionRecords()
+        .withIntent(ProcessMessageSubscriptionIntent.DELETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(subscriptionCount)
+        .count();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureSuspendTime() {
+    // onPartition(1) keeps the timed section to the engine's subscription walk only, and keeps this
+    // comparable with SuspendJobsBenchmark: without it the client scans RecordingExporter to
+    // discover the partition first, adding harness work to the measurement.
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).suspend();
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith100Subscriptions(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("subscriptionCount", "100")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith500Subscriptions(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("subscriptionCount", "500")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith1000Subscriptions(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("subscriptionCount", "1000")).run();
+  }
+
+  @JMHTest("measureSuspendTime")
+  void shouldMeasureSuspendLatencyWith2000Subscriptions(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("subscriptionCount", "2000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendedBufferDrainBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendedBufferDrainBenchmark.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks cancel() latency for a suspended process instance with N commands buffered.
+ * Cancellation always proceeds and clears the buffered-command column family synchronously in one
+ * scan-and-delete ({@code DbSuspensionState#clearBufferedCommands}) while terminating the root.
+ *
+ * <p>The active tree is a single timer catch event, so cancel()'s walk-and-terminate cost stays
+ * constant as {@code bufferedCommandCount} scales - only the buffer clear itself grows. All N
+ * buffered commands target that one element, since the clear doesn't apply buffer contents.
+ */
+// SingleShotTime with fixed iterations: the @Setup that rebuilds the whole buffer (up to 100k
+// commands) dwarfs the timed clear, and a time-based window would repeat it many times per
+// iteration. One measured op per iteration is enough.
+@Warmup(iterations = 3, batchSize = 1)
+@Measurement(iterations = 5, batchSize = 1)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspendedBufferDrainBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspendedBufferDrainBenchmark.class.getName());
+
+  private static final int WRITE_CHUNK_SIZE = 1000;
+
+  @Param({"1000", "10000", "100000"})
+  private int bufferedCommandCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("wait", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    LOG.info("Creating PI with 1 active element, {} buffered commands...", bufferedCommandCount);
+    // engine.reset() in the previous invocation's teardown restores the 5s default wait, and the
+    // await for up to 100k commands to reach BUFFERED below far exceeds it - raise the ceiling
+    // before that await, not only before the timed cancel(). It only bounds how long a wait takes
+    // to fail; it doesn't bias the timed call.
+    RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    final var child =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("wait")
+            .getFirst();
+
+    processInstanceClient.withInstanceKey(processInstanceKey).suspend();
+
+    engine.writeRecordsInChunks(
+        WRITE_CHUNK_SIZE,
+        IntStream.range(0, bufferedCommandCount)
+            .mapToObj(
+                i ->
+                    RecordToWrite.command()
+                        .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, child.getValue())
+                        .key(child.getKey()))
+            .toArray(RecordToWrite[]::new));
+
+    // writeRecords only waits for the log append, not for these commands to be processed; wait
+    // for them to actually reach BUFFERED so the benchmark measures cancel()'s buffer-clear alone
+    RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(
+            r ->
+                ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                    == processInstanceKey)
+        .limit(bufferedCommandCount)
+        .count();
+
+    LOG.info(
+        "PI {} suspended with {} commands buffered.", processInstanceKey, bufferedCommandCount);
+    RecordingExporter.reset();
+    RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureBufferDrainOnCancel() {
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureBufferDrainOnCancel")
+  void shouldMeasureBufferDrainOnCancelWith1kBufferedCommands(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("bufferedCommandCount", "1000")).run();
+  }
+
+  @JMHTest("measureBufferDrainOnCancel")
+  void shouldMeasureBufferDrainOnCancelWith10kBufferedCommands(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("bufferedCommandCount", "10000")).run();
+  }
+
+  @JMHTest("measureBufferDrainOnCancel")
+  void shouldMeasureBufferDrainOnCancelWith100kBufferedCommands(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("bufferedCommandCount", "100000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendedJobTimeoutBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendedJobTimeoutBenchmark.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * Job.SUSPENDED}).
  */
 // SingleShotTime with fixed iterations: the @Setup (re-create, activate and suspend up to
-// 100k jobs) dwarfs the timed burst, and a time-based window would repeat it many times per
+// 10k jobs) dwarfs the timed burst, and a time-based window would repeat it many times per
 // iteration. One measured op per iteration is enough.
 @Warmup(iterations = 3, batchSize = 1)
 @Measurement(iterations = 5, batchSize = 1)
@@ -59,10 +59,10 @@ public class SuspendedJobTimeoutBenchmark {
 
   private static final Duration JOB_TIMEOUT = Duration.ofSeconds(30);
   // one activate() call returns its whole batch in a single record, subject to the 4MB limit;
-  // activate in chunks so the setup can hand out 100k jobs without exceeding it
+  // activate in chunks so the setup can hand out 10k jobs without exceeding it
   private static final int ACTIVATE_CHUNK_SIZE = 1000;
 
-  @Param({"1000", "10000", "100000"})
+  @Param({"1000", "10000"})
   private int jobCount;
 
   private TestContext testContext;
@@ -105,7 +105,7 @@ public class SuspendedJobTimeoutBenchmark {
   public void setupProcessInstance() {
     LOG.info("Creating PI with {} jobs...", jobCount);
     // engine.reset() in the previous invocation's teardown restores the 5s default wait, and
-    // creating/activating up to 100k jobs below far exceeds it - raise the ceiling before them, not
+    // creating/activating up to 10k jobs below far exceeds it - raise the ceiling before them, not
     // only before the timed burst. It only bounds how long a wait takes to fail; it doesn't bias
     // the timed call.
     RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
@@ -176,10 +176,5 @@ public class SuspendedJobTimeoutBenchmark {
   @JMHTest("measureSuspendedJobTimeoutBurst")
   void shouldMeasureSuspendedJobTimeoutBurstWith10kJobs(final JMHTestCase testCase) {
     testCase.withOptions(opts -> opts.param("jobCount", "10000")).run();
-  }
-
-  @JMHTest("measureSuspendedJobTimeoutBurst")
-  void shouldMeasureSuspendedJobTimeoutBurstWith100kJobs(final JMHTestCase testCase) {
-    testCase.withOptions(opts -> opts.param("jobCount", "100000")).run();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendedJobTimeoutBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspendedJobTimeoutBenchmark.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks job-timeout handling for jobs that were activated (handed to a worker) before their
+ * process instance was suspended. Setup creates N parallel jobs, activates all of them (so none
+ * remain activatable, and suspend leaves them untouched), suspends the PI, and the benchmark
+ * advances the clock past the job timeout, measuring the time until all N jobs are parked ({@code
+ * Job.SUSPENDED}).
+ */
+// SingleShotTime with fixed iterations: the @Setup (re-create, activate and suspend up to
+// 100k jobs) dwarfs the timed burst, and a time-based window would repeat it many times per
+// iteration. One measured op per iteration is enough.
+@Warmup(iterations = 3, batchSize = 1)
+@Measurement(iterations = 5, batchSize = 1)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspendedJobTimeoutBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspendedJobTimeoutBenchmark.class.getName());
+
+  private static final Duration JOB_TIMEOUT = Duration.ofSeconds(30);
+  // one activate() call returns its whole batch in a single record, subject to the 4MB limit;
+  // activate in chunks so the setup can hand out 100k jobs without exceeding it
+  private static final int ACTIVATE_CHUNK_SIZE = 1000;
+
+  @Param({"1000", "10000", "100000"})
+  private int jobCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ControlledActorClock clock;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    clock = new ControlledActorClock();
+    testContext = TestEngine.createTestContext(clock);
+    engine = TestEngine.createSinglePartitionEngine(testContext, clock);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("task")
+                        .multiInstance()
+                        .parallel()
+                        .zeebeInputCollectionExpression(TestEngine.collectionExpression(jobCount))
+                        .multiInstanceDone()
+                        .done())
+            .endEvent()
+            .done();
+
+    engine.createDeploymentClient().withXmlResource(process).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @Setup(Level.Invocation)
+  public void setupProcessInstance() {
+    LOG.info("Creating PI with {} jobs...", jobCount);
+    // engine.reset() in the previous invocation's teardown restores the 5s default wait, and
+    // creating/activating up to 100k jobs below far exceeds it - raise the ceiling before them, not
+    // only before the timed burst. It only bounds how long a wait takes to fail; it doesn't bias
+    // the timed call.
+    RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    RecordingExporter.jobRecords()
+        .withIntent(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(jobCount)
+        .count();
+
+    LOG.info("Activating all {} jobs (handing them out to a worker)...", jobCount);
+    // the controlled clock doesn't advance during setup, so already-activated jobs keep their lease
+    // and stay non-activatable - each chunk therefore hands out the next distinct batch of jobs
+    int activated = 0;
+    while (activated < jobCount) {
+      final int inBatch =
+          engine
+              .createJobActivationClient()
+              .withType("task")
+              .withMaxJobsToActivate(Math.min(ACTIVATE_CHUNK_SIZE, jobCount - activated))
+              .withTimeout(JOB_TIMEOUT.toMillis())
+              .activate()
+              .getValue()
+              .getJobKeys()
+              .size();
+      if (inBatch == 0) {
+        throw new IllegalStateException(
+            "Expected to activate %d jobs but stalled after %d".formatted(jobCount, activated));
+      }
+      activated += inBatch;
+    }
+
+    processInstanceClient.withInstanceKey(processInstanceKey).suspend();
+
+    LOG.info("PI {} suspended with {} activated jobs.", processInstanceKey, jobCount);
+    RecordingExporter.reset();
+    RecordingExporter.setMaximumWaitTime(Duration.ofMinutes(5).toMillis());
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // suspended PI (and its N parked jobs) first so state doesn't accumulate across the whole
+    // trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public long measureSuspendedJobTimeoutBurst() {
+    clock.addTime(JOB_TIMEOUT.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+
+    RecordingExporter.jobRecords()
+        .withIntent(JobIntent.SUSPENDED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(jobCount)
+        .count();
+
+    return processInstanceKey;
+  }
+
+  @JMHTest("measureSuspendedJobTimeoutBurst")
+  void shouldMeasureSuspendedJobTimeoutBurstWith1kJobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "1000")).run();
+  }
+
+  @JMHTest("measureSuspendedJobTimeoutBurst")
+  void shouldMeasureSuspendedJobTimeoutBurstWith10kJobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "10000")).run();
+  }
+
+  @JMHTest("measureSuspendedJobTimeoutBurst")
+  void shouldMeasureSuspendedJobTimeoutBurstWith100kJobs(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("jobCount", "100000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspensionBatchLimitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspensionBatchLimitTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stress test finding the number of active elements at which SUSPEND hits
+ * ExceededBatchRecordSizeException (4 MB batch limit). Three configurations: jobs only,
+ * subscriptions only, and both. Each size asserts the previously-observed outcome (success or
+ * EXCEEDED_BATCH_RECORD_SIZE rejection) so a regression in the batch limit is caught rather than
+ * only logged.
+ */
+@Tag("performance")
+class SuspensionBatchLimitTest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspensionBatchLimitTest.class.getName());
+
+  private static final long GENEROUS_WAIT_TIME_MS = Duration.ofSeconds(30).toMillis();
+
+  static Stream<Arguments> jobOnlySizes() {
+    return Stream.of(
+        Arguments.of(100, false),
+        Arguments.of(1000, false),
+        Arguments.of(2000, false),
+        Arguments.of(4000, false),
+        Arguments.of(5000, true),
+        Arguments.of(10000, true));
+  }
+
+  static Stream<Arguments> subscriptionOnlySizes() {
+    return Stream.of(
+        Arguments.of(100, false),
+        Arguments.of(500, false),
+        Arguments.of(1000, false),
+        Arguments.of(2000, false),
+        Arguments.of(5000, false));
+  }
+
+  static Stream<Arguments> bothSizes() {
+    return Stream.of(
+        Arguments.of(100, false),
+        Arguments.of(500, false),
+        Arguments.of(1000, false),
+        Arguments.of(2000, false),
+        Arguments.of(5000, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource("jobOnlySizes")
+  void shouldFindJobOnlyBatchLimit(final int elementCount, final boolean expectRejection)
+      throws Throwable {
+    final TestContext ctx = TestEngine.createTestContext();
+    try {
+      final TestEngine engine = TestEngine.createSinglePartitionEngine(ctx);
+      final ProcessInstanceClient piClient = engine.createProcessInstanceClient();
+      resetExporter();
+
+      // given
+      final BpmnModelInstance process =
+          Bpmn.createExecutableProcess("jobOnly")
+              .startEvent()
+              .serviceTask(
+                  "task",
+                  t ->
+                      t.zeebeJobType("task")
+                          .multiInstance()
+                          .parallel()
+                          .zeebeInputCollectionExpression(
+                              TestEngine.collectionExpression(elementCount))
+                          .multiInstanceDone()
+                          .done())
+              .endEvent()
+              .done();
+
+      engine.createDeploymentClient().withXmlResource(process).deploy();
+      final long piKey = piClient.ofBpmnProcessId("jobOnly").create();
+
+      RecordingExporter.jobRecords()
+          .withIntent(JobIntent.CREATED)
+          .withProcessInstanceKey(piKey)
+          .limit(elementCount)
+          .count();
+
+      engine.reset();
+      resetExporter();
+
+      // when
+      final var result = trySuspend(piClient, piKey, expectRejection);
+      logResult("Jobs only", elementCount, result);
+
+      // then
+      assertSuspendOutcome(result, expectRejection);
+    } finally {
+      ctx.close();
+      RecordingExporter.reset();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("subscriptionOnlySizes")
+  void shouldFindSubscriptionOnlyBatchLimit(final int elementCount, final boolean expectRejection)
+      throws Throwable {
+    final TestContext ctx = TestEngine.createTestContext();
+    try {
+      final TestEngine engine = TestEngine.createSinglePartitionEngine(ctx);
+      final ProcessInstanceClient piClient = engine.createProcessInstanceClient();
+      resetExporter();
+
+      // given
+      final BpmnModelInstance process =
+          Bpmn.createExecutableProcess("subOnly")
+              .startEvent()
+              .receiveTask("receive")
+              .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+              .multiInstance()
+              .parallel()
+              .zeebeInputCollectionExpression(TestEngine.collectionExpression(elementCount))
+              .multiInstanceDone()
+              .endEvent()
+              .done();
+
+      engine.createDeploymentClient().withXmlResource(process).deploy();
+      final long piKey = piClient.ofBpmnProcessId("subOnly").withVariable("key", "k").create();
+
+      RecordingExporter.processMessageSubscriptionRecords()
+          .withIntent(ProcessMessageSubscriptionIntent.CREATED)
+          .withProcessInstanceKey(piKey)
+          .limit(elementCount)
+          .count();
+
+      engine.reset();
+      resetExporter();
+
+      // when
+      final var result = trySuspend(piClient, piKey, expectRejection);
+      logResult("Subscriptions only", elementCount, result);
+
+      // then
+      assertSuspendOutcome(result, expectRejection);
+    } finally {
+      ctx.close();
+      RecordingExporter.reset();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("bothSizes")
+  void shouldFindCombinedBatchLimit(final int elementCount, final boolean expectRejection)
+      throws Throwable {
+    final TestContext ctx = TestEngine.createTestContext();
+    try {
+      final TestEngine engine = TestEngine.createSinglePartitionEngine(ctx);
+      final ProcessInstanceClient piClient = engine.createProcessInstanceClient();
+      resetExporter();
+
+      // given
+      final BpmnModelInstance process =
+          Bpmn.createExecutableProcess("both")
+              .startEvent()
+              .subProcess(
+                  "sub",
+                  s ->
+                      s.embeddedSubProcess()
+                          .startEvent()
+                          .parallelGateway("fork")
+                          .serviceTask("task", t -> t.zeebeJobType("task").done())
+                          .endEvent()
+                          .moveToLastGateway()
+                          .receiveTask("receive")
+                          .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+                          .endEvent()
+                          .subProcessDone()
+                          .multiInstance()
+                          .parallel()
+                          .zeebeInputCollectionExpression(
+                              TestEngine.collectionExpression(elementCount))
+                          .multiInstanceDone())
+              .endEvent()
+              .done();
+
+      engine.createDeploymentClient().withXmlResource(process).deploy();
+      final long piKey = piClient.ofBpmnProcessId("both").withVariable("key", "k").create();
+
+      RecordingExporter.jobRecords()
+          .withIntent(JobIntent.CREATED)
+          .withProcessInstanceKey(piKey)
+          .limit(elementCount)
+          .count();
+
+      RecordingExporter.processMessageSubscriptionRecords()
+          .withIntent(ProcessMessageSubscriptionIntent.CREATED)
+          .withProcessInstanceKey(piKey)
+          .limit(elementCount)
+          .count();
+
+      engine.reset();
+      resetExporter();
+
+      // when
+      final var result = trySuspend(piClient, piKey, expectRejection);
+      logResult("Jobs + subscriptions", elementCount, result);
+
+      // then
+      assertSuspendOutcome(result, expectRejection);
+    } finally {
+      ctx.close();
+      RecordingExporter.reset();
+    }
+  }
+
+  private static void resetExporter() {
+    RecordingExporter.reset();
+    RecordingExporter.setMaximumWaitTime(GENEROUS_WAIT_TIME_MS);
+  }
+
+  private static Record<ProcessInstanceRecordValue> trySuspend(
+      final ProcessInstanceClient piClient, final long piKey, final boolean expectRejection) {
+    final var client = piClient.withInstanceKey(piKey).onPartition(1);
+    if (expectRejection) {
+      return client.expectSuspendRejection().suspend();
+    }
+    return client.suspend();
+  }
+
+  private static void logResult(
+      final String config,
+      final int elementCount,
+      final Record<ProcessInstanceRecordValue> result) {
+    final boolean succeeded = result.getIntent() == ProcessInstanceIntent.SUSPENDED;
+    if (succeeded) {
+      LOG.info("{}, N={}: suspend SUCCEEDED", config, elementCount);
+    } else {
+      LOG.info(
+          "{}, N={}: suspend FAILED ({}): {}",
+          config,
+          elementCount,
+          result.getRejectionType(),
+          result.getRejectionReason());
+    }
+  }
+
+  private static void assertSuspendOutcome(
+      final Record<ProcessInstanceRecordValue> result, final boolean expectRejection) {
+    if (expectRejection) {
+      assertThat(result.getRejectionType()).isEqualTo(RejectionType.EXCEEDED_BATCH_RECORD_SIZE);
+    } else {
+      assertThat(result.getIntent()).isEqualTo(ProcessInstanceIntent.SUSPENDED);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspensionCheckBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspensionCheckBenchmark.java
@@ -60,7 +60,7 @@ public class SuspensionCheckBenchmark {
           .endEvent()
           .done();
 
-  @Param({"0", "10000", "100000", "1000000"})
+  @Param({"0", "10000", "100000", "500000"})
   private int suspendedInstanceCount;
 
   private TestContext testContext;
@@ -138,7 +138,7 @@ public class SuspensionCheckBenchmark {
   }
 
   @JMHTest("measureProcessCreationThroughput")
-  void shouldMeasureSuspensionCheckOverheadWith1MSuspendedInstances(final JMHTestCase testCase) {
-    testCase.withOptions(opts -> opts.param("suspendedInstanceCount", "1000000")).run();
+  void shouldMeasureSuspensionCheckOverheadWith500kSuspendedInstances(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedInstanceCount", "500000")).run();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspensionCheckBenchmark.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/SuspensionCheckBenchmark.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.perf;
+
+import io.camunda.zeebe.engine.perf.TestEngine.TestContext;
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.jmh.JMHTestCase;
+import io.camunda.zeebe.test.util.junit.JMHTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmarks the overhead of SuspensionCheck.resolve() on the engine hot-path with varying numbers
+ * of suspended process instances in state. Each benchmark iteration creates one new process
+ * instance (targeting a non-suspended PI) and measures throughput. The suspension check performs a
+ * RocksDB point-read on the SUSPENDED_PROCESS_INSTANCES column family for every SuspensionAware
+ * command.
+ */
+@Warmup(iterations = 50, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 25, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+    value = 1,
+    jvmArgs = {"-Xmx4g", "-Xms4g", "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"})
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Benchmark)
+public class SuspensionCheckBenchmark {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SuspensionCheckBenchmark.class.getName());
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType("task").done())
+          .endEvent()
+          .done();
+
+  @Param({"0", "10000", "100000", "1000000"})
+  private int suspendedInstanceCount;
+
+  private TestContext testContext;
+  private TestEngine engine;
+  private ProcessInstanceClient processInstanceClient;
+  private long processInstanceKey;
+
+  @Setup
+  public void setup() throws Throwable {
+    testContext = TestEngine.createTestContext();
+    engine = TestEngine.createSinglePartitionEngine(testContext);
+
+    engine.createDeploymentClient().withXmlResource(PROCESS).deploy();
+    processInstanceClient = engine.createProcessInstanceClient();
+
+    LOG.info("Creating and suspending {} process instances...", suspendedInstanceCount);
+    for (int i = 0; i < suspendedInstanceCount; i++) {
+      final long piKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+      RecordingExporter.jobRecords()
+          .withIntent(JobIntent.CREATED)
+          .withProcessInstanceKey(piKey)
+          .getFirst();
+
+      processInstanceClient.withInstanceKey(piKey).suspend();
+
+      RecordingExporter.reset();
+      if (i > 0 && i % 10000 == 0) {
+        LOG.info("\t{} instances suspended.", i);
+        engine.reset();
+      }
+    }
+
+    LOG.info("Setup complete. {} suspended PIs in state.", suspendedInstanceCount);
+    engine.reset();
+  }
+
+  @TearDown
+  public void tearDown() {
+    testContext.close();
+  }
+
+  @TearDown(Level.Invocation)
+  public void resetAfterInvocation() {
+    // engine.reset() only clears the log/exporter, not RocksDB state - cancel this invocation's
+    // created PI first so state doesn't accumulate across the whole trial
+    processInstanceClient.withInstanceKey(processInstanceKey).onPartition(1).cancel();
+    engine.reset();
+  }
+
+  @Benchmark
+  public Record<JobRecordValue> measureProcessCreationThroughput() {
+    processInstanceKey = processInstanceClient.ofBpmnProcessId("process").create();
+
+    return RecordingExporter.jobRecords()
+        .withIntent(JobIntent.CREATED)
+        .withType("task")
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+
+  @JMHTest("measureProcessCreationThroughput")
+  void shouldMeasureSuspensionCheckOverheadWith0SuspendedInstances(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedInstanceCount", "0")).run();
+  }
+
+  @JMHTest("measureProcessCreationThroughput")
+  void shouldMeasureSuspensionCheckOverheadWith10kSuspendedInstances(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedInstanceCount", "10000")).run();
+  }
+
+  @JMHTest("measureProcessCreationThroughput")
+  void shouldMeasureSuspensionCheckOverheadWith100kSuspendedInstances(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedInstanceCount", "100000")).run();
+  }
+
+  @JMHTest("measureProcessCreationThroughput")
+  void shouldMeasureSuspensionCheckOverheadWith1MSuspendedInstances(final JMHTestCase testCase) {
+    testCase.withOptions(opts -> opts.param("suspendedInstanceCount", "1000000")).run();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -16,22 +16,34 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.util.ProcessingExporterTransistor;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender;
 import io.camunda.zeebe.engine.util.TestStreams;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
+import io.camunda.zeebe.engine.util.client.JobActivationClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.scheduler.clock.DefaultActorClock;
 import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FeatureFlags;
+import java.io.IOException;
 import java.time.InstantSource;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.rules.TemporaryFolder;
 
 /** Helper class which should help to make it easy to create an engine for tests. */
@@ -45,6 +57,7 @@ public final class TestEngine {
       final int partitionId,
       final int partitionCount,
       final TestContext testContext,
+      final InstantSource clock,
       final Consumer<StreamProcessorBuilder> processorConfiguration) {
     this.partitionCount = partitionCount;
 
@@ -53,7 +66,7 @@ public final class TestEngine {
             testContext.temporaryFolder(),
             testContext.autoCloseableRule(),
             testContext.actorScheduler(),
-            InstantSource.system());
+            clock);
     testStreams.withStreamProcessorMode(StreamProcessorMode.PROCESSING);
     // for performance reasons we want to enable batch processing
     testStreams.maxCommandsInBatch(100);
@@ -112,13 +125,89 @@ public final class TestEngine {
     return new ProcessInstanceClient(streamProcessingComposite);
   }
 
+  public JobActivationClient createJobActivationClient() {
+    return new JobActivationClient(streamProcessingComposite);
+  }
+
+  public void writeRecords(final RecordToWrite... recordsToWrite) {
+    streamProcessingComposite.writeBatch(recordsToWrite);
+  }
+
+  /**
+   * Appends {@code recordsToWrite} in batches of at most {@code chunkSize}. A single {@code
+   * writeBatch} of many thousands of records exceeds the log's max append size; splitting keeps
+   * each append within bounds while still landing every record.
+   */
+  public void writeRecordsInChunks(final int chunkSize, final RecordToWrite... recordsToWrite) {
+    for (int start = 0; start < recordsToWrite.length; start += chunkSize) {
+      final int end = Math.min(start + chunkSize, recordsToWrite.length);
+      streamProcessingComposite.writeBatch(Arrays.copyOfRange(recordsToWrite, start, end));
+    }
+  }
+
   public static TestEngine createSinglePartitionEngine(final TestContext testContext) {
-    return new TestEngine(1, 1, testContext, cfg -> {});
+    return new TestEngine(1, 1, testContext, InstantSource.system(), cfg -> {});
+  }
+
+  public static TestEngine createSinglePartitionEngine(
+      final TestContext testContext, final InstantSource clock) {
+    return new TestEngine(1, 1, testContext, clock, cfg -> {});
   }
 
   public void reset() {
     RecordingExporter.reset();
     testStreams.resetLog();
+  }
+
+  /**
+   * Builds a FEEL list literal {@code =[1,2,...,count]} for a parallel multi-instance collection.
+   */
+  public static String collectionExpression(final int count) {
+    return "=["
+        + IntStream.rangeClosed(1, count)
+            .mapToObj(Integer::toString)
+            .collect(Collectors.joining(","))
+        + "]";
+  }
+
+  /**
+   * Waits until {@code count} {@code REOPEN} commands for the given process instance's message
+   * subscriptions have reached {@code BUFFERED}. Suspend closes every open subscription and buffers
+   * a {@code REOPEN} once each close's async ack lands, so this trailing work can still be in
+   * flight once {@code suspend()} itself returns.
+   */
+  public static void awaitReopenBuffered(final long processInstanceKey, final int count) {
+    RecordingExporter.records()
+        .withValueType(ValueType.BUFFERED_COMMAND)
+        .withIntent(BufferedCommandIntent.BUFFERED)
+        .filter(
+            r -> {
+              final var buffered = (BufferedCommandRecordValue) r.getValue();
+              return buffered.getProcessInstanceKey() == processInstanceKey
+                  && buffered.getValueType() == ValueType.PROCESS_MESSAGE_SUBSCRIPTION
+                  && buffered.getIntent() == ProcessMessageSubscriptionIntent.REOPEN;
+            })
+        .limit(count)
+        .count();
+  }
+
+  public static TestContext createTestContext() throws IOException {
+    return createTestContext(new DefaultActorClock());
+  }
+
+  public static TestContext createTestContext(final ActorClock clock) throws IOException {
+    final var autoCloseableRule = new AutoCloseableRule();
+    final var temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+    final var actorScheduler =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(1)
+            .setActorClock(clock)
+            .build();
+    autoCloseableRule.manage(actorScheduler);
+    actorScheduler.start();
+    return new TestContext(actorScheduler, temporaryFolder, autoCloseableRule);
   }
 
   /**
@@ -132,5 +221,12 @@ public final class TestEngine {
   public record TestContext(
       ActorScheduler actorScheduler,
       TemporaryFolder temporaryFolder,
-      AutoCloseableRule autoCloseableRule) {}
+      AutoCloseableRule autoCloseableRule) {
+
+    /** Closes all managed resources and deletes the temporary folder. */
+    public void close() {
+      autoCloseableRule.after();
+      temporaryFolder.delete();
+    }
+  }
 }


### PR DESCRIPTION
## Description

Adds JMH microbenchmarks and stress tests for the process instance suspend/resume feature. These
establish performance baselines for future optimization work and guard the feature's known limits.
Results are pending a run on dedicated hardware.

### Benchmarks added (`@JMHTest`, tagged `performance`, excluded from CI, run with `-Pinclude-performance-tests`)

| Benchmark | What it measures | Params |
|-----------|-----------------|--------|
| `SuspensionCheckBenchmark` | `isSuspended()` hot-path overhead during command processing | 0 / 10K / 100K / 1M suspended PIs |
| `SuspendJobsBenchmark` | Suspend latency for a wide tree of activatable jobs | 100 / 1K / 2K / 4K jobs |
| `SuspendWideNonJobTreeBenchmark` | Suspend latency for a wide tree of message subscriptions | 100 / 500 / 1K / 2K subs |
| `SuspendTreeWalkDepthBenchmark` | Suspend tree-walk cost isolated by nesting depth | 10 / 50 / 100 / 200 levels |
| `JobActivationWithSuspendedJobsBenchmark` | Job-activation throughput with suspended jobs in state | 0 / 10K / 100K suspended jobs |
| `ResumeJobsLatencyBenchmark` | Resume latency (drains one job per cycle) | 100 / 1K / 2K / 4K jobs |
| `ResumeBufferDrainBenchmark` | Resume latency draining a large buffered-command backlog | 1K / 10K / 100K commands |
| `SuspendResumeToggleBenchmark` | A full suspend→activate→resume→activate cycle | 10 / 1K / 4K jobs |
| `SuspendedJobTimeoutBenchmark` | Parking of already-activated jobs that time out while suspended | 1K / 10K / 100K jobs |
| `SuspendedBufferDrainBenchmark` | Buffer clear on cancellation of a suspended PI | 1K / 10K / 100K commands |

### Stress / deterministic tests

| Test | What it locks in |
|------|-----------------|
| `SuspensionBatchLimitTest` | The active-element count at which SUSPEND hits the 4MB `ExceededBatchRecordSize` limit (job-only: 4000 succeeds, 5000 rejected) |
| `DefaultExecutionQueueTest` (2 new cases) | The JDBC batch-fragmentation mechanism behind `preserveOrder`'s cost, counted deterministically |

### Design decisions

- **Sizing follows the engine's own limits.** Benchmarks that suspend N *activatable* jobs
  (`SuspendJobsBenchmark`, `SuspendResumeToggleBenchmark`, `ResumeJobsLatencyBenchmark`) top out at
  **4000**: SUSPEND writes `Job.SUSPENDED` for every activatable job in one command, and beyond
  ~4000 that batch exceeds the 4MB record-size limit (`SuspensionBatchLimitTest` verifies 4000
  succeeds, 5000 is rejected). The buffer-drain and suspended-timeout benchmarks are **not** bound
  by that limit and scale to **100K**, injecting/activating in chunks so their own setup stays
  within the append/activation batch limits.
- **Timed sections pin `onPartition(1)`** so the measurement captures engine round trips only, not a
  `RecordingExporter` partition scan.
- **`SuspendedJobTimeoutBenchmark`** relies on `JobTimeOutProcessor`'s `SuspensionBehavior.PROCESS`:
  an already-activated job still times out on schedule while its PI is suspended, then gets parked
  (`Job.SUSPENDED`) instead of handed back to a worker.
- **`SuspendedBufferDrainBenchmark` / `ResumeBufferDrainBenchmark`** cover the buffer-drain
  acceptance criterion (see also #57524). The buffer can't be populated through production traffic
  while suspended (job completion, timer triggers, and message correlation are all rejected rather
  than buffered), so setup injects internal `COMPLETE_ELEMENT` commands directly, mirroring
  `ResumeProcessInstanceDrainTest#bufferCompleteCommands`. The resume benchmark forks a second timer
  branch that keeps the instance alive through the drain, so `RESUMED` is a clean drain-complete
  signal.
- **`preserveOrder`'s cost (message-correlation criterion)** is covered by two deterministic
  `DefaultExecutionQueueTest` cases rather than a microbenchmark: a mocked `SqlSession` runs no real
  JDBC batching, so there is no wall-clock signal — the actual mechanism is JDBC batch fragmentation,
  which the tests count directly. Real flush throughput under high correlation volume is already
  covered by the `rdbms-realistic` load test and its PR-vs-main comparison.
- Shared setup (FEEL collection expression, chunked writes, REOPEN-buffered wait, `TestContext`
  teardown) is factored into `TestEngine` helpers.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #59933
