### PR TITLE
feat: partially migrate forms view to new design system in tasklist

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {Variable} from '@camunda/camunda-api-zod-schemas/8.10';
+import {Card, CardContent, toast} from '@camunda/design-system';
+import {useMemo, useRef, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {CompleteTaskButton} from '#/tasklist/modules/task-details/shadcn.components/CompleteTaskButton';
+import type {CompletionStatus} from '#/tasklist/modules/task-details/useTaskCompletion';
+import {CamundaFormRenderer, type PartialVariable} from '#/tasklist/modules/form-js/CamundaFormRenderer';
+import type {FormManager} from '#/tasklist/modules/form-js/FormManager';
+import {useUploadDocuments} from '#/tasklist/modules/form-js/useUploadDocuments';
+import {tryParseJSON} from '#/tasklist/modules/json/tryParseJSON';
+import {formatVariablesToFormData} from '../formatVariablesToFormData';
+
+type Props = {
+	formSchema: string;
+	variables: Variable[];
+	completionStatus: CompletionStatus;
+	isCompletionAllowed: boolean;
+	isHidden: boolean;
+	onSubmit: (variables: Record<string, unknown>) => void;
+};
+
+function getVariablesFromSubmitPayload(variables: PartialVariable[]) {
+	return variables.reduce<Record<string, unknown>>((accumulator, {name, value}) => {
+		accumulator[name] = tryParseJSON(value);
+		return accumulator;
+	}, {});
+}
+
+const TaskDetailsForm: React.FC<Props> = ({
+	formSchema,
+	variables,
+	completionStatus,
+	isCompletionAllowed,
+	isHidden,
+	onSubmit,
+}) => {
+	const {t} = useTranslation();
+	const formManagerRef = useRef<FormManager | null>(null);
+	const {mutateAsync: uploadDocuments} = useUploadDocuments();
+	const [isImportError, setIsImportError] = useState(false);
+	const [localSubmissionStatus, setLocalSubmissionStatus] = useState<CompletionStatus | null>(null);
+	const formattedData = useMemo(() => formatVariablesToFormData(variables), [variables]);
+	const submissionStatus = localSubmissionStatus ?? completionStatus;
+	const canCompleteTask = isCompletionAllowed && !isImportError;
+
+	return (
+		<div className="h-full min-h-0 w-full" data-testid="task-tab-content">
+			<div className="h-full w-full overflow-y-auto" data-testid="embedded-form" tabIndex={-1}>
+				<div className="flex min-h-full w-full flex-col items-center">
+					<div className="mt-8 w-full px-4 pb-4 [&_.cds--layer-two]:bg-transparent">
+						<Card className="pt-0">
+							<CardContent>
+								<CamundaFormRenderer
+									schema={formSchema}
+									data={formattedData}
+									readOnly={!canCompleteTask}
+									onMount={(formManager) => {
+										formManagerRef.current = formManager;
+									}}
+									handleSubmit={(variables) => {
+										onSubmit(getVariablesFromSubmitPayload(variables));
+										return Promise.resolve();
+									}}
+									handleFileUpload={(files) => uploadDocuments(files)}
+									onImportError={() => {
+										setIsImportError(true);
+										toast.error(t('tasklist.formJSInvalidSchemaErrorNotificationTitle'));
+									}}
+									onSubmitStart={() => {
+										setLocalSubmissionStatus('active');
+									}}
+									onSubmitSuccess={() => {
+										setLocalSubmissionStatus(null);
+									}}
+									onSubmitError={() => {
+										setLocalSubmissionStatus('error');
+									}}
+									onValidationError={() => {
+										setLocalSubmissionStatus(null);
+									}}
+								/>
+							</CardContent>
+						</Card>
+					</div>
+					<footer className="mt-auto flex w-full justify-end border-t border-border px-4 py-3">
+						<CompleteTaskButton
+							status={submissionStatus}
+							onClick={() => {
+								setLocalSubmissionStatus('active');
+								formManagerRef.current?.submit();
+							}}
+							isHidden={isHidden}
+							isDisabled={!canCompleteTask}
+						/>
+					</footer>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export {TaskDetailsForm};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm.tsx
@@ -55,7 +55,7 @@ const TaskDetailsForm: React.FC<Props> = ({
 		<div className="h-full min-h-0 w-full" data-testid="task-tab-content">
 			<div className="h-full w-full overflow-y-auto" data-testid="embedded-form" tabIndex={-1}>
 				<div className="flex min-h-full w-full flex-col items-center">
-					<div className="mt-8 w-full px-4 pb-4 [&_.cds--layer-two]:bg-transparent">
+					<div className="mt-8 w-full px-4 pb-4">
 						<Card className="pt-0">
 							<CardContent>
 								<CamundaFormRenderer

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm.tsx
@@ -8,7 +8,7 @@
 
 import type {Variable} from '@camunda/camunda-api-zod-schemas/8.10';
 import {Card, CardContent, toast} from '@camunda/design-system';
-import {useMemo, useRef, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {CompleteTaskButton} from '#/tasklist/modules/task-details/shadcn.components/CompleteTaskButton';
 import type {CompletionStatus} from '#/tasklist/modules/task-details/useTaskCompletion';
@@ -50,6 +50,34 @@ const TaskDetailsForm: React.FC<Props> = ({
 	const formattedData = useMemo(() => formatVariablesToFormData(variables), [variables]);
 	const submissionStatus = localSubmissionStatus ?? completionStatus;
 	const canCompleteTask = isCompletionAllowed && !isImportError;
+	const handleMount = useCallback((formManager: FormManager) => {
+		formManagerRef.current = formManager;
+	}, []);
+	const handleSubmit = useCallback(
+		(variables: PartialVariable[]) => {
+			onSubmit(getVariablesFromSubmitPayload(variables));
+			return Promise.resolve();
+		},
+		[onSubmit],
+	);
+	const handleFileUpload = useCallback((files: Map<string, File[]>) => uploadDocuments(files), [uploadDocuments]);
+	const handleImportError = useCallback(() => {
+		setIsImportError(true);
+		toast.error(t('tasklist.formJSInvalidSchemaErrorNotificationTitle'));
+	}, [t]);
+	const handleSubmitStart = useCallback(() => {
+		setLocalSubmissionStatus('active');
+	}, []);
+	const handleSubmitReset = useCallback(() => {
+		setLocalSubmissionStatus(null);
+	}, []);
+	const handleSubmitError = useCallback(() => {
+		setLocalSubmissionStatus('error');
+	}, []);
+	const handleCompleteTask = useCallback(() => {
+		setLocalSubmissionStatus('active');
+		formManagerRef.current?.submit();
+	}, []);
 
 	return (
 		<div className="h-full min-h-0 w-full" data-testid="task-tab-content">
@@ -62,30 +90,14 @@ const TaskDetailsForm: React.FC<Props> = ({
 									schema={formSchema}
 									data={formattedData}
 									readOnly={!canCompleteTask}
-									onMount={(formManager) => {
-										formManagerRef.current = formManager;
-									}}
-									handleSubmit={(variables) => {
-										onSubmit(getVariablesFromSubmitPayload(variables));
-										return Promise.resolve();
-									}}
-									handleFileUpload={(files) => uploadDocuments(files)}
-									onImportError={() => {
-										setIsImportError(true);
-										toast.error(t('tasklist.formJSInvalidSchemaErrorNotificationTitle'));
-									}}
-									onSubmitStart={() => {
-										setLocalSubmissionStatus('active');
-									}}
-									onSubmitSuccess={() => {
-										setLocalSubmissionStatus(null);
-									}}
-									onSubmitError={() => {
-										setLocalSubmissionStatus('error');
-									}}
-									onValidationError={() => {
-										setLocalSubmissionStatus(null);
-									}}
+									onMount={handleMount}
+									handleSubmit={handleSubmit}
+									handleFileUpload={handleFileUpload}
+									onImportError={handleImportError}
+									onSubmitStart={handleSubmitStart}
+									onSubmitSuccess={handleSubmitReset}
+									onSubmitError={handleSubmitError}
+									onValidationError={handleSubmitReset}
 								/>
 							</CardContent>
 						</Card>
@@ -93,10 +105,7 @@ const TaskDetailsForm: React.FC<Props> = ({
 					<footer className="mt-auto flex w-full justify-end border-t border-border px-4 py-3">
 						<CompleteTaskButton
 							status={submissionStatus}
-							onClick={() => {
-								setLocalSubmissionStatus('active');
-								formManagerRef.current?.submit();
-							}}
+							onClick={handleCompleteTask}
 							isHidden={isHidden}
 							isDisabled={!canCompleteTask}
 						/>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/shadcn.components/TaskDetailsTaskPage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/shadcn.components/TaskDetailsTaskPage.tsx
@@ -10,7 +10,7 @@ import type {CurrentUser, UserTask, Variable} from '@camunda/camunda-api-zod-sch
 import {useNavigate} from '@tanstack/react-router';
 import {useCallback} from 'react';
 import type {TasklistIndexSearch} from '#/tasklist/modules/available-tasks/searchSchema';
-import {CompleteTaskButton} from '#/tasklist/modules/task-details/shadcn.components/CompleteTaskButton';
+import {TaskDetailsForm} from '#/tasklist/modules/task-details-form/shadcn.components/TaskDetailsForm';
 import {useTaskCompletion} from '#/tasklist/modules/task-details/useTaskCompletion';
 import {TaskDetailsVariables} from '#/tasklist/modules/task-details-variables/shadcn.components/TaskDetailsVariables';
 
@@ -62,16 +62,14 @@ const TaskDetailsTaskPage: React.FC<Props> = ({
 
 	if (formSchema !== null) {
 		return (
-			<div className="flex h-full min-h-0 flex-col" data-testid="task-tab-content">
-				<footer className="mt-auto flex w-full justify-end border-t border-border p-4">
-					<CompleteTaskButton
-						status={status}
-						isDisabled={!isCompletionAllowed}
-						isHidden={isHidden}
-						onClick={() => complete({})}
-					/>
-				</footer>
-			</div>
+			<TaskDetailsForm
+				formSchema={formSchema}
+				variables={variables}
+				completionStatus={status}
+				isCompletionAllowed={isCompletionAllowed}
+				isHidden={isHidden}
+				onSubmit={complete}
+			/>
 		);
 	}
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR partially migrates the `form-js` to the new design system. We need this to be done to fully manage to migrate it https://github.com/bpmn-io/shadcn-theme/issues/4

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

related #60223

- [ ] This PR does not need a linked issue

