### PR TITLE
test: fix the four failing Optimize self-managed E2E tests (backport #60514)

### DIFF
--- a/optimize/client/e2e/sm-tests/Collection.js
+++ b/optimize/client/e2e/sm-tests/Collection.js
@@ -96,13 +96,20 @@ test('add, edit and delete sources', async (t) => {
   // add source by definition
   await t.click(e.emptyStateAdd);
   const definitionName = 'Big variable process';
-  await t.typeText(e.sourceModalSearchField, 'big', {replace: true});
+  await t.typeText(e.sourceModalSearchField, 'big variable', {replace: true});
   await t.click(e.selectAllCheckbox);
   await t.click(Common.modalConfirmButton);
   await t.expect(e.processItem.visible).ok();
   await t.expect(e.processItem.textContent).contains(definitionName);
   await t.expect(e.processItem.textContent).contains('Process');
   // await t.expect(e.processItem.textContent).contains('engineering');
+
+  // a second source, so the single and bulk deletes below each have one to act on
+  await t.click(e.addButton);
+  await t.typeText(e.sourceModalSearchField, 'order', {replace: true});
+  await t.click(e.itemCheckbox(0));
+  await t.click(Common.modalConfirmButton);
+  await t.expect(e.processItem.count).eql(2);
 
   // // add source by tenant
   // await t.click(e.addButton);

--- a/optimize/client/e2e/sm-tests/ProcessReport.js
+++ b/optimize/client/e2e/sm-tests/ProcessReport.js
@@ -588,7 +588,7 @@ test('aggregators', async (t) => {
   await t.click(e.sectionToggle('Filters'));
   await t.click(e.filterButton);
   await t.click(Common.menuOption('Instance state'));
-  await t.click(e.modalOption('Completed'));
+  await t.click(e.modalOption('Running'));
   await t.click(Common.modalConfirmButton);
 
   const avg = await e.reportNumber.textContent;


### PR DESCRIPTION
⤵️ Backport of #60514 → `stable/8.9`

Manual backport — the automation ([workflow run 33499454182](https://github.com/camunda/camunda/actions/runs/33499454182)) failed because the first commit (`61a1d5f`, external URL tile fix) is already on `stable/8.9` via `fa3f450` (#57260). Cherry-picking it produces an empty commit, which the backport-action's `draft_commit_conflicts` mode cannot handle, so it aborted before opening a draft PR.

### Commits backported
- `test: pick the collection sources the delete steps expect`
- `test: measure aggregations over running instances, which the demo data has`

### Commits skipped (with reason)
- `test: verify external URL tile renders without entering sandboxed iframe` — already present on `stable/8.9` (cherry-pick empty).
- `deps: update react-draggable to 4.7.1 so dashboard tiles can be dragged` — the `process is not defined` bug fixed there was introduced in react-draggable **4.7.0**. On `stable/8.9`, `react-grid-layout@1.5.2` resolves `react-draggable` to **4.5.0** (pre-bug), so the bump is a no-op on this branch.
- `test: refresh the variable submenu visual baseline` — the refreshed baseline captures main-only UI (the **Agentic Control Plane** nav entry and the "process or variable?" hint row) that does not exist on `stable/8.9`, so it would not match this branch's rendering.
