### PR TITLE
feat: measure only targeted process definitions and show a target on the overview when it is saved

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeIT.java
@@ -16,6 +16,8 @@ import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetUpsertRequestDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.CycleTimeTargetDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
@@ -50,12 +52,14 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
   private BusinessValueTargetWriter targetWriter;
   private BusinessValueOverviewComputeService computeService;
   private BusinessValueOverviewRepository overviewRepository;
+  private BusinessValueTargetService targetService;
 
   @BeforeEach
   void setUp() {
     targetWriter = embeddedOptimizeExtension.getBean(BusinessValueTargetWriter.class);
     computeService = embeddedOptimizeExtension.getBean(BusinessValueOverviewComputeService.class);
     overviewRepository = embeddedOptimizeExtension.getBean(BusinessValueOverviewRepository.class);
+    targetService = embeddedOptimizeExtension.getBean(BusinessValueTargetService.class);
     // AbstractBrokerlessZeebeCCSMIT.cleanupOptimizeData() wipes Optimize data between tests, so
     // the ApplicationReadyEvent-driven seed is only visible to the first test. Reseed here so the
     // compute service can look up the two per-process seeded reports on every run.
@@ -198,6 +202,8 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
     // persistProcessInstances derives its definitions on the default tenant only, so the
     // other tenant's definition has to be written explicitly for it to enter the sweep
     persistProcessDefinitions(List.of(bvdDefinition(processKey, otherTenant)));
+    givenTargetFor(tenantA, processKey);
+    givenTargetFor(otherTenant, processKey);
 
     // when compute runs for the 7d preset
     computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
@@ -222,6 +228,9 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
             bvdInstanceWithDuration(slow, 10_000L).build(),
             bvdInstanceWithDuration(mid, 5_000L).build(),
             bvdInstanceWithDuration(fast, 1_000L).build()));
+    givenTargetFor(DEFAULT_TENANT, slow);
+    givenTargetFor(DEFAULT_TENANT, mid);
+    givenTargetFor(DEFAULT_TENANT, fast);
 
     // when compute runs for the 7d preset
     computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
@@ -245,6 +254,12 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
     final String neverRun = PROCESS_KEY + "-never-run";
     persistProcessInstances(List.of(bvdInstanceWithDuration(PROCESS_KEY, 4_000L).build()));
     persistProcessDefinitions(List.of(bvdDefinition(neverRun, DEFAULT_TENANT)));
+    // Both are targeted on purpose. The point of this test is that a definition with no instance
+    // index does not disturb its neighbour's evaluation, so it has to reach the evaluation set —
+    // leaving it untargeted would exclude it for an unrelated reason and the missing-index path
+    // would go untested.
+    givenTargetFor(DEFAULT_TENANT, PROCESS_KEY);
+    givenTargetFor(DEFAULT_TENANT, neverRun);
 
     // when compute runs for the 7d preset
     computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
@@ -260,6 +275,90 @@ class BusinessValueOverviewComputeIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(overviewRepository.getByKey(DEFAULT_TENANT, neverRun, MetricRange.SEVEN_DAYS))
         .isPresent()
         .hasValueSatisfying(r -> assertThat(r.getCycleTime().getValue()).isNull());
+  }
+
+  /**
+   * The bug this path exists for: a target saved between sweeps used to sit in the target index
+   * while the overview row kept the target it was last computed with, so L0 showed the old verdict
+   * for a full refresh interval. Deliberately runs no sweep between the save and the read — a test
+   * that swept in between would pass on the broken behaviour too.
+   */
+  @Test
+  void shouldReflectATargetOnTheOverviewRowsWithoutWaitingForASweep() {
+    // given a definition the sweep has measured, with no target yet
+    persistProcessDefinitions(List.of(bvdDefinition(PROCESS_KEY, DEFAULT_TENANT)));
+    computeService.computeOverviewRows(List.of(MetricRange.values()));
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, MetricRange.SEVEN_DAYS))
+        .isPresent()
+        .hasValueSatisfying(r -> assertThat(r.isHasAnyTarget()).isFalse());
+
+    // when a target is saved through the service, and no sweep runs afterwards
+    targetService.upsertTarget(
+        "sherrin@camunda.com",
+        DEFAULT_TENANT,
+        PROCESS_KEY,
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, null), AUTOMATION_TARGET_PCT));
+
+    // then every range preset already carries the target and its verdict
+    for (final MetricRange range : MetricRange.values()) {
+      assertThat(overviewRepository.getByKey(DEFAULT_TENANT, PROCESS_KEY, range))
+          .as("row for range %s", range)
+          .isPresent()
+          .hasValueSatisfying(
+              r -> {
+                assertThat(r.getCycleTime().getTarget()).isEqualTo(CYCLE_TARGET_MILLIS);
+                assertThat(r.getAutomationRate().getTarget()).isEqualTo(AUTOMATION_TARGET_PCT);
+                assertThat(r.isHasAnyTarget()).isTrue();
+                assertThat(r.getTargetsSet()).isEqualTo(2);
+              });
+    }
+  }
+
+  /**
+   * A definition imported since the last sweep has no rows at all, so there is nothing to update —
+   * measuring on save is what creates them.
+   */
+  @Test
+  void shouldCreateRowsWhenATargetIsSetOnADefinitionTheSweepHasNeverSeen() {
+    // given a definition that exists but has never been swept
+    final String freshKey = "fresh-import-" + System.nanoTime();
+    persistProcessDefinitions(List.of(bvdDefinition(freshKey, DEFAULT_TENANT)));
+    assertThat(overviewRepository.getByKey(DEFAULT_TENANT, freshKey, MetricRange.SEVEN_DAYS))
+        .isEmpty();
+
+    // when a target is saved
+    targetService.upsertTarget(
+        "sherrin@camunda.com",
+        DEFAULT_TENANT,
+        freshKey,
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(8L, TargetValueUnit.HOURS, null), AUTOMATION_TARGET_PCT));
+
+    // then the rows are created with the target on them
+    for (final MetricRange range : MetricRange.values()) {
+      assertThat(overviewRepository.getByKey(DEFAULT_TENANT, freshKey, range))
+          .as("row for range %s", range)
+          .isPresent()
+          .hasValueSatisfying(r -> assertThat(r.isHasAnyTarget()).isTrue());
+    }
+  }
+
+  /**
+   * Gives a definition a target, which is what puts it into the sweep's evaluation set — only
+   * targeted definitions are measured. Tests asserting on measured values have to call this for
+   * every definition whose value they check.
+   */
+  private void givenTargetFor(final String tenantId, final String processDefinitionKey) {
+    targetWriter.upsertTarget(
+        new BusinessValueTargetDto(
+            processDefinitionKey,
+            tenantId,
+            CYCLE_TARGET_MILLIS,
+            TargetValueUnit.HOURS,
+            AUTOMATION_TARGET_PCT,
+            OffsetDateTime.parse("2026-08-05T04:00:15Z"),
+            "sherrin@camunda.com"));
   }
 
   private static ProcessDefinitionOptimizeDto bvdDefinition(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetIT.java
@@ -54,6 +54,50 @@ class BusinessValueTargetIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(read).contains(target);
   }
 
+  /**
+   * {@code readByTenants} backs the overview read path, so its terms filter is a tenant-isolation
+   * boundary rather than a convenience. Exercised against the real store because the filter is
+   * built per backend — a unit test can only reach the empty-collection short circuit, and would
+   * pass while either engine's query was wrong.
+   */
+  @Test
+  void shouldReadOnlyTheRequestedTenantsTargets() {
+    // given the same process key targeted on two tenants
+    writer.upsertTarget(target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85));
+    writer.upsertTarget(target(PROCESS_KEY, OTHER_TENANT, 7_200_000L, 40));
+
+    // when reading one tenant
+    final List<BusinessValueTargetDto> defaultTenantTargets =
+        repository.readByTenants(List.of(DEFAULT_TENANT));
+
+    // then only that tenant's target comes back, with its own values
+    assertThat(defaultTenantTargets)
+        .singleElement()
+        .satisfies(
+            t -> {
+              assertThat(t.getTenantId()).isEqualTo(DEFAULT_TENANT);
+              assertThat(t.getCycleTimeTargetMillis()).isEqualTo(28_800_000L);
+            });
+
+    // and asking for both returns both, so the filter is narrowing rather than the fixture being
+    // half-written
+    assertThat(repository.readByTenants(List.of(DEFAULT_TENANT, OTHER_TENANT)))
+        .hasSize(2)
+        .extracting(BusinessValueTargetDto::getTenantId)
+        .containsExactlyInAnyOrder(DEFAULT_TENANT, OTHER_TENANT);
+  }
+
+  /** A caller authorized for no tenants must see nothing, not everything. */
+  @Test
+  void shouldReadNothingForAnEmptyTenantList() {
+    // given targets exist
+    writer.upsertTarget(target(PROCESS_KEY, DEFAULT_TENANT, 28_800_000L, 85));
+
+    // when the caller is authorized for no tenants
+    // then the read is empty rather than falling through to an unfiltered scan
+    assertThat(repository.readByTenants(List.of())).isEmpty();
+  }
+
   @Test
   void shouldOverwriteExistingTargetOnSameTenantAndKey() {
     // given

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.businessvalue;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 
 import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.SimpleDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.AutomationRateBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
@@ -30,6 +31,7 @@ import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
 import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
@@ -72,6 +74,31 @@ import org.springframework.stereotype.Component;
  * scheduler tick, so two full-scope sweeps may build chunk state and upsert the same document ids
  * at once. That is tolerable because a row is a pure function of its inputs and the writes are
  * idempotent, but it is worth knowing before adding per-sweep state that is not.
+ *
+ * <p>That purity holds only because targets are read immediately before the write rather than at
+ * the start of the sweep — a snapshot taken minutes earlier is a second input with a lifetime of
+ * its own, and two overlapping sweeps holding different ones produce different rows for the same
+ * id. Keep target reads adjacent to the write if this is restructured.
+ *
+ * <h2>Known limitations</h2>
+ *
+ * <p>Rows are eventually consistent, converging within one sweep interval. Nothing accumulates and
+ * no state is unrecoverable; the cases below trade a bounded window of slightly-stale measurements
+ * for not serializing writes, which this module has no precedent for.
+ *
+ * <ul>
+ *   <li><b>A target cleared while a sweep runs.</b> The definition was selected for measurement, so
+ *       the sweep writes its row with the target and verdict cleared — correct, but carrying the
+ *       measurements this sweep took rather than the fresher ones the save itself wrote. Only the
+ *       newly-targeted direction is skipped before the write, because there the sweep has no
+ *       measurements at all and would replace good values with nulls.
+ *   <li><b>Two saves for the same definition at once.</b> Each applies the target it persisted, so
+ *       neither can blend the other's values, but the writes are not ordered. If the later save's
+ *       measurement finishes first, the earlier one lands last and the rows end up describing a
+ *       target the target index no longer holds. Ordering this needs a version precondition or a
+ *       per-definition lock; neither is worth it for a window this small, on an action a single
+ *       user performs from one modal.
+ * </ul>
  */
 @Component
 public class BusinessValueOverviewComputeService {
@@ -97,6 +124,7 @@ public class BusinessValueOverviewComputeService {
       org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewComputeService.class);
 
   private final BusinessValueTargetRepository targetRepository;
+  private final BusinessValueOverviewRepository overviewRepository;
   private final BusinessValueOverviewWriter overviewWriter;
   private final DefinitionService definitionService;
   private final ReportService reportService;
@@ -107,6 +135,7 @@ public class BusinessValueOverviewComputeService {
 
   public BusinessValueOverviewComputeService(
       final BusinessValueTargetRepository targetRepository,
+      final BusinessValueOverviewRepository overviewRepository,
       final BusinessValueOverviewWriter overviewWriter,
       final DefinitionService definitionService,
       final ReportService reportService,
@@ -115,6 +144,7 @@ public class BusinessValueOverviewComputeService {
       final SearchLimitsRepository searchLimitsRepository,
       final ConfigurationService configurationService) {
     this.targetRepository = targetRepository;
+    this.overviewRepository = overviewRepository;
     this.overviewWriter = overviewWriter;
     this.definitionService = definitionService;
     this.reportService = reportService;
@@ -146,10 +176,19 @@ public class BusinessValueOverviewComputeService {
       return;
     }
 
-    final Map<String, BusinessValueTargetDto> targetsByDocId = readTargets();
+    // Read once here to decide what is worth measuring, and again below to decide what is written.
+    // The two answer different questions and cannot be collapsed into one: this read has to happen
+    // before the evaluations, the one below has to happen after them, and moving either to the
+    // other side reintroduces a bug — reading only up front lets the sweep overwrite a target saved
+    // mid-run, reading only at the end leaves nothing to select on. A target that lands between the
+    // two is handled by dropping its row before the write; see below.
+    final Set<String> targetedDocIds = targetedDocIds();
+    if (targetedDocIds.isEmpty()) {
+      LOG.debug("No business-value targets set; sweeping rows without measuring any definition");
+    }
+
     final Set<String> keysWithInstanceIndex =
         mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex();
-    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 
     final Map<String, List<DefinitionEntry>> definitionsByTenant =
         definitions.stream()
@@ -166,11 +205,174 @@ public class BusinessValueOverviewComputeService {
               perTenant.getValue(),
               ranges,
               keysWithInstanceIndex,
-              targetsByDocId,
-              now));
+              targetedDocIds));
+    }
+
+    // Targets are read here, after every evaluation has returned, rather than up front: the row
+    // carries the target it was written with, and a target saved while the sweep was still
+    // evaluating would otherwise be overwritten by the snapshot taken before it existed. The upsert
+    // is a blind write with no version precondition, so the sweep always wins that exchange and the
+    // user's target silently reverts until the next tick. Reading last narrows the window from the
+    // whole sweep — tens of seconds, and longer the bigger the catalog — to the bulk write itself.
+    final Map<String, BusinessValueTargetDto> targetsByDocId = readTargets();
+
+    // A definition targeted after the selection snapshot was never evaluated, so the row built for
+    // it here carries null values. The save that created that target has already measured the
+    // definition and written real values, and upserting this row would replace them with nulls —
+    // then stamp it fresh, so the backstop would not treat it as stale either. The user would see
+    // "target set, no data" until the next sweep, which is the outcome this whole change exists to
+    // prevent. Leave those rows out; the next sweep selects and measures them properly.
+    rowsToUpsert.removeIf(
+        row -> {
+          final String docId = targetDocId(row.getTenantId(), row.getProcessDefinitionKey());
+          final BusinessValueTargetDto target = targetsByDocId.get(docId);
+          return target != null && hasAnyTarget(target) && !targetedDocIds.contains(docId);
+        });
+
+    // Stamped here rather than when the sweep started, so that whichever writer touches a row last
+    // also leaves the latest timestamp on it. A sweep that began before a target write and finished
+    // after it would otherwise move the row's freshness backwards, and the stale-read backstop keys
+    // off exactly that field. The cost is that a long sweep overstates freshness by its own
+    // duration, which is the price of the ordering property.
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    for (final BusinessValueOverviewDto row : rowsToUpsert) {
+      row.setLastComputedAt(now);
+      applyTarget(
+          row, targetsByDocId.get(targetDocId(row.getTenantId(), row.getProcessDefinitionKey())));
     }
 
     overviewWriter.bulkUpsertFromScheduler(rowsToUpsert);
+  }
+
+  /**
+   * Writes a target and the verdict it implies onto a row that already carries its measured values.
+   * A {@code null} target clears both, which is what a cleared target must produce.
+   *
+   * <p>Separated from row construction so the target can be applied after every evaluation has
+   * returned rather than from a snapshot taken before the first — see {@link #computeOverviewRows}.
+   * {@link BusinessValueVerdict} is a pure function of the measured value and the target, so
+   * applying it last produces the same row as applying it during construction would have.
+   *
+   * <p>All five fields move together because {@code BusinessValueOverviewWriter} rejects a row
+   * whose {@code targetsSet} or {@code hasAnyTarget} disagrees with its blocks.
+   */
+  static void applyTarget(final BusinessValueOverviewDto row, final BusinessValueTargetDto target) {
+    final CycleTimeBlock cycleTime =
+        BusinessValueVerdict.cycleTimeBlock(
+            row.getCycleTime() == null ? null : row.getCycleTime().getValue(),
+            target == null ? null : target.getCycleTimeTargetMillis());
+    final AutomationRateBlock automationRate =
+        BusinessValueVerdict.automationRateBlock(
+            row.getAutomationRate() == null ? null : row.getAutomationRate().getValue(),
+            target == null ? null : target.getAutomationRateTargetPct());
+
+    final int targetsSet =
+        (cycleTime.getTarget() != null ? 1 : 0) + (automationRate.getTarget() != null ? 1 : 0);
+    final int targetsMet =
+        (Boolean.TRUE.equals(cycleTime.getMet()) ? 1 : 0)
+            + (Boolean.TRUE.equals(automationRate.getMet()) ? 1 : 0);
+
+    row.setCycleTime(cycleTime);
+    row.setAutomationRate(automationRate);
+    row.setHasAnyTarget(targetsSet > 0);
+    row.setTargetsSet(targetsSet);
+    row.setTargetsMet(targetsMet);
+  }
+
+  /**
+   * Measures one definition and writes its overview rows, so the caller's next {@code GET
+   * /business-value/overview} reflects a target the moment it is saved instead of waiting out a
+   * sweep interval.
+   *
+   * <p>Delegates to the same {@link #rowsForTenant} the sweep uses, with a single-entry list. That
+   * also covers a definition imported since the last sweep, which has no rows at all: rowsForTenant
+   * builds a row per range for every definition it is given, evaluated or not, so the row is
+   * created here rather than needing a separate path.
+   *
+   * <p><b>Always evaluates.</b> Re-deriving the verdict from whatever values the row already holds
+   * would be cheaper, and is wrong: a target cleared and re-set months later would pair a fresh
+   * target with a stale measurement and produce a confident, incorrect verdict. The only case where
+   * stored values are used instead is the kill switch below, where the alternative is no update at
+   * all.
+   *
+   * <p>Cost is one definition's worth of aggregations — two reports across four ranges, pinning a
+   * single instance index — which is what makes this affordable inside a request.
+   *
+   * @param target the target exactly as persisted — passed in rather than re-read so that two
+   *     concurrent saves for the same definition cannot each apply the other's value
+   */
+  public void computeRowsForTarget(final BusinessValueTargetDto target) {
+    if (target == null) {
+      throw new IllegalArgumentException("target must not be null");
+    }
+
+    // Evaluation is what overviewComputeEnabled exists to stop, so it is gated here too. Falling
+    // back to the stored values keeps the target itself coherent at no query cost, which is the
+    // behaviour the switch is meant to preserve: numbers freeze, the dashboard keeps working.
+    if (!configurationService.getBusinessValueConfiguration().isOverviewComputeEnabled()) {
+      LOG.debug(
+          "Business-value overview compute is disabled; re-deriving the verdict for tenant [{}] "
+              + "definition [{}] from stored values instead of evaluating",
+          target.getTenantId(),
+          target.getProcessDefinitionKey());
+      applyTargetToExistingRows(target);
+      return;
+    }
+
+    final DefinitionEntry entry =
+        new DefinitionEntry(
+            target.getTenantId(),
+            target.getProcessDefinitionKey(),
+            definitionName(target.getProcessDefinitionKey()));
+
+    final List<BusinessValueOverviewDto> rows =
+        rowsForTenant(
+            target.getTenantId(),
+            List.of(entry),
+            List.of(MetricRange.values()),
+            mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex(),
+            // Measured whatever the new target says, including a clear: the values are refreshed
+            // one last time on the way out, and the sweep stops measuring it from the next tick.
+            Set.of(targetDocId(target.getTenantId(), target.getProcessDefinitionKey())));
+
+    final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    for (final BusinessValueOverviewDto row : rows) {
+      row.setLastComputedAt(now);
+      applyTarget(row, target);
+    }
+    overviewWriter.bulkUpsertFromTargetWrite(rows);
+  }
+
+  /**
+   * Applies a target to the rows that already exist, without measuring anything. Used only when the
+   * sweep is switched off — a definition with no rows yet gets nothing, and {@code
+   * BusinessValueOverviewReadService} surfaces that case by joining live targets onto the rows it
+   * reads.
+   *
+   * <p>{@link BusinessValueOverviewDto#getLastComputedAt()} is left as it was: it records when the
+   * values were measured, and nothing was measured here.
+   */
+  private void applyTargetToExistingRows(final BusinessValueTargetDto target) {
+    final List<BusinessValueOverviewDto> rows = new ArrayList<>();
+    for (final MetricRange range : MetricRange.values()) {
+      overviewRepository
+          .getByKey(target.getTenantId(), target.getProcessDefinitionKey(), range)
+          .ifPresent(
+              row -> {
+                applyTarget(row, target);
+                rows.add(row);
+              });
+    }
+    if (!rows.isEmpty()) {
+      overviewWriter.bulkUpsertFromTargetWrite(rows);
+    }
+  }
+
+  private String definitionName(final String processDefinitionKey) {
+    return definitionService
+        .getProcessDefinitionWithTenants(processDefinitionKey)
+        .map(SimpleDefinitionDto::getName)
+        .orElse(processDefinitionKey);
   }
 
   /**
@@ -183,10 +385,9 @@ public class BusinessValueOverviewComputeService {
       final List<DefinitionEntry> tenantDefinitions,
       final List<MetricRange> ranges,
       final Set<String> keysWithInstanceIndex,
-      final Map<String, BusinessValueTargetDto> targetsByDocId,
-      final OffsetDateTime now) {
+      final Set<String> targetedDocIds) {
     final List<List<DefinitionEntry>> chunks =
-        chunk(evaluableDefinitions(tenantDefinitions, keysWithInstanceIndex));
+        chunk(evaluableDefinitions(tenantDefinitions, keysWithInstanceIndex, targetedDocIds));
     final List<BusinessValueOverviewDto> rows = new ArrayList<>();
 
     for (final MetricRange range : ranges) {
@@ -206,9 +407,7 @@ public class BusinessValueOverviewComputeService {
                 def,
                 range,
                 cycleMillisByKey.get(def.processDefinitionKey()),
-                automationPctByKey.get(def.processDefinitionKey()),
-                targetsByDocId,
-                now));
+                automationPctByKey.get(def.processDefinitionKey())));
       }
     }
     return rows;
@@ -246,13 +445,47 @@ public class BusinessValueOverviewComputeService {
    * from the query and left with a permanently null-valued row.
    */
   private static List<DefinitionEntry> evaluableDefinitions(
-      final List<DefinitionEntry> definitions, final Set<String> lowercasedKeysWithInstanceIndex) {
+      final List<DefinitionEntry> definitions,
+      final Set<String> lowercasedKeysWithInstanceIndex,
+      final Set<String> targetedDocIds) {
     return definitions.stream()
         .filter(
             def ->
                 lowercasedKeysWithInstanceIndex.contains(
                     def.processDefinitionKey().toLowerCase(Locale.ENGLISH)))
+        .filter(
+            def -> targetedDocIds.contains(targetDocId(def.tenantId(), def.processDefinitionKey())))
         .toList();
+  }
+
+  /**
+   * The {@code (tenantId, processDefinitionKey)} pairs worth measuring — those that currently carry
+   * a target.
+   *
+   * <p>Keyed by the pair rather than by definition key alone. The same BPMN process id can be
+   * deployed on several tenants and targeted on only one of them, and the Hub's target modal lets a
+   * user pick that tenant, so a key-level set would measure a definition for tenants nobody asked
+   * about and attribute one tenant's answer to another.
+   *
+   * <p>A cleared target leaves its document behind with null fields rather than deleting it, so
+   * presence alone is not enough — the definition stops being measured only once every target field
+   * is null, which is what clearing is supposed to mean.
+   */
+  private Set<String> targetedDocIds() {
+    return readTargets().entrySet().stream()
+        .filter(entry -> hasAnyTarget(entry.getValue()))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Whether a target document actually carries a target. Clearing a target leaves the document
+   * behind with every field null rather than deleting it, so presence in the index is not the same
+   * as being targeted — the sweep uses this to decide what to measure, and {@code
+   * BusinessValueOverviewReadService} to decide what is worth surfacing.
+   */
+  static boolean hasAnyTarget(final BusinessValueTargetDto target) {
+    return target.getCycleTimeTargetMillis() != null || target.getAutomationRateTargetPct() != null;
   }
 
   /**
@@ -327,40 +560,28 @@ public class BusinessValueOverviewComputeService {
         || c == '~';
   }
 
+  /**
+   * Builds a row carrying its measured values and no target. {@link #applyTarget} fills in the
+   * target and the verdict it implies once every evaluation has returned — see {@link
+   * #computeOverviewRows} for why that happens last rather than here.
+   */
   private BusinessValueOverviewDto buildRow(
       final DefinitionEntry def,
       final MetricRange range,
       final Double cycleMillis,
-      final Double automationPct,
-      final Map<String, BusinessValueTargetDto> targetsByDocId,
-      final OffsetDateTime now) {
-    final BusinessValueTargetDto target =
-        targetsByDocId.get(targetDocId(def.tenantId(), def.processDefinitionKey()));
-
-    final CycleTimeBlock cycleTime =
-        BusinessValueVerdict.cycleTimeBlock(
-            toLongMillis(cycleMillis), target == null ? null : target.getCycleTimeTargetMillis());
-    final AutomationRateBlock automationRate =
-        BusinessValueVerdict.automationRateBlock(
-            automationPct, target == null ? null : target.getAutomationRateTargetPct());
-
-    final int targetsSet =
-        (cycleTime.getTarget() != null ? 1 : 0) + (automationRate.getTarget() != null ? 1 : 0);
-    final int targetsMet =
-        (Boolean.TRUE.equals(cycleTime.getMet()) ? 1 : 0)
-            + (Boolean.TRUE.equals(automationRate.getMet()) ? 1 : 0);
-
+      final Double automationPct) {
     return new BusinessValueOverviewDto(
         def.tenantId(),
         def.processDefinitionKey(),
         def.processDefinitionName(),
         range,
-        now,
-        cycleTime,
-        automationRate,
-        targetsSet > 0,
-        targetsSet,
-        targetsMet);
+        // Replaced with the write-time stamp by the caller; see computeOverviewRows.
+        null,
+        BusinessValueVerdict.cycleTimeBlock(toLongMillis(cycleMillis), null),
+        BusinessValueVerdict.automationRateBlock(automationPct, null),
+        false,
+        0,
+        0);
   }
 
   /**

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeService.java
@@ -89,9 +89,10 @@ import org.springframework.stereotype.Component;
  * <ul>
  *   <li><b>A target cleared while a sweep runs.</b> The definition was selected for measurement, so
  *       the sweep writes its row with the target and verdict cleared — correct, but carrying the
- *       measurements this sweep took rather than the fresher ones the save itself wrote. Only the
- *       newly-targeted direction is skipped before the write, because there the sweep has no
- *       measurements at all and would replace good values with nulls.
+ *       measurements this sweep took rather than the fresher ones the save itself wrote. The
+ *       opposite transition — a definition that became targeted mid-sweep — is the one skipped
+ *       before the write, because there the sweep has no measurements at all and would replace good
+ *       values with nulls.
  *   <li><b>Two saves for the same definition at once.</b> Each applies the target it persisted, so
  *       neither can blend the other's values, but the writes are not ordered. If the later save's
  *       measurement finishes first, the earlier one lands last and the rows end up describing a

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadService.java
@@ -17,18 +17,22 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CategoryDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.CoverageDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto.OffTargetEntryDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,6 +75,7 @@ public class BusinessValueOverviewReadService {
       org.slf4j.LoggerFactory.getLogger(BusinessValueOverviewReadService.class);
 
   private final BusinessValueOverviewRepository overviewRepository;
+  private final BusinessValueTargetRepository targetRepository;
   private final TenantService tenantService;
   private final DefinitionService definitionService;
   private final BusinessValueOverviewComputeService computeService;
@@ -85,11 +90,13 @@ public class BusinessValueOverviewReadService {
 
   public BusinessValueOverviewReadService(
       final BusinessValueOverviewRepository overviewRepository,
+      final BusinessValueTargetRepository targetRepository,
       final TenantService tenantService,
       final DefinitionService definitionService,
       final BusinessValueOverviewComputeService computeService,
       final ConfigurationService configurationService) {
     this.overviewRepository = overviewRepository;
+    this.targetRepository = targetRepository;
     this.tenantService = tenantService;
     this.definitionService = definitionService;
     this.computeService = computeService;
@@ -111,30 +118,30 @@ public class BusinessValueOverviewReadService {
           DatabaseConstants.LIST_FETCH_LIMIT);
     }
 
-    if (rawRows.isEmpty()) {
-      return emptyResponse();
-    }
-
     // Overview rows for deleted process definitions would otherwise persist forever — the
     // scheduler stops upserting them but the repository has no deletion path today. Intersecting
     // against the current fully-imported definition set at read time hides orphans immediately,
     // and skipping them here also prevents the stale-read backstop from resurrecting them via
     // computeService (which would otherwise fall back to a synthetic definition entry).
     // Storage-level cleanup is tracked separately.
-    final Set<DefinitionKey> currentDefinitions = currentDefinitions();
-    final List<BusinessValueOverviewDto> rows =
+    final Map<DefinitionKey, String> currentDefinitions = currentDefinitions();
+    final List<BusinessValueOverviewDto> computedRows =
         rawRows.stream()
             .filter(
                 row ->
-                    currentDefinitions.contains(
+                    currentDefinitions.containsKey(
                         new DefinitionKey(row.getTenantId(), row.getProcessDefinitionKey())))
             .toList();
+
+    final OffsetDateTime now = OffsetDateTime.now();
+    final List<BusinessValueOverviewDto> rows =
+        withTargetOnlyDefinitions(
+            computedRows, currentDefinitions, authorizedTenantIds, range, now);
 
     if (rows.isEmpty()) {
       return emptyResponse();
     }
 
-    final OffsetDateTime now = OffsetDateTime.now();
     final Duration staleThreshold = staleThreshold();
 
     int totalProcesses = 0;
@@ -208,7 +215,11 @@ public class BusinessValueOverviewReadService {
         }
       }
 
-      if (isStale(row.getLastComputedAt(), now, staleThreshold)) {
+      // Only targeted rows are measured by the sweep, so only they can be meaningfully stale. An
+      // untargeted row is never recomputed and its timestamp ages without bound — counting those
+      // would leave the backstop firing a fleet-wide recompute on every single read, forever, as
+      // soon as one untargeted definition exists.
+      if (row.isHasAnyTarget() && isStale(row.getLastComputedAt(), now, staleThreshold)) {
         anyRowStale = true;
       }
     }
@@ -265,16 +276,85 @@ public class BusinessValueOverviewReadService {
         List.of());
   }
 
-  private Set<DefinitionKey> currentDefinitions() {
+  private Map<DefinitionKey, String> currentDefinitions() {
     final List<DefinitionWithTenantIdsDto> definitions =
         definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS);
-    final Set<DefinitionKey> keys = new HashSet<>();
+    final Map<DefinitionKey, String> keys = new HashMap<>();
     for (final DefinitionWithTenantIdsDto definition : definitions) {
+      final String name = definition.getName() != null ? definition.getName() : definition.getKey();
       for (final String tenantId : definition.getTenantIds()) {
-        keys.add(new DefinitionKey(tenantId, definition.getKey()));
+        keys.put(new DefinitionKey(tenantId, definition.getKey()), name);
       }
     }
     return keys;
+  }
+
+  /**
+   * Adds an entry for every definition that has a target but no computed row yet.
+   *
+   * <p>A safety net rather than the usual path: {@link
+   * BusinessValueOverviewComputeService#computeRowsForTarget} measures the definition and writes
+   * its rows when the target is saved, so this only catches the cases where that did not happen —
+   * the write-time measurement failed, or the sweep is switched off and the definition had no rows
+   * to fall back on. Cheap enough to be worth keeping for those.
+   *
+   * <p>The entry carries the target and no values, which is what it is: the target is known, the
+   * measurement is not. It therefore contributes to coverage and to the targets-set count, but is
+   * excluded from the off-target list by the existing null-value guards — there is no measurement
+   * to be off by.
+   *
+   * <p>Stamped with the current time so it never reads as stale. These rows were never computed, so
+   * a truthful timestamp would trip the backstop into a fleet-wide recompute on every read for as
+   * long as one target-only definition exists.
+   *
+   * <p>Not persisted. The sweep owns the index; this only shapes the response.
+   */
+  private List<BusinessValueOverviewDto> withTargetOnlyDefinitions(
+      final List<BusinessValueOverviewDto> computedRows,
+      final Map<DefinitionKey, String> currentDefinitions,
+      final List<String> authorizedTenantIds,
+      final MetricRange range,
+      final OffsetDateTime now) {
+    final Set<DefinitionKey> alreadyComputed = new HashSet<>();
+    for (final BusinessValueOverviewDto row : computedRows) {
+      alreadyComputed.add(new DefinitionKey(row.getTenantId(), row.getProcessDefinitionKey()));
+    }
+
+    final List<BusinessValueOverviewDto> synthesized = new ArrayList<>();
+    for (final BusinessValueTargetDto target :
+        targetRepository.readByTenants(authorizedTenantIds)) {
+      final DefinitionKey key =
+          new DefinitionKey(target.getTenantId(), target.getProcessDefinitionKey());
+      // A cleared target keeps its document with every field null. Synthesizing for those would
+      // add an untargeted process to the coverage denominator while an identical process that was
+      // never targeted stays absent, making the denominator depend on target history.
+      if (alreadyComputed.contains(key)
+          || !currentDefinitions.containsKey(key)
+          || !BusinessValueOverviewComputeService.hasAnyTarget(target)) {
+        continue;
+      }
+      final BusinessValueOverviewDto row =
+          new BusinessValueOverviewDto(
+              target.getTenantId(),
+              target.getProcessDefinitionKey(),
+              currentDefinitions.get(key),
+              range,
+              now,
+              BusinessValueVerdict.cycleTimeBlock(null, null),
+              BusinessValueVerdict.automationRateBlock(null, null),
+              false,
+              0,
+              0);
+      BusinessValueOverviewComputeService.applyTarget(row, target);
+      synthesized.add(row);
+    }
+
+    if (synthesized.isEmpty()) {
+      return computedRows;
+    }
+    final List<BusinessValueOverviewDto> all = new ArrayList<>(computedRows);
+    all.addAll(synthesized);
+    return all;
   }
 
   private Duration staleThreshold() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewSchedulerService.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
  * io.camunda.optimize.service.dashboard.BusinessValueDashboardService#init()} (annotated {@link
  * Ordered#HIGHEST_PRECEDENCE}) has seeded the per-process reports the compute path evaluates.
  * Without this ordering the first tick can run before the reports exist, fail, and then wait the
- * full refresh interval (24h by default) before retrying.
+ * full refresh interval (1h by default) before retrying.
  */
 @Component
 public class BusinessValueOverviewSchedulerService extends AbstractScheduledService {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
@@ -34,10 +34,14 @@ import org.springframework.stereotype.Component;
  *
  * <p>A target write measures the definition and writes its overview rows synchronously, via {@link
  * BusinessValueOverviewComputeService#computeRowsForTarget}, so the caller's next {@code GET
- * /business-value/overview} shows the new verdict. Without it the row keeps the target it was last
- * swept with, and the stale-read backstop does not help: it fires on the age of the measurement,
- * and a row measured minutes ago carrying an hour-old target is not stale by that test. The cost is
- * one definition's aggregations, not the whole catalogue's.
+ * /business-value/overview} shows the new verdict when that compute succeeds. Without it the row
+ * keeps the target it was last swept with, and the stale-read backstop does not help: it fires on
+ * the age of the measurement, and a row measured minutes ago carrying an hour-old target is not
+ * stale by that test. The cost is one definition's aggregations, not the whole catalogue's.
+ *
+ * <p>The compute is best effort. A failure is logged rather than surfaced, because the target is
+ * already durable by then and failing the request would leave the caller unable to tell whether it
+ * saved; the next sweep brings the rows up to date.
  *
  * <p>Field-level input validation ({@code automationRateTargetPct ∈ [0, 100]}, {@code
  * cycleTimeTarget.value ≥ 0}) is expressed as JSR-380 annotations on {@link

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetService.java
@@ -25,20 +25,19 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 /**
  * Application-layer entry point for the two BVD target REST endpoints. Delegates persistence to
  * {@link BusinessValueTargetWriter} / {@link BusinessValueTargetRepository}.
  *
- * <p>Target-write → overview coherence is eventual: the {@link
- * BusinessValueOverviewSchedulerService} refreshes the overview index on a tiered cadence, and the
- * stale-read backstop on {@code /overview} (see {@code BusinessValueOverviewReadService}) triggers
- * a targeted recompute the first time a reader observes a row older than {@code 2 ×} the refresh
- * interval. A per-write synchronous recompute is intentionally omitted here — the compute service
- * on the sibling M2.4 branch has been refactored to a single scheduler-driven entry point, and
- * blasting a cluster-wide recompute on every modal save is too expensive relative to the stale-read
- * latency budget documented in {@code bvd-target-technical-design.md} §3.4.
+ * <p>A target write measures the definition and writes its overview rows synchronously, via {@link
+ * BusinessValueOverviewComputeService#computeRowsForTarget}, so the caller's next {@code GET
+ * /business-value/overview} shows the new verdict. Without it the row keeps the target it was last
+ * swept with, and the stale-read backstop does not help: it fires on the age of the measurement,
+ * and a row measured minutes ago carrying an hour-old target is not stale by that test. The cost is
+ * one definition's aggregations, not the whole catalogue's.
  *
  * <p>Field-level input validation ({@code automationRateTargetPct ∈ [0, 100]}, {@code
  * cycleTimeTarget.value ≥ 0}) is expressed as JSR-380 annotations on {@link
@@ -53,20 +52,26 @@ public class BusinessValueTargetService {
   private static final Map<TargetValueUnit, Duration> UNIT_DURATIONS =
       BusinessValueTargetWriter.SUPPORTED_CYCLE_TIME_UNIT_DURATIONS;
 
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(BusinessValueTargetService.class);
+
   private final BusinessValueTargetWriter writer;
   private final BusinessValueTargetRepository repository;
   private final TenantService tenantService;
   private final DefinitionService definitionService;
+  private final BusinessValueOverviewComputeService overviewComputeService;
 
   public BusinessValueTargetService(
       final BusinessValueTargetWriter writer,
       final BusinessValueTargetRepository repository,
       final TenantService tenantService,
-      final DefinitionService definitionService) {
+      final DefinitionService definitionService,
+      final BusinessValueOverviewComputeService overviewComputeService) {
     this.writer = writer;
     this.repository = repository;
     this.tenantService = tenantService;
     this.definitionService = definitionService;
+    this.overviewComputeService = overviewComputeService;
   }
 
   public BusinessValueTargetResponseDto readTarget(
@@ -89,7 +94,29 @@ public class BusinessValueTargetService {
     final BusinessValueTargetDto toWrite =
         toPersistenceDto(tenantId, processDefinitionKey, request, userId);
     writer.upsertTarget(toWrite);
+    computeOverviewRows(toWrite);
     return toResponseDto(toWrite);
+  }
+
+  /**
+   * Measures the definition and writes its overview rows, after the target itself is durable.
+   *
+   * <p>A failure here is logged rather than surfaced: the target is already persisted, and the next
+   * sweep computes the rows from it, so the only cost is that L0 lags until then. Failing the
+   * request instead would leave the caller unable to tell whether their target was saved — the
+   * worse of the two outcomes, and the reason this runs after the write rather than as part of it.
+   */
+  private void computeOverviewRows(final BusinessValueTargetDto target) {
+    try {
+      overviewComputeService.computeRowsForTarget(target);
+    } catch (final Exception e) {
+      LOG.warn(
+          "Business-value target for tenant [{}] definition [{}] was saved, but computing its "
+              + "overview rows failed; the overview will catch up on the next sweep.",
+          target.getTenantId(),
+          target.getProcessDefinitionKey(),
+          e);
+    }
   }
 
   private void ensureTenantAccess(final String userId, final String tenantId) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.db.repository;
 
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +22,17 @@ public interface BusinessValueTargetRepository {
   Optional<BusinessValueTargetDto> getByKey(String tenantId, String processDefinitionKey);
 
   List<BusinessValueTargetDto> scanAll();
+
+  /**
+   * Reads the targets belonging to the given tenants.
+   *
+   * <p>Passing {@code null} returns every target and is reserved for internal, tenant-agnostic
+   * callers. Passing an empty collection returns no targets — a shortcut for callers that have
+   * already determined the caller sees no tenants. Any non-empty collection is pushed down to a
+   * {@code terms} filter so a request path never pulls another tenant's rows back to filter them in
+   * memory, and so the fetch limit bounds what this caller can see rather than the whole fleet.
+   */
+  List<BusinessValueTargetDto> readByTenants(Collection<String> tenantIds);
 
   static String documentId(final String tenantId, final String processDefinitionKey) {
     if (StringUtils.isBlank(tenantId)) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/BusinessValueTargetRepositoryES.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.db.repository.es;
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch.core.IndexResponse;
@@ -23,9 +24,11 @@ import io.camunda.optimize.service.db.es.builders.OptimizeIndexRequestBuilderES;
 import io.camunda.optimize.service.db.es.builders.OptimizeSearchRequestBuilderES;
 import io.camunda.optimize.service.db.es.reader.ElasticsearchReaderUtil;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
+import io.camunda.optimize.service.db.schema.index.BusinessValueTargetIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -96,6 +99,48 @@ public class BusinessValueTargetRepositoryES implements BusinessValueTargetRepos
       LOG.error(errorMessage, e);
       throw new OptimizeRuntimeException(errorMessage, e);
     }
+  }
+
+  @Override
+  public List<BusinessValueTargetDto> readByTenants(final Collection<String> tenantIds) {
+    if (tenantIds != null && tenantIds.isEmpty()) {
+      return List.of();
+    }
+    final List<FieldValue> tenantFieldValues =
+        tenantIds == null ? null : tenantIds.stream().map(FieldValue::of).toList();
+    final SearchRequest searchRequest =
+        OptimizeSearchRequestBuilderES.of(
+            b ->
+                b.optimizeIndex(esClient, BUSINESS_VALUE_TARGET_INDEX_NAME)
+                    .query(
+                        q ->
+                            tenantFieldValues == null
+                                ? q.matchAll(m -> m)
+                                : q.terms(
+                                    t ->
+                                        t.field(BusinessValueTargetIndex.TENANT_ID)
+                                            .terms(tt -> tt.value(tenantFieldValues))))
+                    .size(LIST_FETCH_LIMIT));
+    final SearchResponse<BusinessValueTargetDto> response;
+    try {
+      response = esClient.search(searchRequest, BusinessValueTargetDto.class);
+    } catch (final IOException e) {
+      final String errorMessage = "Could not read business-value targets for the given tenants.";
+      LOG.error(errorMessage, e);
+      throw new OptimizeRuntimeException(errorMessage, e);
+    }
+    final List<BusinessValueTargetDto> targets =
+        ElasticsearchReaderUtil.mapHits(
+            response.hits(), BusinessValueTargetDto.class, objectMapper);
+    if (targets.size() >= LIST_FETCH_LIMIT) {
+      throw new OptimizeRuntimeException(
+          String.format(
+              "business-value target readByTenants returned %d rows, hitting the "
+                  + "LIST_FETCH_LIMIT cap. Pagination must be introduced before the read path can "
+                  + "rely on complete results.",
+              targets.size()));
+    }
+    return targets;
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/BusinessValueTargetRepositoryOS.java
@@ -10,14 +10,17 @@ package io.camunda.optimize.service.db.repository.os;
 import static io.camunda.optimize.service.db.DatabaseConstants.BUSINESS_VALUE_TARGET_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.LIST_FETCH_LIMIT;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.matchAll;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.stringTerms;
 import static java.lang.String.format;
 
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.db.schema.index.BusinessValueTargetIndex;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -86,6 +89,32 @@ public class BusinessValueTargetRepositoryOS implements BusinessValueTargetRepos
     final GetResponse<BusinessValueTargetDto> response =
         osClient.get(requestBuilder, BusinessValueTargetDto.class, errorMessage);
     return response.found() ? Optional.ofNullable(response.source()) : Optional.empty();
+  }
+
+  @Override
+  public List<BusinessValueTargetDto> readByTenants(final Collection<String> tenantIds) {
+    if (tenantIds != null && tenantIds.isEmpty()) {
+      return List.of();
+    }
+    final SearchRequest.Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(indexNameService.getOptimizeIndexAliasForIndex(BUSINESS_VALUE_TARGET_INDEX_NAME))
+            .query(
+                tenantIds == null
+                    ? matchAll()
+                    : stringTerms(BusinessValueTargetIndex.TENANT_ID, tenantIds))
+            .size(LIST_FETCH_LIMIT);
+    final List<BusinessValueTargetDto> targets =
+        osClient.searchValues(requestBuilder, BusinessValueTargetDto.class);
+    if (targets.size() >= LIST_FETCH_LIMIT) {
+      throw new OptimizeRuntimeException(
+          format(
+              "business-value target readByTenants returned %d rows, hitting the "
+                  + "LIST_FETCH_LIMIT cap. Pagination must be introduced before the read path can "
+                  + "rely on complete results.",
+              targets.size()));
+    }
+    return targets;
   }
 
   @Override

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeKillSwitchTest.java
@@ -7,20 +7,26 @@
  */
 package io.camunda.optimize.service.businessvalue;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.RoleType;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.dto.optimize.query.report.AuthorizedReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
@@ -32,6 +38,7 @@ import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
@@ -39,11 +46,14 @@ import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Covers the operational kill switch for the overview sweep. The value of a kill switch is entirely
@@ -57,6 +67,7 @@ class BusinessValueOverviewComputeKillSwitchTest {
   private BusinessValueOverviewWriter overviewWriter;
   private PlainReportEvaluationHandler reportEvaluationHandler;
   private BusinessValueTargetRepository targetRepository;
+  private BusinessValueOverviewRepository overviewRepository;
   private DefinitionService definitionService;
   private MappingMetadataRepository mappingMetadataRepository;
   private SearchLimitsRepository searchLimitsRepository;
@@ -66,6 +77,7 @@ class BusinessValueOverviewComputeKillSwitchTest {
   @BeforeEach
   void setUp() {
     targetRepository = mock(BusinessValueTargetRepository.class);
+    overviewRepository = mock(BusinessValueOverviewRepository.class);
     overviewWriter = mock(BusinessValueOverviewWriter.class);
     definitionService = mock(DefinitionService.class);
     final ReportService reportService = mock(ReportService.class);
@@ -99,6 +111,7 @@ class BusinessValueOverviewComputeKillSwitchTest {
     computeService =
         new BusinessValueOverviewComputeService(
             targetRepository,
+            overviewRepository,
             overviewWriter,
             definitionService,
             reportService,
@@ -150,6 +163,87 @@ class BusinessValueOverviewComputeKillSwitchTest {
         targetRepository,
         mappingMetadataRepository,
         searchLimitsRepository);
+  }
+
+  /**
+   * The switch sheds background measurement, so a target write must stop evaluating too — otherwise
+   * one save issues eight aggregations while the operator believes BVD is quiet. Falling back to
+   * the stored values keeps the target itself coherent at no query cost, which is what the switch
+   * is for: the numbers freeze, the dashboard keeps working.
+   */
+  @Test
+  void shouldApplyATargetFromStoredValuesWithoutMeasuringWhenComputeIsDisabled() {
+    // given the sweep is switched off, and a definition with rows already measured at 5s
+    businessValueConfiguration.setOverviewComputeEnabled(false);
+    when(overviewRepository.getByKey(eq(TENANT), eq("invoice-process"), any()))
+        .thenAnswer(invocation -> Optional.of(rowFor(invocation.getArgument(2))));
+
+    // when a 1s target is saved
+    computeService.computeRowsForTarget(
+        new BusinessValueTargetDto(
+            "invoice-process",
+            TENANT,
+            1_000L,
+            TargetValueUnit.MILLIS,
+            null,
+            OffsetDateTime.now(),
+            "someone"));
+
+    // then the verdict is brought up to date from the values already on the row, and nothing is
+    // measured — asserting on the evaluation handler rather than only on the write, because a path
+    // that evaluated and then wrote would satisfy the weaker assertion
+    verifyNoInteractions(reportEvaluationHandler);
+    final ArgumentCaptor<List<BusinessValueOverviewDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(overviewWriter).bulkUpsertFromTargetWrite(captor.capture());
+    assertThat(captor.getValue())
+        .isNotEmpty()
+        .allSatisfy(
+            row -> {
+              assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+              assertThat(row.getCycleTime().getTarget()).isEqualTo(1_000L);
+              assertThat(row.getCycleTime().getMet()).isFalse();
+            });
+  }
+
+  /**
+   * With no row to fall back on there is nothing to apply the target to. The read path surfaces
+   * this case instead, by joining live targets onto the rows it reads.
+   */
+  @Test
+  void shouldWriteNothingWhenComputeIsDisabledAndTheDefinitionHasNoRows() {
+    // given the sweep is switched off and the definition has never been measured
+    businessValueConfiguration.setOverviewComputeEnabled(false);
+    when(overviewRepository.getByKey(anyString(), anyString(), any())).thenReturn(Optional.empty());
+
+    // when a target is saved
+    computeService.computeRowsForTarget(
+        new BusinessValueTargetDto(
+            "invoice-process",
+            TENANT,
+            1_000L,
+            TargetValueUnit.MILLIS,
+            null,
+            OffsetDateTime.now(),
+            "someone"));
+
+    // then nothing is measured and nothing is written
+    verifyNoInteractions(reportEvaluationHandler);
+    verify(overviewWriter, never()).bulkUpsertFromTargetWrite(any());
+  }
+
+  private static BusinessValueOverviewDto rowFor(final MetricRange range) {
+    return new BusinessValueOverviewDto(
+        TENANT,
+        "invoice-process",
+        "Invoice",
+        range,
+        OffsetDateTime.now(),
+        new BusinessValueOverviewDto.CycleTimeBlock(5_000L, null, null),
+        new BusinessValueOverviewDto.AutomationRateBlock(50d, null, null),
+        false,
+        0,
+        0);
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewComputeServiceTest.java
@@ -10,7 +10,9 @@ package io.camunda.optimize.service.businessvalue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -21,11 +23,13 @@ import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.RoleType;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
 import io.camunda.optimize.dto.optimize.query.report.AuthorizedReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.SingleReportEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.SingleProcessReportDefinitionRequestDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.group.ProcessDefinitionKeyGroupByDto;
@@ -38,6 +42,7 @@ import io.camunda.optimize.service.dashboard.BusinessValueDashboardService;
 import io.camunda.optimize.service.db.report.PlainReportEvaluationHandler;
 import io.camunda.optimize.service.db.report.ReportEvaluationInfo;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
+import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
 import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.db.repository.MappingMetadataRepository;
 import io.camunda.optimize.service.db.repository.SearchLimitsRepository;
@@ -45,6 +50,8 @@ import io.camunda.optimize.service.db.writer.BusinessValueOverviewWriter;
 import io.camunda.optimize.service.report.ReportService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,13 +60,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 /**
  * Guards the property the fan-in exists for: report evaluations per sweep scale with the number of
@@ -72,6 +82,7 @@ class BusinessValueOverviewComputeServiceTest {
   private static final String DEFAULT_TENANT = "<default>";
 
   private BusinessValueTargetRepository targetRepository;
+  private BusinessValueOverviewRepository overviewRepository;
   private BusinessValueOverviewWriter overviewWriter;
   private DefinitionService definitionService;
   private ReportService reportService;
@@ -100,6 +111,7 @@ class BusinessValueOverviewComputeServiceTest {
   @BeforeEach
   void setUp() {
     targetRepository = mock(BusinessValueTargetRepository.class);
+    overviewRepository = mock(BusinessValueOverviewRepository.class);
     overviewWriter = mock(BusinessValueOverviewWriter.class);
     definitionService = mock(DefinitionService.class);
     reportService = mock(ReportService.class);
@@ -114,6 +126,7 @@ class BusinessValueOverviewComputeServiceTest {
     computeService =
         new BusinessValueOverviewComputeService(
             targetRepository,
+            overviewRepository,
             overviewWriter,
             definitionService,
             reportService,
@@ -132,6 +145,394 @@ class BusinessValueOverviewComputeServiceTest {
               final ProcessReportDataDto reportData =
                   (ProcessReportDataDto) info.getReport().getData();
               return evaluationResultFor(reportData);
+            });
+  }
+
+  /**
+   * The sweep must take its target snapshot after the last evaluation returns, not before the
+   * first. Evaluating a whole catalog takes long enough for a user to save a target in the middle
+   * of it, and the upsert has no version precondition — so a snapshot read up front means the sweep
+   * writes back the target as it was before the save, silently reverting it until the next tick.
+   *
+   * <p>Asserted as an ordering rather than a value because a test that only checked the written row
+   * would pass on a sweep that read early and got lucky on timing.
+   */
+  @Test
+  void shouldReadTargetsAfterEvaluatingAndImmediatelyBeforeWriting() {
+    // given a catalog to sweep
+    givenDefinitions(DEFAULT_TENANT, 2);
+
+    // when a sweep runs
+    computeService.computeOverviewRows(allRanges());
+
+    // then targets are read only once every evaluation has returned, and the write follows
+    final InOrder inOrder = inOrder(reportEvaluationHandler, targetRepository, overviewWriter);
+    inOrder.verify(reportEvaluationHandler, atLeastOnce()).evaluateReport(any());
+    inOrder.verify(targetRepository).scanAll();
+    inOrder.verify(overviewWriter).bulkUpsertFromScheduler(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  /**
+   * The measured value belongs to the row that was just evaluated; the target is applied on top of
+   * it afterwards. This pins that the late target read still lands on the right row rather than
+   * being dropped by the reordering.
+   */
+  @Test
+  void shouldApplyTheTargetItReadToTheRowItEvaluated() {
+    // given one definition measured at 5s against a 1s cycle-time target, and no automation target
+    givenDefinitions(DEFAULT_TENANT, 1);
+    final String key = "process-0";
+    stubbedValuesByKey.put(key, 5_000d);
+    when(targetRepository.scanAll())
+        .thenReturn(List.of(cycleTimeTarget(DEFAULT_TENANT, key, 1_000L)));
+
+    // when a sweep runs for a single range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the written row pairs the evaluated value with the target and the verdict it implies
+    final BusinessValueOverviewDto row = capturedRows().getFirst();
+    assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+    assertThat(row.getCycleTime().getTarget()).isEqualTo(1_000L);
+    assertThat(row.getCycleTime().getMet()).isFalse();
+    assertThat(row.getAutomationRate().getTarget()).isNull();
+    assertThat(row.getTargetsSet()).isEqualTo(1);
+    assertThat(row.getTargetsMet()).isZero();
+    assertThat(row.isHasAnyTarget()).isTrue();
+  }
+
+  /**
+   * A sweep that began before a target write and finished after it would otherwise stamp the row
+   * with its own start time, moving the row's freshness backwards — and the stale-read backstop
+   * keys off exactly that field. Stamping at write time makes the last writer's stamp the latest.
+   *
+   * <p>Asserted against the moment evaluation actually ran, because a stamp taken at the start of
+   * the sweep would sit before it and one taken at the end after it. Comparing to "now" instead
+   * would pass either way.
+   */
+  @Test
+  void shouldStampFreshnessWhenWritingRatherThanWhenTheSweepStarted() {
+    // given a definition, recording when its evaluation ran
+    givenDefinitions(DEFAULT_TENANT, 1);
+    final AtomicReference<OffsetDateTime> evaluatedAt = new AtomicReference<>();
+    when(reportEvaluationHandler.evaluateReport(any(ReportEvaluationInfo.class)))
+        .thenAnswer(
+            invocation -> {
+              evaluationCount.incrementAndGet();
+              evaluatedAt.set(OffsetDateTime.now(ZoneOffset.UTC));
+              return evaluationResultFor(
+                  (ProcessReportDataDto)
+                      ((ReportEvaluationInfo) invocation.getArgument(0)).getReport().getData());
+            });
+
+    // when a sweep runs
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the row was stamped after the measurement, not before it
+    assertThat(evaluatedAt.get()).isNotNull();
+    assertThat(capturedRows())
+        .isNotEmpty()
+        .allSatisfy(row -> assertThat(row.getLastComputedAt()).isAfterOrEqualTo(evaluatedAt.get()));
+  }
+
+  // --- the sweep measures only what someone asked for ---
+
+  /**
+   * Measuring the whole catalogue costs one instance-index scan per definition per range, and most
+   * of that is thrown away: without a target there is no verdict to compute, and L0 shows nothing
+   * about the definition beyond its presence in the coverage denominator.
+   */
+  @Test
+  void shouldMeasureOnlyDefinitionsThatHaveATarget() {
+    // given ten definitions, two of which carry a target
+    givenDefinitions(DEFAULT_TENANT, 10);
+    when(targetRepository.scanAll())
+        .thenReturn(
+            List.of(
+                cycleTimeTarget(DEFAULT_TENANT, "process-2", 1_000L),
+                cycleTimeTarget(DEFAULT_TENANT, "process-7", 1_000L)));
+
+    // when a sweep runs for one range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then only those two are pinned onto the evaluation
+    assertThat(capturedChunkKeys())
+        .allSatisfy(keys -> assertThat(keys).containsExactlyInAnyOrder("process-2", "process-7"));
+  }
+
+  /**
+   * Every definition still gets a row, measured or not. The overview's coverage denominator is the
+   * row count, so dropping untargeted rows would make coverage read "n of n" — always 100%.
+   */
+  @Test
+  void shouldStillWriteARowForEveryDefinitionItDidNotMeasure() {
+    // given ten definitions, one targeted
+    givenDefinitions(DEFAULT_TENANT, 10);
+    when(targetRepository.scanAll())
+        .thenReturn(List.of(cycleTimeTarget(DEFAULT_TENANT, "process-2", 1_000L)));
+
+    // when a sweep runs for one range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then all ten rows are written, and only the targeted one carries a target
+    final List<BusinessValueOverviewDto> rows = capturedRows();
+    assertThat(rows).hasSize(10);
+    assertThat(rows.stream().filter(BusinessValueOverviewDto::isHasAnyTarget).toList())
+        .singleElement()
+        .satisfies(row -> assertThat(row.getProcessDefinitionKey()).isEqualTo("process-2"));
+  }
+
+  /**
+   * The same BPMN process id can be deployed on several tenants and targeted on only one of them —
+   * the Hub's target modal lets a user pick the tenant. Filtering on the definition key alone would
+   * measure it for tenants nobody asked about and blend one tenant's answer into another's row.
+   */
+  @Test
+  void shouldMeasureAKeyOnlyForTheTenantItIsTargetedOn() {
+    // given one process key deployed on two tenants, targeted on one
+    final String sharedKey = "shared-process";
+    final DefinitionWithTenantIdsDto definition =
+        new DefinitionWithTenantIdsDto(
+            sharedKey,
+            sharedKey,
+            DefinitionType.PROCESS,
+            new ArrayList<>(List.of(DEFAULT_TENANT, "tenant-b")),
+            Collections.emptySet());
+    when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
+        .thenReturn(List.of(definition));
+    when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
+        .thenReturn(Set.of(sharedKey));
+    when(targetRepository.scanAll())
+        .thenReturn(List.of(cycleTimeTarget("tenant-b", sharedKey, 1_000L)));
+    // both tenants have a value to return, so an untargeted tenant that got measured anyway would
+    // show it rather than staying null — without this the assertion below passes with no filter
+    valuesByTenant.put("tenant-b", 4_000d);
+    valuesByTenant.put(DEFAULT_TENANT, 9_000d);
+
+    // when a sweep runs for one range
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then only the targeted tenant's row is measured; the other keeps a null value
+    assertThat(capturedRows())
+        .filteredOn(row -> "tenant-b".equals(row.getTenantId()))
+        .singleElement()
+        .satisfies(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(4_000L));
+    assertThat(capturedRows())
+        .filteredOn(row -> DEFAULT_TENANT.equals(row.getTenantId()))
+        .singleElement()
+        .satisfies(
+            row -> {
+              assertThat(row.getCycleTime().getValue()).isNull();
+              assertThat(row.isHasAnyTarget()).isFalse();
+            });
+  }
+
+  /**
+   * Clearing a target leaves its document behind with null fields rather than deleting it, so
+   * presence in the target index is not the same as being targeted.
+   */
+  @Test
+  void shouldStopMeasuringADefinitionWhoseTargetHasBeenCleared() {
+    // given a definition whose target document exists but holds no target values
+    givenDefinitions(DEFAULT_TENANT, 1);
+    when(targetRepository.scanAll())
+        .thenReturn(
+            List.of(
+                new BusinessValueTargetDto(
+                    "process-0",
+                    DEFAULT_TENANT,
+                    null,
+                    null,
+                    null,
+                    OffsetDateTime.now(),
+                    "someone")));
+
+    // when a sweep runs
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then nothing is measured, though the row is still written
+    assertThat(evaluationCount.get()).isZero();
+    assertThat(capturedRows()).hasSize(1);
+  }
+
+  /**
+   * A target saved while a sweep is running was not in the sweep's selection snapshot, so the sweep
+   * never measured it and the row it built carries null values. The save has already measured the
+   * definition and written real ones. Writing the sweep's row anyway would replace them with nulls
+   * and stamp it fresh, so the backstop would not heal it either — the user would see "target set,
+   * no data" until the next tick, which is what this whole change exists to prevent.
+   */
+  @Test
+  void shouldNotOverwriteAFreshlyMeasuredRowForADefinitionTargetedMidSweep() {
+    // given two definitions, only one targeted when the sweep selects its work
+    givenDefinitions(DEFAULT_TENANT, 2);
+    final BusinessValueTargetDto alreadyTargeted =
+        cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L);
+    final BusinessValueTargetDto targetedMidSweep =
+        cycleTimeTarget(DEFAULT_TENANT, "process-1", 1_000L);
+    // the selection read sees one target; the read before the write sees both, as it would if the
+    // second were saved while the evaluations were still running
+    when(targetRepository.scanAll())
+        .thenReturn(List.of(alreadyTargeted))
+        .thenReturn(List.of(alreadyTargeted, targetedMidSweep));
+
+    // when a sweep runs
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the mid-sweep definition's row is left alone rather than written back with null values
+    assertThat(capturedRows())
+        .extracting(BusinessValueOverviewDto::getProcessDefinitionKey)
+        .containsExactly("process-0")
+        .doesNotContain("process-1");
+  }
+
+  /**
+   * A target cleared mid-sweep still has its verdict cleared — only the reverse case is skipped.
+   */
+  @Test
+  void shouldStillWriteARowForADefinitionWhoseTargetWasClearedMidSweep() {
+    // given a targeted definition whose target is cleared while the sweep runs
+    givenDefinitions(DEFAULT_TENANT, 1);
+    when(targetRepository.scanAll())
+        .thenReturn(List.of(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L)))
+        .thenReturn(
+            List.of(
+                new BusinessValueTargetDto(
+                    "process-0",
+                    DEFAULT_TENANT,
+                    null,
+                    null,
+                    null,
+                    OffsetDateTime.now(),
+                    "someone")));
+
+    // when a sweep runs
+    computeService.computeOverviewRows(List.of(MetricRange.SEVEN_DAYS));
+
+    // then the row is written with the target and verdict cleared
+    assertThat(capturedRows())
+        .singleElement()
+        .satisfies(
+            row -> {
+              assertThat(row.getProcessDefinitionKey()).isEqualTo("process-0");
+              assertThat(row.isHasAnyTarget()).isFalse();
+              assertThat(row.getCycleTime().getTarget()).isNull();
+            });
+  }
+
+  // --- computeRowsForTarget: the target-write path ---
+
+  /**
+   * Without this the saved target does not reach L0 until the next sweep: the row carries the
+   * target it was last computed with, and the stale-read backstop keys off the age of the
+   * measurement, so a freshly measured row holding a stale target looks perfectly fresh to it.
+   */
+  @Test
+  void shouldMeasureAndWriteEveryRangeWhenATargetIsSaved() {
+    // given a definition with instances, measured at 5s, and a 1s cycle-time target
+    givenDefinitions(DEFAULT_TENANT, 1);
+    stubbedValuesByKey.put("process-0", 5_000d);
+
+    // when the target is saved
+    computeService.computeRowsForTarget(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L));
+
+    // then one row per range is written, each pairing a fresh measurement with the new target
+    final List<BusinessValueOverviewDto> written = capturedTargetWriteRows();
+    assertThat(written)
+        .extracting(BusinessValueOverviewDto::getMetricRange)
+        .containsExactlyInAnyOrder(MetricRange.values());
+    assertThat(written)
+        .allSatisfy(
+            row -> {
+              assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+              assertThat(row.getCycleTime().getTarget()).isEqualTo(1_000L);
+              assertThat(row.getCycleTime().getMet()).isFalse();
+              assertThat(row.isHasAnyTarget()).isTrue();
+              assertThat(row.getTargetsSet()).isEqualTo(1);
+            });
+  }
+
+  /**
+   * Only the definition whose target changed is measured. Sweeping the catalogue on every modal
+   * save is the cost this path exists to avoid.
+   */
+  @Test
+  void shouldMeasureOnlyTheDefinitionWhoseTargetWasSaved() {
+    // given a catalogue of ten definitions
+    givenDefinitions(DEFAULT_TENANT, 10);
+
+    // when a target is saved on one of them
+    computeService.computeRowsForTarget(cycleTimeTarget(DEFAULT_TENANT, "process-3", 1_000L));
+
+    // then only that definition is pinned, and the cost is two reports x four ranges x one chunk
+    assertThat(capturedChunkKeys())
+        .allSatisfy(keys -> assertThat(keys).containsExactly("process-3"));
+    assertThat(evaluationCount.get()).isEqualTo(2 * 4 * 1);
+    assertThat(capturedTargetWriteRows())
+        .extracting(BusinessValueOverviewDto::getProcessDefinitionKey)
+        .containsOnly("process-3");
+  }
+
+  /**
+   * A definition imported since the last sweep has no rows at all. Measuring on save is what
+   * creates them — otherwise setting a target on a fresh import shows nothing until the next tick.
+   */
+  @Test
+  void shouldCreateRowsForADefinitionThatHasNoneYet() {
+    // given a definition the sweep has never written a row for
+    givenDefinitions(DEFAULT_TENANT, 1);
+    when(overviewRepository.getByKey(anyString(), anyString(), any())).thenReturn(Optional.empty());
+
+    // when a target is saved
+    computeService.computeRowsForTarget(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L));
+
+    // then the rows are created rather than skipped
+    assertThat(capturedTargetWriteRows()).hasSize(MetricRange.values().length);
+  }
+
+  /**
+   * Re-deriving from stored values would be cheaper and is the tempting optimization. It is also
+   * the bug: a target cleared and re-set later would be judged against whatever measurement the row
+   * still held, which could be months old.
+   */
+  @Test
+  void shouldMeasureAgainEvenWhenTheRowAlreadyHasValues() {
+    // given a definition whose rows already carry measurements
+    givenDefinitions(DEFAULT_TENANT, 1);
+    stubbedValuesByKey.put("process-0", 5_000d);
+    givenExistingRowsForAllRanges(DEFAULT_TENANT, "process-0", 999_999L, 1d);
+
+    // when a target is saved
+    computeService.computeRowsForTarget(cycleTimeTarget(DEFAULT_TENANT, "process-0", 1_000L));
+
+    // then the value written is freshly measured, not the one already on the row
+    assertThat(evaluationCount.get()).isPositive();
+    assertThat(capturedTargetWriteRows())
+        .allSatisfy(row -> assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L));
+  }
+
+  /** Clearing a target has to clear the verdict with it, not leave the last one standing. */
+  @Test
+  void shouldClearTheVerdictWhenTheTargetIsCleared() {
+    // given a measured definition
+    givenDefinitions(DEFAULT_TENANT, 1);
+    stubbedValuesByKey.put("process-0", 5_000d);
+
+    // when the target is cleared
+    computeService.computeRowsForTarget(
+        new BusinessValueTargetDto(
+            "process-0", DEFAULT_TENANT, null, null, null, OffsetDateTime.now(), "someone"));
+
+    // then the rows keep their measurements but carry no target, verdict or counters
+    assertThat(capturedTargetWriteRows())
+        .allSatisfy(
+            row -> {
+              assertThat(row.getCycleTime().getValue()).isEqualTo(5_000L);
+              assertThat(row.getCycleTime().getTarget()).isNull();
+              assertThat(row.getCycleTime().getMet()).isNull();
+              assertThat(row.isHasAnyTarget()).isFalse();
+              assertThat(row.getTargetsSet()).isZero();
+              assertThat(row.getTargetsMet()).isZero();
             });
   }
 
@@ -465,6 +866,7 @@ class BusinessValueOverviewComputeServiceTest {
         .thenReturn(List.of(definition));
     when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
         .thenReturn(Set.of("process_1"));
+    givenTargetsFor(List.of(definition));
     stubbedValuesByKey.put("Process_1", 7_000.0);
 
     // when computing a single range
@@ -532,6 +934,7 @@ class BusinessValueOverviewComputeServiceTest {
       final SearchLimitsRepository searchLimits) {
     return new BusinessValueOverviewComputeService(
         targetRepository,
+        overviewRepository,
         overviewWriter,
         definitionService,
         reportService,
@@ -573,6 +976,7 @@ class BusinessValueOverviewComputeServiceTest {
     when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex())
         .thenReturn(
             keys.stream().map(k -> k.toLowerCase(Locale.ENGLISH)).collect(Collectors.toSet()));
+    givenTargetsFor(definitions);
   }
 
   private void givenDefinitionsAcrossTenants(final Map<String, Integer> countsByTenant) {
@@ -597,6 +1001,63 @@ class BusinessValueOverviewComputeServiceTest {
     when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS))
         .thenReturn(definitions);
     when(mappingMetadataRepository.getProcessDefinitionKeysWithInstanceIndex()).thenReturn(keys);
+    givenTargetsFor(definitions);
+  }
+
+  /**
+   * Targets every definition the fixture created. The sweep only measures targeted definitions, so
+   * without this the chunking and fan-in tests would all be asserting on an empty evaluation set.
+   * Tests that care about the target filter itself override {@code targetRepository.scanAll()}.
+   */
+  private void givenTargetsFor(final List<DefinitionWithTenantIdsDto> definitions) {
+    final List<BusinessValueTargetDto> targets = new ArrayList<>();
+    for (final DefinitionWithTenantIdsDto def : definitions) {
+      for (final String tenantId : def.getTenantIds()) {
+        targets.add(cycleTimeTarget(tenantId, def.getKey(), 1_000L));
+      }
+    }
+    when(targetRepository.scanAll()).thenReturn(targets);
+  }
+
+  private static BusinessValueTargetDto cycleTimeTarget(
+      final String tenantId, final String processDefinitionKey, final long cycleTimeMillis) {
+    return new BusinessValueTargetDto(
+        processDefinitionKey,
+        tenantId,
+        cycleTimeMillis,
+        TargetValueUnit.MILLIS,
+        null,
+        OffsetDateTime.now(),
+        "someone");
+  }
+
+  private void givenExistingRowsForAllRanges(
+      final String tenantId,
+      final String processDefinitionKey,
+      final Long cycleMillis,
+      final Double automationPct) {
+    when(overviewRepository.getByKey(eq(tenantId), eq(processDefinitionKey), any()))
+        .thenAnswer(
+            invocation ->
+                Optional.of(
+                    new BusinessValueOverviewDto(
+                        tenantId,
+                        processDefinitionKey,
+                        processDefinitionKey,
+                        invocation.getArgument(2),
+                        OffsetDateTime.now(),
+                        new BusinessValueOverviewDto.CycleTimeBlock(cycleMillis, null, null),
+                        new BusinessValueOverviewDto.AutomationRateBlock(automationPct, null, null),
+                        false,
+                        0,
+                        0)));
+  }
+
+  private List<BusinessValueOverviewDto> capturedTargetWriteRows() {
+    final ArgumentCaptor<List<BusinessValueOverviewDto>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(overviewWriter).bulkUpsertFromTargetWrite(captor.capture());
+    return captor.getValue();
   }
 
   private List<BusinessValueOverviewDto> capturedRows() {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -580,6 +580,30 @@ class BusinessValueOverviewReadServiceTest {
     Awaitility.await().untilAsserted(() -> verify(computeService).computeOverviewRows(any()));
   }
 
+  /**
+   * A null lastComputedAt means the row was written but never measured, which is a distinct state
+   * from "measured a long time ago" and decides whether the backstop fires. Pinned because the
+   * branch is easy to lose: a future refactor that defaulted the timestamp instead of treating null
+   * as stale would leave such a row permanently unmeasured, with nothing to trigger a recompute.
+   */
+  @Test
+  void shouldTreatARowWithNoTimestampAsStale() {
+    // given a targeted row that has never been stamped
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(
+            List.of(
+                stamp(
+                    row(TENANT_A, "never-stamped", cyc(5_000L, 1_000L, false), autoNull(), 1, 0),
+                    null)));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "never-stamped"));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then the backstop fires, rather than the row sitting unmeasured forever
+    Awaitility.await().untilAsserted(() -> verify(computeService).computeOverviewRows(any()));
+  }
+
   // --- target-only definitions: imported since the last sweep, so no computed row yet ---
 
   /**

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueOverviewReadServiceTest.java
@@ -24,9 +24,12 @@ import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOvervie
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.CycleTimeBlock;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewDto.MetricRange;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueOverviewResponseDto;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
 import io.camunda.optimize.dto.optimize.query.definition.DefinitionWithTenantIdsDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value.TargetValueUnit;
 import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.repository.BusinessValueOverviewRepository;
+import io.camunda.optimize.service.db.repository.BusinessValueTargetRepository;
 import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.BusinessValueConfiguration;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -51,6 +54,7 @@ class BusinessValueOverviewReadServiceTest {
   private static final OffsetDateTime NOW = OffsetDateTime.now(ZoneOffset.UTC);
 
   private BusinessValueOverviewRepository overviewRepository;
+  private BusinessValueTargetRepository targetRepository;
   private TenantService tenantService;
   private DefinitionService definitionService;
   private BusinessValueOverviewComputeService computeService;
@@ -60,6 +64,8 @@ class BusinessValueOverviewReadServiceTest {
   @BeforeEach
   void setUp() {
     overviewRepository = mock(BusinessValueOverviewRepository.class);
+    targetRepository = mock(BusinessValueTargetRepository.class);
+    when(targetRepository.readByTenants(any())).thenReturn(List.of());
     tenantService = mock(TenantService.class);
     definitionService = mock(DefinitionService.class);
     computeService = mock(BusinessValueOverviewComputeService.class);
@@ -74,6 +80,7 @@ class BusinessValueOverviewReadServiceTest {
     readService =
         new BusinessValueOverviewReadService(
             overviewRepository,
+            targetRepository,
             tenantService,
             definitionService,
             computeService,
@@ -529,6 +536,189 @@ class BusinessValueOverviewReadServiceTest {
               entry.getKey(), entry.getKey(), DefinitionType.PROCESS, entry.getValue(), Set.of()));
     }
     when(definitionService.getAllDefinitionsWithTenants(DefinitionType.PROCESS)).thenReturn(dtos);
+  }
+
+  /**
+   * The sweep only measures targeted definitions, so an untargeted row is never recomputed and its
+   * timestamp ages without bound. Counting those as stale would leave the backstop firing a
+   * fleet-wide recompute on every single read, forever, from the moment one untargeted definition
+   * exists.
+   */
+  @Test
+  void shouldNotTriggerTheBackstopForAnUntargetedRowHoweverOldItIs() {
+    // given a row with no target, last computed long before the stale threshold
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(
+            List.of(
+                stamp(
+                    row(TENANT_A, "untargeted", cycNull(), autoNull(), 0, 0), NOW.minusYears(1))));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "untargeted"));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    verify(computeService, never()).computeOverviewRows(any());
+  }
+
+  /** A targeted row that has genuinely gone stale must still trigger it. */
+  @Test
+  void shouldStillTriggerTheBackstopForAStaleTargetedRow() {
+    // given a targeted row past the stale threshold
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(
+            List.of(
+                stamp(
+                    row(TENANT_A, "targeted", cyc(5_000L, 1_000L, false), autoNull(), 1, 0),
+                    NOW.minusYears(1))));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "targeted"));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    Awaitility.await().untilAsserted(() -> verify(computeService).computeOverviewRows(any()));
+  }
+
+  // --- target-only definitions: imported since the last sweep, so no computed row yet ---
+
+  /**
+   * Setting a target on a definition the sweep has not measured yet used to leave it absent from L0
+   * entirely — the target was saved, and nothing showed it. The entry is what is actually known: a
+   * target, and no measurement to judge it against.
+   */
+  @Test
+  void shouldSurfaceADefinitionThatHasATargetButNoComputedRow() {
+    // given a current definition with a target and no row
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "fresh-import"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "fresh-import", 1_000L, 90)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then it counts towards coverage and targets set, but nothing is claimed to be met
+    assertThat(response.isHasAnyTarget()).isTrue();
+    assertThat(response.getCoverage().getProcessesWithTarget()).isEqualTo(1);
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(1);
+    assertThat(response.getAttainment().getTargetsSet()).isEqualTo(2);
+    assertThat(response.getAttainment().getTargetsMet()).isZero();
+  }
+
+  /** There is no measurement, so there is no gap to rank — an entry here would be fabricated. */
+  @Test
+  void shouldNotListATargetOnlyDefinitionAsOffTarget() {
+    // given
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "fresh-import"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "fresh-import", 1_000L, 90)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.getOffTarget()).isEmpty();
+  }
+
+  /**
+   * These rows were never computed, so an honest timestamp would read as stale and fire a
+   * fleet-wide recompute on every single read for as long as one target-only definition exists.
+   */
+  @Test
+  void shouldNotTriggerTheBackstopForATargetOnlyDefinition() {
+    // given only a target-only definition, and a sweep that is otherwise up to date
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "fresh-import"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "fresh-import", 1_000L, 90)));
+
+    // when
+    readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    verify(computeService, never()).computeOverviewRows(any());
+  }
+
+  /** A definition that already has a row must not be counted twice. */
+  @Test
+  void shouldNotDuplicateADefinitionThatAlreadyHasAComputedRow() {
+    // given a definition with both a computed row and a target
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any()))
+        .thenReturn(
+            List.of(fresh(row(TENANT_A, "invoice", cyc(5_000L, 1_000L, false), autoNull(), 1, 0))));
+    stubCurrentDefinitions(new DefKey(TENANT_A, "invoice"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "invoice", 1_000L, null)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.getCoverage().getTotalProcesses()).isEqualTo(1);
+  }
+
+  /**
+   * The orphan filter applies to target-only entries too. A target outliving its definition would
+   * otherwise resurrect it on L0 with no way to remove it.
+   */
+  @Test
+  void shouldIgnoreATargetWhoseDefinitionNoLongerExists() {
+    // given a target for a definition that is no longer imported
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions();
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "deleted-process", 1_000L, 90)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then
+    assertThat(response.isHasAnyTarget()).isFalse();
+    assertThat(response.getCoverage().getTotalProcesses()).isZero();
+  }
+
+  /**
+   * Clearing a target leaves its document behind with every field null. Synthesizing an entry for
+   * one would add an untargeted process to the coverage denominator while a process that was never
+   * targeted, and is otherwise identical, stays absent — so the denominator would depend on which
+   * processes happened to carry a target at some point in the past.
+   */
+  @Test
+  void shouldNotSurfaceADefinitionWhoseTargetWasCleared() {
+    // given a current definition whose target document exists but holds no target values
+    when(overviewRepository.readByRange(eq(MetricRange.THIRTY_DAYS), any())).thenReturn(List.of());
+    stubCurrentDefinitions(new DefKey(TENANT_A, "was-targeted"));
+    when(targetRepository.readByTenants(any()))
+        .thenReturn(List.of(target(TENANT_A, "was-targeted", null, null)));
+
+    // when
+    final BusinessValueOverviewResponseDto response =
+        readService.getOverview(USER, MetricRange.THIRTY_DAYS);
+
+    // then it is absent, exactly as a never-targeted definition with no row would be
+    assertThat(response.isHasAnyTarget()).isFalse();
+    assertThat(response.getCoverage().getTotalProcesses()).isZero();
+  }
+
+  private static BusinessValueTargetDto target(
+      final String tenantId,
+      final String processKey,
+      final Long cycleTimeMillis,
+      final Integer automationRatePct) {
+    return new BusinessValueTargetDto(
+        processKey,
+        tenantId,
+        cycleTimeMillis,
+        cycleTimeMillis == null ? null : TargetValueUnit.MILLIS,
+        automationRatePct,
+        OffsetDateTime.now(ZoneOffset.UTC),
+        "someone");
   }
 
   private static BusinessValueOverviewDto row(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/businessvalue/BusinessValueTargetServiceTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 class BusinessValueTargetServiceTest {
 
@@ -49,6 +52,7 @@ class BusinessValueTargetServiceTest {
   private BusinessValueTargetRepository repository;
   private TenantService tenantService;
   private DefinitionService definitionService;
+  private BusinessValueOverviewComputeService overviewComputeService;
   private BusinessValueTargetService service;
 
   @BeforeEach
@@ -57,9 +61,12 @@ class BusinessValueTargetServiceTest {
     repository = mock(BusinessValueTargetRepository.class);
     tenantService = mock(TenantService.class);
     definitionService = mock(DefinitionService.class);
+    overviewComputeService = mock(BusinessValueOverviewComputeService.class);
     when(tenantService.isAuthorizedToSeeTenant(anyString(), anyString())).thenReturn(true);
     stubDefinitionExists(PROCESS_KEY, TENANT);
-    service = new BusinessValueTargetService(writer, repository, tenantService, definitionService);
+    service =
+        new BusinessValueTargetService(
+            writer, repository, tenantService, definitionService, overviewComputeService);
   }
 
   private void stubDefinitionExists(final String processDefinitionKey, final String... tenantIds) {
@@ -138,6 +145,75 @@ class BusinessValueTargetServiceTest {
     // and — response echoes the written state
     assertThat(response.cycleTimeTarget().millis()).isEqualTo(172_800_000L);
     assertThat(response.automationRateTargetPct()).isEqualTo(90);
+  }
+
+  // --- upsert: overview coherence ---
+
+  /**
+   * Without this the saved target does not reach L0 until the next sweep, because the overview row
+   * carries the target it was last computed with and the stale-read backstop keys off the age of
+   * the measurement, not of the target — a freshly measured row holding a stale target looks
+   * perfectly fresh to it.
+   */
+  @Test
+  void shouldComputeOverviewRowsWithTheTargetItJustWrote() {
+    // given
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(2L, TargetValueUnit.DAYS, null), 90);
+
+    // when
+    service.upsertTarget(USER, TENANT, PROCESS_KEY, request);
+
+    // then the compute runs after the target is durable, and on exactly what was persisted
+    final ArgumentCaptor<BusinessValueTargetDto> computeCaptor =
+        ArgumentCaptor.forClass(BusinessValueTargetDto.class);
+    final InOrder inOrder = inOrder(writer, overviewComputeService);
+    inOrder.verify(writer).upsertTarget(any(BusinessValueTargetDto.class));
+    inOrder.verify(overviewComputeService).computeRowsForTarget(computeCaptor.capture());
+    final BusinessValueTargetDto computed = computeCaptor.getValue();
+    assertThat(computed.getTenantId()).isEqualTo(TENANT);
+    assertThat(computed.getProcessDefinitionKey()).isEqualTo(PROCESS_KEY);
+    assertThat(computed.getCycleTimeTargetMillis()).isEqualTo(172_800_000L);
+    assertThat(computed.getAutomationRateTargetPct()).isEqualTo(90);
+  }
+
+  /**
+   * The target is already durable by the time the compute runs, and the next sweep measures the
+   * definition anyway. Failing the request instead would leave the caller unable to tell whether
+   * their target saved — worse than an overview that lags one interval.
+   */
+  @Test
+  void shouldStillReturnTheSavedTargetWhenComputingTheOverviewFails() {
+    // given a compute that blows up
+    doThrow(new IllegalStateException("elasticsearch is having a moment"))
+        .when(overviewComputeService)
+        .computeRowsForTarget(any());
+    final BusinessValueTargetUpsertRequestDto request =
+        new BusinessValueTargetUpsertRequestDto(
+            new CycleTimeTargetDto(2L, TargetValueUnit.DAYS, null), 90);
+
+    // when
+    final BusinessValueTargetResponseDto response =
+        service.upsertTarget(USER, TENANT, PROCESS_KEY, request);
+
+    // then the save stands and the caller sees what was persisted
+    verify(writer).upsertTarget(any(BusinessValueTargetDto.class));
+    assertThat(response.cycleTimeTarget().millis()).isEqualTo(172_800_000L);
+    assertThat(response.automationRateTargetPct()).isEqualTo(90);
+  }
+
+  /** A rejected upsert must not measure anything — there is no new target to propagate. */
+  @Test
+  void shouldNotComputeOverviewRowsWhenTheUpsertIsRejected() {
+    // given a request that fails the service's own cross-field validation
+    final BusinessValueTargetUpsertRequestDto missingUnit =
+        new BusinessValueTargetUpsertRequestDto(new CycleTimeTargetDto(2L, null, null), 90);
+
+    // when / then
+    assertThatThrownBy(() -> service.upsertTarget(USER, TENANT, PROCESS_KEY, missingUnit))
+        .isInstanceOf(BadRequestException.class);
+    verify(overviewComputeService, never()).computeRowsForTarget(any());
   }
 
   // --- upsert: clear semantics ---

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
@@ -9,16 +9,33 @@ package io.camunda.optimize.service.db.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.util.ObjectBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.es.BusinessValueTargetRepositoryES;
+import io.camunda.optimize.service.db.repository.os.BusinessValueTargetRepositoryOS;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class BusinessValueTargetRepositoryTest {
 
@@ -41,6 +58,76 @@ class BusinessValueTargetRepositoryTest {
     // then
     assertThat(targets).isEmpty();
     verifyNoInteractions(esClient);
+  }
+
+  /**
+   * The cap must fail loudly rather than truncate. readByTenants backs the overview read, and a
+   * silently short result would drop a tenant's targets from the response with no signal — the
+   * caller would see fewer targeted processes than they have and have no way to tell.
+   *
+   * <p>Covered per engine because the two implementations build and bound the query separately, so
+   * one could regress while the other stayed correct.
+   */
+  @Test
+  void shouldFailRatherThanTruncateWhenElasticsearchReturnsTheFetchLimit() throws Exception {
+    // given a backend returning exactly the fetch cap
+    final OptimizeElasticsearchClient esClient = mock(OptimizeElasticsearchClient.class);
+    // The request builder resolves the index alias through the client's own indexNameService field
+    // rather than a method, so a bare mock leaves it null and the builder trips before the cap
+    // check is ever reached.
+    final OptimizeIndexNameService nameService = mock(OptimizeIndexNameService.class);
+    when(nameService.getOptimizeIndexAliasForIndex(anyString())).thenReturn("optimize-target");
+    ReflectionTestUtils.setField(esClient, "indexNameService", nameService);
+    final SearchResponse<BusinessValueTargetDto> response = mock(SearchResponse.class);
+    final HitsMetadata<BusinessValueTargetDto> hits = mock(HitsMetadata.class);
+    when(hits.hits()).thenReturn(cappedHits());
+    when(response.hits()).thenReturn(hits);
+    when(esClient.search(any(SearchRequest.class), eq(BusinessValueTargetDto.class)))
+        .thenReturn(response);
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new BusinessValueTargetRepositoryES(esClient, new ObjectMapper())
+                    .readByTenants(List.of("tenant-a")))
+        .isInstanceOf(OptimizeRuntimeException.class)
+        .hasMessageContaining("LIST_FETCH_LIMIT");
+  }
+
+  @Test
+  void shouldFailRatherThanTruncateWhenOpenSearchReturnsTheFetchLimit() {
+    // given a backend returning exactly the fetch cap
+    final OptimizeOpenSearchClient osClient = mock(OptimizeOpenSearchClient.class);
+    when(osClient.searchValues(any(), eq(BusinessValueTargetDto.class)))
+        .thenReturn(
+            IntStream.range(0, DatabaseConstants.LIST_FETCH_LIMIT)
+                .mapToObj(i -> targetFor("process-" + i))
+                .toList());
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new BusinessValueTargetRepositoryOS(osClient, mock(OptimizeIndexNameService.class))
+                    .readByTenants(List.of("tenant-a")))
+        .isInstanceOf(OptimizeRuntimeException.class)
+        .hasMessageContaining("LIST_FETCH_LIMIT");
+  }
+
+  private static List<Hit<BusinessValueTargetDto>> cappedHits() {
+    return IntStream.range(0, DatabaseConstants.LIST_FETCH_LIMIT)
+        .mapToObj(
+            i ->
+                Hit.of(
+                    (Function<
+                            Hit.Builder<BusinessValueTargetDto>,
+                            ObjectBuilder<Hit<BusinessValueTargetDto>>>)
+                        b -> b.index("i").id(String.valueOf(i)).source(targetFor("process-" + i))))
+        .toList();
+  }
+
+  private static BusinessValueTargetDto targetFor(final String processDefinitionKey) {
+    return new BusinessValueTargetDto(
+        processDefinitionKey, "tenant-a", 1_000L, null, null, null, "someone");
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/repository/BusinessValueTargetRepositoryTest.java
@@ -9,11 +9,39 @@ package io.camunda.optimize.service.db.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.query.businessvalue.BusinessValueTargetDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.repository.es.BusinessValueTargetRepositoryES;
 import io.camunda.optimize.service.util.importing.ZeebeConstants;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class BusinessValueTargetRepositoryTest {
+
+  /**
+   * An empty authorized-tenant list means the caller may see nothing, and it must not be allowed to
+   * fall through to the unfiltered read that {@code null} selects. Verified by asserting the client
+   * is never touched rather than that the result is empty — a query that ran and happened to match
+   * nothing would satisfy the weaker assertion while still having read every tenant's targets.
+   */
+  @Test
+  void shouldReadNothingWithoutQueryingWhenTheCallerSeesNoTenants() {
+    // given
+    final OptimizeElasticsearchClient esClient = mock(OptimizeElasticsearchClient.class);
+    final BusinessValueTargetRepositoryES repository =
+        new BusinessValueTargetRepositoryES(esClient, new ObjectMapper());
+
+    // when
+    final List<BusinessValueTargetDto> targets = repository.readByTenants(List.of());
+
+    // then
+    assertThat(targets).isEmpty();
+    verifyNoInteractions(esClient);
+  }
 
   @Test
   void shouldCombineTenantAndProcessKeyIntoDocumentId() {

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -592,14 +592,23 @@ entity:
   nameMaxLength: ${CAMUNDA_OPTIMIZE_ENTITY_NAME_MAX_LENGTH:32768}
 
 businessValue:
-  # How often the business-value overview index is refreshed for all definitions and all range
-  # presets (7d, 30d, 3m, 6m). The given number is the interval in seconds. Default: 24h.
-  overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:86400}
+  # How often the business-value overview index is refreshed, for every range preset (7d, 30d, 3m,
+  # 6m). The given number is the interval in seconds. Default: 1h. Only definitions that carry a
+  # target are measured, so the cost tracks how many targets are set rather than the size of the
+  # process catalogue — a definition nobody targeted is never measured at all. Saving a target
+  # measures that definition straight away, so this interval bounds how long an already-targeted
+  # definition waits to be re-measured, not how long a new target waits to show a value. The
+  # stale-read threshold derives from it at twice its value.
+  overviewRefreshInterval: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_REFRESH_INTERVAL:3600}
   # Kill switch for the background overview computation. Set to false to stop the sweep without
   # taking the dashboard down: existing rows stay readable and the endpoint keeps serving, the
   # numbers simply stop advancing until it is re-enabled. Requires an Optimize restart to take
-  # effect, as configuration is read once at startup. Scoped to the sweep only — it does not affect
-  # the overview or target endpoints, nor the dashboard tiles, which are evaluated per request.
+  # effect, as configuration is read once at startup. The whole sweep is skipped, not just the
+  # measuring: no rows are written either, so a process definition imported while this is off gets
+  # no overview row at all until it is re-enabled. Request paths are unaffected — the overview and
+  # target endpoints keep serving, as do the dashboard tiles, which are evaluated per request.
+  # Saving a target still applies it to whatever rows already exist, so verdicts stay coherent and
+  # only the numbers behind them freeze; a definition with no rows yet gets nothing.
   overviewComputeEnabled: ${CAMUNDA_OPTIMIZE_BUSINESS_VALUE_OVERVIEW_COMPUTE_ENABLED:true}
 
 export:


### PR DESCRIPTION
## Why

**Coherence.** Setting a target did not change L0. The target reached its own index immediately, but the overview row kept the target it was last swept with, so coverage, attainment and the off-target list answered from the previous target for up to a full refresh interval. The stale-read backstop never rescued it: it fires on the age of the *measurement*, and a row measured minutes ago holding an hour-old target is not stale by that test.

**Cost.** The sweep measured every imported definition on every tick. Each evaluation pins its chunk's `process-instance-*` aliases, so the aggregation reads one index per definition — and without a target there is no verdict to compute, so nearly all of it was discarded.

Both resolve the same way: **a target write does not change what was measured, and a definition nobody set a target on does not need measuring.**

## What

1. **`fix:`** the sweep reads targets after its evaluations, immediately before the bulk write, so a target saved mid-sweep is no longer overwritten by a snapshot taken before it existed. `applyTarget` extracted so the derivation lives in one place.
2. **`feat:`** a target write measures that one definition and writes its rows, so the verdict is there on the next read. Reuses the sweep's `rowsForTenant` with a single-entry list, which also creates rows for a definition imported since the last sweep. Gated by `overviewComputeEnabled`; when off it falls back to re-deriving from stored values, so targets stay coherent at zero query cost.
3. **`feat:`** `/overview` joins live targets onto the rows it read and surfaces a definition that has a target but no row — a safety net for when the write-time measurement did not happen.
4. **`perf:`** the sweep measures only definitions carrying a target. Every definition still gets a row, so the coverage denominator is unaffected. **The backstop had to move with it** — untargeted rows are never recomputed, so counting them as stale would fire a fleet-wide recompute on every read, forever.
5. **`fix:`** `lastComputedAt` stamped at write time, so whichever writer lands last leaves the latest timestamp and a row's freshness cannot move backwards.
6. **`feat:`** hourly instead of daily.

## Cost, against what `main` does today

With `D` definitions and `T` targeted, a sweep scans `8D` index-scans today and `8T` after (4). On 1000 definitions with 20 targets:

| | index-scans/day |
|---|---|
| `main` today (daily, everything) | 8,000 |
| targeted only, daily | 160 |
| targeted only, hourly | 3,840 |

The filter alone is ~50× less scanned; spending it on hourly still lands ~2× below today while making the data 24× fresher.

**Break-even is about T/D = 4%.** Past that hourly costs more than today — ~2.4× at 10% adoption, 24× if everything is targeted (the interval change alone). Absolute figures stay small (~19,200/day at 10% adoption, well under one per second), and the interval is settable per environment with `overviewComputeEnabled` as the hard stop. Worth a deliberate opinion in review rather than nodding it through.

## Tenant correctness — please look at this one

The sweep filters on the `(tenantId, processDefinitionKey)` **pair**, not the definition key. This is a correctness requirement, not a defensive measure: `SetTargetModal.tsx` on `camunda-hub` `main` now has a real tenant selector, so a user can target a non-default tenant today. A key-level filter would measure a definition for tenants nobody asked about and attribute one tenant's answer to another's row. Pinned by `shouldMeasureAKeyOnlyForTheTenantItIsTargetedOn`.

## Testing

250 BVD unit tests green; repo-wide `install -Dquickly` green.

Four guards are **mutation-verified** — each fails when the behaviour it protects is reverted:
- moving the target read back to the top of the sweep
- removing the target filter (both the key-level and the tenant-pair test)
- letting untargeted rows count towards staleness
- stamping freshness at sweep start

## Related issues

relates to camunda/camunda-hub#28050

## Screen recording

https://github.com/user-attachments/assets/6728a432-78e8-45e2-b012-c0013fbe80dd




