### PR TITLE
fix: keep the coverage report's index.html out of webpack HTML minification

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -162,6 +162,15 @@ outputs:
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
+  process-test-coverage-frontend-changes:
+    description: Output whether the Camunda Process Test coverage report frontend should be built
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-common.outputs.process-test-coverage-frontend-change == 'true'
+      }}
   zeebe-changes:
     description: Output whether any Zeebe code has changed
     value: >-
@@ -368,6 +377,13 @@ runs:
           - 'tasklist/client/**'
           - 'identity/client/**'
           - 'optimize/client/**'
+
+        # This frontend lives inside a Maven module rather than a client/ folder,
+        # so `frontend-change` above does not reach it. Its npm build runs during
+        # `generate-resources`, which means a break here fails every reactor build
+        # that pulls the module in (see issue #61613).
+        process-test-coverage-frontend-change:
+          - 'testing/camunda-process-test-coverage/**'
 
         protobuf-change:
           - '**/*.proto'

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -378,10 +378,7 @@ runs:
           - 'identity/client/**'
           - 'optimize/client/**'
 
-        # This frontend lives inside a Maven module rather than a client/ folder,
-        # so `frontend-change` above does not reach it. Its npm build runs during
-        # `generate-resources`, which means a break here fails every reactor build
-        # that pulls the module in (see issue #61613).
+        # Lives in a Maven module, not a client/ folder, so `frontend-change` misses it.
         process-test-coverage-frontend-change:
           - 'testing/camunda-process-test-coverage/**'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       optimize-frontend-changes: ${{ steps.filter.outputs.optimize-frontend-changes }}
       optimize-backend-changes: ${{ steps.filter.outputs.optimize-backend-changes }}
       optimize-dockerfile-changes: ${{ steps.filter.outputs.optimize-dockerfile-changes }}
+      process-test-coverage-frontend-changes: ${{ steps.filter.outputs.process-test-coverage-frontend-changes }}
       protobuf-changes: ${{ steps.filter.outputs.protobuf-changes }}
       openapi-changes: ${{ steps.filter.outputs.openapi-changes }}
       stable-branch-changes: ${{ steps.filter.outputs.stable-branch-changes }}
@@ -582,6 +583,38 @@ jobs:
           path: optimize/client/dist
           retention-days: 2
           if-no-files-found: error
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  # Every Java job builds this module with `-Dquickly`, which sets `skip.fe.build`
+  # and skips its npm build entirely; the only place that actually ran it was the
+  # main-only `deploy-snapshots` job. A renovate lockfile bump therefore merged
+  # green and broke the reactor for everyone afterwards (issue #61613). This job
+  # runs the same `npm run build` on the PR that changes the module.
+  process-test-coverage-frontend:
+    if: needs.detect-changes.outputs.process-test-coverage-frontend-changes == 'true'
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        timeout-minutes: 1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-frontend
+        id: build-process-test-coverage-fe
+        with:
+          directory: ./testing/camunda-process-test-coverage
+          package-manager: "npm"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -2762,6 +2795,7 @@ jobs:
       - pin-check
       - pr-maven-snapshot
       - pr-vuln-check
+      - process-test-coverage-frontend
       - protobuf-checks
       - rdbms-integration-tests
       - release-notes-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,11 +593,8 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  # Every Java job builds this module with `-Dquickly`, which sets `skip.fe.build`
-  # and skips its npm build entirely; the only place that actually ran it was the
-  # main-only `deploy-snapshots` job. A renovate lockfile bump therefore merged
-  # green and broke the reactor for everyone afterwards (issue #61613). This job
-  # runs the same `npm run build` on the PR that changes the module.
+  # Java jobs skip this npm build via `-Dquickly`, so without this job it only
+  # ran on main, in `deploy-snapshots` -- too late to keep a break off main.
   process-test-coverage-frontend:
     if: needs.detect-changes.outputs.process-test-coverage-frontend-changes == 'true'
     needs: [ detect-changes ]

--- a/testing/camunda-process-test-coverage/webpack.config.js
+++ b/testing/camunda-process-test-coverage/webpack.config.js
@@ -31,6 +31,16 @@ const STATIC_DIR = path.join(OUTPUT_DIR, 'static');
 module.exports = {
   entry: path.join(FRONTEND_DIR, 'app.js'),
 
+  experiments: {
+    // index.html is a Java-side template, not a webpack HTML asset: it is copied
+    // verbatim below and only becomes valid HTML/JS once CoverageReportUtil
+    // substitutes the {{ COVERAGE_DATA }} placeholder. Since webpack 5.110 the
+    // native HTML experiment defaults on, which makes the default minimizer
+    // claim .html assets and parse their inline <script> with terser — the
+    // placeholder is not JavaScript, so that fails the build.
+    html: false,
+  },
+
   output: {
     path: STATIC_DIR,
     filename: 'bundle.js',

--- a/testing/camunda-process-test-coverage/webpack.config.js
+++ b/testing/camunda-process-test-coverage/webpack.config.js
@@ -32,12 +32,8 @@ module.exports = {
   entry: path.join(FRONTEND_DIR, 'app.js'),
 
   experiments: {
-    // index.html is a Java-side template, not a webpack HTML asset: it is copied
-    // verbatim below and only becomes valid HTML/JS once CoverageReportUtil
-    // substitutes the {{ COVERAGE_DATA }} placeholder. Since webpack 5.110 the
-    // native HTML experiment defaults on, which makes the default minimizer
-    // claim .html assets and parse their inline <script> with terser — the
-    // placeholder is not JavaScript, so that fails the build.
+    // Keeps the minimizer off index.html: its inline {{ COVERAGE_DATA }}
+    // placeholder is not parseable JavaScript until Java substitutes it.
     html: false,
   },
 


### PR DESCRIPTION
## Description

Since the webpack 5.110.1 bump (#61576), every reactor build reaching `camunda-process-test-coverage` fails at `frontend-maven-plugin:npm (npm-build)` with `SyntaxError: Unexpected token: punc ({)`. The npm build runs in `generate-resources`, so unrelated builds break too — the daily load tests hit it via `-pl load-tests/load-tester -am`.

webpack 5.110 defaults `experiments.html` to `"auto"`. The default minimizer then also claims `.html` assets and parses their inline `<script>` with terser. Our `index.html` is a Java-side template copied verbatim by `CopyWebpackPlugin`, and its `{{ COVERAGE_DATA }}` placeholder is not JavaScript. Fix: `experiments: { html: false }` — mode-independent, unlike touching `optimization.minimize`, and JS/CSS minification stay on.

#61576 merged green because nothing on a PR builds this frontend: Java jobs pass `-Dquickly`, which sets `skip.fe.build`, and the one job that runs the npm goals — `deploy-snapshots` — is gated to `main`/`stable/**`. So the second commit adds a paths filter and a job that runs `npm run build` on the PR that changes the module. The filter covers the whole module, not just the lockfile, since `package.json`, the webpack config and the sources break it the same way. `frontend-change` was not reused: it feeds `build-platform-frontend`, whose artifacts `deploy-snapshots` consumes.

## Verification

On Node 24.13.0 (what `frontend-maven-plugin` pins): `npm run build` green with `bundle.js` still minified and the placeholder intact in the emitted HTML; `npm test` 44/44; `conftest` on `ci.yml` 0 failures.

## Related issues

closes #61613