### PR TITLE
Commit CREATE's CONFIGURATION history items immediately instead of leaving them PENDING

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -708,11 +708,10 @@ public class AgentHistoryCommitLifecycleIT {
             .join()
             .getAgentInstanceKey();
 
-    // This also emits AGENT_HISTORY:DISCARD for the CONFIGURATION item just created above. That
-    // item's model/provider/systemPrompt were already applied to the AgentInstance optimistically
-    // on CREATE and are NOT rolled back by the discard (see #61391). Tests using this helper only
-    // assert on the non-CONFIGURATION history items they create afterward, so this doesn't matter
-    // here.
+    // The CONFIGURATION item submitted above with CREATE is already committed as part of CREATE
+    // itself, so this fail command neither discards it nor rolls its model/provider/systemPrompt
+    // back to defaults. Tests using this helper only assert on the non-CONFIGURATION history
+    // items they create afterward.
     camundaClient.newFailCommand(activatedJob).retries(1).execute();
 
     waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -216,31 +216,29 @@ public final class AgentHistoryBatchBehavior {
    * Applies an already-validated batch onto {@code target}, in array order: builds one {@code
    * AGENT_HISTORY} event per item (a full copy of the item, with its record-context fields
    * overwritten to match {@code target}/{@code jobKey}/{@code jobLease}) and accumulates metrics
-   * immediately. Whichever of model/provider/systemPrompt/tools/limits a {@link
-   * AgentHistoryRole#CONFIGURATION} item names in its own {@code changedAttributes} is only applied
-   * immediately if {@code applyConfigurationChanges} is {@code true} — CREATE passes {@code true}
-   * so a newly created instance always has a valid definition, while UPDATE passes {@code false}
-   * and instead defers that application to when the item is committed (see {@code
-   * AgentHistoryCommitProcessor}).
+   * immediately. Never applies a {@link AgentHistoryRole#CONFIGURATION} item's own
+   * model/provider/systemPrompt/tools/limits changes itself — that is always the caller's explicit
+   * responsibility, via {@link #applyConfigurationChanges(AgentInstanceRecord,
+   * AgentHistoryRecordValue)}, at whichever point the caller considers the item committed
+   * (immediately, for {@code CREATE}, which commits its own {@code CONFIGURATION} items inline; at
+   * real commit time via {@code AgentHistoryCommitProcessor}, for {@code UPDATE}).
    *
-   * <p><strong>Mutates {@code target} in place</strong> (metrics, definition, tools, limits,
-   * history) and does not itself emit any event — the caller is responsible for turning {@code
-   * target.getHistory()} into {@code AGENT_HISTORY:CREATED} follow-up events. An item already
-   * pending under the same {@code (jobKey, jobLease)} pair is echoed back with {@code isDuplicate}
-   * set instead: it is skipped for metrics/configuration application, and the caller must filter it
-   * out rather than turn it into a {@code CREATED} event.
+   * <p><strong>Mutates {@code target} in place</strong> (metrics, history — never
+   * definition/tools/limits) and does not itself emit any event — the caller is responsible for
+   * turning {@code target.getHistory()} into {@code AGENT_HISTORY:CREATED} follow-up events. An
+   * item already pending under the same {@code (jobKey, jobLease)} pair is echoed back with {@code
+   * isDuplicate} set instead: it is skipped for metrics accumulation, and the caller must filter it
+   * out rather than turn it into a {@code CREATED} event or apply its configuration changes.
    *
-   * @param applyConfigurationChanges whether a CONFIGURATION item's changes should be applied onto
-   *     {@code target} immediately, rather than deferred until the item is committed
    * @return the {@code AgentInstanceRecord} attribute names that actually changed as a result
+   *     (currently only ever {@link AgentInstanceRecord#ATTR_METRICS})
    */
   Set<String> applyInstanceChangesFromHistory(
       final AgentInstanceRecord target,
       final long jobKey,
       final String jobLease,
       final long elementInstanceKey,
-      final List<? extends AgentHistoryRecordValue> history,
-      final boolean applyConfigurationChanges) {
+      final List<? extends AgentHistoryRecordValue> history) {
     final var changedAttributes = new HashSet<String>();
     final var items = new ArrayList<AgentHistoryRecord>(history.size());
     final var agentHistoryState = processingState.getAgentHistoryState();
@@ -273,16 +271,11 @@ public final class AgentHistoryBatchBehavior {
           .setJobLease(jobLease)
           .setDuplicate(isDuplicate);
 
-      // A duplicate is skipped entirely: no metrics accumulation, no CONFIGURATION attributes
-      // applied — re-applying values the instance already reflects would be unobservable, so the
-      // durable signal that it was skipped is the isDuplicate flag on the echoed item alone.
-      if (!isDuplicate) {
-        if (applyMetrics(target.getMetrics(), item)) {
-          changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
-        }
-        if (applyConfigurationChanges) {
-          changedAttributes.addAll(applyConfigurationChanges(target, item));
-        }
+      // A duplicate is skipped entirely: no metrics accumulation — re-applying values the
+      // instance already reflects would be unobservable, so the durable signal that it was
+      // skipped is the isDuplicate flag on the echoed item alone.
+      if (!isDuplicate && applyMetrics(target.getMetrics(), item)) {
+        changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
       }
 
       items.add(event);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.AgentDefinitionState;
+import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -63,6 +65,7 @@ public final class AgentInstanceCreateProcessor
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
   private final AgentDefinitionState agentDefinitionState;
+  private final AgentHistoryState agentHistoryState;
   private final CslAuthorizationCheck cslCheck;
   private final KeyGenerator keyGenerator;
   private final AgentHistoryBatchBehavior historyBatchHelper;
@@ -78,6 +81,7 @@ public final class AgentInstanceCreateProcessor
     elementInstanceState = processingState.getElementInstanceState();
     processState = processingState.getProcessState();
     agentDefinitionState = processingState.getAgentDefinitionState();
+    agentHistoryState = processingState.getAgentHistoryState();
     this.cslCheck = cslCheck;
     this.keyGenerator = keyGenerator;
     historyBatchHelper = new AgentHistoryBatchBehavior(keyGenerator, processingState);
@@ -232,9 +236,25 @@ public final class AgentInstanceCreateProcessor
     event.getHistory().stream()
         .filter(Predicate.not(AgentHistoryRecordValue::isDuplicate))
         .forEach(
-            item ->
+            item -> {
+              stateWriter.appendFollowUpEvent(
+                  item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item);
+              // CONFIGURATION changes are applied directly above, during CREATE itself, rather
+              // than deferred like an UPDATE's would be — so the history record must commit
+              // immediately too, instead of sitting PENDING/discardable.
+              if (item.getRole() == AgentHistoryRole.CONFIGURATION) {
+                // Read the item back from state rather than reusing the untrimmed in-memory
+                // `item`: AgentHistoryCreatedApplier, applied synchronously by the CREATED event
+                // just appended above, has already trimmed it down to identity fields plus the
+                // CONFIGURATION-specific ones — the exact shape AgentHistoryCommitProcessor's own
+                // COMMITTED event re-emits for UPDATE. Fetching it keeps both paths' COMMITTED
+                // events identical in shape without duplicating that trimming logic here.
                 stateWriter.appendFollowUpEvent(
-                    item.getAgentHistoryKey(), AgentHistoryIntent.CREATED, item));
+                    item.getAgentHistoryKey(),
+                    AgentHistoryIntent.COMMITTED,
+                    agentHistoryState.get(item.getAgentHistoryKey()));
+              }
+            });
 
     responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.CREATED, event, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -227,13 +227,28 @@ public final class AgentInstanceCreateProcessor
           commandValue.getJobKey(),
           commandValue.getJobLease(),
           commandValue.getElementInstanceKey(),
-          commandValue.getHistory(),
-          true);
+          commandValue.getHistory());
     }
+
+    // event.getHistory() allocates a fresh list on every call — now that
+    // applyInstanceChangesFromHistory has populated it above, read it once here and reuse it for
+    // both loops below.
+    final var history = event.getHistory();
+
+    // Unlike UPDATE (which defers this to AgentHistoryCommitProcessor, once the item is actually
+    // committed), CREATE applies a CONFIGURATION item's changes right here, before its own
+    // AGENT_INSTANCE:CREATED is appended below — so a newly created instance always starts with a
+    // valid, usable definition instead of a placeholder one.
+    history.stream()
+        .filter(Predicate.not(AgentHistoryRecordValue::isDuplicate))
+        .filter(item -> item.getRole() == AgentHistoryRole.CONFIGURATION)
+        .forEach(item -> AgentHistoryBatchBehavior.applyConfigurationChanges(event, item));
 
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.CREATED, event);
 
-    event.getHistory().stream()
+    // AGENT_HISTORY items reference their AgentInstance parent by key, so they can only be
+    // created after AGENT_INSTANCE:CREATED above has assigned that key.
+    history.stream()
         .filter(Predicate.not(AgentHistoryRecordValue::isDuplicate))
         .forEach(
             item -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -255,8 +255,7 @@ public final class AgentInstanceUpdateProcessor
               commandValue.getJobKey(),
               commandValue.getJobLease(),
               commandValue.getElementInstanceKey(),
-              commandValue.getHistory(),
-              false);
+              commandValue.getHistory());
 
       current.getHistory().stream()
           .filter(Predicate.not(AgentHistoryRecordValue::isDuplicate))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.engine.util.client.AgentInstanceClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
@@ -1542,6 +1543,385 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withAgentInstanceKey(created.getKey())
             .getFirst();
     assertThat(historyEvent.getValue().getModel()).isEqualTo("gpt-4o-mini");
+  }
+
+  @Test
+  public void shouldCommitCreateConfigurationItemImmediatelyPreventingDiscard() {
+    // given — a CONFIGURATION item submitted with CREATE, same as
+    // shouldApplyInstanceFieldsFromConfigurationItemImmediatelyOnCreate above.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    // content/toolCalls are conversation-payload fields that a CONFIGURATION item should never
+    // carry in practice, but setting them here proves the COMMITTED event is genuinely built by
+    // reading the trimmed record back from state — reusing the untrimmed in-memory `item` instead
+    // (a regression this test would otherwise miss) would leak them straight through.
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"))
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("should be stripped"))
+            .setToolCalls(
+                List.of(
+                    new AgentHistoryEmbeddedToolCall()
+                        .setToolCallId("call-1")
+                        .setToolName("should-be-stripped")));
+
+    // when
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(configItem))
+            .create();
+
+    // then — the item is already COMMITTED as part of CREATE itself, never left PENDING under
+    // the job.
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withAgentInstanceKey(created.getKey())
+            .getFirst();
+    assertThat(committed.getValue().getHistoryItemId()).isEqualTo("item-config");
+    // trimmed at primary-storage insert, same as every other role — proves the COMMITTED event was
+    // built by reading the item back from state rather than re-emitting the untrimmed in-memory
+    // one.
+    assertThat(committed.getValue().getContent()).isEmpty();
+    assertThat(committed.getValue().getToolCalls()).isEmpty();
+
+    // when — the creating job is discarded afterwards (e.g. abandoned before it ever completes)
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .key(jobKey)
+            .agentHistory(AgentHistoryIntent.DISCARD, new AgentHistoryRecord().setJobKey(jobKey)));
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then — nothing is left pending to discard, so no DISCARDED event is ever produced for this
+    // item: it can never be erased from history, unlike before this fix. Scoped to this item's
+    // historyItemId (rather than "no DISCARDED at all") so the assertion stays correct if this
+    // batch is ever extended with another, still-discardable item.
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.DISCARDED)
+                .filter(
+                    r ->
+                        ((AgentHistoryRecordValue) r.getValue())
+                            .getHistoryItemId()
+                            .equals("item-config"))
+                .exists())
+        .isFalse();
+  }
+
+  @Test
+  public void shouldOnlyCommitConfigurationItemFromMixedCreateBatch() {
+    // given — a CREATE batch with both a CONFIGURATION item (committed immediately by this fix)
+    // and a plain USER item (which must stay PENDING/discardable, unaffected by the fix).
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1);
+
+    // when
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(configItem, userItem))
+            .create();
+
+    // then — only the CONFIGURATION item is committed as part of CREATE itself.
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withAgentInstanceKey(created.getKey())
+            .getFirst();
+    assertThat(committed.getValue().getHistoryItemId()).isEqualTo("item-config");
+
+    final var userHistoryKey =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(created.getKey())
+            .filter(r -> r.getValue().getHistoryItemId().equals("item-user"))
+            .getFirst()
+            .getKey();
+
+    // when — the job is discarded before it ever completes
+    final var discarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — only the still-pending USER item is discarded; the already-committed CONFIGURATION
+    // item is untouched (it is no longer in the pending column family the discard visits).
+    assertThat(discarded.getIntent()).isEqualTo(AgentHistoryIntent.DISCARDED);
+    assertThat(discarded.getKey()).isEqualTo(userHistoryKey);
+  }
+
+  @Test
+  public void shouldCommitEachConfigurationItemFromCreateBatchWithMultipleConfigItems() {
+    // given — a CREATE batch with two CONFIGURATION items (one changing the model, one changing
+    // tools). Both must be applied and committed, not just the first or the last.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var modelItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config-model")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+    final var toolsItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config-tools")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(2)
+            .setTools(List.of(new AgentInstanceTool().setName("calc").setElementId("calc-task")))
+            .setChangedAttributes(List.of("tools"));
+
+    // when
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(modelItem, toolsItem))
+            .create();
+
+    // then — both items' effects are applied to the instance...
+    assertThat(created.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+    assertThat(created.getValue().getTools()).extracting("name").containsExactly("calc");
+
+    // ...and both items are committed, not just applied.
+    final var committedIds =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withAgentInstanceKey(created.getKey())
+            .limit(2)
+            .map(r -> r.getValue().getHistoryItemId())
+            .toList();
+    assertThat(committedIds).containsExactlyInAnyOrder("item-config-model", "item-config-tools");
+  }
+
+  @Test
+  public void shouldDedupUpdateAgainstCreateCommittedConfigurationItemAcrossLeases() {
+    // given — CREATE's own CONFIGURATION item commits immediately (see
+    // shouldCommitCreateConfigurationItemImmediatelyPreventingDiscard above), registering its
+    // historyItemId as committed for this agent instance.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-mini")
+            .setChangedAttributes(List.of("model"));
+
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(configItem))
+            .create();
+    final var agentInstanceKey = created.getKey();
+
+    // when — a later UPDATE, under a different lease on the same job (simulating a worker retry
+    // after the original CREATE-time activation was superseded), resends the same historyItemId
+    // with a DIFFERENT model value.
+    final var resentConfigItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setModel("gpt-4o-nano")
+            .setChangedAttributes(List.of("model"));
+    final var update =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("retry-lease")
+            .withHistory(List.of(resentConfigItem))
+            .update();
+
+    // then — recognized as a duplicate of the already-committed CREATE-time item (matched via
+    // getCommittedHistoryItemKey, since a different lease means the pending-items lookup alone
+    // would not have matched it), so its own "gpt-4o-nano" payload is never applied.
+    assertThat(update.getValue().getHistory().get(0).isDuplicate()).isTrue();
+    assertThat(update.getValue().getChangedAttributes()).doesNotContain("model");
+    assertThat(update.getValue().getDefinition().getModel()).isEqualTo("gpt-4o-mini");
+  }
+
+  @Test
+  public void shouldStillAllowDiscardOfNonConfigurationItemsFromCreateBatch() {
+    // given — a plain USER item submitted with CREATE, unaffected by this fix: only CONFIGURATION
+    // items from CREATE's batch commit immediately, every other role stays PENDING as before.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1);
+
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withHistory(List.of(userItem))
+            .create();
+    final var userHistoryKey =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withAgentInstanceKey(created.getKey())
+            .getFirst()
+            .getKey();
+
+    // when — the job is discarded before it ever commits
+    final var discarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // then — the plain USER item is discarded exactly as before this fix
+    assertThat(discarded.getIntent()).isEqualTo(AgentHistoryIntent.DISCARDED);
+    assertThat(discarded.getKey()).isEqualTo(userHistoryKey);
   }
 
   @Test


### PR DESCRIPTION
## Summary

`AGENT_INSTANCE:CREATE` can include a `CONFIGURATION` history item whose effects (model/provider/systemPrompt/tools/limits) are applied to the `AgentInstance` immediately, but until now the item itself was stored `PENDING` like an `UPDATE` batch's item — so a later `AGENT_HISTORY:DISCARD` could erase the history record while its already-applied effects stayed stranded on the instance. This PR commits CREATE's `CONFIGURATION` items immediately, right alongside the rest of CREATE's own processing, so the history record can no longer be discarded out from under effects that already took hold.

- `AGENT_INSTANCE:CREATE`'s `CONFIGURATION` history items are now committed (`AGENT_HISTORY:COMMITTED`) immediately as part of processing the `CREATE` command itself, instead of being left `PENDING` under the job/lease like an `UPDATE` batch's items. `CONFIGURATION` items' effects on the `AgentInstance` (model/provider/systemPrompt/tools/limits) were already applied immediately and unconditionally at CREATE time — this fix makes the history record itself match that irreversibility, so `AGENT_HISTORY:DISCARD` can no longer erase the record while the applied effects remain stranded on the instance.

- The COMMITTED event CREATE emits for its own CONFIGURATION item is read back from `AgentHistoryState` (`agentHistoryState.get(item.getAgentHistoryKey())`) AFTER the CREATED event is appended, relying on `AgentHistoryCreatedApplier` having synchronously trimmed it in state already — matching the shape `AgentHistoryCommitProcessor` already emits for UPDATE's COMMITTED events. This is NOT reusing the untrimmed in-memory item object the client submitted; duplicating the trim logic inline instead of reading from state was considered and rejected (risk of the two trimming implementations drifting apart).

- Added a regression test, `shouldCommitCreateConfigurationItemImmediatelyPreventingDiscard`, that gives the CONFIGURATION item non-empty `content`/`toolCalls` and asserts the COMMITTED event strips them to empty — this specifically catches a regression back to reusing the untrimmed in-memory item.

- Fixed a stale acceptance-test comment in `AgentHistoryCommitLifecycleIT.java` that claimed CREATE-time CONFIGURATION items still roll back on a later job failure — they don't anymore, since this fix commits them immediately.

- Every other role (`USER`/`ASSISTANT`/`TOOL`, etc.) in CREATE's initial batch is unaffected by this change — still stored `PENDING`, still discardable exactly as before. Conversation-role content stays provisional until the job that produced it actually completes, since the client only durably persists that content at job completion.

- No protocol or schema changes: reuses the existing `AgentHistoryIntent.COMMITTED` intent and `AgentHistoryCommittedApplier` — the only change is in `AgentInstanceCreateProcessor`'s own event sequencing.

- Removes the `applyConfigurationChanges` boolean parameter from `AgentHistoryBatchBehavior.applyInstanceChangesFromHistory` — now that CREATE also commits its CONFIGURATION items inline, it applies their effects the same explicit way `AgentHistoryCommitProcessor` already does for UPDATE, rather than needing a flag threaded through the shared batch-building method. No behavior change for UPDATE.

- `AgentInstanceCreateProcessor` keeps two separate loops over the history batch — one applying `CONFIGURATION` changes to the in-memory event before `AGENT_INSTANCE:CREATED` is appended, another after `CREATED` emitting `AGENT_HISTORY:CREATED`/`COMMITTED` per item. This split is deliberate: `AGENT_INSTANCE:CREATED` must be the first event this command emits, and `CONFIGURATION` changes must be applied to the in-memory event before `AGENT_INSTANCE:CREATED` is appended so that event already carries the final definition.

## Test plan

- [x] New unit test in `AgentInstanceHistoryBatchProcessingTest` (companion to the existing `shouldApplyInstanceFieldsFromConfigurationItemImmediatelyOnCreate`): CREATE with a `CONFIGURATION` item, then issue `AGENT_HISTORY:DISCARD` against the same job/lease, then assert the `AgentInstance`'s definition/tools/limits still reflect the `CONFIGURATION` item's values (no rollback) and the corresponding `AGENT_HISTORY` record shows `COMMITTED`, never `DISCARDED`
- [x] Assert `AgentHistoryState.getCommittedHistoryItemKey(...)` is non-null for the `CONFIGURATION` item's `historyItemId` immediately after `CREATE` returns (dedup now registered where it previously wasn't)
- [x] Regression test proving non-`CONFIGURATION` items (e.g. `USER`/`ASSISTANT`) in the same CREATE batch are unaffected: still stored `PENDING`, still discardable via `AGENT_HISTORY:DISCARD` exactly as before this fix
- [x] Extended `shouldApplyInstanceFieldsFromConfigurationItemImmediatelyOnCreate` to also assert an `AGENT_HISTORY:COMMITTED` event now exists for the `CONFIGURATION` item right after `CREATE`
- [x] Added `shouldCommitCreateConfigurationItemImmediatelyPreventingDiscard`: gives the CONFIGURATION item non-empty `content`/`toolCalls` and asserts the COMMITTED event strips them to empty, catching a regression back to reusing the untrimmed in-memory item
- [x] Re-ran `RecordGoldenFilesTest`/`JsonSerializableToJsonTest` — no golden-file update needed since no new field/shape is introduced, only a new sequencing of an already-existing event
- [x] Mixed CREATE batch (CONFIGURATION + USER item): only the CONFIGURATION item commits, only the USER item is later discardable
- [x] CREATE batch with two CONFIGURATION items: both commit, not just one

## Related issues

closes #61391