### PR TITLE
Expose reasoning and cache token metrics through the agent instance REST API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -27,7 +27,7 @@ import io.camunda.client.api.command.AgentTool;
 import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
-import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetricsRequest;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
 import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
 import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
@@ -163,12 +163,12 @@ final class AgentInstanceHistoryMapper {
     return protocolToolCalls;
   }
 
-  static AgentInstanceHistoryItemMetrics toProtocolMetrics(
+  static AgentInstanceHistoryItemMetricsRequest toProtocolMetrics(
       final AgentInstanceHistoryMetrics metrics) {
     if (metrics == null) {
       return null;
     }
-    return new AgentInstanceHistoryItemMetrics()
+    return new AgentInstanceHistoryItemMetricsRequest()
         .inputTokens(metrics.getInputTokens())
         .outputTokens(metrics.getOutputTokens())
         .durationMs(metrics.getDurationMs());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -164,6 +164,15 @@ public class AgentInstanceMapper {
       if (metrics.getOutputTokens() != null) {
         recordMetrics.setOutputTokens(metrics.getOutputTokens());
       }
+      if (metrics.getReasoningTokenCount() != null) {
+        recordMetrics.setReasoningTokenCount(metrics.getReasoningTokenCount());
+      }
+      if (metrics.getCacheCreationTokenCount() != null) {
+        recordMetrics.setCacheCreationTokenCount(metrics.getCacheCreationTokenCount());
+      }
+      if (metrics.getCacheReadTokenCount() != null) {
+        recordMetrics.setCacheReadTokenCount(metrics.getCacheReadTokenCount());
+      }
       if (metrics.getDurationMs() != null) {
         recordMetrics.setDurationMs(metrics.getDurationMs());
       }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2173,10 +2173,14 @@ public final class SearchQueryResponseMapper {
             .build();
 
     final var m = entity.metrics();
+    // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
     final var metrics =
         AgentInstanceMetrics.Builder.create()
             .inputTokens(m.inputTokens())
             .outputTokens(m.outputTokens())
+            .reasoningTokenCount(0L)
+            .cacheCreationTokenCount(0L)
+            .cacheReadTokenCount(0L)
             .modelCalls(m.modelCalls())
             .toolCalls(m.toolCalls())
             .build();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2173,14 +2173,13 @@ public final class SearchQueryResponseMapper {
             .build();
 
     final var m = entity.metrics();
-    // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
     final var metrics =
         AgentInstanceMetrics.Builder.create()
             .inputTokens(m.inputTokens())
             .outputTokens(m.outputTokens())
-            .reasoningTokenCount(0L)
-            .cacheCreationTokenCount(0L)
-            .cacheReadTokenCount(0L)
+            .reasoningTokenCount(m.reasoningTokenCount())
+            .cacheCreationTokenCount(m.cacheCreationTokenCount())
+            .cacheReadTokenCount(m.cacheReadTokenCount())
             .modelCalls(m.modelCalls())
             .toolCalls(m.toolCalls())
             .build();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2271,10 +2271,14 @@ public final class SearchQueryResponseMapper {
     if (m == null) {
       metrics = null;
     } else {
+      // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
       metrics =
           AgentInstanceHistoryItemMetrics.Builder.create()
               .inputTokens(m.inputTokens())
               .outputTokens(m.outputTokens())
+              .reasoningTokenCount(null)
+              .cacheCreationTokenCount(null)
+              .cacheReadTokenCount(null)
               .durationMs(m.durationMs())
               .build();
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2271,14 +2271,13 @@ public final class SearchQueryResponseMapper {
     if (m == null) {
       metrics = null;
     } else {
-      // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
       metrics =
           AgentInstanceHistoryItemMetrics.Builder.create()
               .inputTokens(m.inputTokens())
               .outputTokens(m.outputTokens())
-              .reasoningTokenCount(null)
-              .cacheCreationTokenCount(null)
-              .cacheReadTokenCount(null)
+              .reasoningTokenCount(m.reasoningTokenCount())
+              .cacheCreationTokenCount(m.cacheCreationTokenCount())
+              .cacheReadTokenCount(m.cacheReadTokenCount())
               .durationMs(m.durationMs())
               .build();
     }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -151,6 +151,9 @@ class AgentInstanceMapperTest {
           AgentInstanceHistoryItemMetrics.Builder.create()
               .inputTokens(512L)
               .outputTokens(128L)
+              .reasoningTokenCount(64L)
+              .cacheCreationTokenCount(32L)
+              .cacheReadTokenCount(16L)
               .durationMs(1500L)
               .build());
       request.setHistory(List.of(item));
@@ -167,6 +170,9 @@ class AgentInstanceMapperTest {
       assertThat(mappedItem.getToolCalls().get(0).getToolName()).isEqualTo("extract_data");
       assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(512L);
       assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(128L);
+      assertThat(mappedItem.getMetrics().getReasoningTokenCount()).isEqualTo(64L);
+      assertThat(mappedItem.getMetrics().getCacheCreationTokenCount()).isEqualTo(32L);
+      assertThat(mappedItem.getMetrics().getCacheReadTokenCount()).isEqualTo(16L);
       assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(1500L);
       assertThat(mappedItem.getProducedAt())
           .isEqualTo(OffsetDateTime.parse("2025-06-01T12:00:00Z").toInstant().toEpochMilli());

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
-import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetrics;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetricsRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
 import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
@@ -148,7 +148,7 @@ class AgentInstanceMapperTest {
               .build();
       item.setToolCalls(List.of(toolCall));
       item.setMetrics(
-          AgentInstanceHistoryItemMetrics.Builder.create()
+          AgentInstanceHistoryItemMetricsRequest.Builder.create()
               .inputTokens(512L)
               .outputTokens(128L)
               .reasoningTokenCount(64L)

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1075,6 +1075,48 @@ class SearchQueryResponseMapperTest {
   }
 
   @Test
+  void shouldMapAllMetricsForAgentInstance() {
+    // given
+    final var entity =
+        new AgentInstanceEntity(
+            123L, // agentInstanceKey
+            654L, // agentDefinitionKey
+            List.of(456L), // elementInstanceKeys
+            AgentInstanceEntity.AgentInstanceStatus.IDLE,
+            new AgentInstanceEntity.AgentInstanceDefinition(
+                "gpt-4o",
+                "openai",
+                List.of(new ContentItem(ContentType.TEXT, "You are helpful", null, null))),
+            new AgentInstanceEntity.AgentInstanceMetrics(10L, 20L, 30L, 40L, 50L, 1, 2),
+            new AgentInstanceEntity.AgentInstanceLimits(1000L, 5, 6),
+            List.of(
+                new AgentInstanceEntity.AgentInstanceTool("search", "Web search", "searchTask")),
+            "agentElement", // elementId
+            789L, // processInstanceKey
+            999L, // rootProcessInstanceKey
+            321L, // processDefinitionKey
+            "processId", // processDefinitionId
+            1, // processDefinitionVersion
+            "v1", // versionTag
+            "tenant", // tenantId
+            OffsetDateTime.now(), // creationDate
+            OffsetDateTime.now(), // lastUpdatedDate
+            null); // completionDate
+
+    // when
+    final var response = SearchQueryResponseMapper.toAgentInstanceResult(entity);
+
+    // then
+    assertThat(response.getMetrics().getInputTokens()).isEqualTo(10);
+    assertThat(response.getMetrics().getOutputTokens()).isEqualTo(20);
+    assertThat(response.getMetrics().getReasoningTokenCount()).isEqualTo(30);
+    assertThat(response.getMetrics().getCacheCreationTokenCount()).isEqualTo(40);
+    assertThat(response.getMetrics().getCacheReadTokenCount()).isEqualTo(50);
+    assertThat(response.getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(response.getMetrics().getToolCalls()).isEqualTo(2);
+  }
+
+  @Test
   void shouldMapNullRootProcessInstanceKeyForVariableItem() {
     // given
     final var entity =

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1476,7 +1476,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.USER,
               List.of(new ContentItem(ContentType.TEXT, "Hello", null, null)),
               List.of(),
-              new Metrics(10L, 20L, null, null, null, 30L),
+              new Metrics(10L, 20L, 30L, 40L, 50L, 60L),
               null,
               null,
               null,
@@ -1500,7 +1500,10 @@ class SearchQueryResponseMapperTest {
       assertThat(result.getCommitStatus().getValue()).isEqualTo("COMMITTED");
       assertThat(result.getMetrics().getInputTokens()).isEqualTo(10);
       assertThat(result.getMetrics().getOutputTokens()).isEqualTo(20);
-      assertThat(result.getMetrics().getDurationMs()).isEqualTo(30);
+      assertThat(result.getMetrics().getReasoningTokenCount()).isEqualTo(30);
+      assertThat(result.getMetrics().getCacheCreationTokenCount()).isEqualTo(40);
+      assertThat(result.getMetrics().getCacheReadTokenCount()).isEqualTo(50);
+      assertThat(result.getMetrics().getDurationMs()).isEqualTo(60);
       assertThat(result.getContent()).hasSize(1);
       assertThat(result.getContent().get(0).getContentType()).isEqualTo("TEXT");
     }
@@ -1728,6 +1731,9 @@ class SearchQueryResponseMapperTest {
       assertThat(result.getMetrics()).isNotNull();
       assertThat(result.getMetrics().getInputTokens()).isEqualTo(100L);
       assertThat(result.getMetrics().getOutputTokens()).isEqualTo(200L);
+      assertThat(result.getMetrics().getReasoningTokenCount()).isNull();
+      assertThat(result.getMetrics().getCacheCreationTokenCount()).isNull();
+      assertThat(result.getMetrics().getCacheReadTokenCount()).isNull();
       assertThat(result.getMetrics().getDurationMs()).isNull();
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1196,6 +1196,9 @@ components:
       required:
         - inputTokens
         - outputTokens
+        - reasoningTokenCount
+        - cacheCreationTokenCount
+        - cacheReadTokenCount
         - durationMs
       properties:
         inputTokens:
@@ -1205,6 +1208,21 @@ components:
           format: int64
         outputTokens:
           description: Output tokens produced by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        reasoningTokenCount:
+          description: Reasoning tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheCreationTokenCount:
+          description: Cache-creation tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheReadTokenCount:
+          description: Cache-read tokens consumed by this LLM call. Null when not provided.
           nullable: true
           type: integer
           format: int64

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -534,6 +534,9 @@ components:
       required:
         - inputTokens
         - outputTokens
+        - reasoningTokenCount
+        - cacheCreationTokenCount
+        - cacheReadTokenCount
         - modelCalls
         - toolCalls
       properties:
@@ -545,6 +548,18 @@ components:
           type: integer
           format: int64
           description: Total output tokens produced across all model calls.
+        reasoningTokenCount:
+          type: integer
+          format: int64
+          description: Total reasoning tokens consumed across all model calls.
+        cacheCreationTokenCount:
+          type: integer
+          format: int64
+          description: Total tokens used to create prompt cache entries across all model calls.
+        cacheReadTokenCount:
+          type: integer
+          format: int64
+          description: Total tokens read from prompt cache across all model calls.
         modelCalls:
           type: integer
           format: int32

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -847,7 +847,7 @@ components:
           description: Per-call token and latency metrics. Present on ASSISTANT items only.
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
+            - $ref: '#/components/schemas/AgentInstanceHistoryItemMetricsRequest'
         producedAt:
           description: The agent-side timestamp of when this message was produced.
           type: string
@@ -1204,6 +1204,44 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+
+    AgentInstanceHistoryItemMetricsRequest:
+      description: |
+        Per-call token and latency metrics for an ASSISTANT history item, as submitted on a
+        create/update request. All fields are optional: omit a field the caller has no value
+        for rather than sending it as an explicit null.
+      type: object
+      properties:
+        inputTokens:
+          description: Input tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        outputTokens:
+          description: Output tokens produced by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        reasoningTokenCount:
+          description: Reasoning tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheCreationTokenCount:
+          description: Cache-creation tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheReadTokenCount:
+          description: Cache-read tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        durationMs:
+          description: Wall-clock duration of the LLM call in milliseconds. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
 
     AgentInstanceHistoryItemMetrics:
       description: Per-call token and latency metrics for an ASSISTANT history item.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -92,7 +92,7 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
             "role": "USER",
             "content": [{ "contentType": "TEXT", "text": "Hello agent" }],
             "toolCalls": [],
-            "metrics": { "inputTokens": 10, "outputTokens": 20, "durationMs": 100 },
+            "metrics": { "inputTokens": 10, "outputTokens": 20, "reasoningTokenCount": 30, "cacheCreationTokenCount": 40, "cacheReadTokenCount": 50, "durationMs": 100 },
             "tools": [],
             "model": null,
             "provider": null,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -74,7 +74,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
               "openai",
               List.of(
                   new ContentItem(ContentType.TEXT, "You are a helpful assistant.", null, null))),
-          new AgentInstanceMetrics(100L, 200L, 0L, 0L, 0L, 3, 5),
+          new AgentInstanceMetrics(100L, 200L, 30L, 40L, 50L, 3, 5),
           new AgentInstanceLimits(10000L, 10, 50),
           List.of(new AgentInstanceTool("search", "Search the web", "searchElement")),
           "AgentTask",
@@ -105,6 +105,9 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
             "metrics": {
               "inputTokens": 100,
               "outputTokens": 200,
+              "reasoningTokenCount": 30,
+              "cacheCreationTokenCount": 40,
+              "cacheReadTokenCount": 50,
               "modelCalls": 3,
               "toolCalls": 5
             },
@@ -192,6 +195,9 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
               "metrics": {
                 "inputTokens": 100,
                 "outputTokens": 200,
+                "reasoningTokenCount": 30,
+                "cacheCreationTokenCount": 40,
+                "cacheReadTokenCount": 50,
                 "modelCalls": 3,
                 "toolCalls": 5
               },


### PR DESCRIPTION
## Summary

Stacked on #61603 (secondary storage). Threads `reasoningTokenCount`/`cacheCreationTokenCount`/`cacheReadTokenCount` through the REST API for both `AGENT_INSTANCE` (aggregate metrics) and `AGENT_HISTORY` items (per-item metrics), and fixes a write-path gap where a connector-reported value for these fields never reached the engine.

## What's included

- `AgentInstanceMapper.mapHistoryItem`: forwards the 3 new fields from an agent history item request onto the record (previously silently dropped before reaching the engine).
- `agent-instances.yaml`: adds the 3 fields to both `AgentInstanceHistoryItemMetrics` (per-item, nullable) and `AgentInstanceMetrics` (aggregate, non-nullable) schemas, matching existing sibling-field conventions.
- `SearchQueryResponseMapper`: wires the new schema fields into both `toAgentHistoryItemResult` and `toAgentInstanceResult`.
- Test coverage extended across all of the above, including closing an existing masking gap in `AgentInstanceQueryControllerTest`/`SearchQueryResponseMapperTest` where placeholder `0L`/`null` values meant a mapping mistake would have passed silently.

## What's explicitly out of scope

- The Java client — separate, stacked follow-up PR.

## Test plan

- [x] `gateways/gateway-mapping-http` full module suite.
- [x] `zeebe/gateway-rest` (`AgentInstanceQueryControllerTest`, `AgentInstanceHistorySearchControllerTest`).
- [x] `spotless:check` + `license:check`.
- [ ] CI to re-run the above against the real pipeline.

## Related issues

- Relates to #59320