### PR TITLE
feat: fetch variables from runtime state

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -141,6 +141,7 @@ import io.camunda.client.api.fetch.ResourceContentGetRequest;
 import io.camunda.client.api.fetch.ResourceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
+import io.camunda.client.api.fetch.RuntimeVariablesGetRequest;
 import io.camunda.client.api.fetch.TenantGetRequest;
 import io.camunda.client.api.fetch.TenantScopedClusterVariableGetRequest;
 import io.camunda.client.api.fetch.UserGetRequest;
@@ -1327,6 +1328,15 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a element instance
    */
   ElementInstanceGetRequest newElementInstanceGetRequest(long elementInstanceKey);
+
+  /**
+   * Gets an authoritative runtime variable snapshot for an active process or element instance
+   * scope.
+   *
+   * @param scopeKey the process instance key or element instance key
+   * @return a builder for the runtime variables request
+   */
+  RuntimeVariablesGetRequest newRuntimeVariablesGetRequest(long scopeKey);
 
   /**
    * Command to activate activities within an activated ad-hoc sub-process.

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/RuntimeVariablesGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/RuntimeVariablesGetRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.RuntimeVariables;
+import io.camunda.client.api.search.enums.RuntimeVariableScope;
+
+public interface RuntimeVariablesGetRequest extends FinalCommandStep<RuntimeVariables> {
+
+  RuntimeVariablesGetRequest scope(RuntimeVariableScope scope);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/RuntimeVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/RuntimeVariables.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import java.util.Map;
+
+public interface RuntimeVariables {
+
+  Map<String, Object> getVariables();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/RuntimeVariableScope.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/RuntimeVariableScope.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum RuntimeVariableScope {
+  EFFECTIVE,
+  LOCAL
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -152,6 +152,7 @@ import io.camunda.client.api.fetch.ResourceContentGetRequest;
 import io.camunda.client.api.fetch.ResourceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
+import io.camunda.client.api.fetch.RuntimeVariablesGetRequest;
 import io.camunda.client.api.fetch.TenantGetRequest;
 import io.camunda.client.api.fetch.TenantScopedClusterVariableGetRequest;
 import io.camunda.client.api.fetch.UserGetRequest;
@@ -346,6 +347,7 @@ import io.camunda.client.impl.fetch.ResourceContentBinaryGetRequestImpl;
 import io.camunda.client.impl.fetch.ResourceContentGetRequestImpl;
 import io.camunda.client.impl.fetch.ResourceGetRequestImpl;
 import io.camunda.client.impl.fetch.RoleGetRequestImpl;
+import io.camunda.client.impl.fetch.RuntimeVariablesGetRequestImpl;
 import io.camunda.client.impl.fetch.TenantGetRequestImpl;
 import io.camunda.client.impl.fetch.TenantScopedClusterVariableGetRequestImpl;
 import io.camunda.client.impl.fetch.UserGetRequestImpl;
@@ -1112,6 +1114,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public ElementInstanceGetRequest newElementInstanceGetRequest(final long elementInstanceKey) {
     return new ElementInstanceGetRequestImpl(httpClient, elementInstanceKey);
+  }
+
+  @Override
+  public RuntimeVariablesGetRequest newRuntimeVariablesGetRequest(final long scopeKey) {
+    return new RuntimeVariablesGetRequestImpl(httpClient, scopeKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/RuntimeVariablesGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/RuntimeVariablesGetRequestImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.RuntimeVariablesGetRequest;
+import io.camunda.client.api.response.RuntimeVariables;
+import io.camunda.client.api.search.enums.RuntimeVariableScope;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.RuntimeVariablesImpl;
+import io.camunda.client.protocol.rest.RuntimeVariablesResult;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class RuntimeVariablesGetRequestImpl implements RuntimeVariablesGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long scopeKey;
+  private RuntimeVariableScope scope;
+
+  public RuntimeVariablesGetRequestImpl(final HttpClient httpClient, final long scopeKey) {
+    this.httpClient = httpClient;
+    this.scopeKey = scopeKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public RuntimeVariablesGetRequest scope(final RuntimeVariableScope scope) {
+    this.scope = scope;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<RuntimeVariables> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<RuntimeVariables> send() {
+    final HttpCamundaFuture<RuntimeVariables> result = new HttpCamundaFuture<>();
+    final Map<String, String> queryParams = new HashMap<>();
+    if (scope != null) {
+      queryParams.put("scope", scope.name());
+    }
+    httpClient.get(
+        String.format("/element-instances/%d/variables", scopeKey),
+        queryParams,
+        httpRequestConfig.build(),
+        RuntimeVariablesResult.class,
+        RuntimeVariablesImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/RuntimeVariablesImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/RuntimeVariablesImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.RuntimeVariables;
+import io.camunda.client.protocol.rest.RuntimeVariablesResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class RuntimeVariablesImpl implements RuntimeVariables {
+
+  private final Map<String, Object> variables;
+
+  public RuntimeVariablesImpl(final RuntimeVariablesResult result) {
+    variables = Collections.unmodifiableMap(new HashMap<>(result.getVariables()));
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return variables;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -20,13 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.response.RuntimeVariables;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.client.api.search.enums.RuntimeVariableScope;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.instancio.Instancio;
@@ -364,6 +367,42 @@ public class ElementInstanceTest extends ClientRestTest {
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
     assertThat(request.getUrl()).isEqualTo("/v2/element-instances/" + elementInstanceKey);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  void shouldGetEffectiveRuntimeVariablesByDefault() {
+    // given
+    final long scopeKey = 123L;
+    gatewayService.onRuntimeVariablesRequest(
+        scopeKey,
+        new RuntimeVariablesResult().variables(Collections.singletonMap("orderId", "A-42")));
+
+    // when
+    final RuntimeVariables result = client.newRuntimeVariablesGetRequest(scopeKey).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/element-instances/123/variables");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    assertThat(result.getVariables()).containsOnlyKeys("orderId").containsEntry("orderId", "A-42");
+  }
+
+  @Test
+  void shouldGetLocalRuntimeVariables() {
+    // given
+    final long scopeKey = 123L;
+    gatewayService.onRuntimeVariablesRequest(
+        scopeKey,
+        new RuntimeVariablesResult()
+            .variables(Collections.<String, Object>singletonMap("local", true)));
+
+    // when
+    client.newRuntimeVariablesGetRequest(scopeKey).scope(RuntimeVariableScope.LOCAL).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/element-instances/123/variables?scope=LOCAL");
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -64,6 +64,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/decision-instances/deletion";
   private static final String URL_DEPLOYMENTS = REST_API_PATH + "/deployments";
   private static final String URL_ELEMENT_INSTANCE = REST_API_PATH + "/element-instances/%s";
+  private static final String URL_RUNTIME_VARIABLES =
+      REST_API_PATH + "/element-instances/%s/variables";
   private static final String URL_EXPRESSION_EVALUATION = REST_API_PATH + "/expression/evaluation";
   private static final String URL_GROUP = REST_API_PATH + "/groups/%s";
   private static final String URL_GROUPS = REST_API_PATH + "/groups";
@@ -450,6 +452,10 @@ public class RestGatewayPaths {
 
   public static String getElementInstanceUrl(final long elementInstanceKey) {
     return String.format(URL_ELEMENT_INSTANCE, elementInstanceKey);
+  }
+
+  public static String getRuntimeVariablesUrl(final long scopeKey) {
+    return String.format(URL_RUNTIME_VARIABLES, scopeKey);
   }
 
   public static String getClusterVariablesUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -75,6 +75,7 @@ import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.protocol.rest.RoleCreateResult;
 import io.camunda.client.protocol.rest.RoleResult;
 import io.camunda.client.protocol.rest.RoleUpdateResult;
+import io.camunda.client.protocol.rest.RuntimeVariablesResult;
 import io.camunda.client.protocol.rest.SearchQueryResponse;
 import io.camunda.client.protocol.rest.SecretListResult;
 import io.camunda.client.protocol.rest.SecretResolveResult;
@@ -471,6 +472,13 @@ public class RestGatewayService {
   public void onElementInstanceRequest(
       final long elementInstanceKey, final ElementInstanceResult response) {
     registerGet(RestGatewayPaths.getElementInstanceUrl(elementInstanceKey), response);
+  }
+
+  public void onRuntimeVariablesRequest(
+      final long scopeKey, final RuntimeVariablesResult response) {
+    register(
+        WireMock.get(WireMock.urlPathEqualTo(RestGatewayPaths.getRuntimeVariablesUrl(scopeKey))),
+        response);
   }
 
   public void onCreateClusterVariableRequest(final ClusterVariableResult response) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -86,6 +86,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.Part;
@@ -97,6 +98,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -502,6 +504,22 @@ public class RequestMapper {
     final List<String> validationErrors = new ArrayList<>();
     validateKeyFormat(scopeKey, "scopeKey", validationErrors);
     return createProblemDetail(validationErrors);
+  }
+
+  public static Either<ProblemDetail, RuntimeVariableScope> toRuntimeVariableScope(
+      final @Nullable String scope) {
+    if (scope == null || scope.isBlank()) {
+      return Either.right(RuntimeVariableScope.EFFECTIVE);
+    }
+    try {
+      return Either.right(RuntimeVariableScope.valueOf(scope.toUpperCase(Locale.ROOT)));
+    } catch (final IllegalArgumentException ignored) {
+      return Either.left(
+          GatewayErrorMapper.createProblemDetail(
+              HttpStatus.BAD_REQUEST,
+              "Unexpected runtime variable scope '%s'. Use EFFECTIVE or LOCAL.".formatted(scope),
+              INVALID_ARGUMENT.name()));
+    }
   }
 
   public static Either<ProblemDetail, DeployResourcesRequest> toDeployResourceRequest(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -73,6 +73,7 @@ import io.camunda.gateway.protocol.model.ResolvedSecret;
 import io.camunda.gateway.protocol.model.ResourceResult;
 import io.camunda.gateway.protocol.model.RoleCreateResult;
 import io.camunda.gateway.protocol.model.RoleUpdateResult;
+import io.camunda.gateway.protocol.model.RuntimeVariablesResult;
 import io.camunda.gateway.protocol.model.SecretErrorCode;
 import io.camunda.gateway.protocol.model.SecretListResult;
 import io.camunda.gateway.protocol.model.SecretResolutionError;
@@ -126,6 +127,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -939,6 +941,13 @@ public final class ResponseMapper {
                             .secretName(reference.getSecretReference())
                             .build())
                 .toList())
+        .build();
+  }
+
+  public static RuntimeVariablesResult toRuntimeVariablesResult(
+      final RuntimeVariablesRecord runtimeVariablesRecord) {
+    return RuntimeVariablesResult.Builder.create()
+        .variables(runtimeVariablesRecord.getVariables())
         .build();
   }
 

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -28,8 +28,11 @@ import io.camunda.service.cache.ProcessCacheItem;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerFetchRuntimeVariablesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -119,6 +122,15 @@ public final class ElementInstanceServices
       brokerRequest.setOperationReference(request.operationReference());
     }
     return sendBrokerRequest(brokerRequest, authentication);
+  }
+
+  public CompletableFuture<RuntimeVariablesRecord> fetchRuntimeVariables(
+      final long scopeKey,
+      final RuntimeVariableScope scope,
+      final CamundaAuthentication authentication) {
+    return sendBrokerRequest(
+        new BrokerFetchRuntimeVariablesRequest().setScopeKey(scopeKey).setScope(scope),
+        authentication);
   }
 
   private SearchQueryResult<FlowNodeInstanceEntity> toCacheEnrichedResult(

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -26,6 +26,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.authorization.Authorizations;
 import io.camunda.service.cache.ProcessCache;
 import io.camunda.service.cache.ProcessCacheItem;
@@ -33,9 +34,12 @@ import io.camunda.service.cache.ProcessCacheResult;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
-import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerFetchRuntimeVariablesRequest;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +54,7 @@ public final class ElementInstanceServiceTest {
   private FlowNodeInstanceSearchClient client;
   private WaitStateSearchClient waitStateSearchClient;
   private ProcessCache processCache;
+  private StubbedBrokerClient brokerClient;
   @Mock private IncidentServices incidentServices;
   @Mock private CamundaAuthentication authentication;
 
@@ -59,21 +64,40 @@ public final class ElementInstanceServiceTest {
     waitStateSearchClient = mock(WaitStateSearchClient.class);
     processCache = mock(ProcessCache.class);
     incidentServices = mock(IncidentServices.class);
+    brokerClient = new StubbedBrokerClient();
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(ForkJoinPool.commonPool());
     services =
         new ElementInstanceServices(
             PHYSICAL_TENANT_ID,
-            mock(BrokerClient.class),
+            brokerClient,
             mock(SecurityContextProvider.class),
             client,
             waitStateSearchClient,
             processCache,
             incidentServices,
-            mock(ApiServicesExecutorProvider.class),
-            null);
+            executorProvider,
+            mock(BrokerRequestAuthorizationConverter.class));
 
     when(client.withSecurityContext(any())).thenReturn(client);
     when(waitStateSearchClient.withSecurityContext(any())).thenReturn(waitStateSearchClient);
     when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
+  }
+
+  @Nested
+  class RuntimeVariables {
+
+    @Test
+    void shouldFetchRuntimeVariablesFromRequestedScope() {
+      // when
+      services.fetchRuntimeVariables(123L, RuntimeVariableScope.LOCAL, authentication);
+
+      // then
+      final BrokerFetchRuntimeVariablesRequest request = brokerClient.getSingleBrokerRequest();
+      assertThat(request.getRequestWriter().getScopeKey()).isEqualTo(123L);
+      assertThat(request.getRequestWriter().getScope()).isEqualTo(RuntimeVariableScope.LOCAL);
+      assertThat(request.getPartitionGroup()).isEqualTo(PHYSICAL_TENANT_ID);
+    }
   }
 
   @Nested

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -81,6 +81,7 @@ import io.camunda.zeebe.engine.processing.resource.ResourceFetchProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceReexportReexportProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceReexportStartProcessor;
 import io.camunda.zeebe.engine.processing.resource.RpaReexportMigrator;
+import io.camunda.zeebe.engine.processing.runtimevariables.RuntimeVariablesFetchProcessor;
 import io.camunda.zeebe.engine.processing.scaling.ScalingProcessors;
 import io.camunda.zeebe.engine.processing.secretreference.SecretReferenceProcessors;
 import io.camunda.zeebe.engine.processing.secretreference.SecretResolutionScheduler;
@@ -111,6 +112,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
@@ -527,6 +529,16 @@ public final class EngineProcessors {
         processingState.getElementInstanceState(),
         cslCheck,
         tenantCheck);
+
+    typedRecordProcessors.onCommand(
+        ValueType.RUNTIME_VARIABLES,
+        RuntimeVariablesIntent.FETCH,
+        new RuntimeVariablesFetchProcessor(
+            processingState.getElementInstanceState(),
+            processingState.getVariableState(),
+            cslCheck,
+            tenantCheck,
+            writers));
 
     JobMetricsProcessors.addJobMetricsProcessors(
         typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchProcessor.java
@@ -143,8 +143,6 @@ public final class RuntimeVariablesFetchProcessor
     return ProcessingError.UNEXPECTED_ERROR;
   }
 
-  private static final class RuntimeVariablesTooLargeException extends RuntimeException {}
-
   private void acceptCommand(
       final TypedRecord<RuntimeVariablesRecord> command, final RuntimeVariablesRecord fetched) {
     responseWriter.writeAcceptedResponseOnCommand(
@@ -156,4 +154,6 @@ public final class RuntimeVariablesFetchProcessor
     rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
     responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
   }
+
+  private static final class RuntimeVariablesTooLargeException extends RuntimeException {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchProcessor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.runtimevariables;
+
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
+import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+
+public final class RuntimeVariablesFetchProcessor
+    implements TypedRecordProcessor<RuntimeVariablesRecord> {
+
+  private static final String ERROR_MESSAGE_SCOPE_NOT_FOUND = "No scope found with key '%d'";
+  private static final String ERROR_MESSAGE_NOT_FOUND_FOR_TENANT = "No scope found with key '%d'";
+  private static final String ERROR_MESSAGE_TOO_LARGE =
+      "The requested runtime variable document exceeds the configured maximum message size.";
+
+  private final ElementInstanceState elementInstanceState;
+  private final VariableState variableState;
+  private final CslAuthorizationCheck cslCheck;
+  private final CslTenantCheck tenantCheck;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final StateWriter stateWriter;
+
+  public RuntimeVariablesFetchProcessor(
+      final ElementInstanceState elementInstanceState,
+      final VariableState variableState,
+      final CslAuthorizationCheck cslCheck,
+      final CslTenantCheck tenantCheck,
+      final Writers writers) {
+    this.elementInstanceState = elementInstanceState;
+    this.variableState = variableState;
+    this.cslCheck = cslCheck;
+    this.tenantCheck = tenantCheck;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<RuntimeVariablesRecord> command) {
+    resolveInstance(command.getValue().getScopeKey())
+        .flatMap(instance -> authorize(command, instance))
+        .map(instance -> fetchVariables(command.getValue(), instance))
+        .ifRightOrLeft(
+            fetched -> acceptCommand(command, fetched),
+            rejection -> rejectCommand(command, rejection));
+  }
+
+  private Either<Rejection, ElementInstance> resolveInstance(final long scopeKey) {
+    final var instance = elementInstanceState.getInstance(scopeKey);
+    return instance == null
+        ? Either.left(
+            new Rejection(
+                RejectionType.NOT_FOUND, ERROR_MESSAGE_SCOPE_NOT_FOUND.formatted(scopeKey)))
+        : Either.right(instance);
+  }
+
+  private Either<Rejection, ElementInstance> authorize(
+      final TypedRecord<RuntimeVariablesRecord> command, final ElementInstance instance) {
+    final var value = instance.getValue();
+    final var tenantId = value.getTenantId();
+    return cslCheck
+        .check(
+            command,
+            RequiredAuthorization.of(
+                b ->
+                    b.resourceType(
+                            AuthzModelMapper.fromProtocol(
+                                AuthorizationResourceType.PROCESS_DEFINITION))
+                        .permissionType(
+                            AuthzModelMapper.fromProtocol(PermissionType.READ_PROCESS_INSTANCE))
+                        .resourceId(value.getBpmnProcessId())),
+            instance,
+            AuthorizationRejectionMapper.forbidden(
+                PermissionType.READ_PROCESS_INSTANCE, AuthorizationResourceType.PROCESS_DEFINITION),
+            AuthorizationRejectionMapper::toBareRejection)
+        .flatMap(
+            authorized ->
+                tenantCheck.checkTenant(
+                    command,
+                    tenantId,
+                    authorized,
+                    new Rejection(
+                        RejectionType.NOT_FOUND,
+                        ERROR_MESSAGE_NOT_FOUND_FOR_TENANT.formatted(
+                            command.getValue().getScopeKey()))));
+  }
+
+  private RuntimeVariablesRecord fetchVariables(
+      final RuntimeVariablesRecord request, final ElementInstance instance) {
+    final var scopeKey = request.getScopeKey();
+    final java.util.function.IntPredicate canWriteDocument =
+        length ->
+            stateWriter.canWriteEventOfLength(
+                length + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER);
+    final var variables =
+        request.getScope() == RuntimeVariableScope.LOCAL
+            ? variableState.getVariablesLocalAsDocument(scopeKey, canWriteDocument)
+            : variableState.getVariablesAsDocument(scopeKey, canWriteDocument);
+    if (variables.isEmpty()) {
+      throw new RuntimeVariablesTooLargeException();
+    }
+    return request
+        .setTenantId(instance.getValue().getTenantId())
+        .setVariables(variables.orElseThrow());
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<RuntimeVariablesRecord> command, final Throwable error) {
+    if (error instanceof RuntimeVariablesTooLargeException) {
+      rejectCommand(
+          command, new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_TOO_LARGE));
+      return ProcessingError.EXPECTED_ERROR;
+    }
+    return ProcessingError.UNEXPECTED_ERROR;
+  }
+
+  private static final class RuntimeVariablesTooLargeException extends RuntimeException {}
+
+  private void acceptCommand(
+      final TypedRecord<RuntimeVariablesRecord> command, final RuntimeVariablesRecord fetched) {
+    responseWriter.writeAcceptedResponseOnCommand(
+        fetched.getScopeKey(), RuntimeVariablesIntent.FETCHED, fetched, command);
+  }
+
+  private void rejectCommand(
+      final TypedRecord<RuntimeVariablesRecord> command, final Rejection rejection) {
+    rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+    responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -73,6 +73,7 @@ import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.RuntimeInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
@@ -109,6 +110,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceBusinessIdAppliers(state);
     registerBufferedCommandAppliers(state);
     register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
+    register(RuntimeVariablesIntent.FETCHED, NOOP_EVENT_APPLIER);
     register(ProcessInstanceBatchIntent.ACTIVATED, NOOP_EVENT_APPLIER);
     register(ProcessInstanceBatchIntent.TERMINATED, NOOP_EVENT_APPLIER);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/VariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/VariableState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.variable.VariableInstance;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.IntPredicate;
 import org.agrona.DirectBuffer;
 
 public interface VariableState {
@@ -27,9 +28,13 @@ public interface VariableState {
 
   DirectBuffer getVariablesAsDocument(long scopeKey);
 
+  Optional<DirectBuffer> getVariablesAsDocument(long scopeKey, IntPredicate canWriteDocument);
+
   DirectBuffer getVariablesAsDocument(long scopeKey, Collection<DirectBuffer> names);
 
   DirectBuffer getVariablesLocalAsDocument(long scopeKey);
+
+  Optional<DirectBuffer> getVariablesLocalAsDocument(long scopeKey, IntPredicate canWriteDocument);
 
   boolean isEmpty();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -26,10 +26,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
+import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.MutableBoolean;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.ObjectHashSet;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -240,6 +242,32 @@ public class DbVariableState implements MutableVariableState {
   }
 
   @Override
+  public Optional<DirectBuffer> getVariablesAsDocument(
+      final long scopeKey, final IntPredicate canWriteDocument) {
+    collectedVariables.clear();
+    writer.wrap(documentResultBuffer, 0);
+    writer.reserveMapHeader();
+
+    final boolean exceeded =
+        visitVariables(
+            scopeKey,
+            name -> !collectedVariables.contains(name.getBuffer()),
+            (name, value) -> {
+              writer.writeString(name.getBuffer());
+              writer.writeRaw(value.getValue());
+              collectedVariables.add(new UnsafeBuffer(name.getBuffer()));
+            },
+            () -> !canWriteDocument.test(writer.getOffset()));
+    if (exceeded) {
+      return Optional.empty();
+    }
+
+    writer.writeReservedMapHeader(0, collectedVariables.size());
+    resultView.wrap(documentResultBuffer, 0, writer.getOffset());
+    return Optional.of(resultView);
+  }
+
+  @Override
   public DirectBuffer getVariablesAsDocument(
       final long scopeKey, final Collection<DirectBuffer> names) {
 
@@ -290,6 +318,32 @@ public class DbVariableState implements MutableVariableState {
 
     resultView.wrap(documentResultBuffer, 0, writer.getOffset());
     return resultView;
+  }
+
+  @Override
+  public Optional<DirectBuffer> getVariablesLocalAsDocument(
+      final long scopeKey, final IntPredicate canWriteDocument) {
+    writer.wrap(documentResultBuffer, 0);
+    writer.reserveMapHeader();
+    final MutableInteger variableCount = new MutableInteger();
+
+    final boolean exceeded =
+        visitVariablesLocal(
+            scopeKey,
+            name -> true,
+            (name, value) -> {
+              writer.writeString(name.getBuffer());
+              writer.writeRaw(value.getValue());
+              variableCount.increment();
+            },
+            () -> !canWriteDocument.test(writer.getOffset()));
+    if (exceeded) {
+      return Optional.empty();
+    }
+
+    writer.writeReservedMapHeader(0, variableCount.get());
+    resultView.wrap(documentResultBuffer, 0, writer.getOffset());
+    return Optional.of(resultView);
   }
 
   @Override
@@ -359,7 +413,7 @@ public class DbVariableState implements MutableVariableState {
    * Like {@link #visitVariablesLocal(long, Predicate, BiConsumer, BooleanSupplier)} but walks up
    * the scope hierarchy.
    */
-  private void visitVariables(
+  private boolean visitVariables(
       final long scopeKey,
       final Predicate<DbString> filter,
       final BiConsumer<DbString, VariableInstance> variableConsumer,
@@ -373,6 +427,7 @@ public class DbVariableState implements MutableVariableState {
       currentScope = getParentScopeKey(currentScope);
 
     } while (!completed && currentScope >= 0);
+    return completed;
   }
 
   /**
@@ -391,6 +446,7 @@ public class DbVariableState implements MutableVariableState {
       final BooleanSupplier completionCondition) {
     this.scopeKey.wrapLong(scopeKey);
 
+    final var completed = new MutableBoolean(false);
     variablesColumnFamily.whileEqualPrefix(
         this.scopeKey,
         (compositeKey, variable) -> {
@@ -400,8 +456,9 @@ public class DbVariableState implements MutableVariableState {
             variableConsumer.accept(name, variable);
           }
 
-          return !completionCondition.getAsBoolean();
+          completed.set(completionCondition.getAsBoolean());
+          return !completed.get();
         });
-    return false;
+    return completed.get();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchAuthorizationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.runtimevariables;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RuntimeVariablesFetchAuthorizationTest {
+
+  private static final ConfiguredUser ADMIN =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(ADMIN)))
+          .withSecurityConfig(
+              cfg -> {
+                final var roles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                roles.put("admin", Map.of("users", List.of(ADMIN.getUsername())));
+                cfg.getInitialization().setDefaultRoles(roles);
+              });
+
+  @Test
+  public void shouldRejectWithoutReadProcessInstancePermission() {
+    // given
+    final var processId = "runtime-variables-auth";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", task -> task.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy(ADMIN.getUsername());
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(processId).create(ADMIN.getUsername());
+    final var unauthorizedUser = UUID.randomUUID().toString();
+    engine
+        .user()
+        .newUser(unauthorizedUser)
+        .withPassword(UUID.randomUUID().toString())
+        .withName("Unauthorized")
+        .withEmail(unauthorizedUser + "@example.com")
+        .create();
+    final var runtimeVariables = engine.runtimeVariables();
+
+    // when
+    final var rejection =
+        runtimeVariables.withScopeKey(processInstanceKey).fetchRejection(unauthorizedUser);
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'READ_PROCESS_INSTANCE' on resource"
+                + " 'PROCESS_DEFINITION'");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/runtimevariables/RuntimeVariablesFetchProcessorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.runtimevariables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.RuntimeVariablesClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RuntimeVariablesFetchProcessorTest {
+
+  private static final String PROCESS_ID = "runtime-variables";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  private long processInstanceKey;
+  private long taskInstanceKey;
+  private RuntimeVariablesClient runtimeVariables;
+
+  @Before
+  public void setUp() {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", task -> task.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+    processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("inherited", "root", "shadowed", "root"))
+            .create();
+    taskInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getKey();
+    runtimeVariables = engine.runtimeVariables();
+  }
+
+  @Test
+  public void shouldFetchEffectiveVariablesFromProcessInstance() {
+    // when
+    final var result = runtimeVariables.withScopeKey(processInstanceKey).fetch();
+
+    // then
+    assertThat(result.getVariables())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("inherited", "root", "shadowed", "root"));
+    assertThat(result.getScope()).isEqualTo(RuntimeVariableScope.EFFECTIVE);
+    assertThat(result.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldFetchInheritedAndShadowedEffectiveVariablesFromElement() {
+    // given
+    engine
+        .variables()
+        .ofScope(taskInstanceKey)
+        .withLocalSemantic()
+        .withDocument(Map.of("local", "task", "shadowed", "task"))
+        .update();
+
+    // when
+    final var result = runtimeVariables.withScopeKey(taskInstanceKey).fetch();
+
+    // then
+    assertThat(result.getVariables())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of("inherited", "root", "local", "task", "shadowed", "task"));
+  }
+
+  @Test
+  public void shouldFetchOnlyExactLocalVariablesFromElement() {
+    // given
+    engine
+        .variables()
+        .ofScope(taskInstanceKey)
+        .withLocalSemantic()
+        .withDocument(Map.of("local", "task", "shadowed", "task"))
+        .update();
+
+    // when
+    final var result =
+        runtimeVariables
+            .withScopeKey(taskInstanceKey)
+            .withScope(RuntimeVariableScope.LOCAL)
+            .fetch();
+
+    // then
+    assertThat(result.getVariables())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("local", "task", "shadowed", "task"));
+  }
+
+  @Test
+  public void shouldRejectMissingScope() {
+    // given
+    final var missingScopeKey = 123L;
+
+    // when
+    final var rejection = runtimeVariables.withScopeKey(missingScopeKey).fetchRejection();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason("No scope found with key '123'");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
@@ -90,6 +90,32 @@ public final class VariableStateTest {
   }
 
   @Test
+  public void shouldStopCollectingEffectiveVariablesAtConfiguredSize() {
+    // given
+    declareScope(parent);
+    setVariableLocal(parent, wrapString("large"), asMsgPack("\"" + "x".repeat(100) + "\""));
+
+    // when
+    final var variables = variableState.getVariablesAsDocument(parent, size -> size < 20);
+
+    // then
+    assertThat(variables).isEmpty();
+  }
+
+  @Test
+  public void shouldStopCollectingLocalVariablesAtConfiguredSize() {
+    // given
+    declareScope(parent);
+    setVariableLocal(parent, wrapString("large"), asMsgPack("\"" + "x".repeat(100) + "\""));
+
+    // when
+    final var variables = variableState.getVariablesLocalAsDocument(parent, size -> size < 20);
+
+    // then
+    assertThat(variables).isEmpty();
+  }
+
+  @Test
   public void shouldCollectNoVariablesAsEmptyDocument() {
     // given
     declareScope(parent);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -54,6 +54,7 @@ import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.engine.util.client.ResourceDeletionClient;
 import io.camunda.zeebe.engine.util.client.ResourceFetchClient;
 import io.camunda.zeebe.engine.util.client.RoleClient;
+import io.camunda.zeebe.engine.util.client.RuntimeVariablesClient;
 import io.camunda.zeebe.engine.util.client.ScaleClient;
 import io.camunda.zeebe.engine.util.client.SignalClient;
 import io.camunda.zeebe.engine.util.client.TenantClient;
@@ -536,6 +537,10 @@ public final class EngineRule extends ExternalResource {
 
   public ExpressionClient expression() {
     return new ExpressionClient(environmentRule);
+  }
+
+  public RuntimeVariablesClient runtimeVariables() {
+    return new RuntimeVariablesClient(environmentRule, getCommandResponseWriter());
   }
 
   public JobActivationClient jobs() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RuntimeVariablesClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RuntimeVariablesClient.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockingDetails;
+
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariablesRecordValue;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Random;
+import org.awaitility.Awaitility;
+
+public final class RuntimeVariablesClient {
+
+  private static final long DEFAULT_KEY = -1L;
+
+  private final long requestId = new Random().nextLong();
+  private final int requestStreamId = new Random().nextInt();
+  private final RuntimeVariablesRecord record = new RuntimeVariablesRecord();
+  private final CommandWriter writer;
+  private final CommandResponseWriter responseWriter;
+
+  public RuntimeVariablesClient(
+      final CommandWriter writer, final CommandResponseWriter responseWriter) {
+    this.writer = writer;
+    this.responseWriter = responseWriter;
+  }
+
+  public RuntimeVariablesClient withScopeKey(final long scopeKey) {
+    record.setScopeKey(scopeKey);
+    return this;
+  }
+
+  public RuntimeVariablesClient withScope(final RuntimeVariableScope scope) {
+    record.setScope(scope);
+    return this;
+  }
+
+  public RuntimeVariablesRecord fetch() {
+    writer.writeCommand(
+        DEFAULT_KEY, requestStreamId, requestId, RuntimeVariablesIntent.FETCH, record);
+    Awaitility.await("runtime variables response")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(findResponse()).isNotNull());
+    return findResponse();
+  }
+
+  public RuntimeVariablesRecord fetch(final String username) {
+    writer.writeCommand(
+        DEFAULT_KEY, requestStreamId, requestId, RuntimeVariablesIntent.FETCH, username, record);
+    Awaitility.await("runtime variables response")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(findResponse()).isNotNull());
+    return findResponse();
+  }
+
+  public Record<RuntimeVariablesRecordValue> fetchRejection() {
+    final var position =
+        writer.writeCommand(
+            DEFAULT_KEY, requestStreamId, requestId, RuntimeVariablesIntent.FETCH, record);
+    return findRejection(position);
+  }
+
+  public Record<RuntimeVariablesRecordValue> fetchRejection(final String username) {
+    final var position =
+        writer.writeCommand(
+            DEFAULT_KEY,
+            requestStreamId,
+            requestId,
+            RuntimeVariablesIntent.FETCH,
+            username,
+            record);
+    return findRejection(position);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Record<RuntimeVariablesRecordValue> findRejection(final long sourcePosition) {
+    return (Record<RuntimeVariablesRecordValue>)
+        (Record<?>)
+            RecordingExporter.records()
+                .withValueType(ValueType.RUNTIME_VARIABLES)
+                .onlyCommandRejections()
+                .withSourceRecordPosition(sourcePosition)
+                .getFirst();
+  }
+
+  private RuntimeVariablesRecord findResponse() {
+    return mockingDetails(responseWriter).getInvocations().stream()
+        .filter(invocation -> invocation.getMethod().getName().equals("valueWriter"))
+        .map(invocation -> invocation.getArgument(0))
+        .filter(RuntimeVariablesRecord.class::isInstance)
+        .map(RuntimeVariablesRecord.class::cast)
+        .reduce((first, second) -> second)
+        .orElse(null);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -124,6 +124,7 @@ final class TestSupport {
             ValueType.SBE_UNKNOWN,
             ValueType.NULL_VAL,
             ValueType.PROCESS_INSTANCE_RESULT,
+            ValueType.RUNTIME_VARIABLES,
             ValueType.CLOCK,
             ValueType.SCALE,
             // these are not yet supported

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -125,6 +125,7 @@ final class TestSupport {
             ValueType.SBE_UNKNOWN,
             ValueType.NULL_VAL,
             ValueType.PROCESS_INSTANCE_RESULT,
+            ValueType.RUNTIME_VARIABLES,
             ValueType.CLOCK,
             ValueType.SCALE,
             // these are not yet supported

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -125,6 +125,57 @@ paths:
       x-scope: physical-tenant
 
   /element-instances/{elementInstanceKey}/variables:
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Element instance
+      operationId: getElementInstanceRuntimeVariables
+      x-required-permissions:
+        - { resourceType: PROCESS_DEFINITION, permissionType: READ_PROCESS_INSTANCE }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get runtime variables visible from an element instance
+      description: Returns an authoritative variable snapshot directly from primary runtime state.
+      parameters:
+        - name: elementInstanceKey
+          in: path
+          required: true
+          description: The key of the active element instance whose variables should be returned. The root element instance key is the process instance key.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
+        - name: scope
+          in: query
+          required: false
+          description: EFFECTIVE returns all variables visible from the element. LOCAL returns only variables defined directly at the element scope.
+          schema:
+            $ref: 'variables.yaml#/components/schemas/RuntimeVariableScopeEnum'
+            default: EFFECTIVE
+      responses:
+        "200":
+          description: The runtime variables are successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: 'variables.yaml#/components/schemas/RuntimeVariablesResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: The active element instance scope was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+      x-scope: physical-tenant
     put:
       x-eventually-consistent: false
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -108,6 +108,25 @@ paths:
 
 components:
   schemas:
+    RuntimeVariableScopeEnum:
+      description: The scope from which runtime variables are returned.
+      type: string
+      enum:
+        - EFFECTIVE
+        - LOCAL
+
+    RuntimeVariablesResult:
+      description: An authoritative snapshot of variables from primary runtime state.
+      type: object
+      additionalProperties: false
+      required:
+        - variables
+      properties:
+        variables:
+          description: The complete JSON variable document for the requested scope.
+          type: object
+          additionalProperties: true
+
     VariableSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceController.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
+import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.ElementInstanceResult;
@@ -34,11 +35,13 @@ import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @CamundaRestController
 @RequestMapping("/v2/element-instances")
@@ -74,6 +77,34 @@ public class ElementInstanceController {
         () ->
             elementInstanceServices.setVariables(
                 variablesRequest, authenticationProvider.getCamundaAuthentication()));
+  }
+
+  @CamundaGetMapping(path = "/{elementInstanceKey}/variables")
+  public CompletableFuture<ResponseEntity<Object>> getRuntimeVariables(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable final long elementInstanceKey,
+      @RequestParam(defaultValue = "EFFECTIVE") final String scope) {
+    return RequestMapper.toRuntimeVariableScope(scope)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            runtimeScope ->
+                getRuntimeVariables(physicalTenantId, elementInstanceKey, runtimeScope));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> getRuntimeVariables(
+      final String physicalTenantId,
+      final long elementInstanceKey,
+      final io.camunda.zeebe.protocol.record.value.RuntimeVariableScope runtimeScope) {
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            serviceRegistry
+                .elementInstanceServices(physicalTenantId)
+                .fetchRuntimeVariables(
+                    elementInstanceKey,
+                    runtimeScope,
+                    authenticationProvider.getCamundaAuthentication()),
+        ResponseMapper::toRuntimeVariablesResult,
+        HttpStatus.OK);
   }
 
   @RequiresSecondaryStorage

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceControllerTest.java
@@ -24,10 +24,14 @@ import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -158,6 +162,86 @@ public class ElementInstanceControllerTest extends RestControllerTest {
         .thenReturn(elementInstanceServices);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldGetEffectiveRuntimeVariablesByDefault() {
+    // given
+    final var response =
+        new RuntimeVariablesRecord()
+            .setVariables(
+                new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of("orderId", "A-42"))));
+    when(elementInstanceServices.fetchRuntimeVariables(any(Long.class), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when / then
+    webClient
+        .get()
+        .uri(ELEMENTS_BASE_URL + "/123/variables")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"variables\":{\"orderId\":\"A-42\"}}", JsonCompareMode.STRICT);
+
+    Mockito.verify(elementInstanceServices)
+        .fetchRuntimeVariables(
+            123L, RuntimeVariableScope.EFFECTIVE, AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldGetLocalRuntimeVariables() {
+    // given
+    final var response =
+        new RuntimeVariablesRecord()
+            .setVariables(
+                new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of("local", true))));
+    when(elementInstanceServices.fetchRuntimeVariables(any(Long.class), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when / then
+    webClient
+        .get()
+        .uri(ELEMENTS_BASE_URL + "/123/variables?scope=LOCAL")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"variables\":{\"local\":true}}", JsonCompareMode.STRICT);
+
+    Mockito.verify(elementInstanceServices)
+        .fetchRuntimeVariables(
+            123L, RuntimeVariableScope.LOCAL, AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldGetLocalRuntimeVariablesWithLowercaseScope() {
+    // given
+    final var response = new RuntimeVariablesRecord();
+    when(elementInstanceServices.fetchRuntimeVariables(any(Long.class), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when / then
+    webClient
+        .get()
+        .uri(ELEMENTS_BASE_URL + "/123/variables?scope=local")
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    Mockito.verify(elementInstanceServices)
+        .fetchRuntimeVariables(
+            123L, RuntimeVariableScope.LOCAL, AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldRejectInvalidRuntimeVariableScope() {
+    webClient
+        .get()
+        .uri(ELEMENTS_BASE_URL + "/123/variables?scope=unknown")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFetchRuntimeVariablesRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFetchRuntimeVariablesRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import org.agrona.DirectBuffer;
+
+public final class BrokerFetchRuntimeVariablesRequest
+    extends BrokerExecuteCommand<RuntimeVariablesRecord> {
+
+  private final RuntimeVariablesRecord requestDto = new RuntimeVariablesRecord();
+
+  public BrokerFetchRuntimeVariablesRequest() {
+    super(ValueType.RUNTIME_VARIABLES, RuntimeVariablesIntent.FETCH);
+  }
+
+  public BrokerFetchRuntimeVariablesRequest setScopeKey(final long scopeKey) {
+    requestDto.setScopeKey(scopeKey);
+    setPartitionId(Protocol.decodePartitionId(scopeKey));
+    return this;
+  }
+
+  public BrokerFetchRuntimeVariablesRequest setScope(final RuntimeVariableScope scope) {
+    requestDto.setScope(scope);
+    return this;
+  }
+
+  @Override
+  public RuntimeVariablesRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected RuntimeVariablesRecord toResponseDto(final DirectBuffer buffer) {
+    final var responseDto = new RuntimeVariablesRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFetchRuntimeVariablesRequestTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFetchRuntimeVariablesRequestTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import org.junit.jupiter.api.Test;
+
+final class BrokerFetchRuntimeVariablesRequestTest {
+
+  @Test
+  void shouldRouteToScopePartition() {
+    // given
+    final var scopeKey = Protocol.encodePartitionId(3, 42L);
+
+    // when
+    final var request =
+        new BrokerFetchRuntimeVariablesRequest()
+            .setScopeKey(scopeKey)
+            .setScope(RuntimeVariableScope.LOCAL);
+
+    // then
+    assertThat(request.getValueType()).isEqualTo(ValueType.RUNTIME_VARIABLES);
+    assertThat(request.getIntent()).isEqualTo(RuntimeVariablesIntent.FETCH);
+    assertThat(request.getPartitionId()).isEqualTo(3);
+    assertThat(request.getRequestWriter().getScopeKey()).isEqualTo(scopeKey);
+    assertThat(request.getRequestWriter().getScope()).isEqualTo(RuntimeVariableScope.LOCAL);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -73,6 +73,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.runtimevariables.RuntimeVariablesRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
@@ -223,6 +224,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.EXPRESSION -> new ExpressionRecord();
       case ValueType.MULTI_INSTANCE -> new MultiInstanceRecord();
       case ValueType.RUNTIME_INSTRUCTION -> new RuntimeInstructionRecord();
+      case ValueType.RUNTIME_VARIABLES -> new RuntimeVariablesRecord();
       case ValueType.BATCH_OPERATION_INITIALIZATION -> new BatchOperationInitializationRecord();
       case ValueType.CHECKPOINT -> new CheckpointRecord();
       case ValueType.MESSAGE_SUBSCRIPTION -> new MessageSubscriptionRecord();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/runtimevariables/RuntimeVariablesRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/runtimevariables/RuntimeVariablesRecord.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.runtimevariables;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariablesRecordValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+public final class RuntimeVariablesRecord extends UnifiedRecordValue
+    implements RuntimeVariablesRecordValue {
+
+  private final LongProperty scopeKeyProp = new LongProperty("scopeKey", -1L);
+  private final EnumProperty<RuntimeVariableScope> scopeProp =
+      new EnumProperty<>("scope", RuntimeVariableScope.class, RuntimeVariableScope.EFFECTIVE);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+
+  public RuntimeVariablesRecord() {
+    super(4);
+    declareProperty(scopeKeyProp)
+        .declareProperty(scopeProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(variablesProp);
+  }
+
+  @Override
+  public long getScopeKey() {
+    return scopeKeyProp.getValue();
+  }
+
+  public RuntimeVariablesRecord setScopeKey(final long scopeKey) {
+    scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public RuntimeVariableScope getScope() {
+    return scopeProp.getValue();
+  }
+
+  public RuntimeVariablesRecord setScope(final RuntimeVariableScope scope) {
+    scopeProp.setValue(scope);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public RuntimeVariablesRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public RuntimeVariablesRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/runtimevariables/RuntimeVariablesRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/runtimevariables/RuntimeVariablesRecordTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.runtimevariables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class RuntimeVariablesRecordTest {
+
+  @Test
+  void shouldRoundTripFieldsViaMsgPack() {
+    // given
+    final var original =
+        new RuntimeVariablesRecord()
+            .setScopeKey(123L)
+            .setScope(RuntimeVariableScope.LOCAL)
+            .setTenantId("tenant-a")
+            .setVariables(
+                new UnsafeBuffer(MsgPackConverter.convertToMsgPack(Map.of("foo", "bar"))));
+
+    // when
+    final var copy = new RuntimeVariablesRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getScopeKey()).isEqualTo(123L);
+    assertThat(copy.getScope()).isEqualTo(RuntimeVariableScope.LOCAL);
+    assertThat(copy.getTenantId()).isEqualTo("tenant-a");
+    assertThat(copy.getVariables()).containsExactly(Map.entry("foo", "bar"));
+  }
+
+  @Test
+  void shouldDefaultScopeToEffective() {
+    assertThat(new RuntimeVariablesRecord().getScope()).isEqualTo(RuntimeVariableScope.EFFECTIVE);
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RuntimeVariablesRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RuntimeVariablesRecord.golden
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.runtimevariables;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariableScope;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariablesRecordValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+public final class RuntimeVariablesRecord extends UnifiedRecordValue
+    implements RuntimeVariablesRecordValue {
+
+  private final LongProperty scopeKeyProp = new LongProperty("scopeKey", -1L);
+  private final EnumProperty<RuntimeVariableScope> scopeProp =
+      new EnumProperty<>("scope", RuntimeVariableScope.class, RuntimeVariableScope.EFFECTIVE);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+
+  public RuntimeVariablesRecord() {
+    super(4);
+    declareProperty(scopeKeyProp)
+        .declareProperty(scopeProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(variablesProp);
+  }
+
+  @Override
+  public long getScopeKey() {
+    return scopeKeyProp.getValue();
+  }
+
+  public RuntimeVariablesRecord setScopeKey(final long scopeKey) {
+    scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public RuntimeVariableScope getScope() {
+    return scopeProp.getValue();
+  }
+
+  public RuntimeVariablesRecord setScope(final RuntimeVariableScope scope) {
+    scopeProp.setValue(scope);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public RuntimeVariablesRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public RuntimeVariablesRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -76,6 +76,7 @@ import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.RuntimeInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.RuntimeVariablesIntent;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
@@ -143,6 +144,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordVa
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariablesRecordValue;
 import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
@@ -368,6 +370,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.RUNTIME_INSTRUCTION,
         new Mapping<>(RuntimeInstructionRecordValue.class, RuntimeInstructionIntent.class));
+    mapping.put(
+        ValueType.RUNTIME_VARIABLES,
+        new Mapping<>(RuntimeVariablesRecordValue.class, RuntimeVariablesIntent.class));
     mapping.put(
         ValueType.CLUSTER_VARIABLE,
         new Mapping<>(ClusterVariableRecordValue.class, ClusterVariableIntent.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
@@ -61,6 +61,7 @@ public final class ValueTypes {
           ValueType.CONDITIONAL_SUBSCRIPTION,
           ValueType.CONDITIONAL_EVALUATION,
           ValueType.EXPRESSION,
+          ValueType.RUNTIME_VARIABLES,
           ValueType.GLOBAL_LISTENER,
           ValueType.AGENT_INSTANCE,
           ValueType.AGENT_HISTORY);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -116,6 +116,7 @@ public interface Intent {
     map.put(ValueType.RESOURCE_REEXPORT, ResourceReexportIntent.class);
     map.put(ValueType.ROLE, RoleIntent.class);
     map.put(ValueType.RUNTIME_INSTRUCTION, RuntimeInstructionIntent.class);
+    map.put(ValueType.RUNTIME_VARIABLES, RuntimeVariablesIntent.class);
     map.put(ValueType.SCALE, ScaleIntent.class);
     map.put(ValueType.SECRET_REFERENCE, SecretReferenceIntent.class);
     map.put(ValueType.SIGNAL, SignalIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/RuntimeVariablesIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/RuntimeVariablesIntent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum RuntimeVariablesIntent implements Intent {
+  FETCH(0),
+  FETCHED(1);
+
+  private final short value;
+
+  RuntimeVariablesIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return FETCH;
+      case 1:
+        return FETCHED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return this == FETCHED;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RuntimeVariableScope.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RuntimeVariableScope.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum RuntimeVariableScope {
+  EFFECTIVE,
+  LOCAL
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RuntimeVariablesRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RuntimeVariablesRecordValue.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableRuntimeVariablesRecordValue.Builder.class)
+public interface RuntimeVariablesRecordValue extends RecordValueWithVariables, TenantOwned {
+
+  long getScopeKey();
+
+  @Value.Default
+  default RuntimeVariableScope getScope() {
+    return RuntimeVariableScope.EFFECTIVE;
+  }
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -101,6 +101,7 @@
       <validValue name="SECRET_REFERENCE">75</validValue>
       <validValue name="BUFFERED_COMMAND">76</validValue>
       <validValue name="AGENT_DEFINITION">77</validValue>
+      <validValue name="RUNTIME_VARIABLES">78</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -151,6 +151,7 @@ final class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(RoleIntent.class, RoleIntent::from));
     result.addAll(
         buildParameterSets(RuntimeInstructionIntent.class, RuntimeInstructionIntent::from));
+    result.addAll(buildParameterSets(RuntimeVariablesIntent.class, RuntimeVariablesIntent::from));
     result.addAll(buildParameterSets(ScaleIntent.class, ScaleIntent::from));
     result.addAll(buildParameterSets(SecretReferenceIntent.class, SecretReferenceIntent::from));
     result.addAll(buildParameterSets(SignalIntent.class, SignalIntent::from));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -34,6 +34,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFI
 import static io.camunda.zeebe.protocol.record.ValueType.RESOURCE_REEXPORT;
 import static io.camunda.zeebe.protocol.record.ValueType.ROLE;
 import static io.camunda.zeebe.protocol.record.ValueType.RUNTIME_INSTRUCTION;
+import static io.camunda.zeebe.protocol.record.ValueType.RUNTIME_VARIABLES;
 import static io.camunda.zeebe.protocol.record.ValueType.SIGNAL;
 import static io.camunda.zeebe.protocol.record.ValueType.SIGNAL_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.TIMER;
@@ -136,6 +137,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordVa
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.RuntimeVariablesRecordValue;
 import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
@@ -237,6 +239,7 @@ public class CompactRecordLogger {
           entry(CONDITIONAL_SUBSCRIPTION.name(), "COND_SUB"),
           entry(CONDITIONAL_EVALUATION.name(), "COND_EVAL"),
           entry(EXPRESSION.name(), "EXPR"),
+          entry(RUNTIME_VARIABLES.name(), "RT_VAR"),
           entry(IDENTITY_SETUP.name(), "ID"),
           entry(CHECKPOINT.name(), "CHK"),
           entry(GLOBAL_LISTENER.name(), "GL"),
@@ -337,6 +340,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.CONDITIONAL_SUBSCRIPTION, this::summarizeConditionalSubscription);
     valueLoggers.put(CONDITIONAL_EVALUATION, this::summarizeConditionalEvaluation);
     valueLoggers.put(EXPRESSION, this::summarizeExpression);
+    valueLoggers.put(RUNTIME_VARIABLES, this::summarizeRuntimeVariables);
     valueLoggers.put(ValueType.IDENTITY_SETUP, this::summarizeIdentitySetup);
     valueLoggers.put(ValueType.SCALE, this::summarizeScale);
     valueLoggers.put(ValueType.CHECKPOINT, this::summarizeCheckpoint);
@@ -1328,6 +1332,15 @@ public class CompactRecordLogger {
         + "\" = "
         + formatVariableValue(value.getResultValue())
         + formatVariables(value.getVariables())
+        + formatTenant(value);
+  }
+
+  private String summarizeRuntimeVariables(final Record<?> record) {
+    final var value = (RuntimeVariablesRecordValue) record.getValue();
+    return "scope="
+        + shortenKey(value.getScopeKey())
+        + " "
+        + value.getScope()
         + formatTenant(value);
   }
 


### PR DESCRIPTION
## Summary

- add `GET /v2/element-instances/{elementInstanceKey}/variables` for authoritative variable snapshots from Zeebe primary state
- accept both nested element-instance keys and the root element-instance key, which is the process-instance key
- support the established Zeebe scopes `LOCAL` and `EFFECTIVE`, defaulting to `EFFECTIVE`
- expose the endpoint through `CamundaClient.newRuntimeVariablesGetRequest(scopeKey)`
- enforce process-instance read authorization, tenant isolation, active-scope validation, and bounded response size

## Semantics

`LOCAL` returns variables owned directly by the supplied element scope.

`EFFECTIVE` returns all variables visible from that scope, including inherited variables, with values from inner scopes shadowing values from outer scopes.

For a process instance, pass its process-instance key. The process root is itself an element instance and uses that same key.

The endpoint reads directly from broker primary state. It does not depend on exporters or secondary storage, and it only serves active scopes.

## Verification

- `./mvnw license:format spotless:apply -T1C`
- `./mvnw install -Dquickly -T1C`
- clean focused tests for Java client, protocol/golden records, compact logging, gateway, service, engine state/authorization, and REST controller
- complete `EventAppliersTest`: 313 passed
- Elasticsearch exporter tests: 363 passed
- OpenSearch exporter tests: 321 passed
- live QA validation for process-root, element `LOCAL`, element `EFFECTIVE`, invalid scope, wrong key, authorization, and tenant behavior
