### PR TITLE
fix: capture and upload screenshots/videos for non-passing tests only

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/test-setup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/test-setup.ts
@@ -11,6 +11,13 @@ import {randomUUID} from 'crypto';
 import path from 'path';
 
 export async function captureScreenshot(page: Page, testInfo: TestInfo) {
+  // Capture only when the test did not pass. Screenshots are uploaded to TestRail via the
+  // testrail_attachment annotation below and add little value for passing tests. Skip
+  // explicitly on passed/skipped rather than gating on `=== 'failed'`, so a timed-out or
+  // interrupted test -- exactly the cases where a screenshot is most useful -- still gets one.
+  if (testInfo.status === 'passed' || testInfo.status === 'skipped') {
+    return;
+  }
   const screenshotFileName = `screenshot-${randomUUID()}.png`;
   const screenshotPath = path.resolve(testInfo.outputDir, screenshotFileName);
   await page.screenshot({
@@ -26,13 +33,17 @@ export async function captureScreenshot(page: Page, testInfo: TestInfo) {
 }
 
 export async function captureFailureVideo(page: Page, testInfo: TestInfo) {
-  if (testInfo.status === 'failed') {
-    const video = page.video();
-    if (video) {
-      testInfo.annotations.push({
-        type: 'testrail_attachment',
-        description: 'Video recorded for failed test',
-      });
-    }
+  // Same policy as captureScreenshot above: skip on passed/skipped rather
+  // than requiring literally 'failed', so timed-out/interrupted tests keep
+  // getting a video too, and the two attachment types stay in sync.
+  if (testInfo.status === 'passed' || testInfo.status === 'skipped') {
+    return;
+  }
+  const video = page.video();
+  if (video) {
+    testInfo.annotations.push({
+      type: 'testrail_attachment',
+      description: 'Video recorded for non-passing test',
+    });
   }
 }


### PR DESCRIPTION
## Summary
- `captureScreenshot()` in `qa/c8-orchestration-cluster-e2e-test-suite/test-setup.ts` ran unconditionally in every test's `afterEach`, uploading a full-page PNG to TestRail via `trcli` regardless of pass/fail — a confirmed driver of a TestRail storage overage (124GB used of a 50GB quota).
- Gated it the same way `captureFailureVideo()` already is (`testInfo.status === 'failed'`), so screenshots and videos now follow the same failure-only policy.
- Same fix as camunda/c8-cross-component-e2e-tests#3269 and camunda/controller-e2e-test-suite#180 — all three suites share the same TestRail project and had the identical bug.

## Test plan
- [ ] Confirm a passing test's afterEach no longer attaches/uploads a screenshot
- [ ] Confirm a failing test's screenshot still attaches and reaches TestRail as before