### PR TITLE
ci: track stable/8.10 in the AlwaysGreen streak detector

### DIFF
--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -47,7 +47,7 @@ env:
   STREAK_MARKER_ACTIVE: 'AlwaysGreen streak (active)'
   STREAK_MARKER_RESOLVED: 'AlwaysGreen streak (resolved)'
   # Space-separated list of protected base refs to check every tick.
-  MONITORED_BRANCHES: 'main stable/8.7 stable/8.8 stable/8.9'
+  MONITORED_BRANCHES: 'main stable/8.7 stable/8.8 stable/8.9 stable/8.10'
 
 defaults:
   run:


### PR DESCRIPTION
## Description

`MONITORED_BRANCHES` still ends at `stable/8.9`, so the streak detector has never checked
`stable/8.10` — no `:rotating_light:` in #alwaysgreen-reliability however long that branch
stays red, and no resolved edit when it recovers.

This matters twice over. It is the alert half of the same gap
camunda/camunda#61609 fixes on the pipeline side, and it is the reason the gap went unnoticed
for a week: with zero runs on `stable/8.10` there was nothing to alert on, and nothing to say
that the absence itself was wrong. Once #61609 lands, this is what pages when the branch
breaks.

Adds `stable/8.10` to the list. `MONITORED_BRANCHES` is read only here — no whitelist
elsewhere pairs with it, so there is nothing to keep in sync (unlike
`plan.SUPPORTED_BASE_REFS` / `alwaysgreen-fix.yml`, which #61171 gave a drift guard).

Ordering note: merging this before #61609 is harmless. The detector counts completed runs of
`docker-build-helm-integration.yml` per base ref; with none on `stable/8.10` it finds no
streak and no prior message, which is the "green runs are ignored" path.

## Verification

- YAML parses; `env.MONITORED_BRANCHES == 'main stable/8.7 stable/8.8 stable/8.9 stable/8.10'`.
- The detector runs on `schedule`, so it resolves from the default branch — `main` is the
  correct and only target for this change.

## Checklist

- [ ] Enable backports when necessary — N/A, `schedule` workflows run from the default branch
      only, so stable-branch copies are inert.

## Related issues

- [x] This PR does not need a linked issue
