### PR TITLE
test: align the groups identity tests with the design system

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -8,7 +8,6 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
-import {sleep} from 'utils/sleep';
 import {defaultAssertionOptions} from '../utils/constants';
 import {
   findLocatorInPaginatedList,
@@ -18,6 +17,7 @@ import {
 export class IdentityGroupsPage {
   private page: Page;
   readonly groupsList: Locator;
+  readonly assignedUsersList: Locator;
   readonly createGroupButton: Locator;
   readonly editGroupButton: (rowName?: string) => Locator;
   readonly deleteGroupButton: (rowName?: string) => Locator;
@@ -51,6 +51,8 @@ export class IdentityGroupsPage {
   constructor(page: Page) {
     this.page = page;
     this.groupsList = page.getByRole('table');
+    // The members table on a group's detail page.
+    this.assignedUsersList = page.getByRole('table');
 
     this.selectGroupRow = (name) =>
       this.groupsList.getByRole('row', {name: name});
@@ -231,6 +233,14 @@ export class IdentityGroupsPage {
     await option.click({timeout: 20000});
     await this.assignUserButtonModal.click();
     await expect(this.assignUserModal).toBeHidden();
-    await sleep(8000);
+    // Wait for the member row rather than sleeping for a fixed 8s: both
+    // callers navigate away immediately afterwards, so the assignment has to
+    // be observable before returning. The members table renders username,
+    // name and email, and the email is the unique column.
+    await waitForItemInList(
+      this.page,
+      this.assignedUsersList.getByRole('cell', {name: userEmail}),
+      {timeout: 60000},
+    );
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -40,6 +40,7 @@ export class IdentityGroupsPage {
   readonly deleteGroupModalDeleteButton: Locator;
   readonly emptyStateLocator: Locator;
   readonly assignUserButton: Locator;
+  readonly assignUserModal: Locator;
   readonly searchBox: Locator;
   readonly searchBoxResult: Locator;
   readonly assignUserButtonModal: Locator;
@@ -63,8 +64,15 @@ export class IdentityGroupsPage {
 
     this.editGroupButton = (rowName) =>
       this.groupsList.getByRole('row', {name: rowName}).getByLabel('Edit');
+    // The design-system list renders the destructive row action as a button
+    // labelled by its visible text, not by `aria-label` (`entityListV2` sets
+    // `iconOnly: !!Icon && !isDangerous`), so match it by role and accessible
+    // name. Edit stays on `getByLabel` because it is icon-only and keeps its
+    // `aria-label`.
     this.deleteGroupButton = (rowName) =>
-      this.groupsList.getByRole('row', {name: rowName}).getByLabel('Delete');
+      this.groupsList
+        .getByRole('row', {name: rowName})
+        .getByRole('button', {name: 'Delete', exact: true});
 
     this.createGroupModal = page.getByRole('dialog', {
       name: 'Create group',
@@ -133,11 +141,21 @@ export class IdentityGroupsPage {
     );
     this.emptyStateLocator = page.getByText('No groups created yet');
     this.assignUserButton = page.getByRole('button', {name: 'Assign user'});
-    this.searchBox = page.getByRole('searchbox');
-    this.searchBoxResult = page.getByRole('listitem');
-    this.assignUserButtonModal = page
-      .getByLabel('Assign user')
-      .getByRole('button', {name: 'Assign user'});
+    this.assignUserModal = page.getByRole('dialog', {name: 'Assign user'});
+    // On the new design system the assign-user field is a cmdk combobox. The
+    // groups modal uses `UserMultiSelect`'s default placeholder, so the
+    // accessible name is "Search by username" -- not the "Search by Username
+    // or Name" the roles modal overrides it to.
+    this.searchBox = this.assignUserModal.getByRole('combobox', {
+      name: 'Search by username',
+    });
+    // The results render in a Radix popover that portals as a *sibling* of the
+    // dialog (DS #496), so the listbox is not a descendant of the modal --
+    // scope it to the page.
+    this.searchBoxResult = page.getByRole('listbox');
+    this.assignUserButtonModal = this.assignUserModal.getByRole('button', {
+      name: 'Assign user',
+    });
     this.groupsHeading = this.page.getByRole('heading', {name: 'Groups'});
   }
 
@@ -200,13 +218,19 @@ export class IdentityGroupsPage {
 
   async assignUserToGroup(userName: string, userEmail: string) {
     await this.assignUserButton.click();
+    await expect(this.assignUserModal).toBeVisible();
     await this.searchBox.fill(userName);
-    await this.searchBoxResult
-      .filter({
-        hasText: userEmail,
-      })
-      .click();
+    // Keep matching on the email: this modal leaves `UserMultiSelect`'s
+    // default `itemSubTitle`, so the option renders the username as its title
+    // and the email beneath it, and the email is the unique half.
+    const option = this.searchBoxResult
+      .getByRole('option')
+      .filter({hasText: userEmail})
+      .first();
+    await expect(option).toBeVisible({timeout: 30000});
+    await option.click({timeout: 20000});
     await this.assignUserButtonModal.click();
+    await expect(this.assignUserModal).toBeHidden();
     await sleep(8000);
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/groups.spec.ts
@@ -57,8 +57,11 @@ test.describe.serial('groups CRUD', () => {
     await expect(identityGroupsPage.createGroupModal).toContainText(
       'Please enter a valid group ID',
     );
+    // The Create group modal renders on the new design system, whose Input
+    // marks a failed field with `aria-invalid` instead of Carbon's
+    // `data-invalid`.
     await expect(identityGroupsPage.createGroupIdField).toHaveAttribute(
-      'data-invalid',
+      'aria-invalid',
       'true',
     );
   });


### PR DESCRIPTION
## Description

The groups pages migrated to the Camunda design system (`7baee2bd6`, `a08f244f2`, `3259ba32b`, `3e0644403`) and three E2E tests still target the Carbon markup. This is the follow-up the merged #61553 referred to when it noted the groups failures would be handled separately.

**Create-group modal** — the design-system Input marks a failed field with `aria-invalid`, not Carbon's `data-invalid`. Since `groups CRUD` is a `test.describe.serial` block, that single assertion was skipping the three tests after it, so `creates a group`, `edits a group` and `deletes a group` had not actually run since the migration landed.

**Assign-user modal** — the search field is now a cmdk combobox, and its results render in a Radix popover that portals as a sibling of the dialog (DS #496), so the listbox is not a descendant of the modal. Unlike the roles modal, the groups one leaves `UserMultiSelect`'s `placeholder` and `itemSubTitle` at their defaults, so the combobox is named `"Search by username"` (not roles' `"Search by Username or Name"`) and the option renders the username as its title with the email beneath it. The email stays the match, being the unique half.

**Delete row action** — fixed here rather than after the fact, because unskipping the serial block exposes it. `entityListV2` computes `iconOnly: !!Icon && !isDangerous` and `groups/ListV2.tsx` marks delete `isDangerous`, so Delete renders a visible text label and no `aria-label` while Edit stays icon-only and keeps one. `getByLabel` matches `aria-label` only, so `deletes a group` would have gone red on its first run in weeks. Matched by role and accessible name instead, as `IdentityUsersPage.deleteUserButton` already does.

### Applies to `stable/8.10` too

Groups is migrated on both branches and `pages/IdentityGroupsPage.ts` is byte-identical between them, as are every label the fix depends on (`"Search by username"`, `"Edit"`, `"Delete"`). Both on-demand runs below produce the same failing DOM. Backport requested.

### Verification

Local Elasticsearch stack on `camunda/camunda:SNAPSHOT` revision `d3f75199`, which carries the groups migration.

The serial block, before → after:

| Test | Before | After |
|---|---|---|
| `tries to create a group with invalid id` | ✘ ×2 attempts | ✓ 1.9s |
| `creates a group` | – skipped | ✓ 3.6s |
| `edits a group` | – skipped | ✓ 4.5s |
| `deletes a group` | – skipped | ✓ 6.0s |
| `create a group … assign it to Test user` | ✘ ×2 attempts | ✓ |
| `New user can inherit permissions when assigned to a group` | ✘ ×2 attempts | ✓ 156.8s |

Regression sweep over `tests/identity/` plus `identity-users-flows.spec.ts`: 45 expected, 1 unexpected (below). The shared row-action locators stay green — roles delete, users delete, authorizations delete. `npm run lint` clean.

### Known failure, not a regression from this PR

`tests/identity/tenants.spec.ts › tries to create a tenant with invalid id` still fails. Same `data-invalid` drift, but because tenants migrated on `main` only — `stable/8.10` has no `tenants/ListV2` — the one-line fix is not backportable as-is, so it is deliberately excluded and needs its own change.


Reference runs, both showing these groups failures on the unfixed suite:
- `main`: https://github.com/camunda/camunda/actions/runs/33512273077
- `stable/8.10`: https://github.com/camunda/camunda/actions/runs/33510519179

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. 
   - [x] [here](https://github.com/camunda/camunda/actions/runs/33521404562). As expected - tenant test failed. Will be handled in separate PR

## Related issues

closes #

- [x] This PR does not need a linked issue
