### PR TITLE
Gate agentic tests on agent definition, not job type prefix

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -68,11 +68,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
@@ -24,7 +24,6 @@ import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
 import org.awaitility.Awaitility;
@@ -43,6 +42,7 @@ public class AuditLogAgentIT {
           .withAuthenticatedAccess();
 
   private static final String AGENT_ELEMENT_ID = "test_agent_ahsp";
+  private static final String AGENT_JOB_TYPE = "agent-job";
   private static final String EXTERNAL_AGENT_ELEMENT_ID = "external_agent_service_task";
   private static final String EXTERNAL_AGENT_JOB_TYPE = "external-agent-job";
   private static CamundaClient adminClient;
@@ -54,7 +54,8 @@ public class AuditLogAgentIT {
         Bpmn.createExecutableProcess("AGENT_PROCESS")
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("A1"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
+            .zeebeAiAgentSubProcessDefinition()
             .endEvent("error")
             .moveToActivity(AGENT_ELEMENT_ID)
             .endEvent("end")
@@ -129,8 +130,7 @@ public class AuditLogAgentIT {
             auditLog -> {
               assertThat(auditLog.getActorType()).isEqualTo(AuditLogActorTypeEnum.USER);
               assertThat(auditLog.getActorId()).isEqualTo(DEFAULT_USERNAME);
-              assertThat(auditLog.getEntityDescription())
-                  .isEqualTo(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);
+              assertThat(auditLog.getEntityDescription()).isEqualTo(AGENT_JOB_TYPE);
               assertThat(auditLog.getAgentElementId()).isEqualTo(AGENT_ELEMENT_ID);
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -35,7 +35,6 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -52,6 +51,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 class AgentInstanceAuthorizationIT {
 
   private static final String AGENT_ELEMENT_ID = "agentAuthElement";
+  private static final String AGENT_JOB_TYPE = "agent-task";
   private static final String PROCESS_ID_1 = "agentAuthProcess1";
   private static final String PROCESS_ID_2 = "agentAuthProcess2";
   private static final String PROCESS_ID_3 = "agentAuthProcess3";
@@ -419,7 +419,7 @@ class AgentInstanceAuthorizationIT {
         Bpmn.createExecutableProcess(processId)
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
             .zeebeAiAgentSubProcessDefinition()
             .endEvent()
             .done();
@@ -444,7 +444,7 @@ class AgentInstanceAuthorizationIT {
     final var activatedJobs =
         adminClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
             .send()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -30,7 +30,6 @@ import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -46,6 +45,7 @@ public class AgentHistoryCommitLifecycleIT {
 
   private static final String SERVICE_TASK_ID = "agentTask";
   private static final String PROCESS_ID = "agentHistoryCommitLifecycleProcess";
+  private static final String AGENT_JOB_TYPE = "agent-task";
 
   private static CamundaClient camundaClient;
 
@@ -640,10 +640,7 @@ public class AgentHistoryCommitLifecycleIT {
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .serviceTask(
-                SERVICE_TASK_ID,
-                t ->
-                    t.zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
-                        .zeebeAiAgentTaskDefinition())
+                SERVICE_TASK_ID, t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
             .endEvent()
             .done();
 
@@ -676,7 +673,7 @@ public class AgentHistoryCommitLifecycleIT {
     final var activatedJob =
         camundaClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .withLease(true)
             .timeout(Duration.ofMinutes(5))
@@ -723,7 +720,7 @@ public class AgentHistoryCommitLifecycleIT {
     final var activatedJobs =
         camundaClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .withLease(withLease)
             .timeout(Duration.ofMinutes(5))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -305,7 +305,7 @@ public class AgentHistoryCommitLifecycleIT {
             .serviceTask(
                 SERVICE_TASK_ID,
                 t ->
-                    t.zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                    t.zeebeJobType(AGENT_JOB_TYPE)
                         .zeebeAiAgentTaskDefinition()
                         .multiInstance(
                             m ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -34,7 +34,6 @@ import io.camunda.client.api.search.response.AgentInstance.Tool;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -47,6 +46,7 @@ import org.junit.jupiter.api.Test;
 public class AgentInstanceFetchIT {
 
   private static final String AGENT_ELEMENT_ID = "agentAhsp";
+  private static final String AGENT_JOB_TYPE = "agent-task";
 
   private static CamundaClient camundaClient;
 
@@ -66,7 +66,7 @@ public class AgentInstanceFetchIT {
         Bpmn.createExecutableProcess("AgentInstanceFetchProcess")
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
             .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
@@ -216,7 +216,7 @@ public class AgentInstanceFetchIT {
     final var activatedJobs =
         camundaClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
             .send()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistoryDedupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistoryDedupIT.java
@@ -20,7 +20,6 @@ import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -40,7 +39,7 @@ public class AgentInstanceHistoryDedupIT {
 
   private static final String AGENT_ELEMENT_ID = "agentDedupElement";
   private static final String PROCESS_ID = "agentHistoryDedupProcess";
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String JOB_TYPE = "agent-task";
 
   private static CamundaClient camundaClient;
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -553,7 +553,7 @@ public class AgentInstanceHistorySearchIT {
     final var activatedJobs =
         camundaClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .withLease(true)
             .timeout(Duration.ofMinutes(5))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -25,7 +25,6 @@ import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -43,6 +42,7 @@ public class AgentInstanceHistorySearchIT {
 
   private static final String AGENT_ELEMENT_ID = "agentHistorySearchElement";
   private static final String PROCESS_ID = "agentHistorySearchProcess";
+  private static final String AGENT_JOB_TYPE = "agent-task";
 
   private static CamundaClient camundaClient;
 
@@ -61,7 +61,7 @@ public class AgentInstanceHistorySearchIT {
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
             .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
@@ -89,7 +89,7 @@ public class AgentInstanceHistorySearchIT {
     final var activatedJobs =
         camundaClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .withLease(true)
             .timeout(Duration.ofMinutes(5))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceSearchIT.java
@@ -25,7 +25,6 @@ import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.Test;
 public class AgentInstanceSearchIT {
 
   private static final String AGENT_ELEMENT_ID = "agentAhsp";
+  private static final String AGENT_JOB_TYPE = "agent-task";
 
   private static CamundaClient camundaClient;
 
@@ -64,7 +64,7 @@ public class AgentInstanceSearchIT {
         Bpmn.createExecutableProcess("AgentInstanceSearchProcess1")
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
             .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
@@ -79,7 +79,7 @@ public class AgentInstanceSearchIT {
         Bpmn.createExecutableProcess("AgentInstanceSearchProcess2")
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
             .zeebeAiAgentSubProcessDefinition()
             .endEvent("end")
             .done();
@@ -178,7 +178,7 @@ public class AgentInstanceSearchIT {
     final var activatedJob =
         camundaClient
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .withLease(true)
             .timeout(Duration.ofMinutes(5))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historydeletion/DeleteProcessDefinitionHistoryIT.java
@@ -34,7 +34,6 @@ import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
 import io.camunda.search.query.AgentDefinitionQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
@@ -66,6 +65,7 @@ public class DeleteProcessDefinitionHistoryIT {
 
   private static final Duration DELETION_TIMEOUT = Duration.ofSeconds(30);
   private static final String AGENT_ELEMENT_ID = "agentAhsp";
+  private static final String AGENT_JOB_TYPE = "agent-task";
   private static final String AGENT_ELEMENT_ID_V1_1 = "agentAhspV1First";
   private static final String AGENT_ELEMENT_ID_V1_2 = "agentAhspV1Second";
   private static CamundaClient camundaClient;
@@ -574,10 +574,10 @@ public class DeleteProcessDefinitionHistoryIT {
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .adHocSubProcess(AGENT_ELEMENT_ID_V1_1, p -> p.task("agentTask1"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .adHocSubProcess(AGENT_ELEMENT_ID_V1_2, p -> p.task("agentTask2"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent("end")
                 .done(),
@@ -590,7 +590,7 @@ public class DeleteProcessDefinitionHistoryIT {
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTaskV2"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent("end")
                 .done(),
@@ -611,7 +611,7 @@ public class DeleteProcessDefinitionHistoryIT {
             Bpmn.createExecutableProcess(otherProcessId)
                 .startEvent()
                 .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent("end")
                 .done(),
@@ -648,7 +648,7 @@ public class DeleteProcessDefinitionHistoryIT {
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent("end")
                 .done(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -24,7 +24,6 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -39,6 +38,8 @@ import org.junit.jupiter.api.Test;
 @MultiDbTest
 public class AgentInstanceMigrationIT {
 
+  private static final String AGENT_JOB_TYPE = "agent-task";
+
   private static CamundaClient client;
 
   @Test
@@ -49,7 +50,6 @@ public class AgentInstanceMigrationIT {
     final String targetElementId = "agentTask2";
     final String sourceNextElementId = "nextTask";
     final String targetNextElementId = "nextTask2";
-    final String agentJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
 
     final var sourceProcess =
         deployProcessAndWaitForIt(
@@ -57,7 +57,8 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-service-task_v1")
                 .startEvent()
                 .serviceTask(
-                    sourceElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
+                    sourceElementId,
+                    t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .userTask(sourceNextElementId)
                 .endEvent()
                 .done(),
@@ -68,7 +69,8 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-service-task_v2")
                 .startEvent()
                 .serviceTask(
-                    targetElementId, t -> t.zeebeJobType(agentJobType).zeebeAiAgentTaskDefinition())
+                    targetElementId,
+                    t -> t.zeebeJobType(AGENT_JOB_TYPE).zeebeAiAgentTaskDefinition())
                 .userTask(targetNextElementId)
                 .endEvent()
                 .done(),
@@ -80,7 +82,7 @@ public class AgentInstanceMigrationIT {
     final long sourceAgentDefinitionKey =
         client.newAgentInstanceGetRequest(agentInstanceKey).execute().getAgentDefinitionKey();
 
-    activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
+    activateAndCompleteJobs(client, AGENT_JOB_TYPE, "test-worker", 1);
     waitForElementInstances(
         client, f -> f.elementId(sourceNextElementId).processInstanceKey(processInstanceKey), 1);
 
@@ -113,7 +115,7 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-ahsp_v1")
                 .startEvent()
                 .adHocSubProcess(sourceElementId, p -> p.task("agentTask"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent()
                 .done(),
@@ -124,7 +126,7 @@ public class AgentInstanceMigrationIT {
             Bpmn.createExecutableProcess("migration-agent-ahsp_v2")
                 .startEvent()
                 .adHocSubProcess(targetElementId, p -> p.task("agentTask2"))
-                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .zeebeJobType(AGENT_JOB_TYPE)
                 .zeebeAiAgentSubProcessDefinition()
                 .endEvent()
                 .done(),
@@ -170,7 +172,7 @@ public class AgentInstanceMigrationIT {
     final var activatedJob =
         client
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .timeout(Duration.ofMinutes(5))
             .send()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -25,7 +25,6 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -41,6 +40,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class AgentInstanceTenancyIT {
 
   private static final String AGENT_ELEMENT_ID = "agentTenancyElement";
+  private static final String AGENT_JOB_TYPE = "agent-task";
   private static final String PROCESS_ID = "agentTenancyProcess";
   private static final String ADMIN = "admin";
   private static final String USER1 = "user1";
@@ -85,7 +85,7 @@ public class AgentInstanceTenancyIT {
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .adHocSubProcess(AGENT_ELEMENT_ID, p -> p.task("agentTask"))
-            .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .zeebeJobType(AGENT_JOB_TYPE)
             .zeebeAiAgentSubProcessDefinition()
             .endEvent()
             .done();
@@ -400,7 +400,7 @@ public class AgentInstanceTenancyIT {
     final var activatedJobs =
         client
             .newActivateJobsCommand()
-            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .jobType(AGENT_JOB_TYPE)
             .maxJobsToActivate(1)
             .tenantIds(tenantId)
             .timeout(Duration.ofMinutes(5))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -33,7 +32,7 @@ public class AgentHistoryCommitTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String JOB_TYPE = "agentic-task";
   private static final String EXTERNAL_SERVICE_TASK_PROCESS_ID = "external-agent-service-task";
   private static final String EXTERNAL_SERVICE_TASK_ID = "external-agent-task";
   private static final String EXTERNAL_SERVICE_TASK_JOB_TYPE = "external-agent-job";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -34,7 +33,7 @@ public class AgentHistoryCreateTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String JOB_TYPE = "agentic-task";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -41,8 +41,7 @@ public class AgentHistoryDiscardOnJobDestructionTest {
   private static final String SERVICE_TASK_ID = "agent-task";
   private static final String BOUNDARY_ID = "error-boundary";
   private static final String ERROR_CODE = "boom";
-  private static final String AGENTIC_JOB_TYPE =
-      JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String AGENTIC_JOB_TYPE = "agentic-task";
   private static final String PLAIN_JOB_TYPE = "plain-service-task";
   private static final String EXTERNAL_AGENT_JOB_TYPE = "external-agent-task";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -35,7 +34,7 @@ public class AgentHistoryDiscardTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String JOB_TYPE = "agentic-task";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryItemIdPersistenceTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -40,7 +39,7 @@ public class AgentHistoryItemIdPersistenceTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String JOB_TYPE = "agentic-task";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -58,7 +57,7 @@ public class AgentHistorySuspensionGateTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
-  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String JOB_TYPE = "agentic-task";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteOnProcessInstanceLifecycleTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -40,8 +39,7 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
 
   private static final String PROCESS_ID = "process";
   private static final String AGENT_TASK_ID = "agent-task";
-  private static final String AGENT_JOB_TYPE =
-      JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX + "-agent-instance-complete-test";
+  private static final String AGENT_JOB_TYPE = "agent-instance-complete-test";
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
@@ -205,7 +203,7 @@ public class AgentInstanceCompleteOnProcessInstanceLifecycleTest {
   public void
       shouldDiscardPendingAgentHistoryBeforeCompletingAgentInstanceWhenProcessInstanceCanceled() {
     // given
-    final String agenticJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+    final String agenticJobType = "discard-pending-agent-history-test";
     ENGINE
         .deployment()
         .withXmlResource(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -1180,7 +1180,8 @@ public class JobBasedAdHocSubProcessTest {
 
   @Test
   public void shouldCompleteAgenticJobWithFollowupMetadata() {
-    // given
+    // given — the legacy agentic job type prefix, with no agent definition anywhere; this
+    // exercises the 8.9 compatibility fallback in JobCompleteProcessor#hasAgenticPrefix()
     final var jobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
     final BpmnModelInstance process =
         process(jobType, adHocSubProcess -> adHocSubProcess.task("A1").task("A2"));
@@ -1199,6 +1200,45 @@ public class JobBasedAdHocSubProcessTest {
                     r ->
                         r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
                             && r.getKey() == processInstanceKey))
+        .describedAs(
+            "the legacy agentic job type prefix alone, without any agent definition, must still "
+                + "carry the agent element id on follow-up records")
+        .isNotEmpty()
+        .allMatch(r -> AHSP_ELEMENT_ID.equals(r.getAgent().getElementId()));
+  }
+
+  @Test
+  public void shouldCompleteJobWithFollowupMetadataWhenAdHocSubProcessHasAgentDefinition() {
+    // given — a job type that does not carry the legacy agentic prefix; only the ad-hoc
+    // sub-process's own agent definition marks it as agentic
+    final var jobType = "ahsp-agent-task";
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(
+                AHSP_ELEMENT_ID, adHocSubProcess -> adHocSubProcess.task("A1").task("A2"))
+            .zeebeJobType(jobType)
+            .zeebeAiAgentSubProcessDefinition()
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var jobCompleted = completeJob(jobType, true, Map.of("bar", "foo"));
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .withSourceRecordPosition(jobCompleted.getSourceRecordPosition())
+                .between(
+                    l -> l.getIntent().equals(JobIntent.COMPLETED),
+                    r ->
+                        r.getIntent().equals(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                            && r.getKey() == processInstanceKey))
+        .describedAs(
+            "a job type not matching the legacy agentic prefix must still carry the agent "
+                + "element id when the ad-hoc sub-process has a resolved agent definition")
         .isNotEmpty()
         .allMatch(r -> AHSP_ELEMENT_ID.equals(r.getAgent().getElementId()));
   }


### PR DESCRIPTION
## Description

This PR updates agentic tests to use the resolved agent definition—not the legacy agentic job-type prefix—to determine whether a job is agentic.

Previously, some tests used the prefix, so they could still pass if job-type-based gating returned. They now use plain job types and explicitly configure `zeebeAiAgentTaskDefinition()` or `zeebeAiAgentSubProcessDefinition()` where needed.

Two engine tests intentionally retain the prefix to cover the deprecated `hasAgenticPrefix()` compatibility fallback tracked in #60860. This also adds missing ad-hoc sub-process coverage using a real agent definition.

## Related issues

closes #61629