### PR TITLE
deps: update Surefire plugin version to 3.5.6

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -710,7 +710,7 @@
       ],
     },
     {
-      description: "maven-surefire-plugin 3.5.4 has an issue with inner class tests reports https://github.com/apache/maven-surefire/issues/3203, causing the retry of the wrong tests. 3.5.3 version has a bug preventing ArchUnit tests from running. Enable PRs but block auto-merge until the upstream bug is confirmed fixed.",
+      description: "maven-surefire-plugin has several known issues across 3.5.x: 3.5.3 prevents ArchUnit tests from running; 3.5.4 reports inner class tests incorrectly https://github.com/apache/maven-surefire/issues/3203, causing the retry of the wrong tests; 3.5.6 reports @Nested classes carrying a class-level @DisplayName under their flattened display name instead of their fully-qualified name, breaking FQN-based tooling (hence @DisplayName is commented out on @Nested classes, see AGENTS.md). Enable PRs but block auto-merge until these are manually verified against the new version.",
       matchManagers: [
         "maven",
       ],
@@ -719,7 +719,7 @@
       ],
       automerge: false,
       prBodyNotes: [
-        "**Manual verification required before merging:** Check that [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner class test report bug in 3.5.4) is fixed in this version. Do **not** merge until confirmed.",
+        "**Manual verification required before merging.** Do **not** merge until all three are confirmed against this version:\n\n1. **ArchUnit tests run.** 3.5.3 silently skipped them — confirm `qa/archunit-tests` actually executes tests rather than reporting zero.\n2. **Inner class test reports are correct.** Check [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (present in 3.5.4) is fixed, so test retries target the right tests.\n3. **@Nested classes report their fully-qualified name.** 3.5.6 reported a `@Nested` class with a class-level `@DisplayName` under its flattened display name, breaking FQN-based tooling (flaky-test tracking, CI report parsing). Verify the generated `target/surefire-reports/*.xml` uses `classname=\"...Outer$Nested\"`; if fixed, the `@DisplayName` annotations commented out on `@Nested` classes can be restored (see the testing conventions in `AGENTS.md`).",
       ],
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,7 +303,7 @@ read it. If you can't name both, don't write it.
   avoid cross-run flakiness.
 - Use JUnit 5. Migrate JUnit 4 tests when modifying them.
 - Do not add a class-level `@DisplayName` to a new `@Nested` test class while the repo is on
-  Surefire 3.5.x (`plugin.version.surefire` in `parent/pom.xml`) — a Surefire 3.5.3regression
+  Surefire 3.5.x (`plugin.version.surefire` in `parent/pom.xml`) — a Surefire regression
   reports such classes under their flattened display name instead of their fully-qualified name in
   the XML test report, breaking FQN-based tooling (flaky-test tracking, CI report parsing). Method-
   level `@DisplayName` (on `@Test`/`@ParameterizedTest`) is unaffected. Existing occurrences were

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,13 @@ read it. If you can't name both, don't write it.
 - Always tear down resources you create (indices, containers, clients, clusters), even on failure, to
   avoid cross-run flakiness.
 - Use JUnit 5. Migrate JUnit 4 tests when modifying them.
+- Do not add a class-level `@DisplayName` to a new `@Nested` test class while the repo is on
+  Surefire 3.5.x (`plugin.version.surefire` in `parent/pom.xml`) — a Surefire 3.5.3regression
+  reports such classes under their flattened display name instead of their fully-qualified name in
+  the XML test report, breaking FQN-based tooling (flaky-test tracking, CI report parsing). Method-
+  level `@DisplayName` (on `@Test`/`@ParameterizedTest`) is unaffected. Existing occurrences were
+  commented out rather than deleted — leave that pattern in place until Surefire is upgraded past
+  the regression.
 - Detailed guide: `docs/testing.md` and `docs/testing/`.
 - Reference example: `qa/acceptance-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java`
 

--- a/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.engine.EngineConfiguration;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +22,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class EngineMappingsTest {
 
   @Nested
-  @DisplayName("Default configuration")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Default configuration")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
     BrokerBasedPropertiesOverride.class,
@@ -51,7 +51,8 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  @DisplayName("Explicit property overrides")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Explicit property overrides")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
     BrokerBasedPropertiesOverride.class,
@@ -77,7 +78,8 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  @DisplayName("Comparison mode")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Comparison mode")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
     BrokerBasedPropertiesOverride.class,
@@ -104,7 +106,8 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  @DisplayName("Output mode override (ORDERED)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Output mode override (ORDERED)")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
     BrokerBasedPropertiesOverride.class,

--- a/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class EngineMappingsTest {
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Default configuration")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
@@ -51,7 +51,7 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Explicit property overrides")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
@@ -78,7 +78,7 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Comparison mode")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
@@ -106,7 +106,7 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Output mode override (ORDERED)")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,

--- a/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMappingsTest.java
@@ -130,7 +130,8 @@ public class EngineMappingsTest {
   }
 
   @Nested
-  @DisplayName("Output comparison mode")
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
+  // @DisplayName("Output comparison mode")
   @SpringJUnitConfig({
     UnifiedConfiguration.class,
     BrokerBasedPropertiesOverride.class,

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -39,7 +39,8 @@ class AgentInstanceRequestValidatorTest {
   private final AgentInstanceRequestValidator validator = new AgentInstanceRequestValidator();
 
   @Nested
-  @DisplayName("Existing update rules")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Existing update rules")
   class ExistingUpdateRuleTest {
 
     @Test
@@ -94,7 +95,8 @@ class AgentInstanceRequestValidatorTest {
   }
 
   @Nested
-  @DisplayName("History batch rules")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("History batch rules")
   class HistoryBatchRuleTest {
 
     @Test
@@ -1075,7 +1077,8 @@ class AgentInstanceRequestValidatorTest {
   }
 
   @Nested
-  @DisplayName("Create request rules")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Create request rules")
   class CreateRequestRuleTest {
 
     private AgentInstanceCreationRequest validRequest(final String jobKey) {

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -39,7 +39,7 @@ class AgentInstanceRequestValidatorTest {
   private final AgentInstanceRequestValidator validator = new AgentInstanceRequestValidator();
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Existing update rules")
   class ExistingUpdateRuleTest {
 
@@ -95,7 +95,7 @@ class AgentInstanceRequestValidatorTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("History batch rules")
   class HistoryBatchRuleTest {
 
@@ -1077,7 +1077,7 @@ class AgentInstanceRequestValidatorTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Create request rules")
   class CreateRequestRuleTest {
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -250,7 +250,7 @@
     <plugin.version.shade>3.6.2</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.8.3</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.2</plugin.version.surefire>
+    <plugin.version.surefire>3.5.6</plugin.version.surefire>
     <plugin.version.versions>2.21.0</plugin.version.versions>
     <plugin.version.frontend-maven>2.0.2</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.4.0</plugin.version.maven-source>

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -81,7 +81,6 @@ import java.util.stream.Stream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -884,7 +883,8 @@ public final class ProcessInstanceServiceTest {
   }
 
   @Nested
-  @DisplayName("Retry on different partitions")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Retry on different partitions")
   class RetryPartitionsTest {
 
     private static Stream<Named<Throwable>> retryableErrors() {

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -883,7 +883,7 @@ public final class ProcessInstanceServiceTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Retry on different partitions")
   class RetryPartitionsTest {
 

--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessNestedUnitTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessNestedUnitTest.java
@@ -44,7 +44,7 @@ public class ProcessNestedUnitTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Happy path tests")
   class HappyPathTests {
 

--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessNestedUnitTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ProcessNestedUnitTest.java
@@ -44,7 +44,8 @@ public class ProcessNestedUnitTest {
   }
 
   @Nested
-  @DisplayName("Happy path tests")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Happy path tests")
   class HappyPathTests {
 
     @DisplayName("The happy path")

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -200,7 +200,7 @@ class MetricsExporterTest {
 
   //
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("MetricsExporter should configure a Filter")
   class FilterTest {
 
@@ -272,7 +272,7 @@ class MetricsExporterTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("MetricsExporter records variable metrics")
   class VariableMetricsTest {
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -200,7 +200,8 @@ class MetricsExporterTest {
 
   //
   @Nested
-  @DisplayName("MetricsExporter should configure a Filter")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("MetricsExporter should configure a Filter")
   class FilterTest {
 
     static Stream<TypeCombination> acceptedCombinations() {
@@ -271,7 +272,8 @@ class MetricsExporterTest {
   }
 
   @Nested
-  @DisplayName("MetricsExporter records variable metrics")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("MetricsExporter records variable metrics")
   class VariableMetricsTest {
 
     private static final String BPMN_PROCESS_ID = "process";

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
@@ -208,7 +208,7 @@ class DmnEvaluatedDecisionsTest {
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("If successfully evaluated, the decision")
   class DecisionTypeTests {
 
@@ -255,7 +255,7 @@ class DmnEvaluatedDecisionsTest {
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("If successfully evaluated, the decision table")
   class DecisionTableTest {
 

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
@@ -208,7 +208,8 @@ class DmnEvaluatedDecisionsTest {
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  @DisplayName("If successfully evaluated, the decision")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("If successfully evaluated, the decision")
   class DecisionTypeTests {
 
     private static final String DECISION_TYPES_DRG = "/drg-decision-types.dmn";
@@ -254,7 +255,8 @@ class DmnEvaluatedDecisionsTest {
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  @DisplayName("If successfully evaluated, the decision table")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("If successfully evaluated, the decision table")
   class DecisionTableTest {
 
     // This drg contains different decision tables, each with a special case

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
@@ -157,7 +157,8 @@ class DmnEvaluationTest {
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  @DisplayName("If successfully evaluated, the output")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("If successfully evaluated, the output")
   class OutputTests {
 
     Stream<Arguments> outputs() {

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
@@ -157,7 +157,7 @@ class DmnEvaluationTest {
 
   @Nested
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("If successfully evaluated, the output")
   class OutputTests {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.el.impl.StaticExpression;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,7 +20,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ZeebeExpressionValidatorTest {
 
   @Nested
-  @DisplayName("ZeebeExpressionValidator.isListOfCsv(Expression)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("ZeebeExpressionValidator.isListOfCsv(Expression)")
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
   class IsListOfValues {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ZeebeExpressionValidatorTest {
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("ZeebeExpressionValidator.isListOfCsv(Expression)")
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
   class IsListOfValues {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -464,10 +464,12 @@ class InputMappingResolverComparisonTest {
   // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
   // @DisplayName(
   //    "Rule 8: types survive across input mappings within one resolver context, but not when"
-  //        + " written through MsgPack (confirmed bug camunda/camunda#60011). OrderedMappingResolver"
+  //        + " written through MsgPack (confirmed bug camunda/camunda#60011).
+  // OrderedMappingResolver"
   //        + " is the broken party here: it loses the FEEL type at every mapping boundary via the"
   //        + " MsgPack round-trip. CombinedMappingResolver evaluates all mappings in one FEEL"
-  //        + " context expression, so the type survives. When input-comparison-mode=ORDERED is used"
+  //        + " context expression, so the type survives. When input-comparison-mode=ORDERED is
+  // used"
   //        + " with the COMBINED default, any mapping that reads a FEEL-typed value set by an"
   //        + " earlier mapping WILL trigger comparison warnings -- that is expected and correct."
   //        + " These tests will need updating once #60011 is fixed.")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -354,7 +354,8 @@ class InputMappingResolverComparisonTest {
   // @DisplayName(
   //    "Rule 7: variables from a higher scope are partially shadowed by input mappings"
   //        + " (OrderedInputMappingResolver already implements this correctly; the gap is in"
-  //        + " CombinedInputMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
+  //        + " CombinedInputMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses
+  // an"
   //        + " ancestor's untouched sibling once that object's root has been partially mapped)")
   class Rule7PartiallyShadowsHigherScope {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -80,7 +80,7 @@ class InputMappingResolverComparisonTest {
   private static final CombinedInputMappingResolver LEGACY = new CombinedInputMappingResolver();
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Rule 1: an input mapping creates a local variable")
   class Rule1CreatesALocalVariable {
 
@@ -99,7 +99,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Rule 2: a source can reference variables from a higher scope")
   class Rule2ReadsFromAHigherScope {
 
@@ -135,7 +135,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Rule 3: an unresolvable source yields null, it does not raise an incident")
   class Rule3UnresolvableSourceYieldsNull {
 
@@ -154,7 +154,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Rule 4: input mappings build the local context")
   class Rule4BuildsTheLocalContext {
 
@@ -186,7 +186,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Rule 5: input mappings are evaluated in the order they are defined in")
   class Rule5EvaluatedInDeclarationOrder {
 
@@ -288,7 +288,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Rule 6: later input mappings can replace earlier input mappings")
   class Rule6LaterReplacesEarlier {
 
@@ -350,7 +350,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName(
   //    "Rule 7: variables from a higher scope are partially shadowed by input mappings"
   //        + " (OrderedMappingResolver already implements this correctly; the gap is in"
@@ -461,7 +461,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName(
   //    "Rule 8: types survive across input mappings within one resolver context, but not when"
   //        + " written through MsgPack (confirmed bug camunda/camunda#60011).
@@ -519,7 +519,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("issue #60551 regression coverage (not one of the doc's numbered rules)")
   class Issue60551RegressionCoverage {
 
@@ -570,7 +570,7 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("additional regression coverage not addressed by the rules doc")
   class AdditionalCoverageBeyondTheRulesDoc {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -353,8 +353,8 @@ class InputMappingResolverComparisonTest {
   // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName(
   //    "Rule 7: variables from a higher scope are partially shadowed by input mappings"
-  //        + " (OrderedMappingResolver already implements this correctly; the gap is in"
-  //        + " CombinedMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
+  //        + " (OrderedInputMappingResolver already implements this correctly; the gap is in"
+  //        + " CombinedInputMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
   //        + " ancestor's untouched sibling once that object's root has been partially mapped)")
   class Rule7PartiallyShadowsHigherScope {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -80,7 +80,8 @@ class InputMappingResolverComparisonTest {
   private static final CombinedInputMappingResolver LEGACY = new CombinedInputMappingResolver();
 
   @Nested
-  @DisplayName("Rule 1: an input mapping creates a local variable")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Rule 1: an input mapping creates a local variable")
   class Rule1CreatesALocalVariable {
 
     @Test
@@ -98,7 +99,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Rule 2: a source can reference variables from a higher scope")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Rule 2: a source can reference variables from a higher scope")
   class Rule2ReadsFromAHigherScope {
 
     @Test
@@ -133,7 +135,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Rule 3: an unresolvable source yields null, it does not raise an incident")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Rule 3: an unresolvable source yields null, it does not raise an incident")
   class Rule3UnresolvableSourceYieldsNull {
 
     @Test
@@ -151,7 +154,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Rule 4: input mappings build the local context")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Rule 4: input mappings build the local context")
   class Rule4BuildsTheLocalContext {
 
     @Test
@@ -182,7 +186,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Rule 5: input mappings are evaluated in the order they are defined in")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Rule 5: input mappings are evaluated in the order they are defined in")
   class Rule5EvaluatedInDeclarationOrder {
 
     @Test
@@ -283,7 +288,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Rule 6: later input mappings can replace earlier input mappings")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Rule 6: later input mappings can replace earlier input mappings")
   class Rule6LaterReplacesEarlier {
 
     @Test
@@ -344,11 +350,12 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName(
-      "Rule 7: variables from a higher scope are partially shadowed by input mappings"
-          + " (OrderedInputMappingResolver already implements this correctly; the gap is in"
-          + " CombinedInputMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
-          + " ancestor's untouched sibling once that object's root has been partially mapped)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName(
+  //    "Rule 7: variables from a higher scope are partially shadowed by input mappings"
+  //        + " (OrderedMappingResolver already implements this correctly; the gap is in"
+  //        + " CombinedMappingResolver/8.9.0's combined-FEEL-context evaluation, which loses an"
+  //        + " ancestor's untouched sibling once that object's root has been partially mapped)")
   class Rule7PartiallyShadowsHigherScope {
 
     @Test
@@ -454,15 +461,16 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName(
-      "Rule 8: types survive across input mappings within one resolver context, but not when"
-          + " written through MsgPack (confirmed bug camunda/camunda#60011). OrderedInputMappingResolver"
-          + " is the broken party here: it loses the FEEL type at every mapping boundary via the"
-          + " MsgPack round-trip. CombinedInputMappingResolver evaluates all mappings in one FEEL"
-          + " context expression, so the type survives. When input-comparison-mode=ORDERED is used"
-          + " with the COMBINED default, any mapping that reads a FEEL-typed value set by an"
-          + " earlier mapping WILL trigger comparison warnings -- that is expected and correct."
-          + " These tests will need updating once #60011 is fixed.")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName(
+  //    "Rule 8: types survive across input mappings within one resolver context, but not when"
+  //        + " written through MsgPack (confirmed bug camunda/camunda#60011). OrderedMappingResolver"
+  //        + " is the broken party here: it loses the FEEL type at every mapping boundary via the"
+  //        + " MsgPack round-trip. CombinedMappingResolver evaluates all mappings in one FEEL"
+  //        + " context expression, so the type survives. When input-comparison-mode=ORDERED is used"
+  //        + " with the COMBINED default, any mapping that reads a FEEL-typed value set by an"
+  //        + " earlier mapping WILL trigger comparison warnings -- that is expected and correct."
+  //        + " These tests will need updating once #60011 is fixed.")
   class Rule8TypesSurviveAcrossMappingsNotVariables {
 
     @Test
@@ -509,7 +517,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("issue #60551 regression coverage (not one of the doc's numbered rules)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("issue #60551 regression coverage (not one of the doc's numbered rules)")
   class Issue60551RegressionCoverage {
 
     @Test
@@ -559,7 +568,8 @@ class InputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("additional regression coverage not addressed by the rules doc")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("additional regression coverage not addressed by the rules doc")
   class AdditionalCoverageBeyondTheRulesDoc {
 
     @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/InputMappingResolverComparisonTest.java
@@ -466,9 +466,9 @@ class InputMappingResolverComparisonTest {
   // @DisplayName(
   //    "Rule 8: types survive across input mappings within one resolver context, but not when"
   //        + " written through MsgPack (confirmed bug camunda/camunda#60011).
-  // OrderedMappingResolver"
+  // OrderedInputMappingResolver"
   //        + " is the broken party here: it loses the FEEL type at every mapping boundary via the"
-  //        + " MsgPack round-trip. CombinedMappingResolver evaluates all mappings in one FEEL"
+  //        + " MsgPack round-trip. CombinedInputMappingResolver evaluates all mappings in one FEEL"
   //        + " context expression, so the type survives. When input-comparison-mode=ORDERED is
   // used"
   //        + " with the COMBINED default, any mapping that reads a FEEL-typed value set by an"

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolverComparisonTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/OutputMappingResolverComparisonTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +43,8 @@ class OutputMappingResolverComparisonTest {
   private static final CombinedOutputMappingResolver COMBINED = new CombinedOutputMappingResolver();
 
   @Nested
-  @DisplayName("Non-overlapping targets")
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
+  // @DisplayName("Non-overlapping targets")
   class NonOverlappingTargets {
     @Test
     void shouldProduceSameResultForDistinctTargets() {
@@ -57,7 +57,8 @@ class OutputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Duplicate target with intermediate read")
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
+  // @DisplayName("Duplicate target with intermediate read")
   class DuplicateTargetWithIntermediateRead {
     @Test
     void shouldDifferOnIntermediateValueVisibility() {
@@ -73,7 +74,8 @@ class OutputMappingResolverComparisonTest {
   }
 
   @Nested
-  @DisplayName("Nested target scope seeding")
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
+  // @DisplayName("Nested target scope seeding")
   class NestedTargetScopeSeeding {
     @Test
     void shouldPreserveSiblingKeysForNestedTarget() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
@@ -62,7 +62,7 @@ final class StateQueryServiceTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("getBpmnProcessIdForProcess(processKey)")
   final class GetBpmnProcessIdForProcess {
 
@@ -95,7 +95,7 @@ final class StateQueryServiceTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("getBpmnProcessIdForProcessInstance(processInstanceKey)")
   final class GetBpmnProcessIdForProcessInstance {
 
@@ -130,7 +130,7 @@ final class StateQueryServiceTest {
   }
 
   @Nested
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("getBpmnProcessIdForJob(jobKey)")
   class GetBpmnProcessIdForJob {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
@@ -62,7 +62,8 @@ final class StateQueryServiceTest {
   }
 
   @Nested
-  @DisplayName("getBpmnProcessIdForProcess(processKey)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("getBpmnProcessIdForProcess(processKey)")
   final class GetBpmnProcessIdForProcess {
 
     @Test
@@ -94,7 +95,8 @@ final class StateQueryServiceTest {
   }
 
   @Nested
-  @DisplayName("getBpmnProcessIdForProcessInstance(processInstanceKey)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("getBpmnProcessIdForProcessInstance(processInstanceKey)")
   final class GetBpmnProcessIdForProcessInstance {
 
     @Test
@@ -128,7 +130,8 @@ final class StateQueryServiceTest {
   }
 
   @Nested
-  @DisplayName("getBpmnProcessIdForJob(jobKey)")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("getBpmnProcessIdForJob(jobKey)")
   class GetBpmnProcessIdForJob {
 
     @Test

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -202,7 +202,8 @@ class EitherTest {
     }
   }
 
-  @DisplayName("Streams of Eithers can be collected using .collector()")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Streams of Eithers can be collected using .collector()")
   @Nested
   class CollectorTests {
 
@@ -238,7 +239,8 @@ class EitherTest {
     }
   }
 
-  @DisplayName("Streams of Eithers can be collected using .collectorFoldingLeft()")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("Streams of Eithers can be collected using .collectorFoldingLeft()")
   @Nested
   class CollectorFoldingLeftTests {
 
@@ -271,7 +273,8 @@ class EitherTest {
     }
   }
 
-  @DisplayName("`thenDo` method tests")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("`thenDo` method tests")
   @Nested
   class ThenDoMethodTests {
 
@@ -306,7 +309,8 @@ class EitherTest {
     }
   }
 
-  @DisplayName("`fold` method tests")
+  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName("`fold` method tests")
   @Nested
   class FoldMethodTests {
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -202,7 +202,7 @@ class EitherTest {
     }
   }
 
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Streams of Eithers can be collected using .collector()")
   @Nested
   class CollectorTests {
@@ -239,7 +239,7 @@ class EitherTest {
     }
   }
 
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("Streams of Eithers can be collected using .collectorFoldingLeft()")
   @Nested
   class CollectorFoldingLeftTests {
@@ -273,7 +273,7 @@ class EitherTest {
     }
   }
 
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("`thenDo` method tests")
   @Nested
   class ThenDoMethodTests {
@@ -309,7 +309,7 @@ class EitherTest {
     }
   }
 
-  // @DisplayName can't be used on @Nested classes with surefire 3.5.6, see PR description
+  // @DisplayName can't be used on @Nested classes with this Surefire version, see AGENTS.md
   // @DisplayName("`fold` method tests")
   @Nested
   class FoldMethodTests {


### PR DESCRIPTION
## Description

Bumps plugin.version.surefire from 3.5.2 to 3.5.6 in [parent/pom.xml](vscode-webview://0flkg8sjql9mpislfeul6oorrhsch2g7644vdf5266te2s9jtc4q/parent/pom.xml#L252).

3.5.6 fixes the two issues that pinned us to 3.5.2 — the 3.5.3 bug that silently skipped ArchUnit tests, and the 3.5.4 inner-class report bug ([apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203)) that made test retries target the wrong tests.

One regression remains in 3.5.6: a `@Nested` class carrying a class-level `@DisplayName` is reported in target/surefire-reports/*.xml under its flattened display name instead of its fully-qualified name, which breaks our FQN-based tooling (flaky-test tracking, CI report parsing). To work around it, class-level `@DisplayName` annotations on `@Nested` classes are commented out rather than deleted, so they can be restored in one pass once upstream fixes the report naming. Method-level `@DisplayName` (on `@Test/@ParameterizedTest)``] is unaffected and left untouched.

Changes

- parent/pom.xml — Surefire 3.5.2 → 3.5.6
- Commented out class-level @DisplayName on @Nested classes across 9 test classes (configuration, gateway-mapping-http, service, camunda-process-test-example, broker, dmn, engine)
- AGENTS.md — testing convention documenting the restriction and why the annotations are commented out rather than removed
- .github/renovate.json5 — updated the Surefire package rule description and expanded the manual-verification checklist to all three known issues, so the next bump is checked against each

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

related to #INC-7122

- [x] This PR does not need a linked issue

