### PR TITLE
perf: resolve one-by-one secret stores concurrently

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * <ul>
  *   <li>{@code camunda.secrets.cache.ttl}
  *   <li>{@code camunda.secrets.cache.max-size}
+ *   <li>{@code camunda.secrets.max-concurrency}
  *   <li>{@code camunda.secrets.stores.file.<id>.path}
  *   <li>{@code camunda.secrets.stores.aws.<id>.region}
  *   <li>{@code camunda.secrets.stores.aws.<id>.path-prefix}
@@ -45,8 +46,62 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @NullMarked
 public class Secrets {
 
+  /**
+   * Floor for {@link #DEFAULT_MAX_CONCURRENCY}, so a small container does not end up with fewer
+   * permits than it has callers competing for them: below the number of concurrently resolving
+   * callers, the shared semaphore is a throttle rather than a speed-up, and a two-core node would
+   * otherwise resolve more slowly than it did before the semaphore existed.
+   */
+  private static final int MIN_DEFAULT_MAX_CONCURRENCY = 8;
+
+  /**
+   * Twice the core count, not once: the permits bound blocking backend round trips rather than CPU
+   * work, and staying clear of the virtual-thread carrier pool (sized to the core count) leaves
+   * room for a store whose client pins its carrier. It also keeps the default above
+   * partitions-per-node, which is what the callers competing for these permits scale with.
+   */
+  private static final int DEFAULT_MAX_CONCURRENCY_PER_CORE = 2;
+
+  /**
+   * Default for {@link #maxConcurrency}. Derived from the host rather than fixed, since the callers
+   * sharing these permits (one per partition on this node, plus the REST resolution path) scale
+   * with the node's size, and a fixed number too far below them turns the shared semaphore into a
+   * throttle.
+   *
+   * <p>Computed here rather than read from {@code secret-store-api} for the same reason {@link
+   * Cache}'s defaults are restated as literals: this module deliberately does not depend on that
+   * module.
+   */
+  private static final int DEFAULT_MAX_CONCURRENCY =
+      Math.max(
+          MIN_DEFAULT_MAX_CONCURRENCY,
+          Runtime.getRuntime().availableProcessors() * DEFAULT_MAX_CONCURRENCY_PER_CORE);
+
   @NestedConfigurationProperty private Stores stores = new Stores();
   @NestedConfigurationProperty private Cache cache = new Cache();
+
+  /**
+   * How many sequential backend calls a store whose cost scales with call count ({@code
+   * namesPerCall()} less than the request size) may issue at once, bounded by a semaphore shared by
+   * every such store the registry wraps. {@code 1} resolves exactly as before this setting existed:
+   * one call at a time, on the calling thread. A store that already covers the whole request in one
+   * call (a container-style store, or one backed by local disk) is unaffected either way; a batched
+   * store (e.g. AWS's {@code BatchGetSecretValue} mode) is included once its request needs more
+   * than one batch.
+   *
+   * <p>The permits are shared per node and physical tenant, so the load this puts on the secret
+   * backend is this value times the number of nodes, which is what a provider's request quota sees.
+   *
+   * <p>Raising it past what one request can use changes nothing, since a request is split into
+   * {@code ceil(names / namesPerCall())} chunks and cannot use more permits than it has chunks. The
+   * two callers both cap their request size at 20 names: background resolution at {@code
+   * camunda.processing.engine.secrets.batch-resolution-limit}, and the resolve endpoint at the
+   * {@code maxItems} on its {@code references} array. For a one-by-one store that puts the ceiling
+   * at 20; for a batched store it is 20 divided by the batch size.
+   *
+   * <p>Defaults to twice the available processor count, and never below {@code 8}.
+   */
+  private Integer maxConcurrency = DEFAULT_MAX_CONCURRENCY;
 
   public Stores getStores() {
     return stores;
@@ -67,6 +122,26 @@ public class Secrets {
 
   public void setCache(final Cache cache) {
     this.cache = cache;
+  }
+
+  /**
+   * @throws IllegalArgumentException if max-concurrency is below 1
+   */
+  public int getMaxConcurrency() {
+    if (maxConcurrency < 1) {
+      throw new IllegalArgumentException(
+          "camunda.secrets.max-concurrency must be at least 1, but was " + maxConcurrency);
+    }
+    return maxConcurrency;
+  }
+
+  /**
+   * @param maxConcurrency the configured value, or {@code null}, bound to the same outcome {@code
+   *     ttl}/{@code max-size} already have, rather than the two disagreeing on what an empty value
+   *     means (routine for an env-var-driven deployment)
+   */
+  public void setMaxConcurrency(final @Nullable Integer maxConcurrency) {
+    this.maxConcurrency = maxConcurrency == null ? DEFAULT_MAX_CONCURRENCY : maxConcurrency;
   }
 
   public static class Stores {

--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -89,15 +89,20 @@ public class Secrets {
    * store (e.g. AWS's {@code BatchGetSecretValue} mode) is included once its request needs more
    * than one batch.
    *
-   * <p>The permits are shared per node and physical tenant, so the load this puts on the secret
-   * backend is this value times the number of nodes, which is what a provider's request quota sees.
+   * <p>The permits are shared per node and physical tenant, so they bound how many backend calls
+   * this node has in flight for such stores at once. A request small enough to resolve in a single
+   * call (at most {@code namesPerCall()} names) takes no permit, so actual concurrency can exceed
+   * this value by one such call per concurrent caller. The bound is on call concurrency, not
+   * request rate, so it only approximates a provider quota measured in calls per second rather than
+   * guaranteeing it sees at most this value times the node count.
    *
    * <p>Raising it past what one request can use changes nothing, since a request is split into
    * {@code ceil(names / namesPerCall())} chunks and cannot use more permits than it has chunks. The
-   * two callers both cap their request size at 20 names: background resolution at {@code
-   * camunda.processing.engine.secrets.batch-resolution-limit}, and the resolve endpoint at the
-   * {@code maxItems} on its {@code references} array. For a one-by-one store that puts the ceiling
-   * at 20; for a batched store it is 20 divided by the batch size.
+   * resolve endpoint caps its request size at 20 names via the {@code maxItems} on its {@code
+   * references} array; background resolution defaults to the same 20 via {@code
+   * camunda.processing.engine.secrets.batch-resolution-limit}, but that limit is a configurable
+   * default, not a hard cap. For a one-by-one store the endpoint's cap puts the chunk ceiling at
+   * 20; for a batched store it is {@code ceil(20 / batchSize)}.
    *
    * <p>Defaults to twice the available processor count, and never below {@code 8}.
    */

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -20,6 +20,19 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 @SpringJUnitConfig({UnifiedConfiguration.class, UnifiedConfigurationHelper.class})
 class SecretsTest {
 
+  /**
+   * The floor and the formula behind {@code camunda.secrets.max-concurrency}'s default, restated
+   * here rather than read from {@link Secrets}: the default is derived from the core count of
+   * whatever machine runs this, so a literal could only be pinned on one machine, and reading the
+   * production constant back would assert nothing. Restating it means a change to the formula has
+   * to be made here too, deliberately.
+   */
+  private static final int EXPECTED_MIN_DEFAULT_MAX_CONCURRENCY = 8;
+
+  private static final int EXPECTED_DEFAULT_MAX_CONCURRENCY =
+      Math.max(
+          EXPECTED_MIN_DEFAULT_MAX_CONCURRENCY, Runtime.getRuntime().availableProcessors() * 2);
+
   @Nested
   @TestPropertySource(
       properties = {"camunda.secrets.stores.file.mystore.path=/etc/camunda/secrets.txt"})
@@ -838,6 +851,109 @@ class SecretsTest {
 
       // then the default stands, so getMaxSize() can keep handing an int to the cache factory
       assertThat(cache.getMaxSize()).isEqualTo(1000);
+    }
+  }
+
+  @Nested
+  class WithoutMaxConcurrencyConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithoutMaxConcurrencyConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldDefaultMaxConcurrencyToTwicePerCoreAboveAFloor() {
+      // given no camunda.secrets.max-concurrency property is set
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the max concurrency is the documented default, and never below the floor whatever
+      // core count the machine running this happens to report
+      assertThat(secrets.getMaxConcurrency())
+          .isEqualTo(EXPECTED_DEFAULT_MAX_CONCURRENCY)
+          .isGreaterThanOrEqualTo(EXPECTED_MIN_DEFAULT_MAX_CONCURRENCY);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.max-concurrency=3"})
+  class WithMaxConcurrencyConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithMaxConcurrencyConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindMaxConcurrency() {
+      // given camunda.secrets.max-concurrency is set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then it is bound
+      assertThat(secrets.getMaxConcurrency()).isEqualTo(3);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.max-concurrency=0"})
+  class WithZeroMaxConcurrency {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithZeroMaxConcurrency(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectMaxConcurrencyBelowOne() {
+      // given a max concurrency below 1, which would resolve nothing at all
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // when the validating getter is read
+      // then it is rejected with the property path
+      assertThatThrownBy(secrets::getMaxConcurrency)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("camunda.secrets.max-concurrency")
+          .hasMessageContaining("at least 1");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.max-concurrency="})
+  class WithEmptyMaxConcurrency {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithEmptyMaxConcurrency(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldFallBackToTheDefaultMaxConcurrencyWhenTheValueIsEmpty() {
+      // given an explicitly empty max concurrency, which an env-var-driven deployment produces
+      // routinely
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the default is kept rather than binding as 0, which the minimum would reject at
+      // startup
+      assertThat(secrets.getMaxConcurrency()).isEqualTo(EXPECTED_DEFAULT_MAX_CONCURRENCY);
+    }
+  }
+
+  @Nested
+  class MaxConcurrencyDefaults {
+
+    @Test
+    void shouldKeepTheDefaultMaxConcurrencyWhenSetToNull() {
+      // given the default secrets configuration
+      final Secrets secrets = new Secrets();
+
+      // when a caller sets max concurrency to null directly, which Spring's binder never does
+      secrets.setMaxConcurrency(null);
+
+      // then the default stands, so getMaxConcurrency() can keep handing an int to the pool
+      assertThat(secrets.getMaxConcurrency()).isEqualTo(EXPECTED_DEFAULT_MAX_CONCURRENCY);
     }
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -354,6 +354,7 @@ processing.scheduled-tasks-check-interval
 processing.skip-positions
 secrets.cache.max-size
 secrets.cache.ttl
+secrets.max-concurrency
 secrets.stores.aws
 secrets.stores.file
 secrets.stores.gcp

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1475,6 +1475,22 @@ camunda: # Type: io.camunda.configuration.Camunda
       # Defaults to `20m`.
       ttl: "20m" # Type: Duration, Env: CAMUNDA_SECRETS_CACHE_TTL
 
+    # How many sequential backend calls a store whose cost scales with call count (`namesPerCall()` less
+    # than the request size) may issue at once, bounded by a semaphore shared by every such store the
+    # registry wraps. `1` resolves exactly as before this setting existed: one call at a time, on the
+    # calling thread. A store that already covers the whole request in one call (a container-style store,
+    # or one backed by local disk) is unaffected either way; a batched store (e.g. AWS's
+    # `BatchGetSecretValue` mode) is included once its request needs more than one batch.
+    # The permits are shared per node and physical tenant, so the load this puts on the secret backend is
+    # this value times the number of nodes, which is what a provider's request quota sees.
+    # Raising it past what one request can use changes nothing, since a request is split into `ceil(names
+    # / namesPerCall())` chunks and cannot use more permits than it has chunks. The two callers both cap
+    # their request size at 20 names: background resolution at
+    # `camunda.processing.engine.secrets.batch-resolution-limit`, and the resolve endpoint at the
+    # `maxItems` on its `references` array. For a one-by-one store that puts the ceiling at 20; for a
+    # batched store it is 20 divided by the batch size.
+    # Defaults to twice the available processor count, and never below `8`.
+    max-concurrency: null # Type: Integer, Env: CAMUNDA_SECRETS_MAXCONCURRENCY
     stores: # Type: io.camunda.configuration.Secrets$Stores
       aws: null # Type: Map<String,io.camunda.configuration.Secrets$AwsSecretsManagerStore>, Env: CAMUNDA_SECRETS_STORES_AWS
       file: null # Type: Map<String,io.camunda.configuration.Secrets$FileStore>, Env: CAMUNDA_SECRETS_STORES_FILE

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1481,14 +1481,18 @@ camunda: # Type: io.camunda.configuration.Camunda
     # calling thread. A store that already covers the whole request in one call (a container-style store,
     # or one backed by local disk) is unaffected either way; a batched store (e.g. AWS's
     # `BatchGetSecretValue` mode) is included once its request needs more than one batch.
-    # The permits are shared per node and physical tenant, so the load this puts on the secret backend is
-    # this value times the number of nodes, which is what a provider's request quota sees.
+    # The permits are shared per node and physical tenant, so they bound how many backend calls this node
+    # has in flight for such stores at once. A request small enough to resolve in a single call (at most
+    # `namesPerCall()` names) takes no permit, so actual concurrency can exceed this value by one such call
+    # per concurrent caller. The bound is on call concurrency, not request rate, so it only approximates a
+    # provider quota measured in calls per second rather than guaranteeing it sees at most this value times
+    # the node count.
     # Raising it past what one request can use changes nothing, since a request is split into `ceil(names
-    # / namesPerCall())` chunks and cannot use more permits than it has chunks. The two callers both cap
-    # their request size at 20 names: background resolution at
-    # `camunda.processing.engine.secrets.batch-resolution-limit`, and the resolve endpoint at the
-    # `maxItems` on its `references` array. For a one-by-one store that puts the ceiling at 20; for a
-    # batched store it is 20 divided by the batch size.
+    # / namesPerCall())` chunks and cannot use more permits than it has chunks. The resolve endpoint caps
+    # its request size at 20 names via the `maxItems` on its `references` array; background resolution
+    # defaults to the same 20 via `camunda.processing.engine.secrets.batch-resolution-limit`, but that
+    # limit is a configurable default, not a hard cap. For a one-by-one store the endpoint's cap puts the
+    # chunk ceiling at 20; for a batched store it is `ceil(20 / batchSize)`.
     # Defaults to twice the available processor count, and never below `8`.
     max-concurrency: null # Type: Integer, Env: CAMUNDA_SECRETS_MAXCONCURRENCY
     stores: # Type: io.camunda.configuration.Secrets$Stores

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.configuration.Secrets.FileStore;
 import io.camunda.configuration.Secrets.GcpSecretManagerStore;
 import io.camunda.configuration.Secrets.Stores;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.secretstore.ConcurrentSecretStore;
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretCacheFactory;
 import io.camunda.secretstore.SecretStore;
@@ -37,6 +38,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
@@ -86,6 +90,9 @@ public class SecretStoreConfiguration {
     // tracked for the same reason: a wrapped registry left behind by a failed startup would keep
     // publishing the meters of a cache nothing resolves through
     final List<MeterRegistry> tenantMeterRegistries = new ArrayList<>();
+    // tracked for the same reason: a pool backing a store that gets rolled back must not outlive
+    // it, since nothing else references the pool to shut it down later
+    final List<ExecutorService> concurrencyPools = new ArrayList<>();
     final var timeSource = new ActorClockInstantSource(clockService);
     try {
       resolver
@@ -100,10 +107,12 @@ public class SecretStoreConfiguration {
                           created,
                           timeSource,
                           meterRegistry,
-                          tenantMeterRegistries)));
+                          tenantMeterRegistries,
+                          concurrencyPools)));
     } catch (final RuntimeException e) {
       closeAll(created);
       tenantMeterRegistries.forEach(MicrometerUtil::close);
+      concurrencyPools.forEach(ExecutorService::shutdownNow);
       throw e;
     }
     return new SecretStoreRegistries(Map.copyOf(registries));
@@ -115,7 +124,8 @@ public class SecretStoreConfiguration {
       final List<SecretStore> created,
       final InstantSource timeSource,
       final MeterRegistry meterRegistry,
-      final List<MeterRegistry> tenantMeterRegistries) {
+      final List<MeterRegistry> tenantMeterRegistries,
+      final List<ExecutorService> concurrencyPools) {
     final Stores config = secrets.getStores();
     // cap is one store total per tenant, counted across all store types combined
     final long totalStores =
@@ -150,6 +160,17 @@ public class SecretStoreConfiguration {
               + e.getMessage(),
           e);
     }
+    final int maxConcurrency;
+    try {
+      maxConcurrency = secrets.getMaxConcurrency();
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Physical tenant '"
+              + tenantId
+              + "' has an invalid secret max-concurrency configuration: "
+              + e.getMessage(),
+          e);
+    }
     final Map<String, SecretStore> stores = new LinkedHashMap<>();
     STORE_BINDINGS.forEach(binding -> binding.registerAll(config, stores, created, tenantId));
     if (stores.isEmpty()) {
@@ -158,6 +179,26 @@ public class SecretStoreConfiguration {
       // the three-argument constructor leaves the default cache publishing nothing: the noop store
       // caches nothing, so its hit rate would read 0% forever against no TTL or size to tune
       return new SecretStoreRegistry(Map.copyOf(stores), Map.of(), timeSource);
+    }
+    // one pool and one semaphore shared by every store this tenant configures (today always at
+    // most one store, see the totalStores check above), rather than one per store, since nothing
+    // here needs them kept apart. Built only for a store whose cost scales with the number of
+    // sequential backend calls it issues: wrapping a noop, container, or already-single-call store
+    // would only add a thread hop with nothing to overlap. Threads are virtual (one per chunk, not
+    // one per permit), so the semaphore alone bounds how many backend calls are in flight at once;
+    // the pool itself holds no threads to leak if it is never explicitly shut down.
+    if (maxConcurrency > 1
+        && stores.values().stream().anyMatch(store -> store.namesPerCall() < Integer.MAX_VALUE)) {
+      final var pool =
+          Executors.newThreadPerTaskExecutor(
+              Thread.ofVirtual().name("secret-resolution-" + tenantId + "-", 0).factory());
+      concurrencyPools.add(pool);
+      final var semaphore = new Semaphore(maxConcurrency, true);
+      stores.replaceAll(
+          (id, store) ->
+              store.namesPerCall() < Integer.MAX_VALUE
+                  ? new ConcurrentSecretStore(store, pool, semaphore)
+                  : store);
     }
     // wrapped only now that the tenant is known to have a store worth measuring, so a tenant that
     // fails the rules above never leaves a registry behind either

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -186,9 +187,20 @@ public class SecretStoreConfiguration {
     // sequential backend calls it issues: wrapping a noop, container, or already-single-call store
     // would only add a thread hop with nothing to overlap. Threads are virtual (one per chunk, not
     // one per permit), so the semaphore alone bounds how many backend calls are in flight at once;
-    // the pool itself holds no threads to leak if it is never explicitly shut down.
-    if (maxConcurrency > 1
-        && stores.values().stream().anyMatch(store -> store.namesPerCall() < Integer.MAX_VALUE)) {
+    // the pool itself holds no threads to leak if it is never explicitly shut down. It is also
+    // never shut down on the happy path: it is owned by this Spring singleton bean, so it lives for
+    // the application's lifetime, the same as the registry it backs. The only effect of that is
+    // that in-flight resolutions are not interrupted at shutdown, which is acceptable for calls
+    // this
+    // short-lived.
+    // computed once, rather than calling namesPerCall() again per store below, since a store
+    // answers with the same value for the life of this method
+    final var concurrencyEligibleIds =
+        stores.entrySet().stream()
+            .filter(entry -> entry.getValue().namesPerCall() < Integer.MAX_VALUE)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    if (maxConcurrency > 1 && !concurrencyEligibleIds.isEmpty()) {
       final var pool =
           Executors.newThreadPerTaskExecutor(
               Thread.ofVirtual().name("secret-resolution-" + tenantId + "-", 0).factory());
@@ -196,7 +208,7 @@ public class SecretStoreConfiguration {
       final var semaphore = new Semaphore(maxConcurrency, true);
       stores.replaceAll(
           (id, store) ->
-              store.namesPerCall() < Integer.MAX_VALUE
+              concurrencyEligibleIds.contains(id)
                   ? new ConcurrentSecretStore(store, pool, semaphore)
                   : store);
     }

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -18,6 +18,7 @@ import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Secrets;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.secretstore.CaffeineSecretCache;
+import io.camunda.secretstore.ConcurrentSecretStore;
 import io.camunda.secretstore.LocallyCachedSecretStore;
 import io.camunda.secretstore.SecretCacheMetricsDoc;
 import io.camunda.secretstore.SecretCacheMetricsDoc.SecretCacheKeyNames;
@@ -698,6 +699,41 @@ class SecretStoreConfigurationTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenanta")
         .hasMessageContaining("camunda.secrets.cache.ttl");
+  }
+
+  @Test
+  void shouldFailToBuildRegistriesWhenMaxConcurrencyIsBelowOne() {
+    // given a max-concurrency of 0 and no stores configured at all
+    final var resolver = resolverFor(Map.of("camunda.secrets.max-concurrency", "0"));
+
+    // when / then the registries fail to build, naming the offending property
+    assertThatThrownBy(() -> registries(resolver))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("camunda.secrets.max-concurrency");
+  }
+
+  @Test
+  void shouldNotWrapFileStoreForConcurrency(@TempDir final Path secretsDir) {
+    // given a file store, configured at the default (concurrency-enabled) max-concurrency: a local
+    // disk read pays no round trip, so wrapping it would only add a thread hop with nothing to
+    // overlap
+    try (var construction = mockConstruction(ConcurrentSecretStore.class)) {
+      final var resolver =
+          resolverFor(Map.of("camunda.secrets.stores.file.default.path", secretsDir.toString()));
+
+      // when
+      final var store =
+          registries(resolver)
+              .byPhysicalTenant()
+              .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+              .getStores()
+              .get(SecretStoreRegistry.DEFAULT_STORE_ID);
+
+      // then no concurrency wrapper was ever built, and the store is still identifiable as the
+      // file store it wraps for caching
+      assertThat(construction.constructed()).isEmpty();
+      assertThat(store.is(FileBasedSecretStore.class)).isTrue();
+    }
   }
 
   @Test

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Resolves a {@link SecretStore} whose cost scales with the number of sequential backend calls it
+ * issues ({@link SecretStore#namesPerCall}) by splitting the requested names into chunks of that
+ * size and resolving them concurrently, instead of paying every round trip back to back on the
+ * calling thread.
+ *
+ * <p>Each chunk runs as its own task on {@code pool} (a virtual-thread-per-task executor in
+ * production, so a chunk waiting on a permit costs no platform thread), gated by {@code semaphore}
+ * so that no more than its permit count of backend calls are in flight at once. Both are shared
+ * across every store this wraps and across every caller of this store (every partition's scheduler
+ * and the REST resolution path alike): {@link #close} therefore closes only the wrapped store,
+ * never the pool or the semaphore.
+ *
+ * <p>A store that already covers the whole request in one call ({@code namesPerCall() >=
+ * names.size()}), or a semaphore of one permit, take the same single, un-hopped call the wrapped
+ * store would have taken anyway; the fan-out below never runs for them. The one-permit case is
+ * checked explicitly (rather than left to the semaphore to serialize the chunks one at a time) so
+ * that configuring a concurrency of 1 keeps meaning exactly what it means today: one call at a
+ * time, on the calling thread, with no thread hop at all.
+ *
+ * <p>The bound is the semaphore's own permit count, read once here rather than passed alongside it:
+ * the semaphore is the only thing that actually limits how many backend calls run at once, so a
+ * separately configured number could only ever disagree with it. Reading it at construction is
+ * accurate because a store is built at startup, before any chunk can hold a permit.
+ *
+ * <p>If any chunk throws {@link SecretStoreUnavailableException}, every chunk that has not yet
+ * issued its backend call is skipped rather than dispatched: once a store is known to be
+ * unavailable, letting the remaining chunks call it anyway would only pile more requests onto a
+ * backend that is already failing (e.g. throttling). The whole call then fails with the first such
+ * failure once every chunk has finished; the names of chunks that did succeed are not returned.
+ * They stay pending and are retried on the next resolution cycle, exactly as they would if the
+ * whole unwrapped store call had failed.
+ */
+@NullMarked
+public final class ConcurrentSecretStore implements SecretStore {
+
+  private final SecretStore delegate;
+  private final ExecutorService pool;
+  private final Semaphore semaphore;
+  private final int maxConcurrency;
+
+  public ConcurrentSecretStore(
+      final SecretStore delegate, final ExecutorService pool, final Semaphore semaphore) {
+    maxConcurrency = semaphore.availablePermits();
+    if (maxConcurrency < 1) {
+      throw new IllegalArgumentException(
+          "The shared secret resolution semaphore must carry at least one permit, but carried "
+              + maxConcurrency);
+    }
+    this.delegate = delegate;
+    this.pool = pool;
+    this.semaphore = semaphore;
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    final int callSize = delegate.namesPerCall();
+    if (maxConcurrency == 1 || callSize >= names.size()) {
+      return delegate.resolve(names);
+    }
+
+    // flips once any chunk observes the store is unavailable, so a chunk not yet past the check
+    // below skips its own call instead of piling onto an already-failing backend
+    final var storeUnavailable = new AtomicBoolean();
+    final List<Callable<Map<String, SecretResolutionResult>>> tasks =
+        chunk(names, callSize).stream()
+            .<Callable<Map<String, SecretResolutionResult>>>map(
+                chunkNames -> () -> resolveChunk(chunkNames, storeUnavailable))
+            .toList();
+    final List<Future<Map<String, SecretResolutionResult>>> futures;
+    try {
+      futures = pool.invokeAll(tasks);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new SecretStoreUnavailableException(
+          "Interrupted while resolving secrets concurrently", e);
+    } catch (final RejectedExecutionException e) {
+      // the pool is shut down (startup rollback has closed it, or the application is stopping), so
+      // the store was never read. That is what SecretStoreUnavailableException means, and it is the
+      // only failure the scheduler retries and the REST path reports as UNAVAILABLE: left as a
+      // RejectedExecutionException it would instead be logged as an unexpected engine error.
+      throw new SecretStoreUnavailableException(
+          "Secret resolution pool rejected the concurrent resolution of " + names.size() + " names",
+          e);
+    }
+
+    final Map<String, SecretResolutionResult> results =
+        new LinkedHashMap<>((int) (names.size() / 0.75f) + 1);
+    // every future is already done by the time invokeAll returns, so draining them all before
+    // deciding whether to fail loses nothing and keeps the failure the same shape a single
+    // unwrapped call would have thrown: one SecretStoreUnavailableException for the whole request.
+    // Later failures are attached as suppressed rather than dropped, so a caller inspecting the
+    // thrown exception can still see every chunk that failed, not just the first.
+    RuntimeException firstFailure = null;
+    for (final var future : futures) {
+      try {
+        results.putAll(future.get());
+      } catch (final ExecutionException e) {
+        firstFailure = addFailure(firstFailure, unwrap(e));
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        // the caller is a long-lived shared actor thread, not a short-lived worker: restoring the
+        // flag here is still correct (this thread did not choose to stop waiting, whatever
+        // interrupted it did), it just means the next blocking call on this same thread also sees
+        // the flag set. Nothing in this codebase interrupts actor threads today, so this path is
+        // not expected to be reachable in production.
+        firstFailure =
+            addFailure(
+                firstFailure,
+                new SecretStoreUnavailableException(
+                    "Interrupted while resolving secrets concurrently", e));
+      }
+    }
+    if (firstFailure != null) {
+      throw firstFailure;
+    }
+    return results;
+  }
+
+  /**
+   * Resolves one chunk, skipping the backend call entirely if a sibling chunk has already reported
+   * the store unavailable. The store is checked again after the permit is acquired, in case it
+   * flipped while this chunk was waiting: a chunk queued behind a full semaphore should not issue a
+   * call into a store just found unavailable by the chunk that freed the permit it is about to
+   * take.
+   */
+  private Map<String, SecretResolutionResult> resolveChunk(
+      final Set<String> chunkNames, final AtomicBoolean storeUnavailable)
+      throws InterruptedException {
+    if (storeUnavailable.get()) {
+      throw skippedException();
+    }
+    semaphore.acquire();
+    try {
+      if (storeUnavailable.get()) {
+        throw skippedException();
+      }
+      return delegate.resolve(chunkNames);
+    } catch (final SecretStoreUnavailableException e) {
+      storeUnavailable.set(true);
+      throw e;
+    } finally {
+      semaphore.release();
+    }
+  }
+
+  private static SecretStoreUnavailableException skippedException() {
+    return new SecretStoreUnavailableException(
+        "Skipped: a concurrently-dispatched chunk already reported this store unavailable");
+  }
+
+  private static RuntimeException addFailure(
+      final @Nullable RuntimeException firstFailure, final RuntimeException newFailure) {
+    if (firstFailure == null) {
+      return newFailure;
+    }
+    firstFailure.addSuppressed(newFailure);
+    return firstFailure;
+  }
+
+  @Override
+  public List<String> list() {
+    return delegate.list();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  /**
+   * Answers for the store this wraps rather than for this decorator, so a caller asking which store
+   * was configured gets the same answer whether or not concurrency wrapped it.
+   */
+  @Override
+  public boolean is(final Class<? extends SecretStore> storeType) {
+    return delegate.is(storeType);
+  }
+
+  /**
+   * Turns a chunk's failure into the exception this call fails with. An {@link Error} is rethrown
+   * as it is instead: it is not one of the outcomes a store models, and reporting it as {@link
+   * SecretStoreUnavailableException} would put the scheduler into a retry ladder over a JVM failure
+   * it can neither retry away nor see.
+   */
+  private static RuntimeException unwrap(final ExecutionException e) {
+    final var cause = e.getCause();
+    if (cause instanceof final Error error) {
+      throw error;
+    }
+    if (cause instanceof final RuntimeException runtimeException) {
+      return runtimeException;
+    }
+    return new SecretStoreUnavailableException("Failed to resolve secrets concurrently", cause);
+  }
+
+  private static List<Set<String>> chunk(final Set<String> names, final int callSize) {
+    final var all = new ArrayList<>(names);
+    final List<Set<String>> chunks = new ArrayList<>();
+    for (int i = 0; i < all.size(); i += callSize) {
+      chunks.add(new LinkedHashSet<>(all.subList(i, Math.min(i + callSize, all.size()))));
+    }
+    return chunks;
+  }
+}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
@@ -35,6 +35,10 @@ import org.jspecify.annotations.NullMarked;
  * and the REST resolution path alike): {@link #close} therefore closes only the wrapped store,
  * never the pool or the semaphore.
  *
+ * <p>A chunk holds its permit for the whole duration of {@code delegate.resolve}, including any
+ * retries the delegate performs internally against a throttled backend (e.g. the AWS store's own
+ * retry strategy): one permit can therefore cover several backend requests over time, not just one.
+ *
  * <p>A store that already covers the whole request in one call ({@code namesPerCall() >=
  * names.size()}), or a semaphore of one permit, take the same single, un-hopped call the wrapped
  * store would have taken anyway; the fan-out below never runs for them. The one-permit case is

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
@@ -80,6 +80,16 @@ public final class ConcurrentSecretStore implements SecretStore {
   @Override
   public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
     final int callSize = delegate.namesPerCall();
+    if (callSize < 1) {
+      // a store reporting less than one name per call cannot be chunked (chunk() would either
+      // loop forever on 0 or throw on a negative subList bound): this is a broken namesPerCall()
+      // implementation, not a request this store can serve at all
+      throw new IllegalArgumentException(
+          "A secret store's namesPerCall() must be at least 1, but "
+              + delegate.getClass().getSimpleName()
+              + " returned "
+              + callSize);
+    }
     if (maxConcurrency == 1 || callSize >= names.size()) {
       return delegate.resolve(names);
     }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
@@ -126,13 +126,21 @@ public final class ConcurrentSecretStore implements SecretStore {
           e);
     }
 
+    return drain(futures, names.size());
+  }
+
+  /**
+   * Collects every chunk's result once {@code futures} are all done, or throws the request's {@link
+   * #primaryFailure} if any chunk failed. Draining them all before deciding whether to fail loses
+   * nothing and keeps the failure the same shape a single unwrapped call would have thrown: one
+   * {@link SecretStoreUnavailableException} for the whole request. Later failures are attached as
+   * suppressed rather than dropped, so a caller inspecting the thrown exception can still see every
+   * chunk that failed, not just the first.
+   */
+  private static Map<String, SecretResolutionResult> drain(
+      final List<Future<Map<String, SecretResolutionResult>>> futures, final int nameCount) {
     final Map<String, SecretResolutionResult> results =
-        new LinkedHashMap<>((int) (names.size() / 0.75f) + 1);
-    // every future is already done by the time invokeAll returns, so draining them all before
-    // deciding whether to fail loses nothing and keeps the failure the same shape a single
-    // unwrapped call would have thrown: one SecretStoreUnavailableException for the whole request.
-    // Later failures are attached as suppressed rather than dropped, so a caller inspecting the
-    // thrown exception can still see every chunk that failed, not just the first.
+        new LinkedHashMap<>((int) (nameCount / 0.75f) + 1);
     final List<RuntimeException> failures = new ArrayList<>();
     for (final var future : futures) {
       try {

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/ConcurrentSecretStore.java
@@ -21,7 +21,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Resolves a {@link SecretStore} whose cost scales with the number of sequential backend calls it
@@ -58,6 +57,10 @@ import org.jspecify.annotations.Nullable;
  */
 @NullMarked
 public final class ConcurrentSecretStore implements SecretStore {
+
+  /** Message identifying a chunk failure caused only by a sibling chunk's failure, not its own. */
+  private static final String SKIPPED_MESSAGE =
+      "Skipped: a concurrently-dispatched chunk already reported this store unavailable";
 
   private final SecretStore delegate;
   private final ExecutorService pool;
@@ -126,12 +129,12 @@ public final class ConcurrentSecretStore implements SecretStore {
     // unwrapped call would have thrown: one SecretStoreUnavailableException for the whole request.
     // Later failures are attached as suppressed rather than dropped, so a caller inspecting the
     // thrown exception can still see every chunk that failed, not just the first.
-    RuntimeException firstFailure = null;
+    final List<RuntimeException> failures = new ArrayList<>();
     for (final var future : futures) {
       try {
         results.putAll(future.get());
       } catch (final ExecutionException e) {
-        firstFailure = addFailure(firstFailure, unwrap(e));
+        failures.add(unwrap(e));
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         // the caller is a long-lived shared actor thread, not a short-lived worker: restoring the
@@ -139,17 +142,37 @@ public final class ConcurrentSecretStore implements SecretStore {
         // interrupted it did), it just means the next blocking call on this same thread also sees
         // the flag set. Nothing in this codebase interrupts actor threads today, so this path is
         // not expected to be reachable in production.
-        firstFailure =
-            addFailure(
-                firstFailure,
-                new SecretStoreUnavailableException(
-                    "Interrupted while resolving secrets concurrently", e));
+        failures.add(
+            new SecretStoreUnavailableException(
+                "Interrupted while resolving secrets concurrently", e));
       }
     }
-    if (firstFailure != null) {
-      throw firstFailure;
+    if (!failures.isEmpty()) {
+      throw primaryFailure(failures);
     }
     return results;
+  }
+
+  /**
+   * Picks which of a request's chunk failures becomes the exception this call throws: the first
+   * failure that is not the synthetic {@link #skippedException}, so a caller sees the backend
+   * failure that actually caused the store to be marked unavailable rather than a sibling chunk's
+   * downstream skip. Falls back to the first failure if every one of them was a skip, which is not
+   * expected: the chunk that flips {@code storeUnavailable} always fails with the real cause first.
+   * Every other failure is attached as suppressed, so nothing collected here is dropped.
+   */
+  private static RuntimeException primaryFailure(final List<RuntimeException> failures) {
+    final RuntimeException primary =
+        failures.stream()
+            .filter(failure -> !isSkipped(failure))
+            .findFirst()
+            .orElseGet(() -> failures.get(0));
+    for (final var failure : failures) {
+      if (failure != primary) {
+        primary.addSuppressed(failure);
+      }
+    }
+    return primary;
   }
 
   /**
@@ -180,17 +203,12 @@ public final class ConcurrentSecretStore implements SecretStore {
   }
 
   private static SecretStoreUnavailableException skippedException() {
-    return new SecretStoreUnavailableException(
-        "Skipped: a concurrently-dispatched chunk already reported this store unavailable");
+    return new SecretStoreUnavailableException(SKIPPED_MESSAGE);
   }
 
-  private static RuntimeException addFailure(
-      final @Nullable RuntimeException firstFailure, final RuntimeException newFailure) {
-    if (firstFailure == null) {
-      return newFailure;
-    }
-    firstFailure.addSuppressed(newFailure);
-    return firstFailure;
+  private static boolean isSkipped(final RuntimeException failure) {
+    return failure instanceof SecretStoreUnavailableException
+        && SKIPPED_MESSAGE.equals(failure.getMessage());
   }
 
   @Override

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretStore.java
@@ -53,6 +53,22 @@ public interface SecretStore extends AutoCloseable {
     return storeType.isInstance(this);
   }
 
+  /**
+   * How many names one {@link #resolve} call covers, for a store whose cost scales with the number
+   * of sequential backend calls it issues (a one-by-one cloud store issuing one call per name, or a
+   * batched one issuing several sequential calls each covering {@code batchSize} names). {@link
+   * ConcurrentSecretStore} reads this to split a request into chunks of this size and resolve them
+   * concurrently instead of one after another.
+   *
+   * <p>Returns {@link Integer#MAX_VALUE} for a store whose single {@link #resolve} call already
+   * covers the whole request (a container-style store, or one backed by local disk that pays no
+   * round trip at all): fanning such a store out would only add backend calls or a thread hop, not
+   * remove round trips.
+   */
+  default int namesPerCall() {
+    return Integer.MAX_VALUE;
+  }
+
   @Override
   default void close() {}
 }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ConcurrentSecretStoreTest {
+
+  private static final Duration PER_NAME_DELAY = Duration.ofMillis(50);
+
+  private final ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor();
+
+  @AfterEach
+  void tearDown() {
+    pool.shutdownNow();
+  }
+
+  @Test
+  void shouldFanOutAOneByOneStoreAndRunChunksConcurrently() {
+    // given a store that pays PER_NAME_DELAY per name inside one resolve() call, exactly as a
+    // real one-by-one cloud store would, with more names than the permit count so at least two
+    // chunks must run at once for every name to resolve inside the sleep window
+    final var names = namesUpTo(16);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    delegate.perNameDelay = PER_NAME_DELAY;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when
+    final var results = store.resolve(names);
+
+    // then every name still resolves...
+    names.forEach(name -> assertThat(results.get(name)).isEqualTo(new Resolved(name + "-value")));
+    // ...and more than one chunk was in flight at the same time: a serial (unwrapped) resolution
+    // could never observe more than 1, regardless of how long each chunk takes
+    assertThat(delegate.maxObserved.get()).isGreaterThan(1);
+  }
+
+  @Test
+  void shouldChunkByTheDelegatesNamesPerCallRatherThanByMaxConcurrency() {
+    // given a store whose namesPerCall mirrors AWS's batched mode (several names covered by one
+    // sequential call), with more names than one call covers but fewer chunks than the permit
+    // count allows: chunk count must come from namesPerCall, not be forced to match maxConcurrency
+    final var names = namesUpTo(17);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 4;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when
+    final var results = store.resolve(names);
+
+    // then every name resolves...
+    names.forEach(name -> assertThat(results.get(name)).isEqualTo(new Resolved(name + "-value")));
+    // ...via exactly ceil(17/4) = 5 calls of at most 4 names each, not 8 (maxConcurrency) calls
+    // with some chunks starved and others left idle
+    assertThat(delegate.resolveCalls).hasSize(5);
+    delegate.resolveCalls.forEach(call -> assertThat(call.size()).isLessThanOrEqualTo(4));
+  }
+
+  @Test
+  void shouldNotFanOutWhenDelegateCoversWholeRequestInOneCall() {
+    // given a store that already covers many names per call (e.g. a container or batched store
+    // sized to the whole request): the default namesPerCall, left unset
+    final var names = namesUpTo(16);
+    final var delegate = new FakeOneByOneStore();
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when
+    store.resolve(names);
+
+    // then the whole set reaches the delegate in a single call; chunking it would only cost the
+    // backend more calls for a store that already resolves the whole request in one
+    assertThat(delegate.resolveCalls).containsExactly(names);
+  }
+
+  @Test
+  void shouldNotFanOutWhenMaxConcurrencyIsOne() {
+    // given
+    final var names = namesUpTo(16);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(1, true));
+
+    // when
+    store.resolve(names);
+
+    // then concurrency 1 is today's behavior: exactly one call, no thread hop, regardless of
+    // what the delegate's namesPerCall says
+    assertThat(delegate.resolveCalls).containsExactly(names);
+  }
+
+  @Test
+  void shouldNotFanOutASingleName() {
+    // given
+    final var names = Set.of("only-one");
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when
+    store.resolve(names);
+
+    // then a single name has nothing to gain from a thread hop
+    assertThat(delegate.resolveCalls).containsExactly(names);
+  }
+
+  @Test
+  void shouldPreserveEveryNamesResultAcrossChunks() {
+    // given a mix of resolved and permanently failed names, split across chunks of 3
+    final var names = namesUpTo(9);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 3;
+    delegate.failedNames.add("name-3");
+    delegate.failedNames.add("name-7");
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(4, true));
+
+    // when
+    final var results = store.resolve(names);
+
+    // then every name is answered, with no cross-chunk mixup
+    assertThat(results).hasSameSizeAs(names);
+    names.forEach(
+        name -> {
+          if (delegate.failedNames.contains(name)) {
+            assertThat(results.get(name)).isInstanceOf(Failed.class);
+          } else {
+            assertThat(results.get(name)).isEqualTo(new Resolved(name + "-value"));
+          }
+        });
+  }
+
+  @Test
+  void shouldPropagateStoreUnavailableFromAnyChunk() {
+    // given one of several chunks hits a transient store failure
+    final var names = namesUpTo(9);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 3;
+    delegate.unavailableNames.add("name-5");
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(4, true));
+
+    // when / then: the whole call fails, exactly as an unwrapped one-by-one store failing
+    // mid-batch would; the refs from the succeeded chunks stay pending and are retried next cycle
+    assertThatThrownBy(() -> store.resolve(names))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldSkipAChunkStillWaitingForAPermitOnceASiblingChunkFails() {
+    // given three chunks (namesPerCall=1) all naming a secret the store treats as unavailable, but
+    // only two permits: the third chunk cannot reach the store until a failing chunk frees the
+    // permit it is queued for, and by then the store is known to be down, so it must see the flag
+    // and skip its own call rather than dispatch into a backend already failing. All three names
+    // fail identically, so the outcome does not depend on the order the semaphore admits them in.
+    final var names = new LinkedHashSet<>(List.of("fail-a", "fail-b", "fail-c"));
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    delegate.unavailableNames.addAll(names);
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(2, true));
+
+    // when / then
+    assertThatThrownBy(() -> store.resolve(names))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+
+    // then the queued chunk never reached the delegate: without the shared flag all three would
+    // have called the store, one after another as permits freed up
+    assertThat(delegate.resolveCalls).hasSizeLessThan(3);
+  }
+
+  @Test
+  void shouldRethrowAnErrorFromAChunkRatherThanReportItAsAStoreFailure() {
+    // given a chunk whose store call fails with an Error rather than an exception
+    final var names = namesUpTo(4);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    delegate.erroringNames.add("name-2");
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(2, true));
+
+    // when / then: an Error is not one of the outcomes a store models, so reporting it as
+    // SecretStoreUnavailableException would put the scheduler into a retry ladder over a JVM
+    // failure it can neither retry away nor see
+    assertThatThrownBy(() -> store.resolve(names)).isInstanceOf(FakeStoreError.class);
+  }
+
+  @Test
+  void shouldReportARejectedDispatchAsAStoreFailure() {
+    // given a pool that is already shut down, as it is once startup rollback has closed it
+    final var names = namesUpTo(4);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    final var shutDownPool = Executors.newVirtualThreadPerTaskExecutor();
+    shutDownPool.shutdownNow();
+    final var store = new ConcurrentSecretStore(delegate, shutDownPool, new Semaphore(2, true));
+
+    // when / then: a dispatch the pool refuses leaves the store unread, which is what
+    // SecretStoreUnavailableException means — the scheduler retries that and only logs anything
+    // else as an unexpected engine error
+    assertThatThrownBy(() -> store.resolve(names))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+    assertThat(delegate.resolveCalls).isEmpty();
+  }
+
+  @Test
+  void shouldDelegateListCloseAndIs() {
+    // given
+    final var delegate = new FakeOneByOneStore();
+    delegate.listValue = List.of("a", "b");
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when / then: identified by the store it wraps, exactly as CachingSecretStore is
+    assertThat(store.list()).containsExactly("a", "b");
+    assertThat(store.is(FakeOneByOneStore.class)).isTrue();
+    store.close();
+    assertThat(delegate.closed).isTrue();
+  }
+
+  @Test
+  void shouldRejectASemaphoreCarryingNoPermits() {
+    // a semaphore no chunk can ever acquire from would hang every fan-out rather than resolve
+    // anything, so it is rejected where it is configured instead of at the first resolution
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () -> new ConcurrentSecretStore(new FakeOneByOneStore(), pool, new Semaphore(0, true)));
+  }
+
+  private static Set<String> namesUpTo(final int count) {
+    final var names = new LinkedHashSet<String>();
+    IntStream.range(0, count).forEach(i -> names.add("name-" + i));
+    return names;
+  }
+
+  private static final class FakeOneByOneStore implements SecretStore {
+
+    // a thread-safe list rather than a lock around the whole method: locking resolve() itself
+    // would serialize every concurrently-dispatched chunk on this fake's own monitor, hiding the
+    // very concurrency the fan-out tests exist to prove
+    private final List<Set<String>> resolveCalls = new CopyOnWriteArrayList<>();
+    private int namesPerCall = Integer.MAX_VALUE;
+    private Duration perNameDelay = Duration.ZERO;
+    private final Set<String> failedNames = new LinkedHashSet<>();
+    private final Set<String> unavailableNames = new LinkedHashSet<>();
+    private final Set<String> erroringNames = new LinkedHashSet<>();
+    private List<String> listValue = List.of();
+    private volatile boolean closed;
+
+    // tracks how many resolve() calls are in flight at once, so a fan-out test can assert on
+    // observed concurrency directly instead of on wall-clock duration
+    private final AtomicInteger inFlight = new AtomicInteger();
+    private final AtomicInteger maxObserved = new AtomicInteger();
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      resolveCalls.add(Set.copyOf(names));
+      final var now = inFlight.incrementAndGet();
+      maxObserved.accumulateAndGet(now, Math::max);
+      try {
+        if (!erroringNames.isEmpty() && !Collections.disjoint(names, erroringNames)) {
+          throw new FakeStoreError("store failed irrecoverably for " + names);
+        }
+        if (!unavailableNames.isEmpty() && !Collections.disjoint(names, unavailableNames)) {
+          throw new SecretStoreUnavailableException("store unavailable for " + names);
+        }
+        sleep(perNameDelay.multipliedBy(names.size()));
+        return names.stream().collect(toMap(name -> name, this::resultFor));
+      } finally {
+        inFlight.decrementAndGet();
+      }
+    }
+
+    private SecretResolutionResult resultFor(final String name) {
+      if (failedNames.contains(name)) {
+        return new Failed(SecretErrorCode.NOT_FOUND, "failed: " + name, null);
+      }
+      return new Resolved(name + "-value");
+    }
+
+    @Override
+    public List<String> list() {
+      return listValue;
+    }
+
+    @Override
+    public int namesPerCall() {
+      return namesPerCall;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    private static void sleep(final Duration duration) {
+      if (duration.isZero()) {
+        return;
+      }
+      try {
+        Thread.sleep(duration.toMillis());
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new SecretStoreUnavailableException("interrupted", e);
+      }
+    }
+  }
+
+  /**
+   * Stands in for the Errors a real store call can raise (an {@code OutOfMemoryError} from an
+   * oversized response, a {@code StackOverflowError} from a parser). A dedicated subclass rather
+   * than one of those, so a test asserting on it cannot be satisfied by an Error the JVM raised on
+   * its own.
+   */
+  private static final class FakeStoreError extends Error {
+    private FakeStoreError(final String message) {
+      super(message);
+    }
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
@@ -15,24 +15,26 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ConcurrentSecretStoreTest {
-
-  private static final Duration PER_NAME_DELAY = Duration.ofMillis(50);
 
   private final ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -42,24 +44,29 @@ class ConcurrentSecretStoreTest {
   }
 
   @Test
-  void shouldFanOutAOneByOneStoreAndRunChunksConcurrently() {
-    // given a store that pays PER_NAME_DELAY per name inside one resolve() call, exactly as a
-    // real one-by-one cloud store would, with more names than the permit count so at least two
-    // chunks must run at once for every name to resolve inside the sleep window
-    final var names = namesUpTo(16);
+  void shouldFanOutAOneByOneStoreAndRunChunksConcurrentlyUpToThePermitCount() {
+    // given a store synchronized on a barrier sized to the permit count: resolve() cannot return
+    // until exactly that many chunks are inside it at once, so the bound is proven by
+    // construction instead of inferred from timing (a serial, or over-concurrent, resolution
+    // would either hang past the barrier's timeout or trip it with the wrong number of parties).
+    // Twice as many chunks as permits, so the bound has to hold across two full rounds, not just
+    // one lucky batch.
+    final var permits = 4;
+    final var names = namesUpTo(permits * 2);
     final var delegate = new FakeOneByOneStore();
     delegate.namesPerCall = 1;
-    delegate.perNameDelay = PER_NAME_DELAY;
-    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+    delegate.barrier = new CyclicBarrier(permits);
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(permits, true));
 
     // when
     final var results = store.resolve(names);
 
     // then every name still resolves...
     names.forEach(name -> assertThat(results.get(name)).isEqualTo(new Resolved(name + "-value")));
-    // ...and more than one chunk was in flight at the same time: a serial (unwrapped) resolution
-    // could never observe more than 1, regardless of how long each chunk takes
-    assertThat(delegate.maxObserved.get()).isGreaterThan(1);
+    // ...and exactly `permits` chunks were in flight at once: a regression that dispatched all
+    // chunks at once, or serialized them, would fail this exact-equality check rather than the
+    // weaker "at least one overlap" a `> 1` assertion allows to pass
+    assertThat(delegate.maxObserved.get()).isEqualTo(permits);
   }
 
   @Test
@@ -193,17 +200,27 @@ class ConcurrentSecretStoreTest {
 
   @Test
   void shouldPropagateStoreUnavailableFromAnyChunk() {
-    // given one of several chunks hits a transient store failure
+    // given one of three chunks hits a transient store failure, held back with a latch until the
+    // other two have actually resolved at the delegate: without this, the failing chunk could
+    // otherwise set the shared flag before either sibling even starts, and the assertion below
+    // would no longer prove anything about discarded successes
     final var names = namesUpTo(9);
     final var delegate = new FakeOneByOneStore();
     delegate.namesPerCall = 3;
     delegate.unavailableNames.add("name-5");
+    delegate.releaseFailureAfter = new CountDownLatch(2);
     final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(4, true));
 
     // when / then: the whole call fails, exactly as an unwrapped one-by-one store failing
     // mid-batch would; the refs from the succeeded chunks stay pending and are retried next cycle
     assertThatThrownBy(() -> store.resolve(names))
         .isInstanceOf(SecretStoreUnavailableException.class);
+
+    // then the delegate did resolve the two succeeding chunks, proving their results existed and
+    // were discarded by the failing call rather than never having been attempted
+    assertThat(delegate.resolveCalls).hasSize(3);
+    assertThat(delegate.resolveCalls.stream().flatMap(Set::stream))
+        .containsExactlyInAnyOrderElementsOf(names);
   }
 
   @Test
@@ -337,10 +354,19 @@ class ConcurrentSecretStoreTest {
     // very concurrency the fan-out tests exist to prove
     private final List<Set<String>> resolveCalls = new CopyOnWriteArrayList<>();
     private int namesPerCall = Integer.MAX_VALUE;
-    private Duration perNameDelay = Duration.ZERO;
+    // stands in for a real backend's round trip: rather than sleeping, resolve() blocks here until
+    // as many chunks as the barrier has parties are inside it at once, so a fan-out test asserts
+    // the exact peak concurrency deterministically instead of inferring "some overlap happened"
+    // from wall-clock timing
+    private CyclicBarrier barrier;
     private final Set<String> failedNames = new LinkedHashSet<>();
     private final Set<String> unavailableNames = new LinkedHashSet<>();
     private final Set<String> erroringNames = new LinkedHashSet<>();
+    // held by a chunk about to fail with SecretStoreUnavailableException, released once by every
+    // chunk that resolves successfully: lets a test force the succeeding chunks to actually
+    // complete at the delegate before the failing chunk sets the shared flag, so the ordering a
+    // test wants to observe does not depend on how the pool happens to schedule the chunks
+    private CountDownLatch releaseFailureAfter;
     private List<String> listValue = List.of();
     private volatile boolean closed;
 
@@ -359,10 +385,15 @@ class ConcurrentSecretStoreTest {
           throw new FakeStoreError("store failed irrecoverably for " + names);
         }
         if (!unavailableNames.isEmpty() && !Collections.disjoint(names, unavailableNames)) {
+          awaitLatch(releaseFailureAfter);
           throw new SecretStoreUnavailableException("store unavailable for " + names);
         }
-        sleep(perNameDelay.multipliedBy(names.size()));
-        return names.stream().collect(toMap(name -> name, this::resultFor));
+        awaitBarrier();
+        final var result = names.stream().collect(toMap(name -> name, this::resultFor));
+        if (releaseFailureAfter != null) {
+          releaseFailureAfter.countDown();
+        }
+        return result;
       } finally {
         inFlight.decrementAndGet();
       }
@@ -390,15 +421,39 @@ class ConcurrentSecretStoreTest {
       closed = true;
     }
 
-    private static void sleep(final Duration duration) {
-      if (duration.isZero()) {
+    private void awaitBarrier() {
+      if (barrier == null) {
         return;
       }
       try {
-        Thread.sleep(duration.toMillis());
+        barrier.await(5, TimeUnit.SECONDS);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new SecretStoreUnavailableException("interrupted", e);
+        throw new SecretStoreUnavailableException(
+            "interrupted awaiting the concurrency barrier", e);
+      } catch (final BrokenBarrierException | TimeoutException e) {
+        // fewer parties reached the barrier than expected within the timeout: fail loudly with a
+        // clear cause instead of hanging the remaining chunks (and the test run) indefinitely
+        throw new AssertionError(
+            "Expected "
+                + barrier.getParties()
+                + " chunks in flight at once, but the barrier never tripped within the timeout",
+            e);
+      }
+    }
+
+    private static void awaitLatch(final CountDownLatch latch) {
+      if (latch == null) {
+        return;
+      }
+      try {
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError(
+              "Expected the sibling chunks to resolve within the timeout before this chunk fails");
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new SecretStoreUnavailableException("interrupted awaiting sibling chunks", e);
       }
     }
   }

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
@@ -11,6 +11,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
@@ -189,6 +190,32 @@ class ConcurrentSecretStoreTest {
     // then the queued chunk never reached the delegate: without the shared flag all three would
     // have called the store, one after another as permits freed up
     assertThat(delegate.resolveCalls).hasSizeLessThan(3);
+  }
+
+  @Test
+  void shouldSurfaceARealChunkFailureRatherThanASkippedSiblingAsThePrimaryException() {
+    // given six chunks (namesPerCall=1) all naming a secret the store treats as unavailable, with
+    // only two permits: at most the first two chunks to acquire one can ever call the store for
+    // real (nothing has set the flag yet when they start), and each sets the shared flag before
+    // releasing its permit, so every one of the remaining four chunks is guaranteed to observe the
+    // flag and skip once it acquires. Which chunks win that initial race is left to the scheduler,
+    // so a real failure can land anywhere in chunk order, not only first.
+    final var names =
+        new LinkedHashSet<>(List.of("fail-a", "fail-b", "fail-c", "fail-d", "fail-e", "fail-f"));
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 1;
+    delegate.unavailableNames.addAll(names);
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(2, true));
+
+    // when
+    final var thrown = catchThrowable(() -> store.resolve(names));
+
+    // then the primary exception is the real backend failure, never the synthetic "Skipped: ..."
+    // message a losing chunk throws, regardless of which chunk actually reached the store...
+    assertThat(thrown).isInstanceOf(SecretStoreUnavailableException.class);
+    assertThat(thrown.getMessage()).startsWith("store unavailable for");
+    // ...and every skipped sibling is still visible, attached as suppressed rather than dropped
+    assertThat(thrown.getSuppressed()).isNotEmpty();
   }
 
   @Test

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
@@ -84,6 +84,42 @@ class ConcurrentSecretStoreTest {
   }
 
   @Test
+  void shouldNotFanOutWhenNamesExactlyFillOneCall() {
+    // given exactly as many names as one call covers: the `callSize >= names.size()` short
+    // circuit from the equal side, not just the clearly-larger side the other single-call tests
+    // below exercise
+    final var names = namesUpTo(4);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 4;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when
+    store.resolve(names);
+
+    // then the whole set still reaches the delegate in a single call, not two (one full chunk and
+    // one spuriously empty one)
+    assertThat(delegate.resolveCalls).containsExactly(names);
+  }
+
+  @Test
+  void shouldFanOutIntoExactlyTwoChunks() {
+    // given one more name than a single call covers: the minimal possible fan-out, distinct from
+    // the larger chunk counts the other chunking test above exercises
+    final var names = namesUpTo(5);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 4;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(8, true));
+
+    // when
+    final var results = store.resolve(names);
+
+    // then every name resolves, split across exactly two chunks of at most 4 names each
+    names.forEach(name -> assertThat(results.get(name)).isEqualTo(new Resolved(name + "-value")));
+    assertThat(delegate.resolveCalls).hasSize(2);
+    delegate.resolveCalls.forEach(call -> assertThat(call.size()).isLessThanOrEqualTo(4));
+  }
+
+  @Test
   void shouldNotFanOutWhenDelegateCoversWholeRequestInOneCall() {
     // given a store that already covers many names per call (e.g. a container or batched store
     // sized to the whole request): the default namesPerCall, left unset

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/ConcurrentSecretStoreTest.java
@@ -247,6 +247,20 @@ class ConcurrentSecretStoreTest {
             () -> new ConcurrentSecretStore(new FakeOneByOneStore(), pool, new Semaphore(0, true)));
   }
 
+  @Test
+  void shouldRejectADelegateReportingLessThanOneNamePerCall() {
+    // a namesPerCall below 1 cannot be split into chunks (chunk() would either loop forever on 0
+    // or throw on a negative subList bound), so a store reporting it is rejected outright instead
+    // of hanging or throwing an unrelated exception on the first resolution
+    final var names = namesUpTo(4);
+    final var delegate = new FakeOneByOneStore();
+    delegate.namesPerCall = 0;
+    final var store = new ConcurrentSecretStore(delegate, pool, new Semaphore(4, true));
+
+    // when / then
+    assertThatIllegalArgumentException().isThrownBy(() -> store.resolve(names));
+  }
+
   private static Set<String> namesUpTo(final int count) {
     final var names = new LinkedHashSet<String>();
     IntStream.range(0, count).forEach(i -> names.add("name-" + i));

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretResolver.java
@@ -37,4 +37,14 @@ interface AwsSecretResolver {
    * to the caller, which logs a warning and continues; called once at construction time.
    */
   void validateConnectivity();
+
+  /**
+   * How many names one {@link #resolve} call covers. {@code 1} for the unbatched flat mode, issuing
+   * one {@code GetSecretValue} call per name; the configured batch size for the batched flat mode,
+   * issuing one {@code BatchGetSecretValue} call per that many names; {@link Integer#MAX_VALUE} for
+   * a container secret, which reads every requested name from one shared secret in a single call.
+   */
+  default int namesPerCall() {
+    return Integer.MAX_VALUE;
+  }
 }

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
@@ -165,6 +165,11 @@ public final class AwsSecretsManagerSecretStore implements SecretStore {
   }
 
   @Override
+  public int namesPerCall() {
+    return resolver.namesPerCall();
+  }
+
+  @Override
   public void close() {
     client.close();
   }

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/FlatSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/FlatSecretResolver.java
@@ -252,6 +252,11 @@ final class FlatSecretResolver implements AwsSecretResolver {
     client.listSecrets(ListSecretsRequest.builder().maxResults(1).build());
   }
 
+  @Override
+  public int namesPerCall() {
+    return batchEnabled ? batchSize : 1;
+  }
+
   private String secretId(final String name) {
     return pathPrefix + name;
   }

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
@@ -119,6 +119,25 @@ class AwsSecretsManagerSecretStoreTest {
   }
 
   @Test
+  void shouldResolveOneNamePerCallWhenBatchingDisabled() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "camunda/");
+
+    // then
+    assertThat(store.namesPerCall()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldResolveBatchSizeNamesPerCallWhenBatchingEnabled() {
+    // given batching already covers several secrets per BatchGetSecretValue call, so a request
+    // needing more than one batch still has sequential round trips worth overlapping
+    final var store = new AwsSecretsManagerSecretStore(client, "camunda/", true, 20);
+
+    // then
+    assertThat(store.namesPerCall()).isEqualTo(20);
+  }
+
+  @Test
   void shouldReturnNotFoundForMissingSecret() {
     // given
     final var store = new AwsSecretsManagerSecretStore(client, "");

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/ContainerSecretResolverTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/ContainerSecretResolverTest.java
@@ -37,6 +37,15 @@ class ContainerSecretResolverTest {
   @Mock private SecretsManagerClient client;
 
   @Test
+  void shouldNotBeConcurrencyEligible() {
+    // given a container secret fetches every reference in one GetSecretValue call
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+
+    // then
+    assertThat(resolver.namesPerCall()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
   void shouldResolveEmptyMapWithoutFetchingContainerSecretForEmptyNames() {
     // given
     final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");

--- a/secret-store/secret-store-file/src/test/java/io/camunda/secretstore/file/FileBasedSecretStoreTest.java
+++ b/secret-store/secret-store-file/src/test/java/io/camunda/secretstore/file/FileBasedSecretStoreTest.java
@@ -97,6 +97,17 @@ class FileBasedSecretStoreTest {
   }
 
   @Test
+  void shouldNotBeConcurrencyEligible() {
+    // given a resolve() call reads one file per name, but pays no network round trip doing it: a
+    // local disk read has nothing to overlap, so wrapping it for concurrency would only add a
+    // thread hop
+    final var store = new FileBasedSecretStore(secretsDir);
+
+    // then the default (uneligible) namesPerCall stands
+    assertThat(store.namesPerCall()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
   void shouldListAllSecrets() throws IOException {
     // given
     writeSecret("a", "1");

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStore.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStore.java
@@ -187,6 +187,11 @@ public final class GcpSecretManagerSecretStore implements SecretStore {
   }
 
   @Override
+  public int namesPerCall() {
+    return resolver.namesPerCall();
+  }
+
+  @Override
   public void close() {
     client.close();
   }

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretResolver.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/GcpSecretResolver.java
@@ -37,4 +37,13 @@ interface GcpSecretResolver {
    * to the caller, which logs a warning and continues; called once at store build time.
    */
   void validateConnectivity();
+
+  /**
+   * How many names one {@link #resolve} call covers. {@code 1} for a resolver issuing one {@code
+   * accessSecretVersion} call per name; {@link Integer#MAX_VALUE} for a container secret, which
+   * reads every requested name from one shared secret in a single call.
+   */
+  default int namesPerCall() {
+    return Integer.MAX_VALUE;
+  }
 }

--- a/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/OneByOneSecretResolver.java
+++ b/secret-store/secret-store-gcp/src/main/java/io/camunda/secretstore/gcp/OneByOneSecretResolver.java
@@ -94,6 +94,11 @@ final class OneByOneSecretResolver implements GcpSecretResolver {
   }
 
   @Override
+  public int namesPerCall() {
+    return 1;
+  }
+
+  @Override
   public void validateConnectivity() {
     // one-by-one mode resolves via accessSecretVersion and lists via listSecrets; a single-result
     // listSecrets is the cheapest probe that exercises this mode's IAM footprint.

--- a/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreTest.java
+++ b/secret-store/secret-store-gcp/src/test/java/io/camunda/secretstore/gcp/GcpSecretManagerSecretStoreTest.java
@@ -100,6 +100,26 @@ class GcpSecretManagerSecretStoreTest {
   }
 
   @Test
+  void shouldResolveOneNamePerCallByDefault() {
+    // given a store with no container secret id, so it resolves via one accessSecretVersion call
+    // per reference
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-");
+
+    // then
+    assertThat(store.namesPerCall()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotBeConcurrencyEligibleWithContainerSecret() {
+    // given a container secret fetches every reference in a single accessSecretVersion call, so
+    // chunking it across a thread pool would only add calls, not remove round trips
+    final var store = new GcpSecretManagerSecretStore(client, PROJECT, "camunda-", "app-config");
+
+    // then
+    assertThat(store.namesPerCall()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
   void shouldReturnNotFoundForMissingSecret() {
     // given
     final var store = new GcpSecretManagerSecretStore(client, PROJECT, "");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.secretstore.ConcurrentSecretStore;
 import io.camunda.secretstore.InMemorySecretCache;
 import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretErrorCode;
@@ -48,11 +49,17 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1267,6 +1274,40 @@ final class SecretResolutionSchedulerTest {
                     .doesNotContain("db-password", "s3cr3t"));
   }
 
+  @Test
+  void shouldResolveAOneByOneStoreConcurrentlyThroughTheRealScheduler() throws Exception {
+    // given a store that pays a fixed delay per name inside one resolve() call, the shape a real
+    // one-by-one cloud store's cost takes, wrapped for concurrent resolution as the registry does
+    // in production once max-concurrency is above 1
+    final var perNameDelay = Duration.ofMillis(20);
+    final var refs = IntStream.range(0, 16).mapToObj(i -> "secret-" + i).toArray(String[]::new);
+    final var sleepingStore = new SleepingOneByOneStore(perNameDelay);
+    final ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor();
+    try {
+      final var wrappedStore =
+          new ConcurrentSecretStore(sleepingStore, pool, new Semaphore(8, true));
+      final var registry =
+          new SecretStoreRegistry(
+              Map.of(STORE_ID, wrappedStore), Map.of(STORE_ID, new InMemorySecretCache()));
+      final var localScheduler =
+          new SecretResolutionScheduler(
+              () -> scheduledTaskState, registry, new EngineConfiguration(), metrics);
+      localScheduler.onRecovered(context);
+      stubPending(STORE_ID, refs);
+
+      // when
+      localScheduler.resolveSecrets(resultBuilder);
+
+      // then more than one chunk was in flight at once through the real scheduler path: a serial
+      // (unwrapped) resolution could never observe more than 1, regardless of how long each chunk
+      // takes — this is what collapses the recorded resolution duration in production, without
+      // asserting on a wall-clock threshold here
+      assertThat(sleepingStore.maxObserved.get()).isGreaterThan(1);
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
   private double outcomeCount(final String storeId, final SecretResolutionOutcome outcome) {
     final var counter =
         meterRegistry
@@ -1336,5 +1377,51 @@ final class SecretResolutionSchedulerTest {
             })
         .when(secretReferenceState)
         .visitPendingSecretReferences(any(), any());
+  }
+
+  /**
+   * Pays {@code perNameDelay} per name inside one {@link #resolve} call, exactly as a real
+   * one-by-one cloud store's serialized cost does.
+   */
+  private static final class SleepingOneByOneStore implements SecretStore {
+
+    private final Duration perNameDelay;
+
+    // tracks how many resolve() calls are in flight at once, so the concurrency test can assert
+    // on observed concurrency directly instead of on wall-clock duration
+    private final AtomicInteger inFlight = new AtomicInteger();
+    private final AtomicInteger maxObserved = new AtomicInteger();
+
+    SleepingOneByOneStore(final Duration perNameDelay) {
+      this.perNameDelay = perNameDelay;
+    }
+
+    @Override
+    public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+      final var now = inFlight.incrementAndGet();
+      maxObserved.accumulateAndGet(now, Math::max);
+      try {
+        Thread.sleep(perNameDelay.multipliedBy(names.size()).toMillis());
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new SecretStoreUnavailableException("interrupted", e);
+      } finally {
+        inFlight.decrementAndGet();
+      }
+      final Map<String, SecretResolutionResult> results = new LinkedHashMap<>();
+      names.forEach(
+          name -> results.put(name, new SecretResolutionResult.Resolved(name + "-value")));
+      return results;
+    }
+
+    @Override
+    public List<String> list() {
+      return List.of();
+    }
+
+    @Override
+    public int namesPerCall() {
+      return 1;
+    }
   }
 }


### PR DESCRIPTION
## Related issues

relates to #56589

## Why

Job activation can park on secret resolution, and #56589's benchmark scenario exists to measure
that cost. Two of the resolution path's stores pay per-name latency serially even though nothing
requires it:

- GCP's default resolver issues one `accessSecretVersion` call per name, in a loop, on the calling
  thread.
- AWS's flat resolver does the same with `GetSecretValue` when batching is off (the default), and
  even with batching on it walks its batches one after another.

A batch of 20 refs against a 30ms store round trip therefore costs roughly 600ms per cycle,
regardless of how fast the scheduler ticks. `SecretStore` already documents `resolve` as
thread-safe, so nothing in the contract stops those calls from overlapping.

## Approach

- `SecretStore#namesPerCall()` reports how many names one `resolve()` call covers, for a store
  whose cost scales with call count: 1 for a one-by-one store, the batch size for a batched one.
  It defaults to `Integer.MAX_VALUE`, meaning either that one call already covers the whole
  request (a container-style store) or that there is no round trip to overlap (a store backed by
  local disk), so fanning out would only add calls or a thread hop.
- `ConcurrentSecretStore` splits a request into chunks of that size and resolves them on a
  virtual-thread-per-task executor bounded by a semaphore. It sits under the cache, so a cache hit
  never touches the pool. A store covering the whole request, a one-permit semaphore, or a
  single-name request all take the same un-hopped call the store took before.
- `camunda.secrets.max-concurrency` sizes the semaphore. One executor and one semaphore per
  physical tenant, built at startup only for a tenant with an eligible store, and torn down on the
  existing startup-rollback path.

Failures keep the shape an unwrapped call had. Any chunk's `SecretStoreUnavailableException` fails
the whole call, so refs from chunks that did succeed stay pending and are retried rather than
reported resolved without a durable record of it. A shared flag stops a chunk that has not yet
issued its call from piling onto a backend already failing. An `Error` is rethrown as it is rather
than dressed up as a transient store failure, and a dispatch the executor refuses becomes
`SecretStoreUnavailableException`, which is what it means: the store was never read.

## Concurrency and thread ownership

| Layer | Thread | Scope | Effect |
|---|---|---|---|
| Job activation | `zb-actors` (`cpuThreadCount`, default 2) | node | Untouched: activation only calls `lookupLocal`, answered from memory |
| Background resolution | `zb-fs-workers` (`ioThreadCount`, default 2) | node | Blocks in `invokeAll`, for the slowest chunk instead of the whole serial chain |
| Resolve endpoint | API executor (`camunda.api.rest.executor`, 1x to 2x cores) | node | Blocks in `invokeAll`; the request thread is released |
| Chunk workers | `secret-resolution-<tenant>-N`, virtual | physical tenant | New, one per chunk, at most 20 per request |
| Carriers | ForkJoinPool, parallelism = core count | JVM | At most the permit count busy at once |
| The bound | `Semaphore(max-concurrency, true)` | node and physical tenant | New |

The resolution scheduler's actor is per partition, but it is submitted io-bound, so every
partition's actor is multiplexed onto the node's `zb-fs-workers` pool. Zeebe's actor scheduler is
cooperative, so a cycle blocked in a store call holds one of those threads. That caps how many
background cycles a node can have in flight at `ioThreadCount`, 2 by default, however high
`max-concurrency` goes. The same thread was already blocked before this change, for the whole
serial chain rather than for one chunk, so the effect here is to release it sooner.

The permits are shared per node and physical tenant, so both callers draw on the same budget and
the load a provider's request quota sees is `max-concurrency` times the number of nodes.
Contention between the two callers is the coupling worth watching: the engine side cannot exceed
`ioThreadCount` blocked callers, but the endpoint can add up to twice the core count. Splitting
the semaphore per caller class is the cheap fix if that ever bites; a semaphore per caller is not,
since the store is one shared instance behind the cache.

## Sizing

The default is twice the available processor count, never below 8. Twice, because the permits bound
blocking round trips rather than CPU work, and staying above the carrier pool's parallelism leaves
room for a store client that pins its carrier on Java 21. The floor keeps a small container from
ending up with fewer permits than it has callers. Core count is only a proxy for
partitions-per-node, but the same wiring serves the gateway, where there are no partitions at all.

Raising the value past what one request can use changes nothing: a request splits into
`ceil(names / namesPerCall())` chunks and cannot use more permits than it has chunks, and both
callers cap a request at 20 names, at
`camunda.processing.engine.secrets.batch-resolution-limit` and at the endpoint's `maxItems`. For a
one-by-one store the ceiling is therefore 20, and for a batched store it is 20 divided by the
batch size.

## Verification

Unit tests on `ConcurrentSecretStore` cover the chunking, the opt-out cases and each failure mode,
alongside tests on the config binding and on each store's `namesPerCall()`. A scheduler-level test
wraps a fake store paying a fixed per-name delay exactly as production startup wraps a real
one-by-one store, and asserts the observed concurrency through the real scheduler and metrics path
rather than a wall-clock threshold, which flakes on a loaded runner and does not assert the
property under test.

## Benchmark results

Two clusters running #56589's `secrets` load-test scenario (100 PI/s, 1500 distinct refs, product
default cache), both with the same simulated 30ms per-name store latency layered on the file store
to stand in for a real cloud round trip. Only difference: `camunda.secrets.max-concurrency`, set
explicitly to 1 (today's behavior) against 8.

| Metric | concurrency=1 | concurrency=8 | change |
|---|---|---|---|
| avg resolution call duration | 205ms | 41ms | 5.0x faster |
| p50 | 204ms | 55ms | 3.7x faster |
| p99 | 756ms | 99ms | 7.6x faster |
| resolution cycles/s | 4.80 | 7.02 | +46% |
| refs resolved/s | 32.8 | 38.9 | +19% |
| cache miss rate | 25% | 28% | ~flat (run-to-run noise) |

The 41ms floor against an ideal ~30ms is thread-pool dispatch overhead, expected at concurrency 8
over a batch this size. Throughput moved only modestly since this workload is demand-bound rather
than capacity-bound at these rates; the p99 collapse is what actually determines how long a job
waits behind a cold secret.
