### PR TITLE
feat: allow adding back a zone by broker count instead of broker ids

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -715,7 +715,13 @@ public class ClusterEndpoint {
         if (numberOfBrokers.get() < 1) {
           return invalidRequest("numberOfBrokers must be at least 1.");
         }
-        return sendAddZone(zoneId, request, zonedBrokers(zoneId, numberOfBrokers.get()), dryRun);
+        final List<MemberId> members;
+        try {
+          members = zonedBrokers(zoneId, numberOfBrokers.get());
+        } catch (final IllegalArgumentException invalidZoneId) {
+          return invalidRequest(invalidZoneId.getMessage());
+        }
+        return sendAddZone(zoneId, request, members, dryRun);
       }
       final var brokerIds = brokers.stream().map(BrokerId::toString).toList();
       return withValidMembers(brokerIds, members -> sendAddZone(zoneId, request, members, dryRun));

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
@@ -705,23 +706,47 @@ public class ClusterEndpoint {
       @RequestBody final io.camunda.zeebe.management.cluster.AddZoneRequest request,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
     try {
-      final var brokerIds = request.getBrokers().stream().map(BrokerId::toString).toList();
-      return withValidMembers(
-          brokerIds,
-          members -> {
-            final var addZoneRequest =
-                new AddZoneRequest(
-                    zoneId,
-                    request.getNumberOfReplicas(),
-                    request.getPriority(),
-                    Set.copyOf(members),
-                    dryRun);
-            return ClusterApiUtils.mapOperationResponse(
-                requestSender.addZone(addZoneRequest).join());
-          });
+      final var brokers = Optional.ofNullable(request.getBrokers()).orElse(List.of());
+      final var numberOfBrokers = Optional.ofNullable(request.getNumberOfBrokers());
+      if (brokers.isEmpty() == numberOfBrokers.isEmpty()) {
+        return invalidRequest("Exactly one of brokers and numberOfBrokers must be set.");
+      }
+      if (numberOfBrokers.isPresent()) {
+        if (numberOfBrokers.get() < 1) {
+          return invalidRequest("numberOfBrokers must be at least 1.");
+        }
+        return sendAddZone(zoneId, request, zonedBrokers(zoneId, numberOfBrokers.get()), dryRun);
+      }
+      final var brokerIds = brokers.stream().map(BrokerId::toString).toList();
+      return withValidMembers(brokerIds, members -> sendAddZone(zoneId, request, members, dryRun));
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }
+  }
+
+  private ResponseEntity<?> sendAddZone(
+      final String zoneId,
+      final io.camunda.zeebe.management.cluster.AddZoneRequest request,
+      final Collection<MemberId> members,
+      final boolean dryRun) {
+    final var addZoneRequest =
+        new AddZoneRequest(
+            zoneId,
+            request.getNumberOfReplicas(),
+            request.getPriority(),
+            Set.copyOf(members),
+            dryRun);
+    return ClusterApiUtils.mapOperationResponse(requestSender.addZone(addZoneRequest).join());
+  }
+
+  /**
+   * Derives the member ids of a zone's brokers from their count, mirroring how a broker of a
+   * zone-aware cluster derives its own id: node indices are 0-based within the zone.
+   */
+  private static List<MemberId> zonedBrokers(final String zoneId, final int numberOfBrokers) {
+    return IntStream.range(0, numberOfBrokers)
+        .mapToObj(nodeIdx -> MemberId.from(zoneId, nodeIdx))
+        .toList();
   }
 
   /**

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -279,13 +279,14 @@ schemas:
         example: 1000
 
   AddZoneRequest:
-    description: Request body for adding back a previously force-removed zone. The zone name is
-      given in the path.
+    description: >
+      Request body for adding back a previously force-removed zone. The zone name is given in the
+      path. The zone's brokers are given either as an explicit list in `brokers` or as a count in
+      `numberOfBrokers`; exactly one of the two must be set.
     type: object
     required:
       - numberOfReplicas
       - priority
-      - brokers
     properties:
       numberOfReplicas:
         type: integer
@@ -299,9 +300,19 @@ schemas:
         example: 1000
       brokers:
         type: array
-        description: The brokers to re-add to the zone
+        description: >
+          The brokers to re-add to the zone. Mutually exclusive with `numberOfBrokers`.
         items:
           $ref: "components.yaml#/schemas/BrokerId"
+      numberOfBrokers:
+        type: integer
+        format: int32
+        minimum: 1
+        description: >
+          Number of brokers deployed in the zone. The broker ids are derived from it as
+          `<zoneId>_0` through `<zoneId>_<numberOfBrokers - 1>`, matching the ids the brokers of a
+          zone-aware cluster assign themselves. Mutually exclusive with `brokers`.
+        example: 3
 
   PartitionJoinRequest:
     description: Request body for adding a broker to a partition's replication group. The broker

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.ConfigurationChange;
+import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.GetConfigurationChangesResponse;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
@@ -665,6 +666,28 @@ final class ClusterEndpointTest {
 
       // then
       assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
+    }
+
+    @Test
+    void shouldRejectInvalidZoneIdWhenDerivingFromNumberOfBrokers() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      // underscore is reserved as the zone/nodeIdx separator, so it's not a valid zone character
+      final var response =
+          endpoint.addZone(
+              "zone_a",
+              new AddZoneRequest().numberOfReplicas(1).priority(100).numberOfBrokers(1),
+              false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      assertThat(((Error) response.getBody()).getMessage())
+          .contains("alphanumeric")
+          .contains("hyphens");
       verifyNoInteractions(sender);
     }
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
@@ -32,6 +33,8 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.management.cluster.AddZoneRequest;
+import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.ConfigurationChange;
@@ -564,6 +567,110 @@ final class ClusterEndpointTest {
     private ClusterConfigurationManagementRequestSender senderAcceptingPatch() {
       final var sender = mock(ClusterConfigurationManagementRequestSender.class);
       when(sender.patchCluster(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  Either.right(
+                      new ClusterConfigurationChangeResponse(
+                          1L,
+                          new ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse(
+                              Map.of(), Map.of(), List.of()),
+                          null))));
+      return sender;
+    }
+  }
+
+  @Nested
+  class AddZoneEndpoint {
+
+    @Test
+    void shouldDeriveZonedBrokerIdsFromNumberOfBrokers() {
+      // given
+      final var sender = senderAcceptingAddZone();
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response =
+          endpoint.addZone(
+              "zone-a",
+              new AddZoneRequest().numberOfReplicas(2).priority(100).numberOfBrokers(3),
+              false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(202);
+      verify(sender)
+          .addZone(
+              new ClusterConfigurationManagementRequest.AddZoneRequest(
+                  "zone-a",
+                  2,
+                  100,
+                  Set.of(
+                      MemberId.from("zone-a", 0),
+                      MemberId.from("zone-a", 1),
+                      MemberId.from("zone-a", 2)),
+                  false));
+    }
+
+    @Test
+    void shouldRejectWhenBothBrokersAndNumberOfBrokersSet() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response =
+          endpoint.addZone(
+              "zone-a",
+              new AddZoneRequest()
+                  .numberOfReplicas(1)
+                  .priority(100)
+                  .brokers(List.of(new BrokerId.String("zone-a_0")))
+                  .numberOfBrokers(1),
+              false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
+    }
+
+    @Test
+    void shouldRejectWhenNeitherBrokersNorNumberOfBrokersSet() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response =
+          endpoint.addZone(
+              "zone-a",
+              new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of()),
+              false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
+    }
+
+    @Test
+    void shouldRejectNonPositiveNumberOfBrokers() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response =
+          endpoint.addZone(
+              "zone-a",
+              new AddZoneRequest().numberOfReplicas(1).priority(100).numberOfBrokers(0),
+              false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
+    }
+
+    private ClusterConfigurationManagementRequestSender senderAcceptingAddZone() {
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      when(sender.addZone(any()))
           .thenReturn(
               CompletableFuture.completedFuture(
                   Either.right(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -485,12 +485,12 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
     void shouldRejectAddZoneWithMismatchedBrokers() {
       // given - zoneA has already been force-removed from the shared cluster
 
-      // when - then - empty brokers[] is rejected
+      // when - then - a request naming no brokers at all is rejected
       final var emptyBrokersRequest =
           new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of());
       assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONE_A, emptyBrokersRequest, false))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("at least one broker");
+          .hasMessageContaining("Exactly one of brokers and numberOfBrokers must be set.");
 
       // when - then - fewer brokers than numberOfReplicas is rejected
       final var tooFewBrokersRequest =


### PR DESCRIPTION
## Description

Failing back a force-removed zone via `POST /actuator/zones/{zoneId}` required listing every broker of the zone in `brokers`. For a 10-20 broker zone that means a large body and a script that has to reproduce the internal `<zone>_<nodeIdx>` naming by hand — one wrong id fails the whole change.

Moreover, that made the script aware of the naming convention for the brokerId, which is not ideal.

`AddZoneRequest` now also accepts `numberOfBrokers`, from which the endpoint derives `<zoneId>_0 .. <zoneId>_<numberOfBrokers - 1>` — the same ids a zone-aware broker assigns itself (see `StaticConfigurationGenerator.getZoneAwareRaftGroupMembers`). Exactly one of `brokers` / `numberOfBrokers` must be set; otherwise 400.

Notes:
- `brokers` stays supported and undeprecated — existing runbooks use it, and it is the only way to express a zone whose broker ids are not contiguous from 0.
- Expansion happens in the REST layer, so the internal request, its protobuf encoding and `AddZoneTransformer`'s validation are untouched.
- Named `numberOfBrokers`, not the issue's `brokerCount`, to match the sibling `numberOfReplicas` and config-side `ZoneCfg.numberOfBrokers`.
- Behaviour change to note: `brokers: []` with no `numberOfBrokers` now fails the exclusivity check ("Exactly one of ...") rather than the transformer's "at least one broker"; the corresponding IT assertion was updated.

## Checklist

- [x] Enable backports when necessary — labelled `backport stable/8.10`.

## Related issues

closes #61622