### PR TITLE
fix: distinguish restarted SWIM members from long-lived ones

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -368,7 +368,7 @@ public class SwimMembershipProtocol
     } else if (member.incarnationNumber() >= swimMember.getIncarnationNumber()
         && hasRebooted(member, swimMember)) {
       replaceMember(member, swimMember);
-      return false;
+      return true;
     }
     // If the term has been increased, update the member and record a gossip event.
     else if (member.incarnationNumber() > swimMember.getIncarnationNumber()

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -63,6 +63,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,8 +145,7 @@ public class SwimMembershipProtocol
       final SwimMembershipProtocolConfig config,
       final String actorSchedulerName,
       final MeterRegistry registry) {
-    // the low bit is set so a generated instance ID can never collide with UNKNOWN_INSTANCE_ID
-    this(config, actorSchedulerName, registry, ThreadLocalRandom.current().nextLong() | 1L);
+    this(config, actorSchedulerName, registry, null);
   }
 
   /**
@@ -157,9 +157,11 @@ public class SwimMembershipProtocol
       final SwimMembershipProtocolConfig config,
       final String actorSchedulerName,
       final MeterRegistry registry,
-      final long localInstanceId) {
+      @Nullable final Long localInstanceId) {
     this.config = config;
-    this.localInstanceId = localInstanceId;
+    // the low bit is set so a generated instance ID can never collide with UNKNOWN_INSTANCE_ID
+    this.localInstanceId =
+        localInstanceId != null ? localInstanceId : ThreadLocalRandom.current().nextLong() | 1L;
     swimMembershipProtocolMetrics = new SwimMembershipProtocolMetrics(registry);
 
     LOGGER.debug("Starting SwimMembership protocol with instanceId {}", this.localInstanceId);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -348,17 +348,7 @@ public class SwimMembershipProtocol
       if (!Objects.equals(member.version(), swimMember.version())
           || member.nodeVersion() > swimMember.nodeVersion()
           || hasRebooted(member, swimMember)) {
-        members.remove(member.id());
-        randomMembers.remove(swimMember);
-        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, swimMember.copy()));
-        swimMember = new SwimMember(member);
-        swimMember.setState(State.ALIVE);
-        members.put(member.id(), swimMember);
-        randomMembers.add(swimMember);
-        Collections.shuffle(randomMembers);
-        LOGGER.info("{} - Evicted member for new version {}", localMember.id(), swimMember);
-        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, swimMember.copy()));
-        recordUpdate(swimMember.copy());
+        replaceMember(member, swimMember);
       } else {
         // Update the term for the local member.
         swimMember.setIncarnationNumber(member.incarnationNumber());
@@ -417,6 +407,23 @@ public class SwimMembershipProtocol
       return true;
     }
     return false;
+  }
+
+  /**
+   * Replaces the member we track with the run the update describes, as a removal and an addition.
+   */
+  private void replaceMember(final ImmutableMember member, final SwimMember swimMember) {
+    members.remove(member.id());
+    randomMembers.remove(swimMember);
+    post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, swimMember.copy()));
+    final var newMember = new SwimMember(member);
+    newMember.setState(State.ALIVE);
+    members.put(member.id(), newMember);
+    randomMembers.add(newMember);
+    Collections.shuffle(randomMembers);
+    LOGGER.info("{} - Evicted member for new version {}", localMember.id(), newMember);
+    post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, newMember.copy()));
+    recordUpdate(newMember.copy());
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -367,8 +367,7 @@ public class SwimMembershipProtocol
       return false;
     } else if (member.incarnationNumber() >= swimMember.getIncarnationNumber()
         && hasRebooted(member, swimMember)) {
-      replaceMember(member, swimMember);
-      return true;
+      return applyRebootedMember(member, swimMember);
     }
     // If the term has been increased, update the member and record a gossip event.
     else if (member.incarnationNumber() > swimMember.getIncarnationNumber()
@@ -437,6 +436,30 @@ public class SwimMembershipProtocol
       return updated;
     }
     return false;
+  }
+
+  /**
+   * Applies an update that describes a different run of a member we already track. The run we were
+   * tracking is gone either way, so it is always dropped. The new run is only adopted when the
+   * update says it is alive: taking on a run we were just told is unreachable would resurrect it as
+   * ALIVE and swallow the suspicion, and a run that is really alive is added back by the next
+   * update that says so.
+   */
+  private boolean applyRebootedMember(final ImmutableMember member, final SwimMember swimMember) {
+    if (member.state() == State.ALIVE) {
+      replaceMember(member, swimMember);
+    } else {
+      LOGGER.info(
+          "{} - Removing member {}, its restart is reported as {}",
+          localMember.id(),
+          swimMember,
+          member.state());
+      tryRemoveMember(swimMember);
+      // Gossip the update on, so the death or suspicion of the new run keeps spreading instead of
+      // stopping here.
+      recordUpdate(member);
+    }
+    return true;
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -75,9 +75,9 @@ public class SwimMembershipProtocol
   public static final Type TYPE = new Type();
 
   /**
-   * Reported by a member which does not know its own instance ID: either it runs a version
-   * predating the field, or it is a stub built from discovery data before the real member was ever
-   * probed.
+   * Reported by a member which does not know its own instance ID: this is usually sent by a node
+   * with a version before this field was introduced. Note that because of gossip, information about
+   * an updated node might contain this value if it was sent by a node with an older version.
    */
   static final long UNKNOWN_INSTANCE_ID = 0L;
 
@@ -288,12 +288,14 @@ public class SwimMembershipProtocol
   }
 
   /**
-   * Updates the state for the given member.
+   * Updates the state for the given member. Package private so that tests can reproduce a sequence
+   * which depends on the exact order updates arrive in, which gossip does not let them control.
    *
    * @param member the member for which to update the state
    * @return whether the state for the member was updated
    */
-  private boolean updateState(final ImmutableMember member) {
+  @VisibleForTesting
+  boolean updateState(final ImmutableMember member) {
     // If the member matches the local member, ignore the update.
     if (member.id().equals(localMember.id())) {
       if (member.nodeVersion() > localMember.nodeVersion()) {
@@ -337,21 +339,29 @@ public class SwimMembershipProtocol
           member.nodeVersion());
       return false;
     }
+    else if (member.incarnationNumber() >= swimMember.getIncarnationNumber()
+        && hasRebooted(member, swimMember)) {
+      replaceMember(member, swimMember);
+      return false;
+    }
     // If the term has been increased, update the member and record a gossip event.
     else if (member.incarnationNumber() > swimMember.getIncarnationNumber()
         // Although this would not happen, we handle the case where the higher node version has a
         // lower incarnation number.
         || member.nodeVersion() > swimMember.nodeVersion()) {
-      // If the member's software version, nodeVersion or instance ID has changed, remove the old
-      // member
-      // and add the new member.
+      // If the member's software version or nodeVersion has changed, remove the old member and add
+      // the new member.
       if (!Objects.equals(member.version(), swimMember.version())
-          || member.nodeVersion() > swimMember.nodeVersion()
-          || hasRebooted(member, swimMember)) {
+          || member.nodeVersion() > swimMember.nodeVersion()) {
         replaceMember(member, swimMember);
       } else {
-        // Update the term for the local member.
+        // Update the incarnation number for the member.
         swimMember.setIncarnationNumber(member.incarnationNumber());
+        // The instance ID might not be set even by the original node when the cluster is upgrading:
+        // older nodes gossip that information without the instanceId. Take it from the update
+        // rather than keeping the previous one, so that we never gossip an ID we were not told for
+        // this incarnation number.
+        swimMember.setInstanceId(member.instanceId());
 
         // If the state has been changed to ALIVE, trigger a REACHABILITY_CHANGED event and then
         // update metadata.
@@ -381,30 +391,45 @@ public class SwimMembershipProtocol
         return true;
       }
     }
-    // If the term remained the same but the state has progressed, update the state and trigger
-    // events.
-    else if (member.incarnationNumber() == swimMember.getIncarnationNumber()
-        && member.state().ordinal() > swimMember.getState().ordinal()) {
-      swimMember.setState(member.state());
+    // If the term remained the same, the update can still describe a different run, or progress the
+    // state.
+    else if (member.incarnationNumber() == swimMember.getIncarnationNumber()) {
+      var updated = false;
 
-      // If the updated state is SUSPECT, post a REACHABILITY_CHANGED event and record an update.
-      if (member.state() == State.SUSPECT) {
-        LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
-        post(
-            new GroupMembershipEvent(
-                GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
-        if (config.isNotifySuspect()) {
-          gossip(swimMember, Lists.newArrayList(swimMember.copy()));
+      // The update can carry an instance ID we do not hold for this incarnation number, because a
+      // previous update for it was relayed by an old version and lost the field. Adopt it, so that
+      // we and the peers we gossip to can tell a later restart apart from this run.
+      if (member.instanceId() != UNKNOWN_INSTANCE_ID
+          && member.instanceId() != swimMember.instanceId()) {
+        swimMember.setInstanceId(member.instanceId());
+        recordUpdate(swimMember.copy());
+        updated = true;
+      }
+
+      if (member.state().ordinal() > swimMember.getState().ordinal()) {
+        swimMember.setState(member.state());
+
+        // If the updated state is SUSPECT, post a REACHABILITY_CHANGED event and record an update.
+        if (member.state() == State.SUSPECT) {
+          LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
+          post(
+              new GroupMembershipEvent(
+                  GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
+          if (config.isNotifySuspect()) {
+            gossip(swimMember, Lists.newArrayList(swimMember.copy()));
+          }
         }
+        // If the updated state is DEAD, post a REACHABILITY_CHANGED event if necessary, then post a
+        // MEMBER_REMOVED
+        // event and record an update.
+        else if (member.state() == State.DEAD) {
+          tryRemoveMember(swimMember);
+        }
+        recordUpdate(swimMember.copy());
+        updated = true;
       }
-      // If the updated state is DEAD, post a REACHABILITY_CHANGED event if necessary, then post a
-      // MEMBER_REMOVED
-      // event and record an update.
-      else if (member.state() == State.DEAD) {
-        tryRemoveMember(swimMember);
-      }
-      recordUpdate(swimMember.copy());
-      return true;
+
+      return updated;
     }
     return false;
   }
@@ -427,9 +452,9 @@ public class SwimMembershipProtocol
   }
 
   /**
-   * Whether the update describes a different run of the member we already track. Only meaningful
-   * once the incarnation number has advanced, which is what orders the two runs: a instance ID is
-   * random, so on its own it cannot tell a newer run from gossip about an older one.
+   * Whether the update describes a different run of the member we already track. Judged against the
+   * last instance ID we ever saw for the member, not the one from the most recent update: that
+   * update may have lost the field in relaying, and the comparison has to survive the gap.
    *
    * <p>An {@link #UNKNOWN_INSTANCE_ID} on either side means no answer rather than a different run.
    * A member on a version predating the field always reports it, and so does an update relayed
@@ -438,8 +463,8 @@ public class SwimMembershipProtocol
    */
   private boolean hasRebooted(final ImmutableMember member, final SwimMember swimMember) {
     return member.instanceId() != UNKNOWN_INSTANCE_ID
-        && swimMember.instanceId() != UNKNOWN_INSTANCE_ID
-        && member.instanceId() != swimMember.instanceId();
+        && swimMember.lastKnownInstanceId() != UNKNOWN_INSTANCE_ID
+        && member.instanceId() != swimMember.lastKnownInstanceId();
   }
 
   private void triggerReachabilityEventOnDeath(final SwimMember swimMember) {
@@ -1149,14 +1174,18 @@ public class SwimMembershipProtocol
     private volatile State state;
     private volatile long incarnationNumber;
     private volatile long updated;
-    // revision 3:
-    private final long instanceId;
+    // revision 3: the instance ID the most recent accepted update reported, which is what
+    // copy() passes on, and the last one this member was ever seen with, which is not. They differ
+    // only while the most recent update carried no ID at all.
+    private volatile long instanceId;
+    private volatile long lastKnownInstanceId;
 
     SwimMember(final MemberId id, final Address address) {
       super(id, address);
       version = null;
       timestamp = 0;
       instanceId = UNKNOWN_INSTANCE_ID;
+      lastKnownInstanceId = UNKNOWN_INSTANCE_ID;
     }
 
     SwimMember(
@@ -1174,6 +1203,7 @@ public class SwimMembershipProtocol
       this.version = version;
       this.timestamp = timestamp;
       this.instanceId = instanceId;
+      lastKnownInstanceId = instanceId;
       incarnationNumber = System.currentTimeMillis();
     }
 
@@ -1191,6 +1221,7 @@ public class SwimMembershipProtocol
       state = member.state;
       incarnationNumber = member.incarnationNumber;
       instanceId = member.instanceId;
+      lastKnownInstanceId = member.instanceId;
     }
 
     /**
@@ -1285,12 +1316,37 @@ public class SwimMembershipProtocol
     }
 
     /**
-     * Returns the ID of the run of this member, or {@link #UNKNOWN_INSTANCE_ID} if it is not known.
+     * Returns the instance ID the most recent accepted update reported for this member, or {@link
+     * #UNKNOWN_INSTANCE_ID} if that update carried none.
      *
      * @return this member's instance ID
      */
     long instanceId() {
       return instanceId;
+    }
+
+    /**
+     * Records the instance ID an update reported for this member. {@link #UNKNOWN_INSTANCE_ID}
+     * means the update carried none, which leaves {@link #lastKnownInstanceId} untouched.
+     *
+     * @param instanceId the instance ID the member was last reported with
+     */
+    void setInstanceId(final long instanceId) {
+      this.instanceId = instanceId;
+      if (instanceId != UNKNOWN_INSTANCE_ID) {
+        lastKnownInstanceId = instanceId;
+      }
+    }
+
+    /**
+     * Returns the last instance ID this member was ever seen with, or {@link #UNKNOWN_INSTANCE_ID}
+     * if it was never seen with one. Kept out of {@link #copy()} so that we only ever pass on an ID
+     * we were actually told about.
+     *
+     * @return the last known instance ID of this member
+     */
+    long lastKnownInstanceId() {
+      return lastKnownInstanceId;
     }
 
     @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -174,6 +174,33 @@ public class SwimMembershipProtocol
             namedThreads("atomix-cluster-events", LOGGER, actorSchedulerName));
   }
 
+  private boolean reactOnStatusChange(
+      final ImmutableMember member, final SwimMember swimMember, boolean updated) {
+    if (member.state().ordinal() > swimMember.getState().ordinal()) {
+      swimMember.setState(member.state());
+
+      // If the updated state is SUSPECT, post a REACHABILITY_CHANGED event and record an update.
+      if (member.state() == State.SUSPECT) {
+        LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
+        post(
+            new GroupMembershipEvent(
+                GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
+        if (config.isNotifySuspect()) {
+          gossip(swimMember, Lists.newArrayList(swimMember.copy()));
+        }
+      }
+      // If the updated state is DEAD, post a REACHABILITY_CHANGED event if necessary, then post a
+      // MEMBER_REMOVED
+      // event and record an update.
+      else if (member.state() == State.DEAD) {
+        tryRemoveMember(swimMember);
+      }
+      recordUpdate(swimMember.copy());
+      updated = true;
+    }
+    return updated;
+  }
+
   /**
    * Creates a new bootstrap provider builder.
    *
@@ -338,8 +365,7 @@ public class SwimMembershipProtocol
           swimMember.nodeVersion(),
           member.nodeVersion());
       return false;
-    }
-    else if (member.incarnationNumber() >= swimMember.getIncarnationNumber()
+    } else if (member.incarnationNumber() >= swimMember.getIncarnationNumber()
         && hasRebooted(member, swimMember)) {
       replaceMember(member, swimMember);
       return false;
@@ -406,28 +432,7 @@ public class SwimMembershipProtocol
         updated = true;
       }
 
-      if (member.state().ordinal() > swimMember.getState().ordinal()) {
-        swimMember.setState(member.state());
-
-        // If the updated state is SUSPECT, post a REACHABILITY_CHANGED event and record an update.
-        if (member.state() == State.SUSPECT) {
-          LOGGER.info("{} - Member unreachable {}", localMember.id(), swimMember);
-          post(
-              new GroupMembershipEvent(
-                  GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
-          if (config.isNotifySuspect()) {
-            gossip(swimMember, Lists.newArrayList(swimMember.copy()));
-          }
-        }
-        // If the updated state is DEAD, post a REACHABILITY_CHANGED event if necessary, then post a
-        // MEMBER_REMOVED
-        // event and record an update.
-        else if (member.state() == State.DEAD) {
-          tryRemoveMember(swimMember);
-        }
-        recordUpdate(swimMember.copy());
-        updated = true;
-      }
+      updated = reactOnStatusChange(member, swimMember, updated);
 
       return updated;
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -36,6 +36,7 @@ import io.atomix.utils.net.Address;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.atomix.utils.serializer.Serializer;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,6 +72,14 @@ public class SwimMembershipProtocol
     implements GroupMembershipProtocol {
 
   public static final Type TYPE = new Type();
+
+  /**
+   * Reported by a member which does not know its own instance ID: either it runs a version
+   * predating the field, or it is a stub built from discovery data before the real member was ever
+   * probed.
+   */
+  static final long UNKNOWN_INSTANCE_ID = 0L;
+
   private static final Logger LOGGER = LoggerFactory.getLogger("io.atomix.cluster.protocol.swim");
   private static final Logger GOSSIP_LOGGER =
       LoggerFactory.getLogger("io.atomix.cluster.protocol.swim.gossip");
@@ -95,6 +105,14 @@ public class SwimMembershipProtocol
               .build());
 
   private final SwimMembershipProtocolConfig config;
+
+  /**
+   * Identifies this run of the local member, so that a member which restarts fast enough to keep
+   * its ID and to never be reported as failed is still recognised as a new member. Held per
+   * protocol instance rather than per JVM so that several members can run in one JVM, as tests do.
+   */
+  private final long localInstanceId;
+
   private final AtomicBoolean started = new AtomicBoolean();
   private final Map<MemberId, SwimMember> members = Maps.newConcurrentMap();
   private final List<SwimMember> randomMembers = Lists.newCopyOnWriteArrayList();
@@ -126,8 +144,25 @@ public class SwimMembershipProtocol
       final SwimMembershipProtocolConfig config,
       final String actorSchedulerName,
       final MeterRegistry registry) {
+    // the low bit is set so a generated instance ID can never collide with UNKNOWN_INSTANCE_ID
+    this(config, actorSchedulerName, registry, ThreadLocalRandom.current().nextLong() | 1L);
+  }
+
+  /**
+   * Only for tests, which need to pretend to be a member that reports no instance ID at all, i.e.
+   * one running a version predating the field.
+   */
+  @VisibleForTesting
+  SwimMembershipProtocol(
+      final SwimMembershipProtocolConfig config,
+      final String actorSchedulerName,
+      final MeterRegistry registry,
+      final long localInstanceId) {
     this.config = config;
+    this.localInstanceId = localInstanceId;
     swimMembershipProtocolMetrics = new SwimMembershipProtocolMetrics(registry);
+
+    LOGGER.debug("Starting SwimMembership protocol with instanceId {}", this.localInstanceId);
 
     swimScheduler =
         Executors.newSingleThreadScheduledExecutor(
@@ -177,7 +212,8 @@ public class SwimMembershipProtocol
               member.host(),
               member.properties(),
               member.version(),
-              System.currentTimeMillis());
+              System.currentTimeMillis(),
+              localInstanceId);
       localProperties.putAll(localMember.properties());
       discoveryService.addListener(discoveryEventListener);
 
@@ -304,10 +340,12 @@ public class SwimMembershipProtocol
         // Although this would not happen, we handle the case where the higher node version has a
         // lower incarnation number.
         || member.nodeVersion() > swimMember.nodeVersion()) {
-      // If the member's software version or nodeVersion has changed, remove the old member and add
-      // the new member.
+      // If the member's software version, nodeVersion or instance ID has changed, remove the old
+      // member
+      // and add the new member.
       if (!Objects.equals(member.version(), swimMember.version())
-          || member.nodeVersion() > swimMember.nodeVersion()) {
+          || member.nodeVersion() > swimMember.nodeVersion()
+          || hasRebooted(member, swimMember)) {
         members.remove(member.id());
         randomMembers.remove(swimMember);
         post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, swimMember.copy()));
@@ -377,6 +415,22 @@ public class SwimMembershipProtocol
       return true;
     }
     return false;
+  }
+
+  /**
+   * Whether the update describes a different run of the member we already track. Only meaningful
+   * once the incarnation number has advanced, which is what orders the two runs: a instance ID is
+   * random, so on its own it cannot tell a newer run from gossip about an older one.
+   *
+   * <p>An {@link #UNKNOWN_INSTANCE_ID} on either side means no answer rather than a different run.
+   * A member on a version predating the field always reports it, and so does an update relayed
+   * through such a member, which drops the field when it re-encodes the update. Treating that as a
+   * reboot would evict members repeatedly for the length of a rolling update.
+   */
+  private boolean hasRebooted(final ImmutableMember member, final SwimMember swimMember) {
+    return member.instanceId() != UNKNOWN_INSTANCE_ID
+        && swimMember.instanceId() != UNKNOWN_INSTANCE_ID
+        && member.instanceId() != swimMember.instanceId();
   }
 
   private void triggerReachabilityEventOnDeath(final SwimMember swimMember) {
@@ -970,6 +1024,8 @@ public class SwimMembershipProtocol
    *       properties, version, timestamp, state, incarnationNumber
    *   <li><b>Revision 2:</b> Added {@code nodeVersion} field. Defaults to 0L when deserializing
    *       messages from older versions.
+   *   <li><b>Revision 3:</b> Added {@code instanceId} field. Defaults to {@link
+   *       #UNKNOWN_INSTANCE_ID} when deserializing messages from older versions.
    * </ul>
    */
   static class ImmutableMember extends Member {
@@ -977,6 +1033,8 @@ public class SwimMembershipProtocol
     private final long timestamp;
     private final State state;
     private final long incarnationNumber;
+    // revision 3:
+    private final long instanceId;
 
     ImmutableMember(
         final MemberId id,
@@ -989,12 +1047,14 @@ public class SwimMembershipProtocol
         final Version version,
         final long timestamp,
         final State state,
-        final long incarnationNumber) {
+        final long incarnationNumber,
+        final long instanceId) {
       super(id, nodeVersion, address, zone, rack, host, properties);
       this.version = version;
       this.timestamp = timestamp;
       this.state = state;
       this.incarnationNumber = incarnationNumber;
+      this.instanceId = instanceId;
     }
 
     @Override
@@ -1011,6 +1071,9 @@ public class SwimMembershipProtocol
           .add("timestamp", timestamp())
           .add("state", state())
           .add("incarnationNumber", incarnationNumber());
+      if (instanceId != UNKNOWN_INSTANCE_ID) {
+        helper.add("instanceId", instanceId);
+      }
       return helper.toString();
     }
 
@@ -1041,13 +1104,24 @@ public class SwimMembershipProtocol
     long incarnationNumber() {
       return incarnationNumber;
     }
+
+    /**
+     * Returns the ID of the run of the member this update describes, or {@link
+     * #UNKNOWN_INSTANCE_ID} if it does not report one.
+     *
+     * @return the member's instance ID
+     */
+    long instanceId() {
+      return instanceId;
+    }
   }
 
   /**
    * Swim member.
    *
-   * <p>This class is serialized with Kryo using {@code CompatibleFieldSerializer} with chunked
-   * encoding, which provides backward and forward compatibility for field changes.
+   * <p>This class is serialized with Kryo using {@link
+   * com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer} with chunked encoding, which
+   * provides backward and forward compatibility for field changes.
    *
    * <h2>Serialization Revisions</h2>
    *
@@ -1056,6 +1130,8 @@ public class SwimMembershipProtocol
    *       properties, version, timestamp, state, incarnationNumber, updated
    *   <li><b>Revision 2:</b> Added {@code nodeVersion} field. Defaults to 0L when deserializing
    *       messages from older versions.
+   *   <li><b>Revision 3:</b> Added {@code instanceId} field. Defaults to {@link
+   *       #UNKNOWN_INSTANCE_ID} when deserializing messages from older versions.
    * </ul>
    */
   static class SwimMember extends Member {
@@ -1064,11 +1140,14 @@ public class SwimMembershipProtocol
     private volatile State state;
     private volatile long incarnationNumber;
     private volatile long updated;
+    // revision 3:
+    private final long instanceId;
 
     SwimMember(final MemberId id, final Address address) {
       super(id, address);
       version = null;
       timestamp = 0;
+      instanceId = UNKNOWN_INSTANCE_ID;
     }
 
     SwimMember(
@@ -1080,10 +1159,12 @@ public class SwimMembershipProtocol
         final String host,
         final Properties properties,
         final Version version,
-        final long timestamp) {
+        final long timestamp,
+        final long instanceId) {
       super(id, nodeVersion, address, zone, rack, host, properties);
       this.version = version;
       this.timestamp = timestamp;
+      this.instanceId = instanceId;
       incarnationNumber = System.currentTimeMillis();
     }
 
@@ -1100,6 +1181,7 @@ public class SwimMembershipProtocol
       timestamp = member.timestamp;
       state = member.state;
       incarnationNumber = member.incarnationNumber;
+      instanceId = member.instanceId;
     }
 
     /**
@@ -1189,7 +1271,17 @@ public class SwimMembershipProtocol
           version(),
           timestamp(),
           state,
-          incarnationNumber);
+          incarnationNumber,
+          instanceId);
+    }
+
+    /**
+     * Returns the ID of the run of this member, or {@link #UNKNOWN_INSTANCE_ID} if it is not known.
+     *
+     * @return this member's instance ID
+     */
+    long instanceId() {
+      return instanceId;
     }
 
     @Override

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -71,6 +71,9 @@ public class SwimProtocolTest extends ConcurrentTestCase {
   private static final Duration PROBE_TIMEOUT = Duration.ofMillis(200);
   private static final Duration FAILURE_INTERVAL = Duration.ofMillis(1000);
   private static final Duration SYNC_INTERVAL = Duration.ofMillis(1000);
+  private static final long PREVIOUS_INSTANCE_ID = 0xB0071D01L;
+  private static final long CURRENT_INSTANCE_ID = 0xB0071D02L;
+  private static final long UNKNOWN_INSTANCE_ID = SwimMembershipProtocol.UNKNOWN_INSTANCE_ID;
   private Map<String, Long> versions;
   private final Version version1 = Version.from("1.0.0");
   private final Version version2 = Version.from("2.0.0");
@@ -489,6 +492,136 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     checkNoEvent(member1, Duration.ofSeconds(2));
   }
 
+  /**
+   * A member which relays an update it received re-encodes it, and one running a version predating
+   * the instance ID drops the field while doing so. The stripped update and the authoritative one
+   * describe the same run of the member, so they carry the same incarnation number: the restart has
+   * to be recognised then, not only once a later update raises that number, or the streams held for
+   * the previous run outlive it for as long as the member's incarnation number does not change.
+   */
+  @Test
+  public void shouldDetectRestartRevealedAfterRelayedUpdateStrippedTheInstanceId()
+      throws InterruptedException {
+    // given - a member known to be running the instance it last reported
+    reset(false);
+    final var protocol = startIsolatedProtocol(member1);
+    final var incarnationNumber = System.currentTimeMillis();
+    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+    // events are posted asynchronously, so wait for the ones the setup produces instead of
+    // clearing the queue underneath them
+    checkEvent(member1, MEMBER_ADDED, member1);
+    checkEvent(member1, MEMBER_ADDED, member2);
+
+    // when - it restarts, and the news reaches us first through a member which drops the instance
+    // ID, and only then from the member itself
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+    checkNoEvent(member1, Duration.ofMillis(500));
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
+
+    // then - the previous run is removed and the new one added, without waiting for the member's
+    // incarnation number to change again
+    checkEvent(member1, MEMBER_REMOVED, member2);
+    checkEvent(member1, MEMBER_ADDED, member2);
+    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
+  }
+
+  @Test
+  public void shouldDetectRestartWhenTheStrippedUpdateArrivesLast() throws InterruptedException {
+    // given - a member known to be running the instance it last reported
+    reset(false);
+    final var protocol = startIsolatedProtocol(member1);
+    final var incarnationNumber = System.currentTimeMillis();
+    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+    // events are posted asynchronously, so wait for the ones the setup produces instead of
+    // clearing the queue underneath them
+    checkEvent(member1, MEMBER_ADDED, member1);
+    checkEvent(member1, MEMBER_ADDED, member2);
+
+    // when - the member itself reports the restart before the relayed update reaches us
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
+    checkEvent(member1, MEMBER_REMOVED, member2);
+    checkEvent(member1, MEMBER_ADDED, member2);
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+
+    // then - the update which lost the instance ID does not undo what we already know
+    checkNoEvent(member1, Duration.ofMillis(500));
+    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
+  }
+
+  /**
+   * Passing on the previous run's instance ID alongside an incarnation number we never saw it with
+   * would make every member which receives that gossip attribute that number to the previous run,
+   * and none of them would recognise the restart afterwards.
+   */
+  @Test
+  public void shouldNotGossipPreviousRunsInstanceIdAfterRelayedUpdateDroppedIt()
+      throws InterruptedException {
+    // given - a member known to be running the instance it last reported
+    reset(false);
+    final var protocol = startIsolatedProtocol(member1);
+    final var incarnationNumber = System.currentTimeMillis();
+    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+    // events are posted asynchronously, so wait for the ones the setup produces instead of
+    // clearing the queue underneath them
+    checkEvent(member1, MEMBER_ADDED, member1);
+    checkEvent(member1, MEMBER_ADDED, member2);
+
+    // when - the next update we receive about it lost the instance ID in relaying
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+
+    // then - we report the member as one whose instance ID we do not know
+    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(UNKNOWN_INSTANCE_ID);
+  }
+
+  @Test
+  public void shouldKeepMemberWhenTheStrippedUpdateIsFollowedByTheSameInstanceId()
+      throws InterruptedException {
+    // given - a member known to be running the instance it last reported
+    reset(false);
+    final var protocol = startIsolatedProtocol(member1);
+    final var incarnationNumber = System.currentTimeMillis();
+    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+    // events are posted asynchronously, so wait for the ones the setup produces instead of
+    // clearing the queue underneath them
+    checkEvent(member1, MEMBER_ADDED, member1);
+    checkEvent(member1, MEMBER_ADDED, member2);
+
+    // when - the member did not restart, and its instance ID was only lost in relaying
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, PREVIOUS_INSTANCE_ID));
+
+    // then - the member is kept, and the update confirms it is still the run we already knew
+    checkNoEvent(member1, Duration.ofMillis(500));
+    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(PREVIOUS_INSTANCE_ID);
+  }
+
+  @Test
+  public void shouldStillReportUnreachableWhenTheSameUpdateConfirmsTheInstanceId()
+      throws InterruptedException {
+    // given - a member whose most recent update lost its instance ID in relaying
+    reset(false);
+    final var protocol = startIsolatedProtocol(member1);
+    final var incarnationNumber = System.currentTimeMillis();
+    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+    // events are posted asynchronously, so wait for the ones the setup produces instead of
+    // clearing the queue underneath them
+    checkEvent(member1, MEMBER_ADDED, member1);
+    checkEvent(member1, MEMBER_ADDED, member2);
+    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+
+    // when - a single update carries both the missing instance ID and a progressed state
+    protocol.updateState(
+        update(
+            member2,
+            incarnationNumber,
+            PREVIOUS_INSTANCE_ID,
+            SwimMembershipProtocol.State.SUSPECT));
+
+    // then - confirming the instance ID does not swallow the state the update reports
+    checkEvent(member1, REACHABILITY_CHANGED, member2);
+    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(PREVIOUS_INSTANCE_ID);
+  }
+
   @Test
   public void oldVersionShouldLeaveWhenNewVersionIsDetected() throws InterruptedException {
     // given
@@ -604,6 +737,52 @@ public class SwimProtocolTest extends ConcurrentTestCase {
   }
 
   /**
+   * Starts a member with every periodic activity pushed out of the way, so that a test can drive
+   * its view of the cluster through {@link SwimMembershipProtocol#updateState} alone.
+   */
+  private SwimMembershipProtocol startIsolatedProtocol(final SwimMember member) {
+    return startProtocol(
+        member,
+        config ->
+            config
+                .setProbeInterval(Duration.ofSeconds(30))
+                .setGossipInterval(Duration.ofSeconds(30))
+                .setSyncInterval(Duration.ofSeconds(30))
+                .setFailureTimeout(Duration.ofSeconds(30)),
+        member.id().toString());
+  }
+
+  private ImmutableMember aliveUpdate(
+      final SwimMember member, final long incarnationNumber, final long instanceId) {
+    return update(member, incarnationNumber, instanceId, SwimMembershipProtocol.State.ALIVE);
+  }
+
+  private ImmutableMember update(
+      final SwimMember member,
+      final long incarnationNumber,
+      final long instanceId,
+      final SwimMembershipProtocol.State state) {
+    return new ImmutableMember(
+        member.id(),
+        member.nodeVersion(),
+        member.address(),
+        member.zone(),
+        member.rack(),
+        member.host(),
+        member.properties(),
+        member.version(),
+        member.timestamp(),
+        state,
+        incarnationNumber,
+        instanceId);
+  }
+
+  /** The instance ID the member would report to the rest of the cluster for its current run. */
+  private long trackedInstanceId(final SwimMembershipProtocol protocol, final Member member) {
+    return ((SwimMember) protocol.getMember(member.id())).instanceId();
+  }
+
+  /**
    * Starts a member which reports no instance ID at all, i.e. one running a version predating the
    * field.
    */
@@ -653,9 +832,7 @@ public class SwimProtocolTest extends ConcurrentTestCase {
                 .setFailureTimeout(FAILURE_INTERVAL)
                 .setSyncInterval(SYNC_INTERVAL));
     final SwimMembershipProtocol protocol =
-        instanceId == null
-            ? new SwimMembershipProtocol(config, actorSchedulerName, meterRegistry)
-            : new SwimMembershipProtocol(config, actorSchedulerName, meterRegistry, instanceId);
+        new SwimMembershipProtocol(config, actorSchedulerName, meterRegistry, instanceId);
     final TestGroupMembershipEventListener listener = new TestGroupMembershipEventListener();
     listeners.put(member.id(), listener);
     protocol.addListener(listener);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -101,7 +101,9 @@ public class SwimProtocolTest extends ConcurrentTestCase {
         null,
         new Properties(),
         version,
-        System.currentTimeMillis());
+        System.currentTimeMillis(),
+        // the protocol takes the instance ID of its own run, not the seed member's
+        SwimMembershipProtocol.UNKNOWN_INSTANCE_ID);
   }
 
   @SuppressWarnings("unchecked")
@@ -422,6 +424,72 @@ public class SwimProtocolTest extends ConcurrentTestCase {
   }
 
   @Test
+  public void shouldRemovePreviousRunOfRestartedMember() throws InterruptedException {
+    // given
+    reset(false);
+    startProtocol(member1, member1.id().toString());
+    startProtocol(member2, member2.id().toString());
+
+    awaitMembers(member2, member1, member2);
+    awaitMembers(member1, member1, member2);
+
+    clearEvents(member1, member2);
+
+    // when - member 2 restarts with every property unchanged, and fast enough that member 1 never
+    // reports it as failed. startProtocol stops the previous run without gossiping anything, which
+    // is what a non-graceful kill looks like to the rest of the cluster.
+    startProtocol(member2, "member2-restarted");
+
+    // then - member 1 sees the previous run leave and the new one join, so that anything it holds
+    // per member is rebuilt for the new run
+    Awaitility.await("Previous run of member 2 removed")
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> checkEvent(member1, MEMBER_REMOVED, member2));
+    checkEvent(member1, MEMBER_ADDED, member2);
+  }
+
+  @Test
+  public void shouldKeepRestartedMemberWhichReportsNoInstanceId() throws InterruptedException {
+    // given - a member on a version predating the instance ID
+    reset(false);
+    startProtocol(member1, member1.id().toString());
+    startProtocolWithoutInstanceId(member2, member2.id().toString());
+
+    awaitMembers(member2, member1, member2);
+    awaitMembers(member1, member1, member2);
+
+    clearEvents(member1, member2);
+
+    // when - it restarts, still reporting no instance ID
+    startProtocolWithoutInstanceId(member2, "member2-restarted");
+
+    // then - member 1 cannot tell the two runs apart, so it keeps the member it has rather than
+    // churning through a removal for every update it receives
+    checkNoEvent(member1, Duration.ofSeconds(2));
+  }
+
+  @Test
+  public void shouldKeepMemberWhenAnUpdateStopsReportingItsInstanceId()
+      throws InterruptedException {
+    // given - a member which reports a instance ID
+    reset(false);
+    startProtocol(member1, member1.id().toString());
+    startProtocol(member2, member2.id().toString());
+
+    awaitMembers(member2, member1, member2);
+    awaitMembers(member1, member1, member2);
+
+    clearEvents(member1, member2);
+
+    // when - the same member is next heard of without one, as happens while a rolling update is in
+    // progress and its updates are relayed through a member that drops the field
+    startProtocolWithoutInstanceId(member2, "member2-without-boot-id");
+
+    // then - the missing instance ID is read as no information rather than as a different run
+    checkNoEvent(member1, Duration.ofSeconds(2));
+  }
+
+  @Test
   public void oldVersionShouldLeaveWhenNewVersionIsDetected() throws InterruptedException {
     // given
     reset(true);
@@ -442,7 +510,10 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     final var member2NewVersion =
         member(member2.id().id(), nextVersion, member2.address().host(), nextVersionPort, version2);
     startSwimMembershipProtocol(
-        member2NewVersion, UnaryOperator.identity(), member2.id().toString() + "-v" + nextVersion);
+        member2NewVersion,
+        UnaryOperator.identity(),
+        member2.id().toString() + "-v" + nextVersion,
+        null);
     Awaitility.await("Member 2 old version removed")
         .atMost(Duration.ofSeconds(2))
         .untilAsserted(() -> checkEvent(member1, MEMBER_REMOVED, member2));
@@ -532,12 +603,33 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     return startProtocol(member, UnaryOperator.identity(), actorSchedulerName);
   }
 
+  /**
+   * Starts a member which reports no instance ID at all, i.e. one running a version predating the
+   * field.
+   */
+  private SwimMembershipProtocol startProtocolWithoutInstanceId(
+      final SwimMember member, final String actorSchedulerName) {
+    return startProtocol(
+        member,
+        UnaryOperator.identity(),
+        actorSchedulerName,
+        SwimMembershipProtocol.UNKNOWN_INSTANCE_ID);
+  }
+
   private SwimMembershipProtocol startProtocol(
       final SwimMember member,
       final UnaryOperator<SwimMembershipProtocolConfig> configurator,
       final String actorSchedulerName) {
+    return startProtocol(member, configurator, actorSchedulerName, null);
+  }
+
+  private SwimMembershipProtocol startProtocol(
+      final SwimMember member,
+      final UnaryOperator<SwimMembershipProtocolConfig> configurator,
+      final String actorSchedulerName,
+      final Long instanceId) {
     final SwimMembershipProtocol protocol =
-        startSwimMembershipProtocol(member, configurator, actorSchedulerName);
+        startSwimMembershipProtocol(member, configurator, actorSchedulerName, instanceId);
     final var previous = protocols.put(member.id(), protocol);
     // stops previous one
     if (previous != null) {
@@ -550,18 +642,20 @@ public class SwimProtocolTest extends ConcurrentTestCase {
   private SwimMembershipProtocol startSwimMembershipProtocol(
       final SwimMember member,
       final UnaryOperator<SwimMembershipProtocolConfig> configurator,
-      final String actorSchedulerName) {
+      final String actorSchedulerName,
+      final Long instanceId) {
+    final var config =
+        configurator.apply(
+            new SwimMembershipProtocolConfig()
+                .setGossipInterval(GOSSIP_INTERVAL)
+                .setProbeInterval(PROBE_INTERVAL)
+                .setProbeTimeout(PROBE_TIMEOUT)
+                .setFailureTimeout(FAILURE_INTERVAL)
+                .setSyncInterval(SYNC_INTERVAL));
     final SwimMembershipProtocol protocol =
-        new SwimMembershipProtocol(
-            configurator.apply(
-                new SwimMembershipProtocolConfig()
-                    .setGossipInterval(GOSSIP_INTERVAL)
-                    .setProbeInterval(PROBE_INTERVAL)
-                    .setProbeTimeout(PROBE_TIMEOUT)
-                    .setFailureTimeout(FAILURE_INTERVAL)
-                    .setSyncInterval(SYNC_INTERVAL)),
-            actorSchedulerName,
-            meterRegistry);
+        instanceId == null
+            ? new SwimMembershipProtocol(config, actorSchedulerName, meterRegistry)
+            : new SwimMembershipProtocol(config, actorSchedulerName, meterRegistry, instanceId);
     final TestGroupMembershipEventListener listener = new TestGroupMembershipEventListener();
     listeners.put(member.id(), listener);
     protocol.addListener(listener);
@@ -664,6 +758,13 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     }
   }
 
+  private void checkNoEvent(final Member member, final Duration within)
+      throws InterruptedException {
+    assertThat(listeners.get(member.id()).nextEvent(within))
+        .describedAs("Member %s observed no membership event", member.id())
+        .isNull();
+  }
+
   private GroupMembershipEvent nextEvent(final Member member) throws InterruptedException {
     final TestGroupMembershipEventListener listener = listeners.get(member.id());
     return listener != null ? listener.nextEvent() : null;
@@ -680,7 +781,11 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     }
 
     GroupMembershipEvent nextEvent() throws InterruptedException {
-      return queue.poll(10, TimeUnit.SECONDS);
+      return nextEvent(Duration.ofSeconds(10));
+    }
+
+    GroupMembershipEvent nextEvent(final Duration timeout) throws InterruptedException {
+      return queue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     public void clear() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -59,8 +59,10 @@ import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** SWIM membership protocol test. */
@@ -427,202 +429,6 @@ public class SwimProtocolTest extends ConcurrentTestCase {
   }
 
   @Test
-  public void shouldRemovePreviousRunOfRestartedMember() throws InterruptedException {
-    // given
-    reset(false);
-    startProtocol(member1, member1.id().toString());
-    startProtocol(member2, member2.id().toString());
-
-    awaitMembers(member2, member1, member2);
-    awaitMembers(member1, member1, member2);
-
-    clearEvents(member1, member2);
-
-    // when - member 2 restarts with every property unchanged, and fast enough that member 1 never
-    // reports it as failed. startProtocol stops the previous run without gossiping anything, which
-    // is what a non-graceful kill looks like to the rest of the cluster.
-    startProtocol(member2, "member2-restarted");
-
-    // then - member 1 sees the previous run leave and the new one join, so that anything it holds
-    // per member is rebuilt for the new run
-    Awaitility.await("Previous run of member 2 removed")
-        .atMost(Duration.ofSeconds(2))
-        .untilAsserted(() -> checkEvent(member1, MEMBER_REMOVED, member2));
-    checkEvent(member1, MEMBER_ADDED, member2);
-  }
-
-  @Test
-  public void shouldKeepRestartedMemberWhichReportsNoInstanceId() throws InterruptedException {
-    // given - a member on a version predating the instance ID
-    reset(false);
-    startProtocol(member1, member1.id().toString());
-    startProtocolWithoutInstanceId(member2, member2.id().toString());
-
-    awaitMembers(member2, member1, member2);
-    awaitMembers(member1, member1, member2);
-
-    clearEvents(member1, member2);
-
-    // when - it restarts, still reporting no instance ID
-    startProtocolWithoutInstanceId(member2, "member2-restarted");
-
-    // then - member 1 cannot tell the two runs apart, so it keeps the member it has rather than
-    // churning through a removal for every update it receives
-    checkNoEvent(member1, Duration.ofSeconds(2));
-  }
-
-  @Test
-  public void shouldKeepMemberWhenAnUpdateStopsReportingItsInstanceId()
-      throws InterruptedException {
-    // given - a member which reports a instance ID
-    reset(false);
-    startProtocol(member1, member1.id().toString());
-    startProtocol(member2, member2.id().toString());
-
-    awaitMembers(member2, member1, member2);
-    awaitMembers(member1, member1, member2);
-
-    clearEvents(member1, member2);
-
-    // when - the same member is next heard of without one, as happens while a rolling update is in
-    // progress and its updates are relayed through a member that drops the field
-    startProtocolWithoutInstanceId(member2, "member2-without-boot-id");
-
-    // then - the missing instance ID is read as no information rather than as a different run
-    checkNoEvent(member1, Duration.ofSeconds(2));
-  }
-
-  /**
-   * A member which relays an update it received re-encodes it, and one running a version predating
-   * the instance ID drops the field while doing so. The stripped update and the authoritative one
-   * describe the same run of the member, so they carry the same incarnation number: the restart has
-   * to be recognised then, not only once a later update raises that number, or the streams held for
-   * the previous run outlive it for as long as the member's incarnation number does not change.
-   */
-  @Test
-  public void shouldDetectRestartRevealedAfterRelayedUpdateStrippedTheInstanceId()
-      throws InterruptedException {
-    // given - a member known to be running the instance it last reported
-    reset(false);
-    final var protocol = startIsolatedProtocol(member1);
-    final var incarnationNumber = System.currentTimeMillis();
-    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
-    // events are posted asynchronously, so wait for the ones the setup produces instead of
-    // clearing the queue underneath them
-    checkEvent(member1, MEMBER_ADDED, member1);
-    checkEvent(member1, MEMBER_ADDED, member2);
-
-    // when - it restarts, and the news reaches us first through a member which drops the instance
-    // ID, and only then from the member itself
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
-    checkNoEvent(member1, Duration.ofMillis(500));
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
-
-    // then - the previous run is removed and the new one added, without waiting for the member's
-    // incarnation number to change again
-    checkEvent(member1, MEMBER_REMOVED, member2);
-    checkEvent(member1, MEMBER_ADDED, member2);
-    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
-  }
-
-  @Test
-  public void shouldDetectRestartWhenTheStrippedUpdateArrivesLast() throws InterruptedException {
-    // given - a member known to be running the instance it last reported
-    reset(false);
-    final var protocol = startIsolatedProtocol(member1);
-    final var incarnationNumber = System.currentTimeMillis();
-    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
-    // events are posted asynchronously, so wait for the ones the setup produces instead of
-    // clearing the queue underneath them
-    checkEvent(member1, MEMBER_ADDED, member1);
-    checkEvent(member1, MEMBER_ADDED, member2);
-
-    // when - the member itself reports the restart before the relayed update reaches us
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
-    checkEvent(member1, MEMBER_REMOVED, member2);
-    checkEvent(member1, MEMBER_ADDED, member2);
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
-
-    // then - the update which lost the instance ID does not undo what we already know
-    checkNoEvent(member1, Duration.ofMillis(500));
-    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
-  }
-
-  /**
-   * Passing on the previous run's instance ID alongside an incarnation number we never saw it with
-   * would make every member which receives that gossip attribute that number to the previous run,
-   * and none of them would recognise the restart afterwards.
-   */
-  @Test
-  public void shouldNotGossipPreviousRunsInstanceIdAfterRelayedUpdateDroppedIt()
-      throws InterruptedException {
-    // given - a member known to be running the instance it last reported
-    reset(false);
-    final var protocol = startIsolatedProtocol(member1);
-    final var incarnationNumber = System.currentTimeMillis();
-    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
-    // events are posted asynchronously, so wait for the ones the setup produces instead of
-    // clearing the queue underneath them
-    checkEvent(member1, MEMBER_ADDED, member1);
-    checkEvent(member1, MEMBER_ADDED, member2);
-
-    // when - the next update we receive about it lost the instance ID in relaying
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
-
-    // then - we report the member as one whose instance ID we do not know
-    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(UNKNOWN_INSTANCE_ID);
-  }
-
-  @Test
-  public void shouldKeepMemberWhenTheStrippedUpdateIsFollowedByTheSameInstanceId()
-      throws InterruptedException {
-    // given - a member known to be running the instance it last reported
-    reset(false);
-    final var protocol = startIsolatedProtocol(member1);
-    final var incarnationNumber = System.currentTimeMillis();
-    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
-    // events are posted asynchronously, so wait for the ones the setup produces instead of
-    // clearing the queue underneath them
-    checkEvent(member1, MEMBER_ADDED, member1);
-    checkEvent(member1, MEMBER_ADDED, member2);
-
-    // when - the member did not restart, and its instance ID was only lost in relaying
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, PREVIOUS_INSTANCE_ID));
-
-    // then - the member is kept, and the update confirms it is still the run we already knew
-    checkNoEvent(member1, Duration.ofMillis(500));
-    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(PREVIOUS_INSTANCE_ID);
-  }
-
-  @Test
-  public void shouldStillReportUnreachableWhenTheSameUpdateConfirmsTheInstanceId()
-      throws InterruptedException {
-    // given - a member whose most recent update lost its instance ID in relaying
-    reset(false);
-    final var protocol = startIsolatedProtocol(member1);
-    final var incarnationNumber = System.currentTimeMillis();
-    protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
-    // events are posted asynchronously, so wait for the ones the setup produces instead of
-    // clearing the queue underneath them
-    checkEvent(member1, MEMBER_ADDED, member1);
-    checkEvent(member1, MEMBER_ADDED, member2);
-    protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
-
-    // when - a single update carries both the missing instance ID and a progressed state
-    protocol.updateState(
-        update(
-            member2,
-            incarnationNumber,
-            PREVIOUS_INSTANCE_ID,
-            SwimMembershipProtocol.State.SUSPECT));
-
-    // then - confirming the instance ID does not swallow the state the update reports
-    checkEvent(member1, REACHABILITY_CHANGED, member2);
-    assertThat(trackedInstanceId(protocol, member2)).isEqualTo(PREVIOUS_INSTANCE_ID);
-  }
-
-  @Test
   public void oldVersionShouldLeaveWhenNewVersionIsDetected() throws InterruptedException {
     // given
     reset(true);
@@ -967,6 +773,259 @@ public class SwimProtocolTest extends ConcurrentTestCase {
 
     public void clear() {
       queue.clear();
+    }
+  }
+
+  @Nested
+  class MemberReboots {
+    @Test
+    public void shouldRemovePreviousRunOfRestartedMember() throws InterruptedException {
+      // given
+      reset(false);
+      startProtocol(member1, member1.id().toString());
+      startProtocol(member2, member2.id().toString());
+
+      awaitMembers(member2, member1, member2);
+      awaitMembers(member1, member1, member2);
+
+      clearEvents(member1, member2);
+
+      // when - member 2 restarts with every property unchanged, and fast enough that member 1 never
+      // reports it as failed. startProtocol stops the previous run without gossiping anything,
+      // which
+      // is what a non-graceful kill looks like to the rest of the cluster.
+      startProtocol(member2, "member2-restarted");
+
+      // then - member 1 sees the previous run leave and the new one join, so that anything it holds
+      // per member is rebuilt for the new run
+      Awaitility.await("Previous run of member 2 removed")
+          .atMost(Duration.ofSeconds(2))
+          .untilAsserted(() -> checkEvent(member1, MEMBER_REMOVED, member2));
+      checkEvent(member1, MEMBER_ADDED, member2);
+    }
+
+    @Test
+    public void shouldKeepRestartedMemberWhichReportsNoInstanceId() throws InterruptedException {
+      // given - a member on a version predating the instance ID
+      reset(false);
+      startProtocol(member1, member1.id().toString());
+      startProtocolWithoutInstanceId(member2, member2.id().toString());
+
+      awaitMembers(member2, member1, member2);
+      awaitMembers(member1, member1, member2);
+
+      clearEvents(member1, member2);
+
+      // when - it restarts, still reporting no instance ID
+      startProtocolWithoutInstanceId(member2, "member2-restarted");
+
+      // then - member 1 cannot tell the two runs apart, so it keeps the member it has rather than
+      // churning through a removal for every update it receives
+      checkNoEvent(member1, Duration.ofSeconds(2));
+    }
+
+    @Test
+    public void shouldKeepMemberWhenAnUpdateStopsReportingItsInstanceId()
+        throws InterruptedException {
+      // given - a member which reports a instance ID
+      reset(false);
+      startProtocol(member1, member1.id().toString());
+      startProtocol(member2, member2.id().toString());
+
+      awaitMembers(member2, member1, member2);
+      awaitMembers(member1, member1, member2);
+
+      clearEvents(member1, member2);
+
+      // when - the same member is next heard of without one, as happens while a rolling update is
+      // in
+      // progress and its updates are relayed through a member that drops the field
+      startProtocolWithoutInstanceId(member2, "member2-without-boot-id");
+
+      // then - the missing instance ID is read as no information rather than as a different run
+      checkNoEvent(member1, Duration.ofSeconds(2));
+    }
+
+    /**
+     * A member which relays an update it received re-encodes it, and one running a version
+     * predating the instance ID drops the field while doing so. The stripped update and the
+     * authoritative one describe the same run of the member, so they carry the same incarnation
+     * number: the restart has to be recognised then, not only once a later update raises that
+     * number, or the streams held for the previous run outlive it for as long as the member's
+     * incarnation number does not change.
+     */
+    @Test
+    public void shouldDetectRestartRevealedAfterRelayedUpdateStrippedTheInstanceId()
+        throws InterruptedException {
+      // given - a member known to be running the instance it last reported
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+
+      // when - it restarts, and the news reaches us first through a member which drops the instance
+      // ID, and only then from the member itself
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+      checkNoEvent(member1, Duration.ofMillis(500));
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
+
+      // then - the previous run is removed and the new one added, without waiting for the member's
+      // incarnation number to change again
+      checkEvent(member1, MEMBER_REMOVED, member2);
+      checkEvent(member1, MEMBER_ADDED, member2);
+      assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
+    }
+
+    @Test
+    public void shouldDetectRestartWhenTheStrippedUpdateArrivesLast() throws InterruptedException {
+      // given - a member known to be running the instance it last reported
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+
+      // when - the member itself reports the restart before the relayed update reaches us
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
+      checkEvent(member1, MEMBER_REMOVED, member2);
+      checkEvent(member1, MEMBER_ADDED, member2);
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+
+      // then - the update which lost the instance ID does not undo what we already know
+      checkNoEvent(member1, Duration.ofMillis(500));
+      assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
+    }
+
+    @Test
+    public void shouldNotGossipPreviousRunsInstanceIdAfterRelayedUpdateDroppedIt()
+        throws InterruptedException {
+      // given - a member known to be running the instance it last reported
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+
+      // when - the next update we receive about it lost the instance ID in relaying
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+
+      // then - we report the member as one whose instance ID we do not know
+      assertThat(trackedInstanceId(protocol, member2)).isEqualTo(UNKNOWN_INSTANCE_ID);
+    }
+
+    @Test
+    public void shouldKeepMemberWhenTheStrippedUpdateIsFollowedByTheSameInstanceId()
+        throws InterruptedException {
+      // given - a member known to be running the instance it last reported
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+
+      // when - the member did not restart, and its instance ID was only lost in relaying
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, PREVIOUS_INSTANCE_ID));
+
+      // then - the member is kept, and the update confirms it is still the run we already knew
+      checkNoEvent(member1, Duration.ofMillis(500));
+      assertThat(trackedInstanceId(protocol, member2)).isEqualTo(PREVIOUS_INSTANCE_ID);
+    }
+
+    @Test
+    public void shouldStillReportUnreachableWhenTheSameUpdateConfirmsTheInstanceId()
+        throws InterruptedException {
+      // given - a member whose most recent update lost its instance ID in relaying
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber - 1, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, UNKNOWN_INSTANCE_ID));
+
+      // when - a single update carries both the missing instance ID and a progressed state
+      protocol.updateState(
+          update(
+              member2,
+              incarnationNumber,
+              PREVIOUS_INSTANCE_ID,
+              SwimMembershipProtocol.State.SUSPECT));
+
+      // then - confirming the instance ID does not swallow the state the update reports
+      checkEvent(member1, REACHABILITY_CHANGED, member2);
+      assertThat(trackedInstanceId(protocol, member2)).isEqualTo(PREVIOUS_INSTANCE_ID);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = SwimMembershipProtocol.State.class,
+        names = {"SUSPECT", "DEAD"})
+    public void shouldNotResurrectRestartedMemberReportedAsUnreachable(
+        final SwimMembershipProtocol.State state) throws InterruptedException {
+      // given - a member known to be running the instance it last reported
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+
+      // when - the restart is only heard of through an update which reports the new run as
+      // unreachable
+      protocol.updateState(update(member2, incarnationNumber, CURRENT_INSTANCE_ID, state));
+
+      // then - the run we tracked is removed, and the one reported unreachable is not taken on
+      checkEvent(member1, MEMBER_REMOVED, member2);
+      checkNoEvent(member1, Duration.ofMillis(500));
+      assertThat(protocol.getMember(member2.id())).isNull();
+    }
+
+    @Test
+    public void shouldAddRestartedMemberOnceItIsReportedAlive() throws InterruptedException {
+      // given - a member whose restart we only heard of as a suspicion, and which we therefore
+      // removed
+      reset(false);
+      final var protocol = startIsolatedProtocol(member1);
+      final var incarnationNumber = System.currentTimeMillis();
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, PREVIOUS_INSTANCE_ID));
+      // events are posted asynchronously, so wait for the ones the setup produces instead of
+      // clearing the queue underneath them
+      checkEvent(member1, MEMBER_ADDED, member1);
+      checkEvent(member1, MEMBER_ADDED, member2);
+      protocol.updateState(
+          update(
+              member2,
+              incarnationNumber,
+              CURRENT_INSTANCE_ID,
+              SwimMembershipProtocol.State.SUSPECT));
+      checkEvent(member1, MEMBER_REMOVED, member2);
+
+      // when - a later update reports the new run as alive
+      protocol.updateState(aliveUpdate(member2, incarnationNumber, CURRENT_INSTANCE_ID));
+
+      // then - the new run is added, so a suspicion which turns out to be wrong does not cost us
+      // the
+      // member for good
+      checkEvent(member1, MEMBER_ADDED, member2);
+      assertThat(trackedInstanceId(protocol, member2)).isEqualTo(CURRENT_INSTANCE_ID);
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -329,8 +329,10 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
             new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of(brokerId(0)));
         final var addZoneResponse = actuator.addZone(ZONE_A, addZoneRequest, false);
 
-        // then - the cluster recovers: zoneA is back in the distribution and hosts partitions
+        // then - the cluster recovers: zoneA is back in the distribution and hosts partitions.
+        // wait more than 10s to allow for partition join to be retried
         Awaitility.await()
+            .atMost(Duration.ofMinutes(1))
             .untilAsserted(
                 () ->
                     ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(addZoneResponse));


### PR DESCRIPTION
## Description
Adds a new field `instanceId` to `SwimMember`  that is initialized once per `SwimMembershipProtocol` to a random value. 
`SwimMembershipProtocol` is initialized once per camunda instance so it allows testing inside the same JVM with multiple instances.

When the same node id (e.g. a broker or an embeddede gateway inside a broker) restarts before it's marked as dead by SWIM, its lifecycle events were never triggered, leading for example streams started by the gateway hanging in the broker. 

When a member contains a different `instanceId` then we emit MEMBER_REMOVED/MEMBER_ADDED events so that all subsystems can react to the restart of the node.

The field is initialized to 0 when a node with an older version is not serializing the field, making it backward/forward compatible. 



## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #28374 

- [ ] This PR does not need a linked issue

