### PR TITLE
test: stop RingBuffer concurrency tests from timing out on busy CI runners

### DIFF
--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBufferTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.atomic.AtomicLongArray;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -328,7 +328,7 @@ final class RingBufferTest {
 
     // Capacity must exceed ITERATIONS to avoid wraparound in tests that assert exact entries
     private static final int CAPACITY = 1 << 17; // 131072
-    private static final int ITERATIONS = 100_000;
+    private static final int ITERATIONS = 10_000;
 
     /**
      * Simulates the FlowControl access pattern: one writer thread puts entries (sequencer), a
@@ -341,7 +341,7 @@ final class RingBufferTest {
       final var buffer = new RingBuffer(CAPACITY);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
-      final var indices = new long[ITERATIONS + 1];
+      final var indices = new AtomicLongArray(ITERATIONS + 1);
 
       final var writer =
           new Thread(
@@ -349,7 +349,7 @@ final class RingBufferTest {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   final var entry = newEntry(pos);
-                  indices[(int) pos] = buffer.put(entry);
+                  indices.set((int) pos, buffer.put(entry));
                 }
               });
 
@@ -359,8 +359,8 @@ final class RingBufferTest {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   InFlightEntry entry;
-                  while ((entry = buffer.get(indices[(int) pos], pos)) == null) {
-                    LockSupport.parkNanos(1);
+                  while ((entry = buffer.get(indices.get((int) pos), pos)) == null) {
+                    Thread.onSpinWait();
                   }
                   try {
                     assertThat(entry.highestPosition).isEqualTo(pos);
@@ -406,13 +406,12 @@ final class RingBufferTest {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
                   while (pos > publishedPosition.get()) {
-                    LockSupport.parkNanos(1);
+                    Thread.onSpinWait();
                   }
 
-                  InFlightEntry entry = null;
-                  while (entry == null) {
-                    entry = buffer.findAndRemove(pos);
-                    LockSupport.parkNanos(1);
+                  InFlightEntry entry;
+                  while ((entry = buffer.findAndRemove(pos)) == null) {
+                    Thread.onSpinWait();
                   }
                   try {
                     assertThat(entry.highestPosition).isEqualTo(pos);
@@ -439,14 +438,14 @@ final class RingBufferTest {
       final var buffer = new RingBuffer(CAPACITY);
       final var failures = new ConcurrentLinkedQueue<Throwable>();
       final var startLatch = new CountDownLatch(1);
-      final var indices = new long[ITERATIONS + 1];
+      final var indices = new AtomicLongArray(ITERATIONS + 1);
 
       final var writer =
           new Thread(
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  indices[(int) pos] = buffer.put(newEntry(pos));
+                  indices.set((int) pos, buffer.put(newEntry(pos)));
                 }
               });
 
@@ -458,8 +457,8 @@ final class RingBufferTest {
                   awaitLatch(startLatch);
                   for (long pos = 1; pos <= ITERATIONS; pos++) {
                     InFlightEntry entry;
-                    while ((entry = buffer.get(indices[(int) pos], pos)) == null) {
-                      LockSupport.parkNanos(1);
+                    while ((entry = buffer.get(indices.get((int) pos), pos)) == null) {
+                      Thread.onSpinWait();
                     }
                     try {
                       assertThat(entry.highestPosition).isEqualTo(pos);
@@ -485,9 +484,11 @@ final class RingBufferTest {
      * in order. Because entries are indexed sequentially, displacement only occurs after the full
      * buffer capacity is used (unlike position-based indexing where it depended on batch size).
      *
-     * <p>The test asserts that both hits (entry found and processed) and misses (entry displaced
-     * before processing) occurred, and that every hit returned the correct entry (position guard
-     * was not bypassed).
+     * <p>The test asserts that every entry the reader does find is the one it asked for, i.e. the
+     * position guard was not bypassed. Whether a given entry is found or was already displaced
+     * depends on how far the writer has run ahead, so the hit/miss split is not asserted here —
+     * displacement itself is covered deterministically by {@link
+     * RingBufferTest#getReturnsNullAfterDisplacement()}.
      */
     @Test
     void sequentialIndexingWorksUnderConcurrentWraparound() {
@@ -510,16 +511,13 @@ final class RingBufferTest {
                 }
               });
 
-      final var hits = new AtomicLong(0);
-      final var misses = new AtomicLong(0);
-
       final var reader =
           new Thread(
               () -> {
                 awaitLatch(startLatch);
                 for (long pos = 1; pos <= ITERATIONS; pos++) {
-                  if (pos > publishedIndex.get()) {
-                    LockSupport.parkNanos(1);
+                  while (pos > publishedIndex.get()) {
+                    Thread.onSpinWait();
                   }
                   final var entry = buffer.findAndRemove(pos);
                   if (entry != null) {
@@ -529,9 +527,6 @@ final class RingBufferTest {
                       failures.add(e);
                       return;
                     }
-                    hits.incrementAndGet();
-                  } else {
-                    misses.incrementAndGet();
                   }
                 }
               });
@@ -539,8 +534,6 @@ final class RingBufferTest {
       // when / then
       runAndAwait(startLatch, failures, writer, reader);
       assertThat(failures).isEmpty();
-      assertThat(hits.get()).as("expected some hits (entry still present)").isGreaterThan(0);
-      assertThat(misses.get()).as("expected some misses (entry displaced)").isGreaterThan(0);
     }
 
     /** Starts all threads, releases the latch, and waits for all threads to finish. */


### PR DESCRIPTION
## Description

`RingBufferTest$ConcurrencyTests.findAndRemoveWorksAcrossThreads` times out after 60s on busy
runners — it failed all four surefire retries on #61627, a PR that touches nothing in logstreams.

Not a hang, a cost problem: the processor loop parked on **every** iteration rather than only when
the entry was missing.

```java
InFlightEntry entry = null;
while (entry == null) {
  entry = buffer.findAndRemove(pos);
  LockSupport.parkNanos(1);   // runs even after success
}
```

`findAndRemove` normally succeeds on the first call (capacity `1 << 17` ≫ 100k iterations, so
nothing is ever displaced), yet the park still ran 100,000 times. `parkNanos(1)` does not sleep 1ns
— it costs a full timer-slack round trip, measured at ~52µs/call on an idle machine, so ~5s of pure
park time as a floor. With several forks competing for CPU that slack grows an order of magnitude
and the test blows past the deadline. The earlier fix for this flake (#53291) only raised the
deadline 30s → 60s, moving the threshold without removing the cost.

**Changes**

- Spin with `Thread.onSpinWait()` and only while the entry is absent. The waits are bounded by the
  co-running producer, so there is nothing to sleep for.
- `ITERATIONS` 100k → 10k. The tests exercise a sequential handoff; 100k repetitions add no coverage
  the first few thousand don't.
- `indices` was a plain `long[]` shared between writer and readers with no happens-before edge — a
  reader spinning on `buffer.get(indices[pos], pos)` could hoist a stale `0` and spin forever, which
  is the same timeout symptom. Now an `AtomicLongArray`.
- `sequentialIndexingWorksUnderConcurrentWraparound` gated its reader with `if` instead of `while`,
  so at capacity 64 the reader could fall permanently behind: `findAndRemove` matches nothing,
  `lastProcessedIndex` never advances, every later call misses, and `hits > 0` fails.

**Why the hits/misses assertions are gone.** Neither bound is a property of `RingBuffer` — both are
properties of thread timing, and `misses > 0` would have started failing *because of* this fix: the
old reader parked ~52µs per iteration, so the writer always ran >64 ahead and displacement was
guaranteed; the new reader keeps up, so a clean run can legitimately produce zero misses. What the
test still asserts is the part that catches a bypassed position guard: any entry `findAndRemove`
returns is the one asked for. Deterministic displacement coverage already lives in
`getReturnsNullAfterDisplacement` and `findAndRemoveFindsFirstLapEntriesAfterWraparound`.

`RingBuffer` itself is unchanged and was never implicated — production access is a single writer
under the sequencer lock plus an in-order `findAndRemove` from the stream processor.

**Verification.** Full `zeebe/logstreams` UT suite green; `RingBufferTest` 5 consecutive runs green.
Concurrency class runtime 20s+ → 0.44s.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #61635
