### PR TITLE
Expose reasoning and cache token metrics on the Java client agent instance API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryMetrics.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryMetrics.java
@@ -19,6 +19,9 @@ package io.camunda.client.api.command;
 public final class AgentInstanceHistoryMetrics {
   private Long inputTokens;
   private Long outputTokens;
+  private Long reasoningTokenCount;
+  private Long cacheCreationTokenCount;
+  private Long cacheReadTokenCount;
   private Long durationMs;
 
   public AgentInstanceHistoryMetrics inputTokens(final long inputTokens) {
@@ -28,6 +31,21 @@ public final class AgentInstanceHistoryMetrics {
 
   public AgentInstanceHistoryMetrics outputTokens(final long outputTokens) {
     this.outputTokens = outputTokens;
+    return this;
+  }
+
+  public AgentInstanceHistoryMetrics reasoningTokenCount(final long reasoningTokenCount) {
+    this.reasoningTokenCount = reasoningTokenCount;
+    return this;
+  }
+
+  public AgentInstanceHistoryMetrics cacheCreationTokenCount(final long cacheCreationTokenCount) {
+    this.cacheCreationTokenCount = cacheCreationTokenCount;
+    return this;
+  }
+
+  public AgentInstanceHistoryMetrics cacheReadTokenCount(final long cacheReadTokenCount) {
+    this.cacheReadTokenCount = cacheReadTokenCount;
     return this;
   }
 
@@ -42,6 +60,18 @@ public final class AgentInstanceHistoryMetrics {
 
   public Long getOutputTokens() {
     return outputTokens;
+  }
+
+  public Long getReasoningTokenCount() {
+    return reasoningTokenCount;
+  }
+
+  public Long getCacheCreationTokenCount() {
+    return cacheCreationTokenCount;
+  }
+
+  public Long getCacheReadTokenCount() {
+    return cacheReadTokenCount;
   }
 
   public Long getDurationMs() {

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstance.java
@@ -111,6 +111,18 @@ public interface AgentInstance {
     /** Returns the total number of output tokens produced across all model calls. */
     long getOutputTokens();
 
+    /** Returns the total number of reasoning tokens consumed across all model calls. */
+    long getReasoningTokenCount();
+
+    /**
+     * Returns the total number of tokens used to create prompt cache entries across all model
+     * calls.
+     */
+    long getCacheCreationTokenCount();
+
+    /** Returns the total number of tokens read from prompt cache across all model calls. */
+    long getCacheReadTokenCount();
+
     /** Returns the total number of LLM calls made. */
     int getModelCalls();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -171,6 +171,9 @@ final class AgentInstanceHistoryMapper {
     return new AgentInstanceHistoryItemMetricsRequest()
         .inputTokens(metrics.getInputTokens())
         .outputTokens(metrics.getOutputTokens())
+        .reasoningTokenCount(metrics.getReasoningTokenCount())
+        .cacheCreationTokenCount(metrics.getCacheCreationTokenCount())
+        .cacheReadTokenCount(metrics.getCacheReadTokenCount())
         .durationMs(metrics.getDurationMs());
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AgentInstanceHistoryMapper.java
@@ -27,7 +27,7 @@ import io.camunda.client.api.command.AgentTool;
 import io.camunda.client.api.response.DocumentMetadata;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
-import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
+import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetricsRequest;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryRoleEnum;
 import io.camunda.client.protocol.rest.AgentInstanceMessageContent;
 import io.camunda.client.protocol.rest.AgentInstanceObjectContent;
@@ -163,12 +163,12 @@ final class AgentInstanceHistoryMapper {
     return protocolToolCalls;
   }
 
-  static AgentInstanceHistoryItemMetrics toProtocolMetrics(
+  static AgentInstanceHistoryItemMetricsRequest toProtocolMetrics(
       final AgentInstanceHistoryMetrics metrics) {
     if (metrics == null) {
       return null;
     }
-    return new AgentInstanceHistoryItemMetrics()
+    return new AgentInstanceHistoryItemMetricsRequest()
         .inputTokens(metrics.getInputTokens())
         .outputTokens(metrics.getOutputTokens())
         .durationMs(metrics.getDurationMs());

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -226,6 +226,9 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
     return new AgentInstanceHistoryMetrics()
         .inputTokens(proto.getInputTokens())
         .outputTokens(proto.getOutputTokens())
+        .reasoningTokenCount(proto.getReasoningTokenCount())
+        .cacheCreationTokenCount(proto.getCacheCreationTokenCount())
+        .cacheReadTokenCount(proto.getCacheReadTokenCount())
         .durationMs(proto.getDurationMs());
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -223,13 +223,29 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
     if (proto == null) {
       return null;
     }
-    return new AgentInstanceHistoryMetrics()
-        .inputTokens(proto.getInputTokens())
-        .outputTokens(proto.getOutputTokens())
-        .reasoningTokenCount(proto.getReasoningTokenCount())
-        .cacheCreationTokenCount(proto.getCacheCreationTokenCount())
-        .cacheReadTokenCount(proto.getCacheReadTokenCount())
-        .durationMs(proto.getDurationMs());
+    // Every field on the wire type is nullable ("Null when not provided") and partial nulls are
+    // preserved rather than defaulted upstream, so each field must be guarded individually before
+    // unboxing into the primitive-accepting fluent setters below.
+    final AgentInstanceHistoryMetrics metrics = new AgentInstanceHistoryMetrics();
+    if (proto.getInputTokens() != null) {
+      metrics.inputTokens(proto.getInputTokens());
+    }
+    if (proto.getOutputTokens() != null) {
+      metrics.outputTokens(proto.getOutputTokens());
+    }
+    if (proto.getReasoningTokenCount() != null) {
+      metrics.reasoningTokenCount(proto.getReasoningTokenCount());
+    }
+    if (proto.getCacheCreationTokenCount() != null) {
+      metrics.cacheCreationTokenCount(proto.getCacheCreationTokenCount());
+    }
+    if (proto.getCacheReadTokenCount() != null) {
+      metrics.cacheReadTokenCount(proto.getCacheReadTokenCount());
+    }
+    if (proto.getDurationMs() != null) {
+      metrics.durationMs(proto.getDurationMs());
+    }
+    return metrics;
   }
 
   private static class LimitsImpl implements AgentInstance.Limits {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceImpl.java
@@ -211,12 +211,18 @@ public class AgentInstanceImpl implements AgentInstance {
 
     private final long inputTokens;
     private final long outputTokens;
+    private final long reasoningTokenCount;
+    private final long cacheCreationTokenCount;
+    private final long cacheReadTokenCount;
     private final int modelCalls;
     private final int toolCalls;
 
     MetricsImpl(final io.camunda.client.protocol.rest.AgentInstanceMetrics proto) {
       inputTokens = proto.getInputTokens();
       outputTokens = proto.getOutputTokens();
+      reasoningTokenCount = proto.getReasoningTokenCount();
+      cacheCreationTokenCount = proto.getCacheCreationTokenCount();
+      cacheReadTokenCount = proto.getCacheReadTokenCount();
       modelCalls = proto.getModelCalls();
       toolCalls = proto.getToolCalls();
     }
@@ -229,6 +235,21 @@ public class AgentInstanceImpl implements AgentInstance {
     @Override
     public long getOutputTokens() {
       return outputTokens;
+    }
+
+    @Override
+    public long getReasoningTokenCount() {
+      return reasoningTokenCount;
+    }
+
+    @Override
+    public long getCacheCreationTokenCount() {
+      return cacheCreationTokenCount;
+    }
+
+    @Override
+    public long getCacheReadTokenCount() {
+      return cacheReadTokenCount;
     }
 
     @Override

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/GetAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/GetAgentInstanceTest.java
@@ -80,6 +80,9 @@ class GetAgentInstanceTest extends ClientRestTest {
                 new AgentInstanceMetrics()
                     .inputTokens(100L)
                     .outputTokens(200L)
+                    .reasoningTokenCount(70L)
+                    .cacheCreationTokenCount(80L)
+                    .cacheReadTokenCount(90L)
                     .modelCalls(5)
                     .toolCalls(3))
             .limits(new AgentInstanceLimits().maxModelCalls(10).maxToolCalls(20).maxTokens(5000L)));
@@ -154,6 +157,18 @@ class GetAgentInstanceTest extends ClientRestTest {
           final AgentInstance.Metrics metrics = result.getMetrics();
           softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(100L);
           softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isEqualTo(200L);
+          softly
+              .assertThat(metrics.getReasoningTokenCount())
+              .as("reasoningTokenCount")
+              .isEqualTo(70L);
+          softly
+              .assertThat(metrics.getCacheCreationTokenCount())
+              .as("cacheCreationTokenCount")
+              .isEqualTo(80L);
+          softly
+              .assertThat(metrics.getCacheReadTokenCount())
+              .as("cacheReadTokenCount")
+              .isEqualTo(90L);
           softly.assertThat(metrics.getModelCalls()).as("modelCalls").isEqualTo(5);
           softly.assertThat(metrics.getToolCalls()).as("toolCalls").isEqualTo(3);
 

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -273,6 +273,9 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
                 new AgentInstanceHistoryItemMetrics()
                     .inputTokens(10L)
                     .outputTokens(20L)
+                    .reasoningTokenCount(30L)
+                    .cacheCreationTokenCount(40L)
+                    .cacheReadTokenCount(50L)
                     .durationMs(100L))
             .toolCalls(
                 Collections.singletonList(
@@ -335,6 +338,18 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
           final AgentInstanceHistoryMetrics metrics = item.getMetrics();
           softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(10L);
           softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isEqualTo(20L);
+          softly
+              .assertThat(metrics.getReasoningTokenCount())
+              .as("reasoningTokenCount")
+              .isEqualTo(30L);
+          softly
+              .assertThat(metrics.getCacheCreationTokenCount())
+              .as("cacheCreationTokenCount")
+              .isEqualTo(40L);
+          softly
+              .assertThat(metrics.getCacheReadTokenCount())
+              .as("cacheReadTokenCount")
+              .isEqualTo(50L);
           softly.assertThat(metrics.getDurationMs()).as("durationMs").isEqualTo(100L);
 
           softly.assertThat(item.getToolCalls()).as("toolCalls").hasSize(1);

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -392,6 +392,45 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
   }
 
   @Test
+  void shouldMapPartiallyPopulatedMetrics() {
+    // given
+    gatewayService.onAgentInstanceHistorySearchRequest(
+        AGENT_INSTANCE_KEY,
+        Instancio.create(AgentInstanceHistorySearchQueryResult.class)
+            .items(
+                Collections.singletonList(
+                    Instancio.create(AgentInstanceHistoryItemResult.class)
+                        .historyItemKey("1")
+                        .agentInstanceKey("1")
+                        .elementInstanceKey("1")
+                        .jobKey("1")
+                        .producedAt(null)
+                        .metrics(
+                            new AgentInstanceHistoryItemMetrics()
+                                .inputTokens(10L)
+                                .cacheCreationTokenCount(5L)))));
+
+    // when
+    final SearchResponse<AgentInstanceHistory> result =
+        client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    final AgentInstanceHistoryMetrics metrics = result.items().get(0).getMetrics();
+    assertSoftly(
+        softly -> {
+          softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(10L);
+          softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isNull();
+          softly.assertThat(metrics.getReasoningTokenCount()).as("reasoningTokenCount").isNull();
+          softly
+              .assertThat(metrics.getCacheCreationTokenCount())
+              .as("cacheCreationTokenCount")
+              .isEqualTo(5L);
+          softly.assertThat(metrics.getCacheReadTokenCount()).as("cacheReadTokenCount").isNull();
+          softly.assertThat(metrics.getDurationMs()).as("durationMs").isNull();
+        });
+  }
+
+  @Test
   void shouldMapDocumentContent() {
     // given
     final DocumentReference ref = new DocumentReference().documentId("doc-1").storeId("store-a");

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceTest.java
@@ -227,6 +227,9 @@ class SearchAgentInstanceTest extends ClientRestTest {
                 new AgentInstanceMetrics()
                     .inputTokens(50L)
                     .outputTokens(100L)
+                    .reasoningTokenCount(30L)
+                    .cacheCreationTokenCount(40L)
+                    .cacheReadTokenCount(60L)
                     .modelCalls(2)
                     .toolCalls(1))
             .limits(new AgentInstanceLimits().maxTokens(1000L).maxModelCalls(5).maxToolCalls(10))
@@ -302,6 +305,18 @@ class SearchAgentInstanceTest extends ClientRestTest {
           final AgentInstance.Metrics metrics = item.getMetrics();
           softly.assertThat(metrics.getInputTokens()).as("inputTokens").isEqualTo(50L);
           softly.assertThat(metrics.getOutputTokens()).as("outputTokens").isEqualTo(100L);
+          softly
+              .assertThat(metrics.getReasoningTokenCount())
+              .as("reasoningTokenCount")
+              .isEqualTo(30L);
+          softly
+              .assertThat(metrics.getCacheCreationTokenCount())
+              .as("cacheCreationTokenCount")
+              .isEqualTo(40L);
+          softly
+              .assertThat(metrics.getCacheReadTokenCount())
+              .as("cacheReadTokenCount")
+              .isEqualTo(60L);
           softly.assertThat(metrics.getModelCalls()).as("modelCalls").isEqualTo(2);
           softly.assertThat(metrics.getToolCalls()).as("toolCalls").isEqualTo(1);
 

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/UpdateAgentInstanceCommandTest.java
@@ -265,6 +265,9 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
                   new AgentInstanceHistoryMetrics()
                       .inputTokens(100L)
                       .outputTokens(50L)
+                      .reasoningTokenCount(30L)
+                      .cacheCreationTokenCount(40L)
+                      .cacheReadTokenCount(60L)
                       .durationMs(200L));
 
       // when
@@ -293,6 +296,9 @@ class UpdateAgentInstanceCommandTest extends ClientRestTest {
               });
       assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(100L);
       assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(50L);
+      assertThat(mappedItem.getMetrics().getReasoningTokenCount()).isEqualTo(30L);
+      assertThat(mappedItem.getMetrics().getCacheCreationTokenCount()).isEqualTo(40L);
+      assertThat(mappedItem.getMetrics().getCacheReadTokenCount()).isEqualTo(60L);
       assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(200L);
     }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -167,6 +167,15 @@ public class AgentInstanceMapper {
       if (metrics.getOutputTokens() != null) {
         recordMetrics.setOutputTokens(metrics.getOutputTokens());
       }
+      if (metrics.getReasoningTokenCount() != null) {
+        recordMetrics.setReasoningTokenCount(metrics.getReasoningTokenCount());
+      }
+      if (metrics.getCacheCreationTokenCount() != null) {
+        recordMetrics.setCacheCreationTokenCount(metrics.getCacheCreationTokenCount());
+      }
+      if (metrics.getCacheReadTokenCount() != null) {
+        recordMetrics.setCacheReadTokenCount(metrics.getCacheReadTokenCount());
+      }
       if (metrics.getDurationMs() != null) {
         recordMetrics.setDurationMs(metrics.getDurationMs());
       }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2173,10 +2173,14 @@ public final class SearchQueryResponseMapper {
             .build();
 
     final var m = entity.metrics();
+    // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
     final var metrics =
         AgentInstanceMetrics.Builder.create()
             .inputTokens(m.inputTokens())
             .outputTokens(m.outputTokens())
+            .reasoningTokenCount(0L)
+            .cacheCreationTokenCount(0L)
+            .cacheReadTokenCount(0L)
             .modelCalls(m.modelCalls())
             .toolCalls(m.toolCalls())
             .build();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2173,14 +2173,13 @@ public final class SearchQueryResponseMapper {
             .build();
 
     final var m = entity.metrics();
-    // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
     final var metrics =
         AgentInstanceMetrics.Builder.create()
             .inputTokens(m.inputTokens())
             .outputTokens(m.outputTokens())
-            .reasoningTokenCount(0L)
-            .cacheCreationTokenCount(0L)
-            .cacheReadTokenCount(0L)
+            .reasoningTokenCount(m.reasoningTokenCount())
+            .cacheCreationTokenCount(m.cacheCreationTokenCount())
+            .cacheReadTokenCount(m.cacheReadTokenCount())
             .modelCalls(m.modelCalls())
             .toolCalls(m.toolCalls())
             .build();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2271,10 +2271,14 @@ public final class SearchQueryResponseMapper {
     if (m == null) {
       metrics = null;
     } else {
+      // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
       metrics =
           AgentInstanceHistoryItemMetrics.Builder.create()
               .inputTokens(m.inputTokens())
               .outputTokens(m.outputTokens())
+              .reasoningTokenCount(null)
+              .cacheCreationTokenCount(null)
+              .cacheReadTokenCount(null)
               .durationMs(m.durationMs())
               .build();
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2271,14 +2271,13 @@ public final class SearchQueryResponseMapper {
     if (m == null) {
       metrics = null;
     } else {
-      // TODO: reasoning/cache token counts are not yet exposed here; wired in a follow-up change.
       metrics =
           AgentInstanceHistoryItemMetrics.Builder.create()
               .inputTokens(m.inputTokens())
               .outputTokens(m.outputTokens())
-              .reasoningTokenCount(null)
-              .cacheCreationTokenCount(null)
-              .cacheReadTokenCount(null)
+              .reasoningTokenCount(m.reasoningTokenCount())
+              .cacheCreationTokenCount(m.cacheCreationTokenCount())
+              .cacheReadTokenCount(m.cacheReadTokenCount())
               .durationMs(m.durationMs())
               .build();
     }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -151,6 +151,9 @@ class AgentInstanceMapperTest {
           AgentInstanceHistoryItemMetrics.Builder.create()
               .inputTokens(512L)
               .outputTokens(128L)
+              .reasoningTokenCount(64L)
+              .cacheCreationTokenCount(32L)
+              .cacheReadTokenCount(16L)
               .durationMs(1500L)
               .build());
       request.setHistory(List.of(item));
@@ -167,6 +170,9 @@ class AgentInstanceMapperTest {
       assertThat(mappedItem.getToolCalls().get(0).getToolName()).isEqualTo("extract_data");
       assertThat(mappedItem.getMetrics().getInputTokens()).isEqualTo(512L);
       assertThat(mappedItem.getMetrics().getOutputTokens()).isEqualTo(128L);
+      assertThat(mappedItem.getMetrics().getReasoningTokenCount()).isEqualTo(64L);
+      assertThat(mappedItem.getMetrics().getCacheCreationTokenCount()).isEqualTo(32L);
+      assertThat(mappedItem.getMetrics().getCacheReadTokenCount()).isEqualTo(16L);
       assertThat(mappedItem.getMetrics().getDurationMs()).isEqualTo(1500L);
       assertThat(mappedItem.getProducedAt())
           .isEqualTo(OffsetDateTime.parse("2025-06-01T12:00:00Z").toInstant().toEpochMilli());

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapperTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.mapping.http.validator.AgentInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.AgentInstanceCreationRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryItem;
-import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetrics;
+import io.camunda.gateway.protocol.model.AgentInstanceHistoryItemMetricsRequest;
 import io.camunda.gateway.protocol.model.AgentInstanceHistoryRoleEnum;
 import io.camunda.gateway.protocol.model.AgentInstanceLimits;
 import io.camunda.gateway.protocol.model.AgentInstanceMessageContent;
@@ -148,7 +148,7 @@ class AgentInstanceMapperTest {
               .build();
       item.setToolCalls(List.of(toolCall));
       item.setMetrics(
-          AgentInstanceHistoryItemMetrics.Builder.create()
+          AgentInstanceHistoryItemMetricsRequest.Builder.create()
               .inputTokens(512L)
               .outputTokens(128L)
               .reasoningTokenCount(64L)

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1075,6 +1075,48 @@ class SearchQueryResponseMapperTest {
   }
 
   @Test
+  void shouldMapAllMetricsForAgentInstance() {
+    // given
+    final var entity =
+        new AgentInstanceEntity(
+            123L, // agentInstanceKey
+            654L, // agentDefinitionKey
+            List.of(456L), // elementInstanceKeys
+            AgentInstanceEntity.AgentInstanceStatus.IDLE,
+            new AgentInstanceEntity.AgentInstanceDefinition(
+                "gpt-4o",
+                "openai",
+                List.of(new ContentItem(ContentType.TEXT, "You are helpful", null, null))),
+            new AgentInstanceEntity.AgentInstanceMetrics(10L, 20L, 30L, 40L, 50L, 1, 2),
+            new AgentInstanceEntity.AgentInstanceLimits(1000L, 5, 6),
+            List.of(
+                new AgentInstanceEntity.AgentInstanceTool("search", "Web search", "searchTask")),
+            "agentElement", // elementId
+            789L, // processInstanceKey
+            999L, // rootProcessInstanceKey
+            321L, // processDefinitionKey
+            "processId", // processDefinitionId
+            1, // processDefinitionVersion
+            "v1", // versionTag
+            "tenant", // tenantId
+            OffsetDateTime.now(), // creationDate
+            OffsetDateTime.now(), // lastUpdatedDate
+            null); // completionDate
+
+    // when
+    final var response = SearchQueryResponseMapper.toAgentInstanceResult(entity);
+
+    // then
+    assertThat(response.getMetrics().getInputTokens()).isEqualTo(10);
+    assertThat(response.getMetrics().getOutputTokens()).isEqualTo(20);
+    assertThat(response.getMetrics().getReasoningTokenCount()).isEqualTo(30);
+    assertThat(response.getMetrics().getCacheCreationTokenCount()).isEqualTo(40);
+    assertThat(response.getMetrics().getCacheReadTokenCount()).isEqualTo(50);
+    assertThat(response.getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(response.getMetrics().getToolCalls()).isEqualTo(2);
+  }
+
+  @Test
   void shouldMapNullRootProcessInstanceKeyForVariableItem() {
     // given
     final var entity =

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1476,7 +1476,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.USER,
               List.of(new ContentItem(ContentType.TEXT, "Hello", null, null)),
               List.of(),
-              new Metrics(10L, 20L, null, null, null, 30L),
+              new Metrics(10L, 20L, 30L, 40L, 50L, 60L),
               null,
               null,
               null,
@@ -1500,7 +1500,10 @@ class SearchQueryResponseMapperTest {
       assertThat(result.getCommitStatus().getValue()).isEqualTo("COMMITTED");
       assertThat(result.getMetrics().getInputTokens()).isEqualTo(10);
       assertThat(result.getMetrics().getOutputTokens()).isEqualTo(20);
-      assertThat(result.getMetrics().getDurationMs()).isEqualTo(30);
+      assertThat(result.getMetrics().getReasoningTokenCount()).isEqualTo(30);
+      assertThat(result.getMetrics().getCacheCreationTokenCount()).isEqualTo(40);
+      assertThat(result.getMetrics().getCacheReadTokenCount()).isEqualTo(50);
+      assertThat(result.getMetrics().getDurationMs()).isEqualTo(60);
       assertThat(result.getContent()).hasSize(1);
       assertThat(result.getContent().get(0).getContentType()).isEqualTo("TEXT");
     }
@@ -1728,6 +1731,9 @@ class SearchQueryResponseMapperTest {
       assertThat(result.getMetrics()).isNotNull();
       assertThat(result.getMetrics().getInputTokens()).isEqualTo(100L);
       assertThat(result.getMetrics().getOutputTokens()).isEqualTo(200L);
+      assertThat(result.getMetrics().getReasoningTokenCount()).isNull();
+      assertThat(result.getMetrics().getCacheCreationTokenCount()).isNull();
+      assertThat(result.getMetrics().getCacheReadTokenCount()).isNull();
       assertThat(result.getMetrics().getDurationMs()).isNull();
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceFetchIT.java
@@ -181,7 +181,13 @@ public class AgentInstanceFetchIT {
                                 .toolCallId(UUID.randomUUID().toString())
                                 .toolName("search")
                                 .elementId("searchTask")))
-                    .metrics(new AgentInstanceHistoryMetrics().inputTokens(50L).outputTokens(100L)),
+                    .metrics(
+                        new AgentInstanceHistoryMetrics()
+                            .inputTokens(50L)
+                            .outputTokens(100L)
+                            .reasoningTokenCount(10L)
+                            .cacheCreationTokenCount(5L)
+                            .cacheReadTokenCount(2L)),
                 new AgentInstanceHistoryItem()
                     .historyItemId(UUID.randomUUID().toString())
                     .loopIteration(2)
@@ -193,7 +199,13 @@ public class AgentInstanceFetchIT {
                             new AgentInstanceHistoryToolCall()
                                 .toolCallId(UUID.randomUUID().toString())
                                 .toolName("summarize")))
-                    .metrics(new AgentInstanceHistoryMetrics().inputTokens(50L).outputTokens(100L)),
+                    .metrics(
+                        new AgentInstanceHistoryMetrics()
+                            .inputTokens(50L)
+                            .outputTokens(100L)
+                            .reasoningTokenCount(10L)
+                            .cacheCreationTokenCount(5L)
+                            .cacheReadTokenCount(2L)),
                 new AgentInstanceHistoryItem()
                     .historyItemId(UUID.randomUUID().toString())
                     .loopIteration(3)
@@ -201,7 +213,12 @@ public class AgentInstanceFetchIT {
                     .content(List.of(AgentInstanceHistoryContent.text("Done.")))
                     .producedAt(OffsetDateTime.now())
                     .metrics(
-                        new AgentInstanceHistoryMetrics().inputTokens(50L).outputTokens(100L))))
+                        new AgentInstanceHistoryMetrics()
+                            .inputTokens(50L)
+                            .outputTokens(100L)
+                            .reasoningTokenCount(10L)
+                            .cacheCreationTokenCount(5L)
+                            .cacheReadTokenCount(2L))))
         .send()
         .join();
     camundaClient.newCompleteCommand(activatedJob2).execute();
@@ -286,6 +303,18 @@ public class AgentInstanceFetchIT {
           softly.assertThat(metrics).as("metrics").isNotNull();
           softly.assertThat(metrics.getInputTokens()).as("metrics.inputTokens").isEqualTo(0L);
           softly.assertThat(metrics.getOutputTokens()).as("metrics.outputTokens").isEqualTo(0L);
+          softly
+              .assertThat(metrics.getReasoningTokenCount())
+              .as("metrics.reasoningTokenCount")
+              .isEqualTo(0L);
+          softly
+              .assertThat(metrics.getCacheCreationTokenCount())
+              .as("metrics.cacheCreationTokenCount")
+              .isEqualTo(0L);
+          softly
+              .assertThat(metrics.getCacheReadTokenCount())
+              .as("metrics.cacheReadTokenCount")
+              .isEqualTo(0L);
           softly.assertThat(metrics.getModelCalls()).as("metrics.modelCalls").isEqualTo(0);
           softly.assertThat(metrics.getToolCalls()).as("metrics.toolCalls").isEqualTo(0);
 
@@ -349,6 +378,18 @@ public class AgentInstanceFetchIT {
           final var metrics = response.getMetrics();
           softly.assertThat(metrics.getInputTokens()).as("metrics.inputTokens").isEqualTo(150L);
           softly.assertThat(metrics.getOutputTokens()).as("metrics.outputTokens").isEqualTo(300L);
+          softly
+              .assertThat(metrics.getReasoningTokenCount())
+              .as("metrics.reasoningTokenCount")
+              .isEqualTo(30L);
+          softly
+              .assertThat(metrics.getCacheCreationTokenCount())
+              .as("metrics.cacheCreationTokenCount")
+              .isEqualTo(15L);
+          softly
+              .assertThat(metrics.getCacheReadTokenCount())
+              .as("metrics.cacheReadTokenCount")
+              .isEqualTo(6L);
           softly.assertThat(metrics.getModelCalls()).as("metrics.modelCalls").isEqualTo(3);
           softly.assertThat(metrics.getToolCalls()).as("metrics.toolCalls").isEqualTo(2);
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -156,6 +156,9 @@ public class AgentInstanceHistorySearchIT {
                             new AgentInstanceHistoryMetrics()
                                 .inputTokens(512L)
                                 .outputTokens(148L)
+                                .reasoningTokenCount(64L)
+                                .cacheCreationTokenCount(32L)
+                                .cacheReadTokenCount(16L)
                                 .durationMs(1200L)),
                     new AgentInstanceHistoryItem()
                         .historyItemId(UUID.randomUUID().toString())
@@ -346,6 +349,15 @@ public class AgentInstanceHistorySearchIT {
               assertThat(m.getOutputTokens())
                   .as("outputTokens must match the value provided at creation")
                   .isEqualTo(148L);
+              assertThat(m.getReasoningTokenCount())
+                  .as("reasoningTokenCount must match the value provided at creation")
+                  .isEqualTo(64L);
+              assertThat(m.getCacheCreationTokenCount())
+                  .as("cacheCreationTokenCount must match the value provided at creation")
+                  .isEqualTo(32L);
+              assertThat(m.getCacheReadTokenCount())
+                  .as("cacheReadTokenCount must match the value provided at creation")
+                  .isEqualTo(16L);
               assertThat(m.getDurationMs())
                   .as("durationMs must match the value provided at creation")
                   .isEqualTo(1200L);

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1196,6 +1196,9 @@ components:
       required:
         - inputTokens
         - outputTokens
+        - reasoningTokenCount
+        - cacheCreationTokenCount
+        - cacheReadTokenCount
         - durationMs
       properties:
         inputTokens:
@@ -1205,6 +1208,21 @@ components:
           format: int64
         outputTokens:
           description: Output tokens produced by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        reasoningTokenCount:
+          description: Reasoning tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheCreationTokenCount:
+          description: Cache-creation tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheReadTokenCount:
+          description: Cache-read tokens consumed by this LLM call. Null when not provided.
           nullable: true
           type: integer
           format: int64

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -534,6 +534,9 @@ components:
       required:
         - inputTokens
         - outputTokens
+        - reasoningTokenCount
+        - cacheCreationTokenCount
+        - cacheReadTokenCount
         - modelCalls
         - toolCalls
       properties:
@@ -545,6 +548,18 @@ components:
           type: integer
           format: int64
           description: Total output tokens produced across all model calls.
+        reasoningTokenCount:
+          type: integer
+          format: int64
+          description: Total reasoning tokens consumed across all model calls.
+        cacheCreationTokenCount:
+          type: integer
+          format: int64
+          description: Total tokens used to create prompt cache entries across all model calls.
+        cacheReadTokenCount:
+          type: integer
+          format: int64
+          description: Total tokens read from prompt cache across all model calls.
         modelCalls:
           type: integer
           format: int32

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -847,7 +847,7 @@ components:
           description: Per-call token and latency metrics. Present on ASSISTANT items only.
           nullable: true
           allOf:
-            - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
+            - $ref: '#/components/schemas/AgentInstanceHistoryItemMetricsRequest'
         producedAt:
           description: The agent-side timestamp of when this message was produced.
           type: string
@@ -1204,6 +1204,44 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+
+    AgentInstanceHistoryItemMetricsRequest:
+      description: |
+        Per-call token and latency metrics for an ASSISTANT history item, as submitted on a
+        create/update request. All fields are optional: omit a field the caller has no value
+        for rather than sending it as an explicit null.
+      type: object
+      properties:
+        inputTokens:
+          description: Input tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        outputTokens:
+          description: Output tokens produced by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        reasoningTokenCount:
+          description: Reasoning tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheCreationTokenCount:
+          description: Cache-creation tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        cacheReadTokenCount:
+          description: Cache-read tokens consumed by this LLM call. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
+        durationMs:
+          description: Wall-clock duration of the LLM call in milliseconds. Null when not provided.
+          nullable: true
+          type: integer
+          format: int64
 
     AgentInstanceHistoryItemMetrics:
       description: Per-call token and latency metrics for an ASSISTANT history item.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -92,7 +92,7 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
             "role": "USER",
             "content": [{ "contentType": "TEXT", "text": "Hello agent" }],
             "toolCalls": [],
-            "metrics": { "inputTokens": 10, "outputTokens": 20, "durationMs": 100 },
+            "metrics": { "inputTokens": 10, "outputTokens": 20, "reasoningTokenCount": 30, "cacheCreationTokenCount": 40, "cacheReadTokenCount": 50, "durationMs": 100 },
             "tools": [],
             "model": null,
             "provider": null,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceQueryControllerTest.java
@@ -74,7 +74,7 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
               "openai",
               List.of(
                   new ContentItem(ContentType.TEXT, "You are a helpful assistant.", null, null))),
-          new AgentInstanceMetrics(100L, 200L, 0L, 0L, 0L, 3, 5),
+          new AgentInstanceMetrics(100L, 200L, 30L, 40L, 50L, 3, 5),
           new AgentInstanceLimits(10000L, 10, 50),
           List.of(new AgentInstanceTool("search", "Search the web", "searchElement")),
           "AgentTask",
@@ -105,6 +105,9 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
             "metrics": {
               "inputTokens": 100,
               "outputTokens": 200,
+              "reasoningTokenCount": 30,
+              "cacheCreationTokenCount": 40,
+              "cacheReadTokenCount": 50,
               "modelCalls": 3,
               "toolCalls": 5
             },
@@ -192,6 +195,9 @@ class AgentInstanceQueryControllerTest extends RestControllerTest {
               "metrics": {
                 "inputTokens": 100,
                 "outputTokens": 200,
+                "reasoningTokenCount": 30,
+                "cacheCreationTokenCount": 40,
+                "cacheReadTokenCount": 50,
                 "modelCalls": 3,
                 "toolCalls": 5
               },


### PR DESCRIPTION
## Summary

Adds `reasoningTokenCount`, `cacheCreationTokenCount`, and `cacheReadTokenCount` to the Java client's agent-instance metrics types, alongside the existing `inputTokens`/`outputTokens`.

The aggregate `AgentInstance.Metrics` response interface gets three new primitive `long` getters, mirroring the existing required aggregate fields, and its `AgentInstanceImpl.MetricsImpl` implementation maps them from the generated REST model.

The per-item `AgentInstanceHistoryMetrics` command type gets three new boxed `Long` fields with primitive-accepting fluent setters, mirroring the existing nullable-but-required per-item fields, wired through both the read path (`AgentInstanceHistoryImpl`) and the write path (`AgentInstanceHistoryMapper`).

Review also surfaced a pre-existing NPE: `AgentInstanceHistoryImpl.toMetrics` unboxed the generated model's nullable `Long` getters straight into the primitive-`long` fluent setters, so any per-item metrics response with a field left unset would crash on unboxing. This affected all six per-item fields (the three new ones and the three pre-existing `inputTokens`/`outputTokens`/`durationMs`), since the schema marks every per-item metric field nullable and partial nulls are preserved end-to-end rather than defaulted. Fixed by guarding each field individually before unboxing.

Extended the client-facing acceptance ITs (`AgentInstanceFetchIT`, `AgentInstanceHistorySearchIT`) to submit and assert on the three new fields as part of their existing end-to-end round trips.

## Test plan

- [x] `clients/java` module: `SearchAgentInstanceTest`, `GetAgentInstanceTest`, `SearchAgentInstanceHistoryTest`, `UpdateAgentInstanceCommandTest` — 77 tests, 0 failures
- [x] `clients/java` full module suite — 2127 tests, 0 failures, 0 errors
- [x] Added a WireMock-backed unit test with a partially-populated per-item metrics response, asserting the set fields survive and the absent ones return `null` — reproduces and covers the NPE fix
- [x] Verified the NPE fix by reverting it locally and confirming the new test fails with the exact reported stack trace, then restoring the fix and confirming it passes
- [x] Extended `AgentInstanceFetchIT` (per-instance and aggregate metrics) and `AgentInstanceHistorySearchIT` (per-item metrics) to cover the three new fields end-to-end (compiles cleanly; full IT run requires a live broker)

## Related issues

- Relates to #59320
