### PR TITLE
refactor: Encapsulate MsgPack conversion in agent history setters

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -245,7 +245,7 @@ public class AgentInstanceMapper {
     } else if (content instanceof final AgentInstanceObjectContent obj) {
       result.setContentType(AgentHistoryContentType.OBJECT);
       if (obj.getObject() != null) {
-        result.setObject(toMsgPackBuffer(obj.getObject()));
+        result.setObject(obj.getObject());
       }
     }
     return result;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -259,7 +259,7 @@ public class AgentInstanceMapper {
       result.setElementId(toolCall.getElementId());
     }
     if (toolCall.getArguments() != null) {
-      result.setArguments(toMsgPackBuffer(toolCall.getArguments()));
+      result.setArguments(toolCall.getArguments());
     }
     return result;
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -26,7 +26,6 @@ import io.camunda.gateway.protocol.model.AgentInstanceUpdateResult;
 import io.camunda.gateway.protocol.model.AgentInstanceUpdateStatusEnum;
 import io.camunda.gateway.protocol.model.AgentTool;
 import io.camunda.gateway.protocol.model.DocumentMetadataResponse;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
@@ -37,11 +36,9 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.http.ProblemDetail;
 
@@ -262,10 +259,6 @@ public class AgentInstanceMapper {
       result.setArguments(toolCall.getArguments());
     }
     return result;
-  }
-
-  private DirectBuffer toMsgPackBuffer(final Object value) {
-    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(value));
   }
 
   private void fillDocumentReferenceMetadata(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
@@ -18,7 +17,6 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -114,7 +112,7 @@ public final class AgentHistoryClient {
             .setToolCallId(toolCallId)
             .setToolName(toolName)
             .setElementId(elementId)
-            .setArguments(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(Map.of()))));
+            .setArguments(Map.of()));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryEmbeddedToolCall.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryEmbeddedToolCall.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -16,7 +15,6 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryEmbeddedToolCallValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
-import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({"encodedLength", "empty"})
 public final class AgentHistoryEmbeddedToolCall extends ObjectValue
@@ -70,20 +68,15 @@ public final class AgentHistoryEmbeddedToolCall extends ObjectValue
     return MsgPackConverter.convertToMap(argumentsProp.getValue());
   }
 
-  public AgentHistoryEmbeddedToolCall setArguments(final DirectBuffer arguments) {
-    argumentsProp.setValue(arguments);
+  public AgentHistoryEmbeddedToolCall setArguments(final Map<String, Object> arguments) {
+    argumentsProp.setValue(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(arguments)));
     return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getArgumentsBuffer() {
-    return argumentsProp.getValue();
   }
 
   public void copy(final AgentHistoryEmbeddedToolCallValue other) {
     setToolCallId(other.getToolCallId());
     setToolName(other.getToolName());
     setElementId(other.getElementId());
-    setArguments(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(other.getArguments())));
+    setArguments(other.getArguments());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMessageContent.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMessageContent.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
@@ -75,25 +74,19 @@ public final class AgentHistoryMessageContent extends ObjectValue
     return MsgPackConverter.convertToObject(objectProp.getValue(), Object.class);
   }
 
-  public AgentHistoryMessageContent setObject(final DirectBuffer object) {
-    objectProp.setValue(object);
+  public AgentHistoryMessageContent setObject(final Object object) {
+    final var data =
+        object == null
+            ? NIL_OBJECT
+            : BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(object));
+    objectProp.setValue(data);
     return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getObjectBuffer() {
-    return objectProp.getValue();
   }
 
   public void copy(final AgentHistoryMessageContentValue other) {
     setContentType(other.getContentType());
     setText(other.getText());
     getDocumentReference().copy(other.getDocumentReference());
-    final var obj = other.getObject();
-    if (obj != null) {
-      setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(obj)));
-    } else {
-      setObject(NIL_OBJECT);
-    }
+    setObject(other.getObject());
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5497,7 +5497,7 @@ final class JsonSerializableToJsonTest {
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
-                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack(Map.of("page", 1)))));
+                      .setObject(Map.of("page", 1)));
               record.addSystemPrompt(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.TEXT)
@@ -5590,27 +5590,23 @@ final class JsonSerializableToJsonTest {
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
-                      .setObject(
-                          wrapArray(
-                              MsgPackConverter.convertToMsgPack(
-                                  List.of(Map.of("id", 1), Map.of("id", 2))))));
+                      .setObject(List.of(Map.of("id", 1), Map.of("id", 2))));
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
-                      .setObject(
-                          wrapArray(MsgPackConverter.convertToMsgPack(List.of(10, 20, 30)))));
+                      .setObject(List.of(10, 20, 30)));
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
-                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack(42))));
+                      .setObject(42));
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
-                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack(true))));
+                      .setObject(true));
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.OBJECT)
-                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack((Object) "hello"))));
+                      .setObject("hello"));
               return record;
             },
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5507,9 +5507,7 @@ final class JsonSerializableToJsonTest {
                       .setToolCallId("call_abc123")
                       .setToolName("extract_line_items")
                       .setElementId("extract-line-items-task")
-                      .setArguments(
-                          wrapArray(
-                              MsgPackConverter.convertToMsgPack(Map.of("documentId", "inv-001")))));
+                      .setArguments(Map.of("documentId", "inv-001")));
               record.getMetrics().setInputTokens(512L).setOutputTokens(148L).setDurationMs(1200L);
               return record;
             },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -134,7 +134,7 @@ final class AgentHistoryRecordTest {
     final var objectBlock =
         new AgentHistoryMessageContent()
             .setContentType(AgentHistoryContentType.OBJECT)
-            .setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(objectData)));
+            .setObject(objectData);
 
     final AgentHistoryRecord original =
         new AgentHistoryRecord().setContent(List.of(textBlock, documentBlock, objectBlock));
@@ -180,7 +180,7 @@ final class AgentHistoryRecordTest {
     final var content =
         new AgentHistoryMessageContent()
             .setContentType(AgentHistoryContentType.OBJECT)
-            .setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(value)));
+            .setObject(value);
 
     // when
     final var copy = new AgentHistoryMessageContent();

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -10,13 +10,11 @@ package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceToolValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -237,7 +235,7 @@ final class AgentHistoryRecordTest {
             .setToolCallId("call-123")
             .setToolName("myTool")
             .setElementId("element-456")
-            .setArguments(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(args)));
+            .setArguments(args);
 
     final AgentHistoryRecord original = new AgentHistoryRecord().setToolCalls(List.of(toolCall));
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -170,7 +170,8 @@ final class AgentHistoryRecordTest {
         Arguments.of(Named.named("array of scalars", List.of(10, 20, 30)), List.class),
         Arguments.of(Named.named("number", 42), Integer.class),
         Arguments.of(Named.named("boolean", true), Boolean.class),
-        Arguments.of(Named.named("string scalar", "hello"), String.class));
+        Arguments.of(Named.named("string scalar", "hello"), String.class),
+        Arguments.of(Named.named("null", null), null));
   }
 
   @ParameterizedTest(name = "shouldRoundTripObjectContent [{0}]")
@@ -187,7 +188,11 @@ final class AgentHistoryRecordTest {
     copy.copy(content);
 
     // then
-    assertThat(copy.getObject()).isInstanceOf(expectedType).isEqualTo(value);
+    if (value == null) {
+      assertThat(copy.getObject()).isNull();
+    } else {
+      assertThat(copy.getObject()).isInstanceOf(expectedType).isEqualTo(value);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

### What changed

`AgentHistoryMessageContent#setObject` and `AgentHistoryEmbeddedToolCall#setArguments` used to take a raw `DirectBuffer`. Every caller had to manually serialize its value first via `BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(...))` just to satisfy the signature. This PR moves that serialization inside the two setters, which now accept the Java-typed value directly (`Object` and `Map<String, Object>` respectively), matching the existing `getObject()`/`getArguments()` getters. The now-redundant `AgentInstanceMapper#toMsgPackBuffer` helper and the now-uncalled raw-buffer getters `getObjectBuffer()`/`getArgumentsBuffer()` are removed as a result.

### Why

Every caller manufacturing a `DirectBuffer` just to satisfy the signature is boilerplate that leaks the MsgPack storage detail into callers and risks bugs like double-wrapping an already-serialized value. The getters already hid the deserialization inside the record; the setters now do the same for serialization, making the API self-contained and symmetric.

#### What it enables

- Production and test code can pass plain `Object`/`Map` values directly to these setters instead of pre-serializing them.
- Removes a class of latent bugs where a caller could accidentally double-serialize or mismatch encodings before calling the setter.
- Cleans up `AgentInstanceMapper`, which no longer needs its private `toMsgPackBuffer` bridge.

#### Out of scope

- No behavioral or wire-format change — the underlying MsgPack encoding is unchanged, only how callers reach it.
- `AgentHistoryEmbeddedToolCall#argumentsProp` remains a `DocumentProperty` restricted to JSON objects (unlike `AgentHistoryMessageContent#objectProp`, which is a `BinaryProperty` accepting any JSON value) — tool-call arguments are always a map, so this is intentional and unrelated to this change.
- No nullability enforcement was added to `setArguments` — every current caller is already guaranteed non-null, so a `requireNonNull` guard was considered and deliberately left out.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56686