### PR TITLE
refactor: add JSpecify annotations to backup store common

### DIFF
--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/FileSet.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/FileSet.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.zeebe.backup.common;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** FileSet use in Manifest serialization, in order to list all stored files. */
@@ -19,7 +20,7 @@ public record FileSet(List<NamedFile> files) {
       "Expected file name '%s' to be unique, but occurred '%s' times in %s";
 
   public FileSet {
-    Objects.requireNonNull(files);
+    requireNonNull(files);
 
     // It might happen that the manifest has been corrupted, we want to prevent
     // that either on storing or restoring this is silently failing (ignored)
@@ -45,7 +46,7 @@ public record FileSet(List<NamedFile> files) {
 
   public record NamedFile(String name) {
     public NamedFile {
-      Objects.requireNonNull(name);
+      requireNonNull(name);
     }
   }
 }

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/FileSet.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/FileSet.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 /** FileSet use in Manifest serialization, in order to list all stored files. */
 public record FileSet(List<NamedFile> files) {
@@ -36,7 +37,7 @@ public record FileSet(List<NamedFile> files) {
     }
   }
 
-  public static FileSet of(final NamedFileSet fileSet) {
+  public static FileSet of(final @Nullable NamedFileSet fileSet) {
     if (fileSet == null) {
       return new FileSet(List.of());
     }

--- a/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/package-info.java
+++ b/zeebe/backup-stores/common/src/main/java/io/camunda/zeebe/backup/common/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FileSetManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.filesystem;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.FileSet;
@@ -71,7 +73,11 @@ final class FileSetManager {
     try {
       FileUtil.deleteFolder(fileSetPath);
       final var dirLimit = contentsPath.resolve(String.valueOf(id.partitionId()));
-      FilesystemBackupStore.backtrackDeleteEmptyParents(fileSetPath.getParent(), dirLimit);
+      final var parent =
+          requireNonNull(
+              fileSetPath.getParent(),
+              () -> String.format("Parent directory of %s is null.", fileSetPath));
+      FilesystemBackupStore.backtrackDeleteEmptyParents(parent, dirLimit);
     } catch (final NoSuchFileException e) {
       LOGGER.warn("Try to remove unknown fileset {} in backup {}", fileSetName, id);
     } catch (final IOException e) {

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupConfig.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupConfig.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.backup.filesystem;
 
-public record FilesystemBackupConfig(String basePath) {
+import org.jspecify.annotations.Nullable;
+
+public record FilesystemBackupConfig(@Nullable String basePath) {
 
   public static class Builder {
 
-    private String basePath;
+    private @Nullable String basePath;
 
     /**
      * The base path to store all related backup files in.
@@ -25,7 +27,6 @@ public record FilesystemBackupConfig(String basePath) {
     }
 
     public FilesystemBackupConfig build() {
-
       return new FilesystemBackupConfig(basePath);
     }
   }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.filesystem;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
@@ -100,7 +102,7 @@ public final class FilesystemBackupStore implements BackupStore {
             fileSetManager.save(backup.id(), SEGMENTS_FILESET_NAME, backup.segments());
             manifestManager.completeManifest(manifest);
           } catch (final Exception e) {
-            manifestManager.markAsFailed(manifest.id(), e.getMessage());
+            manifestManager.markAsFailed(manifest.id(), e.toString());
             throw e;
           }
         },
@@ -160,13 +162,14 @@ public final class FilesystemBackupStore implements BackupStore {
                     ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
             case COMPLETED -> {
               final var completed = manifest.asCompleted();
+              final var descriptor = requireNonNull(manifest.descriptor());
               final var snapshot =
                   fileSetManager.restore(
                       id, SNAPSHOT_FILESET_NAME, completed.snapshot(), targetFolder);
               final var segments =
                   fileSetManager.restore(
                       id, SEGMENTS_FILESET_NAME, completed.segments(), targetFolder);
-              yield new BackupImpl(id, manifest.descriptor(), snapshot, segments);
+              yield new BackupImpl(id, descriptor, snapshot, segments);
             }
           };
         },
@@ -189,7 +192,7 @@ public final class FilesystemBackupStore implements BackupStore {
     return CompletableFuture.supplyAsync(
         () -> {
           final var manifest = manifestManager.getManifest(id);
-          manifestManager.markAsDeleted(manifest);
+          manifestManager.markAsDeleted(requireNonNull(manifest));
           return BackupStatusCode.DELETED;
         },
         executor);
@@ -301,7 +304,7 @@ public final class FilesystemBackupStore implements BackupStore {
         }
       }
       Files.delete(traversePath);
-      traversePath = traversePath.getParent();
+      traversePath = requireNonNull(traversePath.getParent());
     }
     FileUtil.flushDirectory(traversePath);
   }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/ManifestManager.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.filesystem;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +39,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +82,7 @@ public final class ManifestManager {
     final var path = manifestPath(manifest);
 
     try {
-      FileUtil.ensureDirectoryExists(path.getParent());
+      FileUtil.ensureDirectoryExists(requireNonNull(path.getParent()));
     } catch (final IOException e) {
       throw new UncheckedIOException(
           "Unable to create directories for manifest: " + path.getParent(), e);
@@ -167,7 +169,7 @@ public final class ManifestManager {
       final var path = manifestPath(manifest);
       Files.delete(path);
       final var dirLimit = manifestsPath.resolve(String.valueOf(manifest.id().partitionId()));
-      FilesystemBackupStore.backtrackDeleteEmptyParents(path.getParent(), dirLimit);
+      FilesystemBackupStore.backtrackDeleteEmptyParents(requireNonNull(path.getParent()), dirLimit);
     } catch (final NoSuchFileException e) {
       LOGGER.warn("Try to remove unknown manifest with id {}", manifest.id());
     } catch (final IOException e) {
@@ -175,7 +177,7 @@ public final class ManifestManager {
     }
   }
 
-  Manifest getManifest(final BackupIdentifier id) {
+  @Nullable Manifest getManifest(final BackupIdentifier id) {
     return getManifestWithPath(getManifestPath(id));
   }
 
@@ -189,7 +191,7 @@ public final class ManifestManager {
     return collector.manifests();
   }
 
-  private Manifest getManifestWithPath(final Path path) {
+  private @Nullable Manifest getManifestWithPath(final Path path) {
     if (!Files.exists(path)) {
       return null;
     }
@@ -272,7 +274,7 @@ public final class ManifestManager {
 
     @Override
     public @NonNull FileVisitResult postVisitDirectory(
-        final @NonNull Path directory, final IOException failure) throws IOException {
+        final @NonNull Path directory, final @Nullable IOException failure) throws IOException {
       return failure == null
           ? FileVisitResult.CONTINUE
           : continueIfDeletedConcurrently(directory, failure);

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/package-info.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.zeebe.backup.filesystem;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

- Mark the backup store common package with `@NullMarked`.
- Document the existing nullable `FileSet.of(...)` boundary.
- Use static imports for `requireNonNull`.

## Related issues

closes #53244

## Testing

- `just format`
- `./mvnw verify -pl zeebe/backup-stores/common -Dquickly -DskipTests=false -T1C`
- `./mvnw install -Dquickly -T1C`