### PR TITLE
feat: add Operate Batch Operation details page

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -64,6 +64,11 @@ const mockQueryBatchOperationsEndpoint = createEndpointMock({
 	method: endpoints.queryBatchOperations.method,
 });
 
+const mockGetBatchOperationEndpoint = createEndpointMock({
+	endpoint: endpoints.getBatchOperation.getUrl({batchOperationKey: ':batchOperationKey'}),
+	method: endpoints.getBatchOperation.method,
+});
+
 const mockQueryBatchOperationItemsEndpoint = createEndpointMock({
 	endpoint: endpoints.queryBatchOperationItems.getUrl(),
 	method: endpoints.queryBatchOperationItems.method,
@@ -221,6 +226,7 @@ export {
 	mockGetIncidentProcessInstanceStatisticsByDefinitionEndpoint,
 	mockQueryBatchOperationsEndpoint,
 	mockQueryProcessInstancesEndpoint,
+	mockGetBatchOperationEndpoint,
 	mockQueryBatchOperationItemsEndpoint,
 	mockGetDecisionInstanceEndpoint,
 	mockQueryDecisionDefinitionsEndpoint,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.test.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {HttpResponse} from 'msw';
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {mockQueryBatchOperationItemsEndpoint} from '#/shared-test-modules/mock-handlers';
+import {
+	createBatchOperationItem,
+	createQueryBatchOperationItemsResponse,
+} from '#/shared-test-modules/api-mocks/batch-operations';
+import {BatchItemsTable} from './BatchItemsTable';
+
+const BATCH_OPERATION_KEY = 'migrate-operation-123';
+
+function renderTable(batchOperationType: Parameters<typeof BatchItemsTable>[0]['batchOperationType']) {
+	return renderWithRouter(
+		() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType={batchOperationType} />,
+		{path: '/operate/batch-operations'},
+	);
+}
+
+describe('<BatchItemsTable />', () => {
+	it('should render the empty state when there are no items', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(createQueryBatchOperationItemsResponse()),
+			}),
+		);
+
+		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+
+		await expect.element(screen.getByText('No items found')).toBeVisible();
+	});
+
+	it('should render a process instance key column with a link for a non-completed item', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [createBatchOperationItem({state: 'FAILED', processInstanceKey: '2251799813685250'})],
+						page: {totalItems: 1, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+
+		const link = screen.getByRole('link', {name: 'View process instance 2251799813685250'});
+		await expect.element(link).toBeVisible();
+		await expect.element(link).toHaveAttribute('href', '/operate/processes/2251799813685250');
+	});
+
+	it('should still render the process instance link for a completed item of most operation types', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [createBatchOperationItem({state: 'COMPLETED', processInstanceKey: '2251799813685250'})],
+						page: {totalItems: 1, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+
+		await expect.element(screen.getByRole('link', {name: 'View process instance 2251799813685250'})).toBeVisible();
+	});
+
+	it('should not render a process instance link for a completed process instance deletion item', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [
+							createBatchOperationItem({
+								state: 'COMPLETED',
+								processInstanceKey: '2251799813685250',
+								operationType: 'DELETE_PROCESS_INSTANCE',
+							}),
+						],
+						page: {totalItems: 1, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderTable('DELETE_PROCESS_INSTANCE');
+
+		await expect.element(screen.getByText('2251799813685250')).toBeVisible();
+		await expect.element(screen.getByRole('link')).not.toBeInTheDocument();
+	});
+
+	it('should render a decision instance key column for a decision instance deletion operation', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [
+							createBatchOperationItem({
+								itemKey: 'item-1',
+								state: 'FAILED',
+								operationType: 'DELETE_DECISION_INSTANCE',
+							}),
+						],
+						page: {totalItems: 1, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderTable('DELETE_DECISION_INSTANCE');
+
+		await expect.element(screen.getByRole('columnheader', {name: 'Decision instance key'})).toBeVisible();
+		await expect.element(screen.getByRole('link', {name: 'View decision instance item-1'})).toBeVisible();
+	});
+
+	it('should render an incident key column for a resolve incident operation', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [
+							createBatchOperationItem({
+								itemKey: 'incident-key-1',
+								processInstanceKey: '2251799813685250',
+								state: 'COMPLETED',
+								operationType: 'RESOLVE_INCIDENT',
+							}),
+						],
+						page: {totalItems: 1, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderTable('RESOLVE_INCIDENT');
+
+		await expect.element(screen.getByRole('columnheader', {name: 'Incident key'})).toBeVisible();
+		await expect.element(screen.getByText('incident-key-1')).toBeVisible();
+		await expect.element(screen.getByRole('link', {name: 'View process instance 2251799813685250'})).toBeVisible();
+	});
+
+	it('should render a failed item with its state', async ({worker}) => {
+		worker.use(
+			mockQueryBatchOperationItemsEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryBatchOperationItemsResponse({
+						items: [createBatchOperationItem({state: 'FAILED', errorMessage: 'Something went wrong'})],
+						page: {totalItems: 1, startCursor: null, endCursor: null, hasMoreTotalItems: false},
+					}),
+				),
+			}),
+		);
+
+		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+
+		await expect.element(screen.getByText(/^Failed$/)).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.test.tsx
@@ -19,13 +19,6 @@ import {BatchItemsTable} from './BatchItemsTable';
 
 const BATCH_OPERATION_KEY = 'migrate-operation-123';
 
-function renderTable(batchOperationType: Parameters<typeof BatchItemsTable>[0]['batchOperationType']) {
-	return renderWithRouter(
-		() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType={batchOperationType} />,
-		{path: '/operate/batch-operations'},
-	);
-}
-
 describe('<BatchItemsTable />', () => {
 	it('should render the empty state when there are no items', async ({worker}) => {
 		worker.use(
@@ -34,7 +27,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="CANCEL_PROCESS_INSTANCE" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		await expect.element(screen.getByText('No items found')).toBeVisible();
 	});
@@ -51,7 +47,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="CANCEL_PROCESS_INSTANCE" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		const link = screen.getByRole('link', {name: 'View process instance 2251799813685250'});
 		await expect.element(link).toBeVisible();
@@ -70,7 +69,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="CANCEL_PROCESS_INSTANCE" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		await expect.element(screen.getByRole('link', {name: 'View process instance 2251799813685250'})).toBeVisible();
 	});
@@ -93,7 +95,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('DELETE_PROCESS_INSTANCE');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="DELETE_PROCESS_INSTANCE" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		await expect.element(screen.getByText('2251799813685250')).toBeVisible();
 		await expect.element(screen.getByRole('link')).not.toBeInTheDocument();
@@ -117,7 +122,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('DELETE_DECISION_INSTANCE');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="DELETE_DECISION_INSTANCE" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		await expect.element(screen.getByRole('columnheader', {name: 'Decision instance key'})).toBeVisible();
 		await expect.element(screen.getByRole('link', {name: 'View decision instance item-1'})).toBeVisible();
@@ -142,7 +150,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('RESOLVE_INCIDENT');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="RESOLVE_INCIDENT" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		await expect.element(screen.getByRole('columnheader', {name: 'Incident key'})).toBeVisible();
 		await expect.element(screen.getByText('incident-key-1')).toBeVisible();
@@ -161,7 +172,10 @@ describe('<BatchItemsTable />', () => {
 			}),
 		);
 
-		const screen = await renderTable('CANCEL_PROCESS_INSTANCE');
+		const screen = await renderWithRouter(
+			() => <BatchItemsTable batchOperationKey={BATCH_OPERATION_KEY} batchOperationType="CANCEL_PROCESS_INSTANCE" />,
+			{path: '/operate/batch-operations'},
+		);
 
 		await expect.element(screen.getByText(/^Failed$/)).toBeVisible();
 	});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import type {BatchOperationItem, BatchOperationType} from '@camunda/camunda-api-zod-schemas/8.10';
+import {PaginatedSortableTable} from '#/operate/shared/PaginatedSortableTable/PaginatedSortableTable';
+import {PanelHeader} from '#/operate/shared/PanelHeader/PanelHeader';
+import {EmptyMessage} from '#/operate/shared/EmptyMessage/EmptyMessage';
+import {ErrorMessage} from '#/operate/shared/ErrorMessage/ErrorMessage';
+import {formatDate} from './utils';
+import {ItemKeyCell} from './ItemKeyCell';
+import {StateCell} from './StateCell';
+import {useBatchOperationItems} from './useBatchOperationItems';
+import {TableContainer} from './styled';
+
+type Props = {
+	batchOperationKey: string;
+	batchOperationType: BatchOperationType | undefined;
+};
+
+const BatchItemsTable: React.FC<Props> = ({batchOperationKey, batchOperationType}) => {
+	const {t} = useTranslation();
+	const {
+		items,
+		totalItems,
+		hasMoreTotalItems,
+		status,
+		isFetching,
+		hasPreviousPage,
+		fetchPreviousPage,
+		isFetchingPreviousPage,
+		hasNextPage,
+		fetchNextPage,
+		isFetchingNextPage,
+	} = useBatchOperationItems(batchOperationKey);
+
+	const columns = (() => {
+		const state = {
+			key: 'state',
+			label: t('operate.batchOperation.itemsTable.state'),
+			render: (row: BatchOperationItem) => <StateCell item={row} />,
+		};
+		const processedDate = {
+			key: 'processedDate',
+			label: t('operate.batchOperation.itemsTable.date'),
+			render: (row: BatchOperationItem) => formatDate(row.processedDate),
+		};
+		const processInstanceKey = {
+			key: 'processInstanceKey',
+			label: t('operate.batchOperation.itemsTable.processInstanceKey'),
+			render: (row: BatchOperationItem) => (
+				<ItemKeyCell
+					itemKey={row.processInstanceKey}
+					fallbackText={t('operate.batchOperation.itemsTable.noProcessInstance')}
+					href={`/operate/processes/${row.processInstanceKey}`}
+					label={t('operate.batchOperation.itemsTable.viewProcessInstance', {key: row.processInstanceKey})}
+				/>
+			),
+		};
+
+		if (batchOperationType === 'DELETE_DECISION_INSTANCE') {
+			return [
+				{
+					key: 'decisionInstanceKey',
+					label: t('operate.batchOperation.itemsTable.decisionInstanceKey'),
+					render: (row: BatchOperationItem) => (
+						<ItemKeyCell
+							itemKey={row.itemKey}
+							fallbackText={t('operate.batchOperation.itemsTable.noDecisionInstance')}
+							href={row.state === 'COMPLETED' ? undefined : `/operate/decisions/${row.itemKey}`}
+							label={
+								row.state === 'COMPLETED'
+									? undefined
+									: t('operate.batchOperation.itemsTable.viewDecisionInstance', {key: row.itemKey})
+							}
+						/>
+					),
+				},
+				state,
+				processedDate,
+			];
+		}
+
+		if (batchOperationType === 'DELETE_PROCESS_INSTANCE') {
+			return [
+				{
+					key: 'processInstanceKey',
+					label: t('operate.batchOperation.itemsTable.processInstanceKey'),
+					render: (row: BatchOperationItem) => (
+						<ItemKeyCell
+							itemKey={row.processInstanceKey}
+							fallbackText={t('operate.batchOperation.itemsTable.noProcessInstance')}
+							href={row.state === 'COMPLETED' ? undefined : `/operate/processes/${row.processInstanceKey}`}
+							label={
+								row.state === 'COMPLETED'
+									? undefined
+									: t('operate.batchOperation.itemsTable.viewProcessInstance', {key: row.processInstanceKey})
+							}
+						/>
+					),
+				},
+				state,
+				processedDate,
+			];
+		}
+
+		if (batchOperationType === 'RESOLVE_INCIDENT') {
+			return [
+				processInstanceKey,
+				{
+					key: 'incidentKey',
+					label: t('operate.batchOperation.itemsTable.incidentKey'),
+					render: (row: BatchOperationItem) => (
+						<ItemKeyCell itemKey={row.itemKey} fallbackText={t('operate.batchOperation.itemsTable.noIncident')} />
+					),
+				},
+				state,
+				processedDate,
+			];
+		}
+
+		return [processInstanceKey, state, processedDate];
+	})();
+
+	const emptyState =
+		status === 'error' ? (
+			<ErrorMessage />
+		) : (
+			<EmptyMessage message={t('operate.batchOperation.itemsTable.emptyMessage')} />
+		);
+
+	return (
+		<TableContainer>
+			<PanelHeader
+				title={t('operate.batchOperation.itemsTable.title')}
+				count={totalItems}
+				hasMoreTotalItems={hasMoreTotalItems}
+			/>
+			<PaginatedSortableTable<BatchOperationItem>
+				size="md"
+				columns={columns}
+				rows={items}
+				rowKey={(row) => row.itemKey}
+				isFetching={isFetching && !isFetchingPreviousPage && !isFetchingNextPage}
+				emptyState={emptyState}
+				pagination={{
+					hasPreviousPage,
+					hasNextPage,
+					isFetchingPreviousPage,
+					isFetchingNextPage,
+					fetchPreviousPage,
+					fetchNextPage,
+				}}
+				data-testid="batch-items-table"
+			/>
+		</TableContainer>
+	);
+};
+
+export {BatchItemsTable};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchItemsTable.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {BatchOperationItem, BatchOperationType} from '@camunda/camunda-api-zod-schemas/8.10';
 import {PaginatedSortableTable} from '#/operate/shared/PaginatedSortableTable/PaginatedSortableTable';
@@ -39,7 +40,7 @@ const BatchItemsTable: React.FC<Props> = ({batchOperationKey, batchOperationType
 		isFetchingNextPage,
 	} = useBatchOperationItems(batchOperationKey);
 
-	const columns = (() => {
+	const columns = useMemo(() => {
 		const state = {
 			key: 'state',
 			label: t('operate.batchOperation.itemsTable.state'),
@@ -125,7 +126,7 @@ const BatchItemsTable: React.FC<Props> = ({batchOperationKey, batchOperationType
 		}
 
 		return [processInstanceKey, state, processedDate];
-	})();
+	}, [batchOperationType, t]);
 
 	const emptyState =
 		status === 'error' ? (

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {afterEach, describe, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {HttpResponse} from 'msw';
+import {it} from '#/vitest-modules/test-extend';
+import {renderWithRouter} from '#/vitest-modules/render-with-router';
+import {mockGetBatchOperationEndpoint, mockQueryBatchOperationItemsEndpoint} from '#/shared-test-modules/mock-handlers';
+import {
+	createBatchOperation,
+	createQueryBatchOperationItemsResponse,
+} from '#/shared-test-modules/api-mocks/batch-operations';
+import {createProblemDetails} from '#/shared-test-modules/api-mocks/shared';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {BatchOperation, BatchOperationSkeleton} from './BatchOperation';
+
+const BATCH_OPERATION_KEY = 'migrate-operation-123';
+
+const EMPTY_ITEMS_RESPONSE = HttpResponse.json(createQueryBatchOperationItemsResponse());
+
+function renderPage() {
+	return renderWithRouter(() => <BatchOperation batchOperationKey={BATCH_OPERATION_KEY} />, {
+		path: '/operate/batch-operations/$batchOperationKey',
+		initialEntry: `/operate/batch-operations/${BATCH_OPERATION_KEY}`,
+	});
+}
+
+describe('<BatchOperation />', () => {
+	afterEach(() => {
+		notificationsStore.reset();
+	});
+
+	it('should render the page title and operation details tiles', async ({worker}) => {
+		worker.use(
+			mockGetBatchOperationEndpoint({
+				successResponse: HttpResponse.json(
+					createBatchOperation({
+						batchOperationKey: BATCH_OPERATION_KEY,
+						batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
+					}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({successResponse: EMPTY_ITEMS_RESPONSE}),
+		);
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByRole('heading', {name: 'Migrate Process Instance'})).toBeVisible();
+		await expect.element(screen.getByText('Summary of items')).toBeVisible();
+		await expect.element(screen.getByText('Start date')).toBeVisible();
+		await expect.element(screen.getByText('End date')).toBeVisible();
+		await expect.element(screen.getByText('Actor')).toBeVisible();
+	});
+
+	it('should render the batch state and actor', async ({worker}) => {
+		worker.use(
+			mockGetBatchOperationEndpoint({
+				successResponse: HttpResponse.json(
+					createBatchOperation({batchOperationKey: BATCH_OPERATION_KEY, state: 'COMPLETED', actorId: 'demo'}),
+				),
+			}),
+			mockQueryBatchOperationItemsEndpoint({successResponse: EMPTY_ITEMS_RESPONSE}),
+		);
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText(/^Completed$/)).toBeVisible();
+		await expect.element(screen.getByText('demo')).toBeVisible();
+	});
+
+	it('should show an error notification when the batch operation fails to load', async ({worker}) => {
+		worker.use(
+			mockGetBatchOperationEndpoint({
+				successResponse: HttpResponse.json(createProblemDetails({status: 500}), {status: 500}),
+			}),
+			mockQueryBatchOperationItemsEndpoint({successResponse: EMPTY_ITEMS_RESPONSE}),
+		);
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('Failed to load batch operation details')).toBeVisible();
+	});
+
+	it('should show the forbidden state when the user lacks permission', async ({worker}) => {
+		worker.use(
+			mockGetBatchOperationEndpoint({
+				successResponse: HttpResponse.json(createProblemDetails({status: 403}), {status: 403}),
+			}),
+			mockQueryBatchOperationItemsEndpoint({successResponse: EMPTY_ITEMS_RESPONSE}),
+		);
+
+		const screen = await renderPage();
+
+		await expect.element(screen.getByText('403 - You do not have permission to view this information')).toBeVisible();
+	});
+
+	it('should redirect to the batch operations list and notify when the batch operation is not found', async ({
+		worker,
+	}) => {
+		worker.use(
+			mockGetBatchOperationEndpoint({
+				successResponse: HttpResponse.json(createProblemDetails({status: 404}), {status: 404}),
+			}),
+			mockQueryBatchOperationItemsEndpoint({successResponse: EMPTY_ITEMS_RESPONSE}),
+		);
+
+		const screen = await renderPage();
+
+		await expect.poll(() => screen.router.state.location.pathname).toBe('/operate/batch-operations');
+		await expect
+			.poll(() => notificationsStore.notifications.map((notification) => notification.title))
+			.toContain(`Batch operation ${BATCH_OPERATION_KEY} could not be found`);
+	});
+});
+
+describe('<BatchOperationSkeleton />', () => {
+	it('should render placeholder tiles for every tile the loaded page shows', async () => {
+		const screen = await render(<BatchOperationSkeleton />);
+
+		await expect.element(screen.getByText('Batch state')).toBeVisible();
+		await expect.element(screen.getByText('Summary of items')).toBeVisible();
+		await expect.element(screen.getByText('Start date')).toBeVisible();
+		await expect.element(screen.getByText('End date')).toBeVisible();
+		await expect.element(screen.getByText('Actor')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.test.tsx
@@ -110,12 +110,30 @@ describe('<BatchOperation />', () => {
 			mockQueryBatchOperationItemsEndpoint({successResponse: EMPTY_ITEMS_RESPONSE}),
 		);
 
-		const screen = await renderPage();
+		const renderedErrors: string[] = [];
+		// Capture transient alerts that disappear before the redirect completes.
+		const observer = new MutationObserver((mutations) => {
+			for (const mutation of mutations) {
+				for (const node of mutation.addedNodes) {
+					if (node.textContent?.includes('Failed to load batch operation details')) {
+						renderedErrors.push(node.textContent);
+					}
+				}
+			}
+		});
+		observer.observe(document.body, {childList: true, subtree: true});
 
-		await expect.poll(() => screen.router.state.location.pathname).toBe('/operate/batch-operations');
-		await expect
-			.poll(() => notificationsStore.notifications.map((notification) => notification.title))
-			.toContain(`Batch operation ${BATCH_OPERATION_KEY} could not be found`);
+		try {
+			const screen = await renderPage();
+
+			await expect.poll(() => screen.router.state.location.pathname).toBe('/operate/batch-operations');
+			await expect
+				.poll(() => notificationsStore.notifications.map((notification) => notification.title))
+				.toContain(`Batch operation ${BATCH_OPERATION_KEY} could not be found`);
+			expect(renderedErrors).toEqual([]);
+		} finally {
+			observer.disconnect();
+		}
 	});
 });
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigate} from '@tanstack/react-router';
+import {IconButton, SkeletonText, InlineNotification} from '@carbon/react';
+import {ArrowLeft} from '@carbon/react/icons';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {ForbiddenError} from '#/shared/errors';
+import {requestErrorSchema} from '#/shared/http/request';
+import {VisuallyHiddenH1} from '#/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1';
+import {BatchStateIndicator} from '#/operate/shared/BatchStateIndicator';
+import {BatchItemsCount} from '#/operate/shared/BatchItemsCount';
+import {EmptyState} from '#/operate/components/EmptyState/EmptyState';
+import permissionDeniedIconUrl from '#/operate/assets/permission-denied.svg';
+import {useBatchOperation} from './batchOperation.queries';
+import {formatOperationType, formatDate} from './utils';
+import {BatchItemsTable} from './BatchItemsTable';
+import {PageContainer, Header, HeaderTitleContainer, TilesContainer, Tile, TileLabel} from './styled';
+
+const TILE_LABEL_KEYS = [
+	'operate.batchOperation.tiles.state',
+	'operate.batchOperation.tiles.summaryOfItems',
+	'operate.batchOperation.tiles.startDate',
+	'operate.batchOperation.tiles.endDate',
+	'operate.batchOperation.tiles.actor',
+] as const;
+
+const BatchOperationSkeleton: React.FC = () => {
+	const {t} = useTranslation();
+
+	return (
+		<PageContainer gap={5}>
+			<VisuallyHiddenH1>{t('operate.batchOperation.title')}</VisuallyHiddenH1>
+			<Header>
+				<HeaderTitleContainer>
+					<SkeletonText data-testid="text-skeleton" />
+				</HeaderTitleContainer>
+			</Header>
+			<TilesContainer gap={4} orientation="horizontal">
+				{TILE_LABEL_KEYS.map((labelKey) => (
+					<Tile key={labelKey}>
+						<TileLabel>{t(labelKey)}</TileLabel>
+						<SkeletonText data-testid="text-skeleton" />
+					</Tile>
+				))}
+			</TilesContainer>
+		</PageContainer>
+	);
+};
+
+type Props = {
+	batchOperationKey: string;
+};
+
+const BatchOperation: React.FC<Props> = ({batchOperationKey}) => {
+	const {t} = useTranslation();
+	const navigate = useNavigate();
+	const {data, error} = useBatchOperation(batchOperationKey);
+
+	const requestError = requestErrorSchema.safeParse(error);
+	const isUnauthorized = error instanceof ForbiddenError;
+	const isNotFound = requestError.success && requestError.data.response?.status === 404;
+
+	useEffect(() => {
+		if (isNotFound) {
+			notificationsStore.displayNotification({
+				kind: 'error',
+				title: t('operate.batchOperation.notFoundNotificationTitle', {batchOperationKey}),
+				isDismissable: true,
+			});
+			void navigate({to: '/operate/batch-operations', replace: true});
+		}
+	}, [isNotFound, batchOperationKey, navigate, t]);
+
+	if (isUnauthorized) {
+		return (
+			<EmptyState
+				icon={<img src={permissionDeniedIconUrl} alt="" />}
+				heading={t('operate.batchOperation.forbidden.heading')}
+				description={t('operate.batchOperation.forbidden.description')}
+				link={{
+					label: t('operate.batchOperation.forbidden.learnMoreLink'),
+					href: 'https://docs.camunda.io/docs/self-managed/operate-deployment/operate-authentication/#resource-based-permissions',
+				}}
+			/>
+		);
+	}
+
+	const operationType = formatOperationType(data?.batchOperationType ?? '');
+
+	const tileData = [
+		{
+			label: t('operate.batchOperation.tiles.state'),
+			content: data ? <BatchStateIndicator state={data.state} /> : null,
+		},
+		{
+			label: t('operate.batchOperation.tiles.summaryOfItems'),
+			content: (
+				<BatchItemsCount
+					totalCount={data?.operationsTotalCount ?? 0}
+					completedCount={data?.operationsCompletedCount ?? 0}
+					failedCount={data?.operationsFailedCount ?? 0}
+				/>
+			),
+		},
+		{
+			label: t('operate.batchOperation.tiles.startDate'),
+			content: formatDate(data?.startDate),
+		},
+		{
+			label: t('operate.batchOperation.tiles.endDate'),
+			content: formatDate(data?.endDate),
+		},
+		{
+			label: t('operate.batchOperation.tiles.actor'),
+			content: data?.actorId ?? '--',
+		},
+	];
+
+	return (
+		<PageContainer gap={5}>
+			<VisuallyHiddenH1>{t('operate.batchOperation.title')}</VisuallyHiddenH1>
+			<Header>
+				<HeaderTitleContainer>
+					<IconButton
+						kind="ghost"
+						size="md"
+						label={t('operate.batchOperation.backButton')}
+						align="bottom-start"
+						onClick={() => navigate({to: '/operate/batch-operations'})}
+					>
+						<ArrowLeft />
+					</IconButton>
+					<h3>{operationType}</h3>
+				</HeaderTitleContainer>
+			</Header>
+			{error && (
+				<InlineNotification
+					kind="error"
+					statusIconDescription="notification"
+					hideCloseButton
+					role="alert"
+					title={t('operate.batchOperation.loadErrorTitle')}
+				/>
+			)}
+			<TilesContainer gap={4} orientation="horizontal">
+				{tileData.map(({label, content}) => (
+					<Tile key={label}>
+						<TileLabel>{label}</TileLabel>
+						{content}
+					</Tile>
+				))}
+			</TilesContainer>
+			<BatchItemsTable batchOperationKey={batchOperationKey} batchOperationType={data?.batchOperationType} />
+		</PageContainer>
+	);
+};
+
+export {BatchOperation, BatchOperationSkeleton};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.tsx
@@ -141,7 +141,7 @@ const BatchOperation: React.FC<Props> = ({batchOperationKey}) => {
 					<h3>{operationType}</h3>
 				</HeaderTitleContainer>
 			</Header>
-			{error && (
+			{error && !isNotFound && (
 				<InlineNotification
 					kind="error"
 					statusIconDescription="notification"

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/BatchOperation.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect} from 'react';
+import {useEffect, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from '@tanstack/react-router';
 import {IconButton, SkeletonText, InlineNotification} from '@carbon/react';
@@ -79,6 +79,40 @@ const BatchOperation: React.FC<Props> = ({batchOperationKey}) => {
 		}
 	}, [isNotFound, batchOperationKey, navigate, t]);
 
+	const operationType = formatOperationType(data?.batchOperationType ?? '');
+
+	const tileData = useMemo(
+		() => [
+			{
+				label: t('operate.batchOperation.tiles.state'),
+				content: data ? <BatchStateIndicator state={data.state} /> : null,
+			},
+			{
+				label: t('operate.batchOperation.tiles.summaryOfItems'),
+				content: (
+					<BatchItemsCount
+						totalCount={data?.operationsTotalCount ?? 0}
+						completedCount={data?.operationsCompletedCount ?? 0}
+						failedCount={data?.operationsFailedCount ?? 0}
+					/>
+				),
+			},
+			{
+				label: t('operate.batchOperation.tiles.startDate'),
+				content: formatDate(data?.startDate),
+			},
+			{
+				label: t('operate.batchOperation.tiles.endDate'),
+				content: formatDate(data?.endDate),
+			},
+			{
+				label: t('operate.batchOperation.tiles.actor'),
+				content: data?.actorId ?? '--',
+			},
+		],
+		[data, t],
+	);
+
 	if (isUnauthorized) {
 		return (
 			<EmptyState
@@ -92,37 +126,6 @@ const BatchOperation: React.FC<Props> = ({batchOperationKey}) => {
 			/>
 		);
 	}
-
-	const operationType = formatOperationType(data?.batchOperationType ?? '');
-
-	const tileData = [
-		{
-			label: t('operate.batchOperation.tiles.state'),
-			content: data ? <BatchStateIndicator state={data.state} /> : null,
-		},
-		{
-			label: t('operate.batchOperation.tiles.summaryOfItems'),
-			content: (
-				<BatchItemsCount
-					totalCount={data?.operationsTotalCount ?? 0}
-					completedCount={data?.operationsCompletedCount ?? 0}
-					failedCount={data?.operationsFailedCount ?? 0}
-				/>
-			),
-		},
-		{
-			label: t('operate.batchOperation.tiles.startDate'),
-			content: formatDate(data?.startDate),
-		},
-		{
-			label: t('operate.batchOperation.tiles.endDate'),
-			content: formatDate(data?.endDate),
-		},
-		{
-			label: t('operate.batchOperation.tiles.actor'),
-			content: data?.actorId ?? '--',
-		},
-	];
 
 	return (
 		<PageContainer gap={5}>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/ItemKeyCell.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/ItemKeyCell.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {ItemKeyCell} from './ItemKeyCell';
+
+describe('<ItemKeyCell />', () => {
+	it('should render the fallback text when there is no associated item', async () => {
+		const screen = await render(<ItemKeyCell itemKey="-1" fallbackText="No process instance" />);
+
+		await expect.element(screen.getByText('No process instance')).toBeVisible();
+		await expect.element(screen.getByRole('link')).not.toBeInTheDocument();
+	});
+
+	it('should render a link when a href is provided', async () => {
+		const screen = await render(
+			<ItemKeyCell
+				itemKey="123"
+				fallbackText="No process instance"
+				href="/operate/processes/123"
+				label="View process instance 123"
+			/>,
+		);
+
+		const link = screen.getByRole('link', {name: 'View process instance 123'});
+		await expect.element(link).toBeVisible();
+		await expect.element(link).toHaveAttribute('href', '/operate/processes/123');
+		await expect.element(link).toHaveTextContent('123');
+	});
+
+	it('should render plain text when no href is provided', async () => {
+		const screen = await render(<ItemKeyCell itemKey="incident-key-1" fallbackText="No incident" />);
+
+		await expect.element(screen.getByText('incident-key-1')).toBeVisible();
+		await expect.element(screen.getByRole('link')).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/ItemKeyCell.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/ItemKeyCell.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ItemLink} from './styled';
+
+type Props = {
+	itemKey: string;
+	fallbackText: string;
+	href?: string;
+	label?: string;
+};
+
+const ItemKeyCell: React.FC<Props> = ({itemKey, fallbackText, href, label}) => {
+	if (itemKey === '-1') {
+		return <>{fallbackText}</>;
+	}
+
+	if (href !== undefined) {
+		return (
+			<ItemLink href={href} title={label} aria-label={label}>
+				{itemKey}
+			</ItemLink>
+		);
+	}
+
+	return <>{itemKey}</>;
+};
+
+export {ItemKeyCell};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
+import {it} from '#/vitest-modules/test-extend';
+import {createBatchOperationItem} from '#/shared-test-modules/api-mocks/batch-operations';
+import {StateCell} from './StateCell';
+
+describe('<StateCell />', () => {
+	it('should render just the state indicator when there is no error', async () => {
+		const screen = await render(<StateCell item={createBatchOperationItem({state: 'COMPLETED'})} />);
+
+		await expect.element(screen.getByText('Completed')).toBeVisible();
+	});
+
+	it('should show the failure reason in a tooltip on hover for a failed item', async () => {
+		const item = createBatchOperationItem({state: 'FAILED', errorMessage: 'Something went wrong'});
+		const screen = await render(<StateCell item={item} />);
+
+		await expect.element(screen.getByText('Failed')).toBeVisible();
+		await expect.element(screen.getByText('Failure reason: Something went wrong')).not.toBeVisible();
+
+		await userEvent.hover(screen.getByTestId('item-state-with-error'));
+
+		await expect.element(screen.getByText('Failure reason: Something went wrong')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.test.tsx
@@ -18,6 +18,7 @@ describe('<StateCell />', () => {
 		const screen = await render(<StateCell item={createBatchOperationItem({state: 'COMPLETED'})} />);
 
 		await expect.element(screen.getByText('Completed')).toBeVisible();
+		await expect.element(screen.getByRole('status', {name: 'Item status: Completed'})).toBeVisible();
 	});
 
 	it('should show the failure reason in a tooltip on hover for a failed item', async () => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Tooltip} from '@carbon/react';
+import {useTranslation} from 'react-i18next';
+import type {BatchOperationItem} from '@camunda/camunda-api-zod-schemas/8.10';
+import {BatchStateIndicator} from '#/operate/shared/BatchStateIndicator';
+
+type Props = {
+	item: BatchOperationItem;
+};
+
+const StateCell: React.FC<Props> = ({item}) => {
+	const {t} = useTranslation();
+	const indicator = <BatchStateIndicator state={item.state} />;
+
+	if (!item.errorMessage) {
+		return indicator;
+	}
+
+	return (
+		<Tooltip
+			description={t('operate.batchOperation.itemsTable.failureReason', {message: item.errorMessage})}
+			align="bottom"
+		>
+			<span tabIndex={0} data-testid="item-state-with-error">
+				{indicator}
+			</span>
+		</Tooltip>
+	);
+};
+
+export {StateCell};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/StateCell.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 const StateCell: React.FC<Props> = ({item}) => {
 	const {t} = useTranslation();
-	const indicator = <BatchStateIndicator state={item.state} />;
+	const indicator = <BatchStateIndicator state={item.state} ariaLabelPrefix="Item status" />;
 
 	if (!item.errorMessage) {
 		return indicator;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/batchOperation.queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/batchOperation.queries.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {queryOptions, useQuery} from '@tanstack/react-query';
+import type {BatchOperation} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request} from '#/shared/http/request';
+import {mapQueryError} from '#/shared/http/mapQueryError';
+import {endpoints} from '#/shared/http/endpoints';
+
+function getBatchOperationOptions(batchOperationKey: string) {
+	return queryOptions({
+		queryKey: ['batchOperation', batchOperationKey] as const,
+		queryFn: async (): Promise<BatchOperation> => {
+			const {response, error} = await request(endpoints.getBatchOperation({batchOperationKey}));
+			if (error !== null) {
+				throw mapQueryError(error);
+			}
+			return response.json();
+		},
+	});
+}
+
+function useBatchOperation(batchOperationKey: string) {
+	return useQuery(getBatchOperationOptions(batchOperationKey));
+}
+
+export {getBatchOperationOptions, useBatchOperation};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/styled.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Link, Stack, Tile as CarbonTile} from '@carbon/react';
+import styled from 'styled-components';
+
+const PageContainer = styled(Stack)`
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	box-sizing: border-box;
+	padding: var(--cds-spacing-09) var(--cds-spacing-05) 0;
+	background-color: var(--cds-layer);
+`;
+
+const Header = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+`;
+
+const HeaderTitleContainer = styled.div`
+	display: flex;
+	align-items: center;
+	gap: var(--cds-spacing-02);
+`;
+
+const TilesContainer = styled(Stack)`
+	align-self: flex-start;
+`;
+
+const Tile = styled(CarbonTile)`
+	min-width: 200px;
+	border: 1px solid var(--cds-border-subtle-01);
+	padding: var(--cds-spacing-05);
+`;
+
+const TileLabel = styled.span`
+	display: block;
+	font-size: var(--cds-label-01-font-size);
+	margin-bottom: var(--cds-spacing-03);
+	color: var(--cds-text-weak);
+`;
+
+const TableContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	overflow-y: hidden;
+`;
+
+const ItemLink = styled(Link)`
+	&& {
+		text-decoration: underline;
+	}
+`;
+
+export {PageContainer, Header, HeaderTitleContainer, TilesContainer, Tile, TileLabel, TableContainer, ItemLink};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/useBatchOperationItems.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/useBatchOperationItems.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useInfiniteQuery} from '@tanstack/react-query';
+import type {QueryBatchOperationItemsResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request} from '#/shared/http/request';
+import {mapQueryError} from '#/shared/http/mapQueryError';
+import {endpoints} from '#/shared/http/endpoints';
+
+const PAGE_LIMIT = 50;
+
+function useBatchOperationItems(batchOperationKey: string) {
+	const query = useInfiniteQuery({
+		queryKey: ['batchOperationItems', batchOperationKey] as const,
+		queryFn: async ({pageParam}): Promise<QueryBatchOperationItemsResponseBody> => {
+			const {response, error} = await request(
+				endpoints.queryBatchOperationItems({
+					filter: {batchOperationKey},
+					sort: [{field: 'processedDate', order: 'desc'}],
+					page: {from: pageParam, limit: PAGE_LIMIT},
+				}),
+			);
+			if (error !== null) {
+				throw mapQueryError(error);
+			}
+			return response.json();
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage, _, lastPageParam) => {
+			const nextPage = lastPageParam + PAGE_LIMIT;
+			return nextPage >= lastPage.page.totalItems ? undefined : nextPage;
+		},
+		getPreviousPageParam: (_, __, firstPageParam) => {
+			const previousPage = firstPageParam - PAGE_LIMIT;
+			return previousPage < 0 ? undefined : previousPage;
+		},
+		maxPages: 2,
+	});
+
+	const {
+		data,
+		status,
+		isFetching,
+		isFetchingPreviousPage,
+		hasPreviousPage,
+		fetchPreviousPage,
+		isFetchingNextPage,
+		hasNextPage,
+		fetchNextPage,
+	} = query;
+
+	const items = data?.pages.flatMap((page) => page.items) ?? [];
+	const totalItems = data?.pages.at(0)?.page.totalItems ?? 0;
+	const hasMoreTotalItems = data?.pages.at(0)?.page.hasMoreTotalItems ?? false;
+
+	return {
+		status,
+		isFetching,
+		isFetchingPreviousPage,
+		hasPreviousPage,
+		fetchPreviousPage,
+		isFetchingNextPage,
+		hasNextPage,
+		fetchNextPage,
+		items,
+		totalItems,
+		hasMoreTotalItems,
+	};
+}
+
+export {useBatchOperationItems};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/utils.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/BatchOperation/utils.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {format, parseISO} from 'date-fns';
+
+function formatOperationType(type: string): string {
+	return type
+		.split('_')
+		.map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+		.join(' ');
+}
+
+function formatDate(date: string | null | undefined): string {
+	return date ? format(parseISO(date), 'yyyy-MM-dd HH:mm:ss') : '--';
+}
+
+export {formatOperationType, formatDate};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/BatchItemsCount.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/BatchItemsCount.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {userEvent} from 'vitest/browser';
+import {it} from '#/vitest-modules/test-extend';
+import {BatchItemsCount} from './index';
+
+describe('<BatchItemsCount />', () => {
+	it('should show a "no items" indicator when there are no items at all', async () => {
+		const screen = await render(<BatchItemsCount totalCount={0} completedCount={0} failedCount={0} />);
+
+		await expect.element(screen.getByLabelText('no items')).toBeVisible();
+	});
+
+	it('should show a "not started" indicator when items are pending but none have progressed', async () => {
+		const screen = await render(<BatchItemsCount totalCount={5} completedCount={0} failedCount={0} />);
+
+		await expect.element(screen.getByLabelText('not started')).toBeVisible();
+	});
+
+	it('should show per-status counts once at least one item has progressed', async () => {
+		const screen = await render(<BatchItemsCount totalCount={10} completedCount={3} failedCount={1} />);
+
+		await expect.element(screen.getByRole('status', {name: '3 successful'})).toBeVisible();
+		await expect.element(screen.getByRole('status', {name: '1 failed'})).toBeVisible();
+		await expect.element(screen.getByRole('status', {name: '6 pending'})).toBeVisible();
+	});
+
+	it('should show the failure reason in a tooltip on hover', async () => {
+		const screen = await render(<BatchItemsCount totalCount={10} completedCount={3} failedCount={1} />);
+
+		await expect.element(screen.getByText('1 failed')).not.toBeVisible();
+
+		await userEvent.hover(screen.getByRole('status', {name: '1 failed'}));
+
+		await expect.element(screen.getByText('1 failed')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchItemsCount/index.tsx
@@ -23,8 +23,8 @@ const BatchItemsCount: React.FC<Props> = ({totalCount, completedCount, failedCou
 	const pendingCount = totalCount - completedCount - failedCount;
 	const hasAnyProgress = completedCount > 0 || failedCount > 0;
 
-	if (!hasAnyProgress && pendingCount > 0) {
-		const description = 'not started';
+	if (!hasAnyProgress) {
+		const description = pendingCount > 0 ? 'not started' : 'no items';
 		return (
 			<Tooltip description={description} align="bottom">
 				<Item $color="var(--cds-status-gray)" aria-label={description}>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/BatchStateIndicator.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/BatchStateIndicator.test.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {BatchStateIndicator} from './index';
+
+describe('<BatchStateIndicator />', () => {
+	it('should expose a batch-operation-specific status label by default', async () => {
+		const screen = await render(<BatchStateIndicator state="COMPLETED" />);
+
+		await expect.element(screen.getByRole('status', {name: 'Batch operation status: Completed'})).toBeVisible();
+	});
+
+	it('should expose an item-specific status label when used for item states', async () => {
+		const screen = await render(<BatchStateIndicator state="FAILED" ariaLabelPrefix="Item status" />);
+
+		await expect.element(screen.getByRole('status', {name: 'Item status: Failed'})).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
@@ -14,9 +14,10 @@ import {
 	InProgress,
 	MisuseOutline,
 	PauseOutlineFilled,
+	SkipForwardFilled,
 	type CarbonIconType,
 } from '@carbon/react/icons';
-import type {BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {BatchOperationItemState, BatchOperationState} from '@camunda/camunda-api-zod-schemas/8.10';
 import {Container} from './styled';
 
 type Config = {
@@ -25,7 +26,7 @@ type Config = {
 	label: string;
 };
 
-const STATE_CONFIG: Record<BatchOperationState, Config> = {
+const STATE_CONFIG: Record<BatchOperationState | BatchOperationItemState, Config> = {
 	COMPLETED: {Icon: CheckmarkFilled, color: 'var(--cds-status-green)', label: 'Completed'},
 	ACTIVE: {Icon: InProgress, color: 'var(--cds-status-blue)', label: 'Active'},
 	SUSPENDED: {Icon: PauseOutlineFilled, color: 'var(--cds-status-gray)', label: 'Suspended'},
@@ -33,10 +34,11 @@ const STATE_CONFIG: Record<BatchOperationState, Config> = {
 	FAILED: {Icon: ErrorFilled, color: 'var(--cds-status-red)', label: 'Failed'},
 	CREATED: {Icon: CircleDash, color: 'var(--cds-status-gray)', label: 'Created'},
 	PARTIALLY_COMPLETED: {Icon: Incomplete, color: 'var(--cds-status-blue)', label: 'Partially completed'},
+	SKIPPED: {Icon: SkipForwardFilled, color: 'var(--cds-status-gray)', label: 'Skipped'},
 };
 
 type Props = {
-	state: BatchOperationState;
+	state: BatchOperationState | BatchOperationItemState;
 };
 
 const BatchStateIndicator: React.FC<Props> = ({state}) => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/BatchStateIndicator/index.tsx
@@ -39,12 +39,13 @@ const STATE_CONFIG: Record<BatchOperationState | BatchOperationItemState, Config
 
 type Props = {
 	state: BatchOperationState | BatchOperationItemState;
+	ariaLabelPrefix?: string;
 };
 
-const BatchStateIndicator: React.FC<Props> = ({state}) => {
+const BatchStateIndicator: React.FC<Props> = ({state, ariaLabelPrefix = 'Batch operation status'}) => {
 	const {Icon, color, label} = STATE_CONFIG[state];
 	return (
-		<Container role="status" aria-label={`Batch operation status: ${label}`}>
+		<Container role="status" aria-label={`${ariaLabelPrefix}: ${label}`}>
 			<Icon style={{color}} aria-hidden="true" focusable="false" />
 			{label}
 		</Container>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
@@ -38,6 +38,8 @@ import { Route as CarbonAuthTasklistProcessesRouteRouteImport } from './routes/_
 import { Route as ShadcnAuthTasklistSplatRouteImport } from './routes/shadcn/_auth/tasklist/$'
 import { Route as ShadcnAuthTasklistTasksRouteRouteImport } from './routes/shadcn/_auth/tasklist/_tasks/route'
 import { Route as ShadcnAuthTasklistProcessesRouteRouteImport } from './routes/shadcn/_auth/tasklist/processes/route'
+import { Route as CarbonAuthOperateBatchOperationsIndexRouteImport } from './routes/_carbon/_auth/operate/batch-operations/index'
+import { Route as CarbonAuthOperateBatchOperationsBatchOperationKeyRouteImport } from './routes/_carbon/_auth/operate/batch-operations/$batchOperationKey'
 import { Route as CarbonAuthOperateDecisionsIndexRouteImport } from './routes/_carbon/_auth/operate/decisions/index'
 import { Route as CarbonAuthOperateDecisionsDecisionInstanceIdRouteImport } from './routes/_carbon/_auth/operate/decisions/$decisionInstanceId'
 import { Route as CarbonAuthTasklistTasksIndexRouteImport } from './routes/_carbon/_auth/tasklist/_tasks/index'
@@ -203,6 +205,18 @@ const ShadcnAuthTasklistProcessesRouteRoute =
     path: '/processes',
     getParentRoute: () => ShadcnAuthTasklistRouteRoute,
   } as any)
+const CarbonAuthOperateBatchOperationsIndexRoute =
+  CarbonAuthOperateBatchOperationsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => CarbonAuthOperateBatchOperationsRoute,
+  } as any)
+const CarbonAuthOperateBatchOperationsBatchOperationKeyRoute =
+  CarbonAuthOperateBatchOperationsBatchOperationKeyRouteImport.update({
+    id: '/$batchOperationKey',
+    path: '/$batchOperationKey',
+    getParentRoute: () => CarbonAuthOperateBatchOperationsRoute,
+  } as any)
 const CarbonAuthOperateDecisionsIndexRoute =
   CarbonAuthOperateDecisionsIndexRouteImport.update({
     id: '/',
@@ -317,7 +331,7 @@ export interface FileRoutesByFullPath {
   '/shadcn/tasklist/processes': typeof ShadcnAuthTasklistProcessesRouteRouteWithChildren
   '/admin/$': typeof CarbonAuthAdminSplatRoute
   '/operate/$': typeof CarbonAuthOperateSplatRoute
-  '/operate/batch-operations': typeof CarbonAuthOperateBatchOperationsRoute
+  '/operate/batch-operations': typeof CarbonAuthOperateBatchOperationsRouteWithChildren
   '/operate/decisions': typeof CarbonAuthOperateDecisionsRouteWithChildren
   '/operate/operations-log': typeof CarbonAuthOperateOperationsLogRoute
   '/operate/processes': typeof CarbonAuthOperateProcessesRoute
@@ -327,7 +341,9 @@ export interface FileRoutesByFullPath {
   '/operate/': typeof CarbonAuthOperateIndexRoute
   '/tasklist/$userTaskKey': typeof CarbonAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/shadcn/tasklist/$userTaskKey': typeof ShadcnAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
+  '/operate/batch-operations/$batchOperationKey': typeof CarbonAuthOperateBatchOperationsBatchOperationKeyRoute
   '/operate/decisions/$decisionInstanceId': typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
+  '/operate/batch-operations/': typeof CarbonAuthOperateBatchOperationsIndexRoute
   '/operate/decisions/': typeof CarbonAuthOperateDecisionsIndexRoute
   '/tasklist/': typeof CarbonAuthTasklistTasksIndexRoute
   '/shadcn/tasklist/': typeof ShadcnAuthTasklistTasksIndexRoute
@@ -356,14 +372,15 @@ export interface FileRoutesByTo {
   '/shadcn/tasklist/processes': typeof ShadcnAuthTasklistProcessesRouteRouteWithChildren
   '/admin/$': typeof CarbonAuthAdminSplatRoute
   '/operate/$': typeof CarbonAuthOperateSplatRoute
-  '/operate/batch-operations': typeof CarbonAuthOperateBatchOperationsRoute
   '/operate/operations-log': typeof CarbonAuthOperateOperationsLogRoute
   '/operate/processes': typeof CarbonAuthOperateProcessesRoute
   '/tasklist/$': typeof CarbonAuthTasklistSplatRoute
   '/shadcn/tasklist/$': typeof ShadcnAuthTasklistSplatRoute
   '/admin': typeof CarbonAuthAdminIndexRoute
   '/operate': typeof CarbonAuthOperateIndexRoute
+  '/operate/batch-operations/$batchOperationKey': typeof CarbonAuthOperateBatchOperationsBatchOperationKeyRoute
   '/operate/decisions/$decisionInstanceId': typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
+  '/operate/batch-operations': typeof CarbonAuthOperateBatchOperationsIndexRoute
   '/operate/decisions': typeof CarbonAuthOperateDecisionsIndexRoute
   '/tasklist/$userTaskKey/history': typeof CarbonAuthTasklistTasksUserTaskKeyHistoryRouteRouteWithChildren
   '/shadcn/tasklist/$userTaskKey/history': typeof ShadcnAuthTasklistTasksUserTaskKeyHistoryRouteRouteWithChildren
@@ -399,7 +416,7 @@ export interface FileRoutesById {
   '/shadcn/_auth/tasklist/processes': typeof ShadcnAuthTasklistProcessesRouteRouteWithChildren
   '/_carbon/_auth/admin/$': typeof CarbonAuthAdminSplatRoute
   '/_carbon/_auth/operate/$': typeof CarbonAuthOperateSplatRoute
-  '/_carbon/_auth/operate/batch-operations': typeof CarbonAuthOperateBatchOperationsRoute
+  '/_carbon/_auth/operate/batch-operations': typeof CarbonAuthOperateBatchOperationsRouteWithChildren
   '/_carbon/_auth/operate/decisions': typeof CarbonAuthOperateDecisionsRouteWithChildren
   '/_carbon/_auth/operate/operations-log': typeof CarbonAuthOperateOperationsLogRoute
   '/_carbon/_auth/operate/processes': typeof CarbonAuthOperateProcessesRoute
@@ -409,7 +426,9 @@ export interface FileRoutesById {
   '/_carbon/_auth/operate/': typeof CarbonAuthOperateIndexRoute
   '/_carbon/_auth/tasklist/_tasks/$userTaskKey': typeof CarbonAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/shadcn/_auth/tasklist/_tasks/$userTaskKey': typeof ShadcnAuthTasklistTasksUserTaskKeyRouteRouteWithChildren
+  '/_carbon/_auth/operate/batch-operations/$batchOperationKey': typeof CarbonAuthOperateBatchOperationsBatchOperationKeyRoute
   '/_carbon/_auth/operate/decisions/$decisionInstanceId': typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
+  '/_carbon/_auth/operate/batch-operations/': typeof CarbonAuthOperateBatchOperationsIndexRoute
   '/_carbon/_auth/operate/decisions/': typeof CarbonAuthOperateDecisionsIndexRoute
   '/_carbon/_auth/tasklist/_tasks/': typeof CarbonAuthTasklistTasksIndexRoute
   '/shadcn/_auth/tasklist/_tasks/': typeof ShadcnAuthTasklistTasksIndexRoute
@@ -453,7 +472,9 @@ export interface FileRouteTypes {
     | '/operate/'
     | '/tasklist/$userTaskKey'
     | '/shadcn/tasklist/$userTaskKey'
+    | '/operate/batch-operations/$batchOperationKey'
     | '/operate/decisions/$decisionInstanceId'
+    | '/operate/batch-operations/'
     | '/operate/decisions/'
     | '/tasklist/'
     | '/shadcn/tasklist/'
@@ -482,14 +503,15 @@ export interface FileRouteTypes {
     | '/shadcn/tasklist/processes'
     | '/admin/$'
     | '/operate/$'
-    | '/operate/batch-operations'
     | '/operate/operations-log'
     | '/operate/processes'
     | '/tasklist/$'
     | '/shadcn/tasklist/$'
     | '/admin'
     | '/operate'
+    | '/operate/batch-operations/$batchOperationKey'
     | '/operate/decisions/$decisionInstanceId'
+    | '/operate/batch-operations'
     | '/operate/decisions'
     | '/tasklist/$userTaskKey/history'
     | '/shadcn/tasklist/$userTaskKey/history'
@@ -534,7 +556,9 @@ export interface FileRouteTypes {
     | '/_carbon/_auth/operate/'
     | '/_carbon/_auth/tasklist/_tasks/$userTaskKey'
     | '/shadcn/_auth/tasklist/_tasks/$userTaskKey'
+    | '/_carbon/_auth/operate/batch-operations/$batchOperationKey'
     | '/_carbon/_auth/operate/decisions/$decisionInstanceId'
+    | '/_carbon/_auth/operate/batch-operations/'
     | '/_carbon/_auth/operate/decisions/'
     | '/_carbon/_auth/tasklist/_tasks/'
     | '/shadcn/_auth/tasklist/_tasks/'
@@ -760,6 +784,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShadcnAuthTasklistProcessesRouteRouteImport
       parentRoute: typeof ShadcnAuthTasklistRouteRoute
     }
+    '/_carbon/_auth/operate/batch-operations/': {
+      id: '/_carbon/_auth/operate/batch-operations/'
+      path: '/'
+      fullPath: '/operate/batch-operations/'
+      preLoaderRoute: typeof CarbonAuthOperateBatchOperationsIndexRouteImport
+      parentRoute: typeof CarbonAuthOperateBatchOperationsRoute
+    }
+    '/_carbon/_auth/operate/batch-operations/$batchOperationKey': {
+      id: '/_carbon/_auth/operate/batch-operations/$batchOperationKey'
+      path: '/$batchOperationKey'
+      fullPath: '/operate/batch-operations/$batchOperationKey'
+      preLoaderRoute: typeof CarbonAuthOperateBatchOperationsBatchOperationKeyRouteImport
+      parentRoute: typeof CarbonAuthOperateBatchOperationsRoute
+    }
     '/_carbon/_auth/operate/decisions/': {
       id: '/_carbon/_auth/operate/decisions/'
       path: '/'
@@ -888,6 +926,24 @@ const CarbonAuthAdminRouteRouteChildren: CarbonAuthAdminRouteRouteChildren = {
 const CarbonAuthAdminRouteRouteWithChildren =
   CarbonAuthAdminRouteRoute._addFileChildren(CarbonAuthAdminRouteRouteChildren)
 
+interface CarbonAuthOperateBatchOperationsRouteChildren {
+  CarbonAuthOperateBatchOperationsBatchOperationKeyRoute: typeof CarbonAuthOperateBatchOperationsBatchOperationKeyRoute
+  CarbonAuthOperateBatchOperationsIndexRoute: typeof CarbonAuthOperateBatchOperationsIndexRoute
+}
+
+const CarbonAuthOperateBatchOperationsRouteChildren: CarbonAuthOperateBatchOperationsRouteChildren =
+  {
+    CarbonAuthOperateBatchOperationsBatchOperationKeyRoute:
+      CarbonAuthOperateBatchOperationsBatchOperationKeyRoute,
+    CarbonAuthOperateBatchOperationsIndexRoute:
+      CarbonAuthOperateBatchOperationsIndexRoute,
+  }
+
+const CarbonAuthOperateBatchOperationsRouteWithChildren =
+  CarbonAuthOperateBatchOperationsRoute._addFileChildren(
+    CarbonAuthOperateBatchOperationsRouteChildren,
+  )
+
 interface CarbonAuthOperateDecisionsRouteChildren {
   CarbonAuthOperateDecisionsDecisionInstanceIdRoute: typeof CarbonAuthOperateDecisionsDecisionInstanceIdRoute
   CarbonAuthOperateDecisionsIndexRoute: typeof CarbonAuthOperateDecisionsIndexRoute
@@ -907,7 +963,7 @@ const CarbonAuthOperateDecisionsRouteWithChildren =
 
 interface CarbonAuthOperateRouteRouteChildren {
   CarbonAuthOperateSplatRoute: typeof CarbonAuthOperateSplatRoute
-  CarbonAuthOperateBatchOperationsRoute: typeof CarbonAuthOperateBatchOperationsRoute
+  CarbonAuthOperateBatchOperationsRoute: typeof CarbonAuthOperateBatchOperationsRouteWithChildren
   CarbonAuthOperateDecisionsRoute: typeof CarbonAuthOperateDecisionsRouteWithChildren
   CarbonAuthOperateOperationsLogRoute: typeof CarbonAuthOperateOperationsLogRoute
   CarbonAuthOperateProcessesRoute: typeof CarbonAuthOperateProcessesRoute
@@ -918,7 +974,7 @@ const CarbonAuthOperateRouteRouteChildren: CarbonAuthOperateRouteRouteChildren =
   {
     CarbonAuthOperateSplatRoute: CarbonAuthOperateSplatRoute,
     CarbonAuthOperateBatchOperationsRoute:
-      CarbonAuthOperateBatchOperationsRoute,
+      CarbonAuthOperateBatchOperationsRouteWithChildren,
     CarbonAuthOperateDecisionsRoute:
       CarbonAuthOperateDecisionsRouteWithChildren,
     CarbonAuthOperateOperationsLogRoute: CarbonAuthOperateOperationsLogRoute,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/batch-operations.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/batch-operations.tsx
@@ -6,25 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {DataTableSkeleton} from '@carbon/react';
-import {createFileRoute} from '@tanstack/react-router';
-import {z} from 'zod';
-import {BatchOperations} from '#/operate/pages/BatchOperations/BatchOperations';
-import {batchOperationsOptions} from '#/operate/pages/BatchOperations/batchOperations.queries';
-
-const batchOperationsSearchSchema = z.object({
-	page: z.number().int().positive().default(1),
-	pageSize: z.number().int().positive().default(20),
-	sort: z.string().optional(),
-});
+import {createFileRoute, Outlet} from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_carbon/_auth/operate/batch-operations')({
-	validateSearch: batchOperationsSearchSchema,
-	loaderDeps: ({search}) => ({...search}),
-	loader: ({context: {queryClient}, deps}) => queryClient.ensureQueryData(batchOperationsOptions(deps)),
-	pendingComponent: () => <DataTableSkeleton columnCount={5} rowCount={5} showHeader={false} showToolbar={false} />,
-	component: function BatchOperationsRoute() {
-		const {page, pageSize, sort} = Route.useSearch();
-		return <BatchOperations page={page} pageSize={pageSize} sort={sort} />;
-	},
+	component: () => <Outlet />,
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/batch-operations/$batchOperationKey.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/batch-operations/$batchOperationKey.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createFileRoute} from '@tanstack/react-router';
+import {t} from 'i18next';
+import {BatchOperation, BatchOperationSkeleton} from '#/operate/pages/BatchOperation/BatchOperation';
+import {getBatchOperationOptions} from '#/operate/pages/BatchOperation/batchOperation.queries';
+import {formatOperationType} from '#/operate/pages/BatchOperation/utils';
+
+export const Route = createFileRoute('/_carbon/_auth/operate/batch-operations/$batchOperationKey')({
+	loader: async ({context: {queryClient}, params: {batchOperationKey}}) => {
+		try {
+			return await queryClient.ensureQueryData(getBatchOperationOptions(batchOperationKey));
+		} catch {
+			return undefined;
+		}
+	},
+	head: ({loaderData}) => ({
+		meta: loaderData
+			? [{title: t('operate.batchOperation.pageTitle', {name: formatOperationType(loaderData.batchOperationType)})}]
+			: [],
+	}),
+	pendingComponent: () => <BatchOperationSkeleton />,
+	component: function BatchOperationRoute() {
+		const {batchOperationKey} = Route.useParams();
+		return <BatchOperation batchOperationKey={batchOperationKey} />;
+	},
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/batch-operations/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_carbon/_auth/operate/batch-operations/index.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {DataTableSkeleton} from '@carbon/react';
+import {createFileRoute} from '@tanstack/react-router';
+import {z} from 'zod';
+import {BatchOperations} from '#/operate/pages/BatchOperations/BatchOperations';
+import {batchOperationsOptions} from '#/operate/pages/BatchOperations/batchOperations.queries';
+
+const batchOperationsSearchSchema = z.object({
+	page: z.number().int().positive().default(1),
+	pageSize: z.number().int().positive().default(20),
+	sort: z.string().optional(),
+});
+
+export const Route = createFileRoute('/_carbon/_auth/operate/batch-operations/')({
+	validateSearch: batchOperationsSearchSchema,
+	loaderDeps: ({search}) => ({...search}),
+	loader: ({context: {queryClient}, deps}) => queryClient.ensureQueryData(batchOperationsOptions(deps)),
+	pendingComponent: () => <DataTableSkeleton columnCount={5} rowCount={5} showHeader={false} showToolbar={false} />,
+	component: function BatchOperationsRoute() {
+		const {page, pageSize, sort} = Route.useSearch();
+		return <BatchOperations page={page} pageSize={pageSize} sort={sort} />;
+	},
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -699,6 +699,40 @@
 			"batchOperations": {
 				"title": "Stapeloperationen"
 			},
+			"batchOperation": {
+				"title": "Stapeloperationen",
+				"pageTitle": "Operate: Stapeloperation {{name}}",
+				"notFoundNotificationTitle": "Stapeloperation {{batchOperationKey}} konnte nicht gefunden werden",
+				"loadErrorTitle": "Details der Stapeloperation konnten nicht geladen werden",
+				"backButton": "Zurück zu Stapeloperationen",
+				"forbidden": {
+					"heading": "403 - Sie haben keine Berechtigung, diese Informationen anzuzeigen",
+					"description": "Wenden Sie sich an Ihren Administrator, um Zugriff zu erhalten.",
+					"learnMoreLink": "Mehr über Berechtigungen erfahren"
+				},
+				"tiles": {
+					"state": "Stapelstatus",
+					"summaryOfItems": "Zusammenfassung der Elemente",
+					"startDate": "Startdatum",
+					"endDate": "Enddatum",
+					"actor": "Akteur"
+				},
+				"itemsTable": {
+					"title": "Elemente",
+					"state": "Stapelstatus",
+					"date": "Datum",
+					"processInstanceKey": "Prozessinstanzschlüssel",
+					"decisionInstanceKey": "Entscheidungsinstanzschlüssel",
+					"incidentKey": "Vorfallschlüssel",
+					"noProcessInstance": "Keine Prozessinstanz",
+					"noDecisionInstance": "Keine Entscheidungsinstanz",
+					"noIncident": "Kein Vorfall",
+					"viewProcessInstance": "Prozessinstanz {{key}} anzeigen",
+					"viewDecisionInstance": "Entscheidungsinstanz {{key}} anzeigen",
+					"failureReason": "Fehlerursache: {{message}}",
+					"emptyMessage": "Keine Elemente gefunden"
+				}
+			},
 			"shared": {
 				"errorMessage": {
 					"message": "Daten konnten nicht abgerufen werden",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -714,7 +714,7 @@
 				"title": "Batch Operations"
 			},
 			"batchOperation": {
-				"title": "Batch operations",
+				"title": "Batch Operations",
 				"pageTitle": "Operate: Batch Operation {{name}}",
 				"notFoundNotificationTitle": "Batch operation {{batchOperationKey}} could not be found",
 				"loadErrorTitle": "Failed to load batch operation details",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -713,6 +713,40 @@
 			"batchOperations": {
 				"title": "Batch Operations"
 			},
+			"batchOperation": {
+				"title": "Batch operations",
+				"pageTitle": "Operate: Batch Operation {{name}}",
+				"notFoundNotificationTitle": "Batch operation {{batchOperationKey}} could not be found",
+				"loadErrorTitle": "Failed to load batch operation details",
+				"backButton": "Back to batch operations",
+				"forbidden": {
+					"heading": "403 - You do not have permission to view this information",
+					"description": "Contact your administrator to get access.",
+					"learnMoreLink": "Learn more about permissions"
+				},
+				"tiles": {
+					"state": "Batch state",
+					"summaryOfItems": "Summary of items",
+					"startDate": "Start date",
+					"endDate": "End date",
+					"actor": "Actor"
+				},
+				"itemsTable": {
+					"title": "Items",
+					"state": "Batch state",
+					"date": "Date",
+					"processInstanceKey": "Process instance key",
+					"decisionInstanceKey": "Decision instance key",
+					"incidentKey": "Incident key",
+					"noProcessInstance": "No process instance",
+					"noDecisionInstance": "No decision instance",
+					"noIncident": "No incident",
+					"viewProcessInstance": "View process instance {{key}}",
+					"viewDecisionInstance": "View decision instance {{key}}",
+					"failureReason": "Failure reason: {{message}}",
+					"emptyMessage": "No items found"
+				}
+			},
 			"shared": {
 				"errorMessage": {
 					"message": "Data could not be fetched",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -699,6 +699,40 @@
 			"batchOperations": {
 				"title": "Operaciones en lote"
 			},
+			"batchOperation": {
+				"title": "Operaciones en lote",
+				"pageTitle": "Operate: Operación en lote {{name}}",
+				"notFoundNotificationTitle": "No se pudo encontrar la operación en lote {{batchOperationKey}}",
+				"loadErrorTitle": "No se pudieron cargar los detalles de la operación en lote",
+				"backButton": "Volver a operaciones en lote",
+				"forbidden": {
+					"heading": "403 - No tiene permiso para ver esta información",
+					"description": "Póngase en contacto con su administrador para obtener acceso.",
+					"learnMoreLink": "Más información sobre los permisos"
+				},
+				"tiles": {
+					"state": "Estado del lote",
+					"summaryOfItems": "Resumen de elementos",
+					"startDate": "Fecha de inicio",
+					"endDate": "Fecha de finalización",
+					"actor": "Actor"
+				},
+				"itemsTable": {
+					"title": "Elementos",
+					"state": "Estado del lote",
+					"date": "Fecha",
+					"processInstanceKey": "Clave de instancia de proceso",
+					"decisionInstanceKey": "Clave de instancia de decisión",
+					"incidentKey": "Clave de incidente",
+					"noProcessInstance": "Sin instancia de proceso",
+					"noDecisionInstance": "Sin instancia de decisión",
+					"noIncident": "Sin incidente",
+					"viewProcessInstance": "Ver instancia de proceso {{key}}",
+					"viewDecisionInstance": "Ver instancia de decisión {{key}}",
+					"failureReason": "Motivo del fallo: {{message}}",
+					"emptyMessage": "No se encontraron elementos"
+				}
+			},
 			"shared": {
 				"errorMessage": {
 					"message": "No se pudieron recuperar los datos",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -702,6 +702,40 @@
 			"batchOperations": {
 				"title": "Opérations par lots"
 			},
+			"batchOperation": {
+				"title": "Opérations par lots",
+				"pageTitle": "Operate : Opération par lots {{name}}",
+				"notFoundNotificationTitle": "L'opération par lots {{batchOperationKey}} n'a pas pu être trouvée",
+				"loadErrorTitle": "Impossible de charger les détails de l'opération par lots",
+				"backButton": "Retour aux opérations par lots",
+				"forbidden": {
+					"heading": "403 - Vous n'avez pas la permission de consulter ces informations",
+					"description": "Contactez votre administrateur pour obtenir l'accès.",
+					"learnMoreLink": "En savoir plus sur les autorisations"
+				},
+				"tiles": {
+					"state": "État du lot",
+					"summaryOfItems": "Résumé des éléments",
+					"startDate": "Date de début",
+					"endDate": "Date de fin",
+					"actor": "Acteur"
+				},
+				"itemsTable": {
+					"title": "Éléments",
+					"state": "État du lot",
+					"date": "Date",
+					"processInstanceKey": "Clé d'instance de processus",
+					"decisionInstanceKey": "Clé d'instance de décision",
+					"incidentKey": "Clé d'incident",
+					"noProcessInstance": "Aucune instance de processus",
+					"noDecisionInstance": "Aucune instance de décision",
+					"noIncident": "Aucun incident",
+					"viewProcessInstance": "Voir l'instance de processus {{key}}",
+					"viewDecisionInstance": "Voir l'instance de décision {{key}}",
+					"failureReason": "Raison de l'échec : {{message}}",
+					"emptyMessage": "Aucun élément trouvé"
+				}
+			},
 			"shared": {
 				"errorMessage": {
 					"message": "Les données n'ont pas pu être récupérées",


### PR DESCRIPTION
## Description

Ports the Batch Operation details page from legacy Operate (`operate/client/src/App/BatchOperation/`) to the unified webapp: the already-shipped Batch Operations list page links each row to `/operate/batch-operations/${batchOperationKey}`, but that route didn't exist, so the link was dead.

Adds: header with back navigation, the state/summary/dates/actor tiles, and the paginated items table (columns vary by batch operation type — process instance, decision instance, or incident — matching legacy). The route is wired in by splitting `batch-operations.tsx` into a parent layout plus `index.tsx` (list) and `$batchOperationKey.tsx` (details), mirroring the Decisions page's existing split, with a `pendingComponent` skeleton matching `decisions/$decisionInstanceId`.

`BatchStateIndicator` (shared) only covered `BatchOperationState`; item rows also carry `BatchOperationItemState` (adds `SKIPPED`, drops a few batch-only states), so its prop and state config are widened to accept both.

Also fixes a pre-existing bug in the shared `BatchItemsCount` tile, found while wiring it into this page's "Summary of items" tile: it rendered blank for a batch operation with zero items instead of legacy's gray "no items" indicator, because its guard required `pendingCount > 0` where legacy only checks `!hasAnyProgress`.

**Deferred to a follow-up PR:** `OperationActions` (suspend/resume/cancel). They need new write endpoints and are a separable, independently reviewable unit — matching how #59421 split the Decisions delete operation out of its own decision panel PR.

i18n: de/fr/es are LLM-translated, native speaker review requested.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #62194 (details implementation owned by this PR)
relates to #55642 (page tracking)

OperationActions and action recovery remain in #62196 for a follow-up PR.
