### PR TITLE
ci: let AlwaysGreen dispatch specs an open fix PR does not claim

### DIFF
--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -373,7 +373,7 @@ def covered_fingerprints() -> set[str]:
     return out
 
 
-def open_fix_pr_keys() -> tuple[set[str], bool]:
+def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
     """Dispatch keys that already have an open fix PR, in any repo a fix can land in.
 
     Read from the `alwaysgreen-key:<base_ref>:<surface>` label the fix workflow
@@ -384,10 +384,14 @@ def open_fix_pr_keys() -> tuple[set[str], bool]:
     cannot wedge its surface shut for good; `covered_fingerprints` still suppresses a
     repeat of the specs it already claims.
 
-    Returns (keys, ok). As with `inflight_keys`, a failed lookup makes the caller
-    suppress rather than risk a duplicate PR.
+    Returns (keys, keys_with_coverage, ok). `keys_with_coverage` is the subset whose
+    every holding PR published a coverage block, so `plan` can decide those keys per
+    spec instead of locking the surface; a key any of whose holders published none
+    stays out of it and keeps the coarse lock. As with `inflight_keys`, a failed
+    lookup makes the caller suppress rather than risk a duplicate PR.
     """
     out: set[str] = set()
+    uncovered: set[str] = set()
     ok = True
     now = datetime.now(timezone.utc)
     for repo in FIX_PR_REPOS:
@@ -395,7 +399,7 @@ def open_fix_pr_keys() -> tuple[set[str], bool]:
             [
                 "pr", "list", "--repo", repo,
                 "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "labels,number,createdAt",
+                "--limit", "100", "--json", "labels,number,createdAt,body",
             ],
             None,
         )
@@ -422,7 +426,21 @@ def open_fix_pr_keys() -> tuple[set[str], bool]:
                 )
                 continue
             out |= keys
-    return out, ok
+            covered = planning.parse_coverage_block(pr.get("body"))
+            if not covered:
+                uncovered |= keys
+            # Named in the log so a suppressed run says which PR held it shut without
+            # anyone cross-listing open fix PRs by hand.
+            log(
+                f"open fix PR {repo}#{pr.get('number')} holds "
+                f"{', '.join(sorted(keys))}: "
+                + (
+                    f"{len(covered)} spec(s) claimed, others dispatchable"
+                    if covered
+                    else "no coverage block, whole surface locked"
+                )
+            )
+    return out, out - uncovered, ok
 
 
 def inflight_keys() -> tuple[set[str], bool]:
@@ -737,9 +755,10 @@ def main() -> int:
             keys = {c.key for c in candidates}
             log("::warning::in-flight lookup failed; suppressing dispatch this run")
 
-        pr_keys, pr_keys_ok = open_fix_pr_keys()
+        pr_keys, pr_keys_covered, pr_keys_ok = open_fix_pr_keys()
         if not pr_keys_ok:
             pr_keys = {c.key for c in candidates}
+            pr_keys_covered = set()
             log("::warning::open fix PR lookup failed; suppressing dispatch this run")
 
         run = gh_json(["api", f"repos/{REPO}/actions/runs/{args.run_id}"], {})
@@ -750,6 +769,7 @@ def main() -> int:
             covered_fingerprints=covered_fingerprints(),
             inflight_keys=keys,
             open_pr_keys=pr_keys,
+            open_pr_keys_with_coverage=pr_keys_covered,
             product_bug_fingerprints=product_bug_fingerprints(),
             recent_no_fix_fingerprints=recent_no_fix_fingerprints(workdir),
             fixed_upstream_fingerprints=fixed_upstream_fingerprints(candidates, started),

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -65,10 +65,19 @@ if os.environ.get("ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS"):
         file=sys.stderr,
     )
 #: How long an open fix PR keeps holding its dispatch key; see
-#: planning.PR_LOCK_TTL_DAYS. Set to 0 to restore the old never-expiring lock.
-PR_LOCK_TTL_DAYS = int(
-    os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_DAYS", str(planning.PR_LOCK_TTL_DAYS))
+#: planning.PR_LOCK_TTL_HOURS. Set to 0 to restore the old never-expiring lock.
+PR_LOCK_TTL_HOURS = int(
+    os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", str(planning.PR_LOCK_TTL_HOURS))
 )
+#: Refused rather than converted, for the reason given above the no-fix knob: reading
+#: `..._DAYS=2` as 48 hours would restore the window this replaced.
+if os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_DAYS"):
+    print(
+        "::warning::ALWAYSGREEN_PR_LOCK_TTL_DAYS is no longer read. The open fix PR "
+        "lock is now set in hours via ALWAYSGREEN_PR_LOCK_TTL_HOURS "
+        f"(currently {PR_LOCK_TTL_HOURS}h).",
+        file=sys.stderr,
+    )
 #: Cap on artifact downloads while reading past verdicts, so a burst of agent runs
 #: cannot make triage slow.
 NO_FIX_MAX_RUNS = 20
@@ -380,7 +389,7 @@ def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
     stamps, not from the PR body: the body's coverage block is written by the agent
     and cannot be relied on to exist.
 
-    A PR past PR_LOCK_TTL_DAYS stops holding its key, so a fix PR left unreviewed
+    A PR past PR_LOCK_TTL_HOURS stops holding its key, so a fix PR left unreviewed
     cannot wedge its surface shut for good; `covered_fingerprints` still suppresses a
     repeat of the specs it already claims.
 
@@ -420,10 +429,10 @@ def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
             if not keys:
                 continue
             if planning.pr_lock_expired(
-                pr.get("createdAt") or "", now, PR_LOCK_TTL_DAYS
+                pr.get("createdAt") or "", now, PR_LOCK_TTL_HOURS
             ):
                 log(
-                    f"lock expired after {PR_LOCK_TTL_DAYS}d: {repo}#{pr.get('number')} "
+                    f"lock expired after {PR_LOCK_TTL_HOURS}h: {repo}#{pr.get('number')} "
                     f"no longer holds {', '.join(sorted(keys))}"
                 )
                 continue

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -69,7 +69,7 @@ if os.environ.get("ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS"):
 PR_LOCK_TTL_HOURS = int(
     os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", str(planning.PR_LOCK_TTL_HOURS))
 )
-#: Refused rather than converted, for the reason given above the no-fix knob: reading
+#: Refused rather than converted, for the same reason as the no-fix knob above: reading
 #: `..._DAYS=2` as 48 hours would restore the window this replaced.
 if os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_DAYS"):
     print(

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -66,9 +66,21 @@ if os.environ.get("ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS"):
     )
 #: How long an open fix PR keeps holding its dispatch key; see
 #: planning.PR_LOCK_TTL_HOURS. Set to 0 to restore the old never-expiring lock.
-PR_LOCK_TTL_HOURS = int(
-    os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", str(planning.PR_LOCK_TTL_HOURS))
-)
+#: Read defensively, matching the degrade-don't-crash bias of everything else here: an
+#: unreadable `createdAt` keeps the lock and a failed lookup suppresses, so a malformed
+#: dial must not raise at import and take down every entry point in this module.
+try:
+    PR_LOCK_TTL_HOURS = int(
+        os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_HOURS", "").strip()
+        or planning.PR_LOCK_TTL_HOURS
+    )
+except ValueError:
+    print(
+        "::warning::unparseable ALWAYSGREEN_PR_LOCK_TTL_HOURS; using the default "
+        f"({planning.PR_LOCK_TTL_HOURS}h).",
+        file=sys.stderr,
+    )
+    PR_LOCK_TTL_HOURS = planning.PR_LOCK_TTL_HOURS
 #: Refused rather than converted, for the same reason as the no-fix knob above: reading
 #: `..._DAYS=2` as 48 hours would restore the window this replaced.
 if os.environ.get("ALWAYSGREEN_PR_LOCK_TTL_DAYS"):

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -360,98 +360,104 @@ def downstream_ci_specs(downstream_id: str) -> list[classify.FailingSpec]:
 # ---------------------------------------------------------------------------
 
 
-def covered_fingerprints() -> set[str]:
-    """Fingerprints claimed by an open fix PR, in any repo a fix can land in.
+def open_fix_prs(repo: str) -> tuple[list[dict], bool]:
+    """Open fix PRs in one repository, with the fields dedupe needs. Returns (prs, ok).
 
-    Scoped to every repo in FIX_PR_REPOS, not just the monorepo: most fixes land in
-    the e2e or chart repo, and reading only `REPO` made those coverage blocks
-    invisible here, so their specs stayed dispatchable.
+    A seam, so `dedupe_inputs` can be unit-tested without a token.
     """
-    out: set[str] = set()
-    for repo in FIX_PR_REPOS:
-        prs = gh_json(
-            [
-                "pr", "list", "--repo", repo,
-                "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "number,body",
-            ],
-            [],
-        )
-        for pr in prs if isinstance(prs, list) else []:
-            out |= planning.parse_coverage_block(pr.get("body"))
-    return out
+    prs, err = gh_json_ex(
+        [
+            "pr", "list", "--repo", repo,
+            "--search", f"label:{FIX_LABEL} is:open",
+            "--limit", "100", "--json", "labels,number,createdAt,body",
+        ],
+        None,
+    )
+    if prs is None or not isinstance(prs, list):
+        log(f"::warning::open fix PR lookup failed for {repo}: {err.strip()[:200]}")
+        return [], False
+    return prs, True
 
 
-def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
-    """Dispatch keys that already have an open fix PR, in any repo a fix can land in.
+def dedupe_inputs() -> tuple[set[str], set[str], set[str], bool]:
+    """(covered fingerprints, keys with an open PR, keys decided per spec, ok).
 
-    Read from the `alwaysgreen-key:<base_ref>:<surface>` label the fix workflow
-    stamps, not from the PR body: the body's coverage block is written by the agent
-    and cannot be relied on to exist.
+    One lookup behind one `ok`, across every repo a fix can land in. Coverage used to
+    come from a second, separate `gh` call whose failure was swallowed into an empty
+    set. That was survivable while every open fix PR locked its whole surface, because
+    the key layer caught what the empty set missed; once a claiming PR's key stops
+    locking, the two must agree or a failed coverage lookup dispatches a duplicate fix
+    for a spec that PR already claims.
+
+    Read from the `alwaysgreen-key:<base_ref>:<surface>` label the fix workflow stamps,
+    not from the PR body: the body's coverage block is written by the agent and cannot
+    be relied on to exist.
 
     A PR past PR_LOCK_TTL_HOURS stops holding its key, so a fix PR left unreviewed
-    cannot wedge its surface shut for good; `covered_fingerprints` still suppresses a
-    repeat of the specs it already claims.
+    cannot wedge its surface shut for good.
 
-    Returns (keys, keys_with_coverage, ok). `keys_with_coverage` is the subset whose
-    every holding PR claims at least one fingerprint, so `plan` can decide those keys
-    per spec instead of locking the surface. A block that parses to nothing — absent,
-    or present with no `fp=` line — claims nothing, and a key any of whose holders
-    claims nothing stays out of the subset and keeps the coarse lock: the marker
-    comment alone is not a statement of remit. As with `inflight_keys`, a failed
-    lookup makes the caller suppress rather than risk a duplicate PR.
+    `keys_with_coverage` is the subset whose every active holder claims at least one
+    fingerprint, so `plan` can decide those keys per spec instead of locking the
+    surface. A block that parses to nothing — absent, or present with no `fp=` line —
+    claims nothing, and a key any of whose active holders claims nothing stays out of
+    the subset: the marker comment alone is not a statement of remit.
+
+    Coverage is collected from every open fix PR, expired or not: the specs a PR claims
+    stay claimed for as long as it is open, and only the coarse key lock is time-bound.
+
+    As with `inflight_keys`, a failed lookup makes the caller suppress rather than risk
+    a duplicate PR.
     """
-    out: set[str] = set()
+    covered: set[str] = set()
+    keys: set[str] = set()
     uncovered: set[str] = set()
     ok = True
     now = datetime.now(timezone.utc)
     for repo in FIX_PR_REPOS:
-        prs, err = gh_json_ex(
-            [
-                "pr", "list", "--repo", repo,
-                "--search", f"label:{FIX_LABEL} is:open",
-                "--limit", "100", "--json", "labels,number,createdAt,body",
-            ],
-            None,
-        )
-        if prs is None:
-            log(f"::warning::open fix PR lookup failed for {repo}: {err.strip()[:200]}")
+        prs, repo_ok = open_fix_prs(repo)
+        if not repo_ok:
             ok = False
             continue
-        for pr in prs if isinstance(prs, list) else []:
-            keys: set[str] = set()
+        for pr in prs:
+            claims = planning.parse_coverage_block(pr.get("body"))
+            covered |= claims
+            pr_keys: set[str] = set()
             for label in pr.get("labels") or []:
                 name = (label.get("name") or "").strip()
                 if name.startswith(KEY_LABEL_PREFIX):
                     key = name[len(KEY_LABEL_PREFIX) :].strip()
                     if key:
-                        keys.add(key)
-            if not keys:
+                        pr_keys.add(key)
+            if not pr_keys:
                 continue
             if planning.pr_lock_expired(
                 pr.get("createdAt") or "", now, PR_LOCK_TTL_HOURS
             ):
                 log(
                     f"lock expired after {PR_LOCK_TTL_HOURS}h: {repo}#{pr.get('number')} "
-                    f"no longer holds {', '.join(sorted(keys))}"
+                    f"no longer holds {', '.join(sorted(pr_keys))}"
                 )
                 continue
-            out |= keys
-            covered = planning.parse_coverage_block(pr.get("body"))
-            if not covered:
-                uncovered |= keys
-            # Named in the log so a suppressed run says which PR held it shut without
-            # anyone cross-listing open fix PRs by hand.
+            keys |= pr_keys
+            if not claims:
+                uncovered |= pr_keys
             log(
                 f"open fix PR {repo}#{pr.get('number')} holds "
-                f"{', '.join(sorted(keys))}: "
-                + (
-                    f"{len(covered)} spec(s) claimed, others dispatchable"
-                    if covered
-                    else "claims no specs, whole surface locked"
-                )
+                f"{', '.join(sorted(pr_keys))}, claiming {len(claims)} spec(s)"
             )
-    return out, out - uncovered, ok
+    # Per key, not per PR: dispatchability is an intersection over every active holder,
+    # so a PR-level line cannot state it. Logged so a suppressed run names its blocker
+    # without anyone cross-listing open fix PRs by hand.
+    for key in sorted(keys):
+        log(
+            f"key {key}: "
+            + (
+                "locked (a holder claims no specs)"
+                if key in uncovered
+                else "decided per spec (every holder claims some)"
+            )
+        )
+    return covered, keys, keys - uncovered, ok
 
 
 def inflight_keys() -> tuple[set[str], bool]:
@@ -766,8 +772,11 @@ def main() -> int:
             keys = {c.key for c in candidates}
             log("::warning::in-flight lookup failed; suppressing dispatch this run")
 
-        pr_keys, pr_keys_covered, pr_keys_ok = open_fix_pr_keys()
-        if not pr_keys_ok:
+        covered, pr_keys, pr_keys_covered, dedupe_ok = dedupe_inputs()
+        if not dedupe_ok:
+            # Cannot prove what an open PR already covers, so suppress every candidate:
+            # the key set and the coverage set must be one snapshot or a partial read
+            # licenses a duplicate PR.
             pr_keys = {c.key for c in candidates}
             pr_keys_covered = set()
             log("::warning::open fix PR lookup failed; suppressing dispatch this run")
@@ -777,7 +786,7 @@ def main() -> int:
 
         result = planning.plan_dispatches(
             candidates,
-            covered_fingerprints=covered_fingerprints(),
+            covered_fingerprints=covered,
             inflight_keys=keys,
             open_pr_keys=pr_keys,
             open_pr_keys_with_coverage=pr_keys_covered,

--- a/.github/scripts/alwaysgreen/discover.py
+++ b/.github/scripts/alwaysgreen/discover.py
@@ -385,9 +385,11 @@ def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
     repeat of the specs it already claims.
 
     Returns (keys, keys_with_coverage, ok). `keys_with_coverage` is the subset whose
-    every holding PR published a coverage block, so `plan` can decide those keys per
-    spec instead of locking the surface; a key any of whose holders published none
-    stays out of it and keeps the coarse lock. As with `inflight_keys`, a failed
+    every holding PR claims at least one fingerprint, so `plan` can decide those keys
+    per spec instead of locking the surface. A block that parses to nothing — absent,
+    or present with no `fp=` line — claims nothing, and a key any of whose holders
+    claims nothing stays out of the subset and keeps the coarse lock: the marker
+    comment alone is not a statement of remit. As with `inflight_keys`, a failed
     lookup makes the caller suppress rather than risk a duplicate PR.
     """
     out: set[str] = set()
@@ -437,7 +439,7 @@ def open_fix_pr_keys() -> tuple[set[str], set[str], bool]:
                 + (
                     f"{len(covered)} spec(s) claimed, others dispatchable"
                     if covered
-                    else "no coverage block, whole surface locked"
+                    else "claims no specs, whole surface locked"
                 )
             )
     return out, out - uncovered, ok

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -58,8 +58,8 @@ SUPPORTED_BASE_REFS = frozenset(
 #:
 #: The TTL alone still leaves the surface shut for two days against failures the
 #: holding PR never claimed, so `open_pr_keys_with_coverage` narrows the lock further:
-#: a PR that published a coverage block is read at spec granularity immediately, and
-#: only a PR that published none falls back to locking its whole surface.
+#: a PR that claims at least one fingerprint is read at spec granularity immediately,
+#: and only a PR that claims none falls back to locking its whole surface.
 PR_LOCK_TTL_DAYS = 2
 
 
@@ -266,8 +266,10 @@ def plan_dispatches(
     after the failing run started, so the run executed source that is already superseded.
 
     `open_pr_keys_with_coverage` are the keys of `open_pr_keys` whose every holding PR
-    published a coverage block. Those PRs state which specs they claim, so the coarse
-    per-surface lock is skipped for them and the per-spec accounting below decides.
+    claims at least one fingerprint in its coverage block. Those PRs state which specs
+    they claim, so the coarse per-surface lock is skipped for them and the per-spec
+    accounting below decides. A PR whose block claims nothing — absent, or present but
+    empty — is not one of them and keeps its surface locked.
     """
     plan = Plan()
     no_fix = recent_no_fix_fingerprints or set()
@@ -294,10 +296,10 @@ def plan_dispatches(
             plan.suppressed.append(Suppression(cand, SUPPRESSED_IN_FLIGHT, cand.key))
             continue
 
-        # An open fix PR that published no coverage block stops a second agent on its
-        # surface: the block is written by the agent, so a PR that omitted it states
-        # nothing about which specs it claims and the whole surface has to be assumed.
-        # A PR that did publish one is authoritative per spec through
+        # An open fix PR that claims no specs stops a second agent on its surface: the
+        # coverage block is written by the agent, so one that is missing or empty
+        # states nothing about its remit and the whole surface has to be assumed.
+        # A PR that claims at least one spec is authoritative per spec through
         # `covered_fingerprints`, so locking its surface only hides its neighbours: on
         # 2026-09-02 c8-cross-component-e2e-tests#3267 claimed three cluster-creation
         # setup specs on `main:saas-smoke-e2e`, and run 33605992250's unrelated

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -310,6 +310,13 @@ def plan_dispatches(
         # setup specs on `main:saas-smoke-e2e`, and run 33605992250's unrelated
         # `smoke-tests.spec.ts` failure was suppressed as `open-fix-pr-for-surface`
         # rather than dispatched.
+        #
+        # Scope note: this gate holds a claim-nothing PR's surface only until
+        # PR_LOCK_TTL_HOURS elapses. Past that its key is released and it contributed no
+        # fingerprints, so the same cause can dispatch again. That is deliberate — the
+        # alternative is the unbounded wedge the TTL exists to remove — but it is a real
+        # residual, bounded by `inflight_keys` and the dispatch caps rather than by this
+        # gate.
         if cand.key in open_pr_keys and cand.key not in pr_keys_with_coverage:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -311,6 +311,14 @@ def plan_dispatches(
         # `smoke-tests.spec.ts` failure was suppressed as `open-fix-pr-for-surface`
         # rather than dispatched.
         #
+        # Assumed here: a PR that claims anything claims EVERYTHING it fixed. The gate
+        # only distinguishes "claims nothing" from "claims something", so a partially
+        # written block — three specs fixed, one `fp=` listed — reads as authoritative
+        # and the two unlisted specs can dispatch a second, overlapping agent. The fix
+        # workflow hands the agent `/tmp/fingerprints.json` and requires the body to
+        # claim them, but stamps only the label; it never validates the block. Making it
+        # verify the block against that file is the fix for this, not a wider lock.
+        #
         # Scope note: this gate holds a claim-nothing PR's surface only until
         # PR_LOCK_TTL_HOURS elapses. Past that its key is released and it contributed no
         # fingerprints, so the same cause can dispatch again. That is deliberate — the

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -55,6 +55,11 @@ SUPPORTED_BASE_REFS = frozenset(
 #: nothing. Past the TTL this coarse per-surface lock lifts and the per-spec coverage
 #: block takes over: a repeat of the same failure is still suppressed as
 #: `open-pr-covers-all-specs`, while a genuinely new one gets an agent.
+#:
+#: The TTL alone still leaves the surface shut for two days against failures the
+#: holding PR never claimed, so `open_pr_keys_with_coverage` narrows the lock further:
+#: a PR that published a coverage block is read at spec granularity immediately, and
+#: only a PR that published none falls back to locking its whole surface.
 PR_LOCK_TTL_DAYS = 2
 
 
@@ -240,6 +245,7 @@ def plan_dispatches(
     inflight_keys: set[str],
     open_pr_keys: set[str],
     product_bug_fingerprints: set[str],
+    open_pr_keys_with_coverage: set[str] | None = None,
     recent_no_fix_fingerprints: set[str] | None = None,
     fixed_upstream_fingerprints: set[str] | None = None,
     supported_base_refs: frozenset[str] = SUPPORTED_BASE_REFS,
@@ -258,10 +264,15 @@ def plan_dispatches(
 
     `fixed_upstream_fingerprints` are those whose test code changed in the e2e repo
     after the failing run started, so the run executed source that is already superseded.
+
+    `open_pr_keys_with_coverage` are the keys of `open_pr_keys` whose every holding PR
+    published a coverage block. Those PRs state which specs they claim, so the coarse
+    per-surface lock is skipped for them and the per-spec accounting below decides.
     """
     plan = Plan()
     no_fix = recent_no_fix_fingerprints or set()
     fixed_upstream = fixed_upstream_fingerprints or set()
+    pr_keys_with_coverage = open_pr_keys_with_coverage or set()
 
     for cand in merge_by_key(candidates):
         # Before anything reads .specs or derives fingerprints from them.
@@ -283,10 +294,16 @@ def plan_dispatches(
             plan.suppressed.append(Suppression(cand, SUPPRESSED_IN_FLIGHT, cand.key))
             continue
 
-        # An open fix PR for this surface stops a second agent regardless of what the
-        # PR body claims. The coverage block is written by the agent, so a PR that
-        # omitted it would otherwise be invisible here and the failure re-dispatched.
-        if cand.key in open_pr_keys:
+        # An open fix PR that published no coverage block stops a second agent on its
+        # surface: the block is written by the agent, so a PR that omitted it states
+        # nothing about which specs it claims and the whole surface has to be assumed.
+        # A PR that did publish one is authoritative per spec through
+        # `covered_fingerprints`, so locking its surface only hides its neighbours: on
+        # 2026-09-02 c8-cross-component-e2e-tests#3267 claimed three cluster-creation
+        # setup specs on `main:saas-smoke-e2e`, and run 33605992250's unrelated
+        # `smoke-tests.spec.ts` failure was suppressed as `open-fix-pr-for-surface`
+        # rather than dispatched.
+        if cand.key in open_pr_keys and cand.key not in pr_keys_with_coverage:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue
 

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -56,26 +56,31 @@ SUPPORTED_BASE_REFS = frozenset(
 #: block takes over: a repeat of the same failure is still suppressed as
 #: `open-pr-covers-all-specs`, while a genuinely new one gets an agent.
 #:
-#: The TTL alone still leaves the surface shut for two days against failures the
-#: holding PR never claimed, so `open_pr_keys_with_coverage` narrows the lock further:
-#: a PR that claims at least one fingerprint is read at spec granularity immediately,
-#: and only a PR that claims none falls back to locking its whole surface.
-PR_LOCK_TTL_DAYS = 2
+#: Two things bound how long one PR can hold a surface, and both matter. The lock is
+#: skipped outright for a PR that claims at least one fingerprint (see
+#: `open_pr_keys_with_coverage`), so a claim-nothing PR is the only case the TTL still
+#: governs — and for that case the window is what decides how long an unrelated
+#: failure waits. A surface carries many independent causes, so a two-day window meant
+#: one silent PR parked every other failure on its surface until a human merged it.
+#: Two hours is roughly three failing runs at the 20-40 minute pipeline cadence: long
+#: enough that the same cause is not re-dispatched while an agent's PR is still being
+#: read, short enough that a different cause waits hours rather than days.
+PR_LOCK_TTL_HOURS = 2
 
 
 def pr_lock_expired(
-    created_at: str | None, now: datetime, ttl_days: int = PR_LOCK_TTL_DAYS
+    created_at: str | None, now: datetime, ttl_hours: int = PR_LOCK_TTL_HOURS
 ) -> bool:
     """Whether an open fix PR is too old to keep holding its dispatch key.
 
-    A missing or unparseable timestamp keeps the lock, and `ttl_days <= 0` disables
+    A missing or unparseable timestamp keeps the lock, and `ttl_hours <= 0` disables
     expiry altogether: the bias matches the `ok` flags in discover's key lookups,
     where an unproven state suppresses rather than risks a duplicate PR.
 
     Either timestamp is read as UTC when it carries no offset, so a naive `now` does
     not raise against GitHub's offset-aware `createdAt`.
     """
-    if ttl_days <= 0:
+    if ttl_hours <= 0:
         return False
     text = (created_at or "").strip()
     if not text:
@@ -88,7 +93,7 @@ def pr_lock_expired(
         created = created.replace(tzinfo=timezone.utc)
     if now.tzinfo is None:
         now = now.replace(tzinfo=timezone.utc)
-    return now - created > timedelta(days=ttl_days)
+    return now - created > timedelta(hours=ttl_hours)
 
 
 def spec_suite(spec_file: str) -> str | None:

--- a/.github/scripts/alwaysgreen/plan.py
+++ b/.github/scripts/alwaysgreen/plan.py
@@ -311,20 +311,11 @@ def plan_dispatches(
         # `smoke-tests.spec.ts` failure was suppressed as `open-fix-pr-for-surface`
         # rather than dispatched.
         #
-        # Assumed here: a PR that claims anything claims EVERYTHING it fixed. The gate
-        # only distinguishes "claims nothing" from "claims something", so a partially
-        # written block — three specs fixed, one `fp=` listed — reads as authoritative
-        # and the two unlisted specs can dispatch a second, overlapping agent. The fix
-        # workflow hands the agent `/tmp/fingerprints.json` and requires the body to
-        # claim them, but stamps only the label; it never validates the block. Making it
-        # verify the block against that file is the fix for this, not a wider lock.
-        #
-        # Scope note: this gate holds a claim-nothing PR's surface only until
-        # PR_LOCK_TTL_HOURS elapses. Past that its key is released and it contributed no
-        # fingerprints, so the same cause can dispatch again. That is deliberate — the
-        # alternative is the unbounded wedge the TTL exists to remove — but it is a real
-        # residual, bounded by `inflight_keys` and the dispatch caps rather than by this
-        # gate.
+        # Two residuals it does not cover. A partially written block reads as
+        # authoritative, since the gate only asks "claims anything?"; validating it
+        # against `/tmp/fingerprints.json` in alwaysgreen-fix.yml is the fix. And a
+        # claim-nothing PR holds its surface only until PR_LOCK_TTL_HOURS, past which
+        # `inflight_keys` and the dispatch caps are the only bound.
         if cand.key in open_pr_keys and cand.key not in pr_keys_with_coverage:
             plan.suppressed.append(Suppression(cand, SUPPRESSED_PR_OPEN, cand.key))
             continue

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -1,0 +1,138 @@
+"""Unit tests for the dedupe snapshot discover hands to the planner.
+
+`test_plan.py` passes `open_pr_keys_with_coverage` in ready-made, so it asserts what
+`plan` does with the answer, never how it is computed. The derivation is where the
+"does this whole surface stay locked" decision is actually made — per-PR key grouping,
+the TTL skip, and the intersection over holders — so it is tested here against a stubbed
+`open_fix_prs`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import discover
+import plan as planning
+
+NOW = datetime.now(timezone.utc)
+
+
+def _ago(**kw):
+    return (NOW - timedelta(**kw)).isoformat().replace("+00:00", "Z")
+
+
+def _pr(number, keys, *, claims=(), age_hours=0):
+    body = ""
+    if claims:
+        body = f"Fixes.\n\n{planning.render_coverage_block(set(claims))}\n"
+    return {
+        "number": number,
+        "body": body,
+        "createdAt": _ago(hours=age_hours),
+        "labels": [{"name": f"{discover.KEY_LABEL_PREFIX}{k}"} for k in keys],
+    }
+
+
+def _stub(monkeypatch, prs, *, ok=True):
+    """Serve `prs` from the first fix repo and nothing from the rest."""
+    seen = {"n": 0}
+
+    def fake(repo):
+        seen["n"] += 1
+        return (list(prs), ok) if seen["n"] == 1 else ([], ok)
+
+    monkeypatch.setattr(discover, "open_fix_prs", fake)
+
+
+def test_a_claiming_holder_frees_its_key_for_other_specs(monkeypatch):
+    _stub(monkeypatch, [_pr(1, ["main:saas-smoke-e2e"], claims=["aaaaaaaa"])])
+    covered, keys, per_spec, ok = discover.dedupe_inputs()
+    assert ok is True
+    assert covered == {"aaaaaaaa"}
+    assert keys == {"main:saas-smoke-e2e"}
+    assert per_spec == {"main:saas-smoke-e2e"}
+
+
+def test_a_holder_claiming_nothing_keeps_its_key_locked(monkeypatch):
+    _stub(monkeypatch, [_pr(1, ["main:saas-smoke-e2e"])])
+    covered, keys, per_spec, ok = discover.dedupe_inputs()
+    assert covered == set()
+    assert keys == {"main:saas-smoke-e2e"}
+    assert per_spec == set()
+
+
+def test_an_empty_coverage_block_claims_nothing(monkeypatch):
+    # The marker alone is not a statement of remit, so it must not free the surface.
+    pr = _pr(1, ["main:saas-smoke-e2e"])
+    pr["body"] = f"Fixes.\n\n{planning.COVERAGE_BEGIN}\nfp=\n{planning.COVERAGE_END}\n"
+    _stub(monkeypatch, [pr])
+    _covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert keys == {"main:saas-smoke-e2e"}
+    assert per_spec == set()
+
+
+def test_one_non_claiming_holder_locks_a_key_another_holder_claims(monkeypatch):
+    # The intersection over holders: this is the case a per-PR view gets wrong.
+    _stub(
+        monkeypatch,
+        [
+            _pr(1, ["main:saas-smoke-e2e"], claims=["aaaaaaaa"]),
+            _pr(2, ["main:saas-smoke-e2e"]),
+        ],
+    )
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}
+    assert keys == {"main:saas-smoke-e2e"}
+    assert per_spec == set()
+
+
+def test_an_expired_non_claiming_holder_does_not_lock_a_claiming_one(monkeypatch):
+    # Only ACTIVE holders decide the key, so an expired PR cannot veto a fresh one.
+    _stub(
+        monkeypatch,
+        [
+            _pr(1, ["main:saas-smoke-e2e"], claims=["aaaaaaaa"]),
+            _pr(2, ["main:saas-smoke-e2e"], age_hours=99),
+        ],
+    )
+    _covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert keys == {"main:saas-smoke-e2e"}
+    assert per_spec == {"main:saas-smoke-e2e"}
+
+
+def test_an_expired_holder_releases_its_key_but_keeps_its_claims(monkeypatch):
+    # The specs a PR claims stay claimed while it is open; only the coarse key lock is
+    # time-bound, so the failure it fixed is still suppressed per spec.
+    _stub(monkeypatch, [_pr(1, ["main:saas-smoke-e2e"], claims=["aaaaaaaa"], age_hours=99)])
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}
+    assert keys == set()
+    assert per_spec == set()
+
+
+def test_a_pr_carrying_two_key_labels_holds_both(monkeypatch):
+    _stub(
+        monkeypatch,
+        [_pr(1, ["main:saas-smoke-e2e", "stable/8.10:saas-smoke-e2e"], claims=["aaaaaaaa"])],
+    )
+    _covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert keys == {"main:saas-smoke-e2e", "stable/8.10:saas-smoke-e2e"}
+    assert per_spec == keys
+
+
+def test_a_pr_with_no_key_label_still_contributes_its_claims(monkeypatch):
+    # A fix PR whose key label was never stamped: it locks nothing, but the specs it
+    # claims must still suppress a repeat.
+    _stub(monkeypatch, [_pr(1, [], claims=["aaaaaaaa"])])
+    covered, keys, per_spec, _ok = discover.dedupe_inputs()
+    assert covered == {"aaaaaaaa"}
+    assert keys == set()
+    assert per_spec == set()
+
+
+def test_a_failed_lookup_reports_not_ok(monkeypatch):
+    # Coverage and keys are one snapshot behind one `ok`. A partial read must not let
+    # the caller skip the coarse lock while believing nothing is claimed.
+    _stub(monkeypatch, [_pr(1, ["main:saas-smoke-e2e"], claims=["aaaaaaaa"])], ok=False)
+    _covered, _keys, _per_spec, ok = discover.dedupe_inputs()
+    assert ok is False

--- a/.github/scripts/alwaysgreen/test_discover.py
+++ b/.github/scripts/alwaysgreen/test_discover.py
@@ -34,12 +34,15 @@ def _pr(number, keys, *, claims=(), age_hours=0):
 
 
 def _stub(monkeypatch, prs, *, ok=True):
-    """Serve `prs` from the first fix repo and nothing from the rest."""
-    seen = {"n": 0}
+    """Serve `prs` from the first fix repo and nothing from the rest.
+
+    Keyed on the repo, not on a call counter: a counter is consumed by the first
+    `dedupe_inputs` pass over FIX_PR_REPOS, so a second call in the same test would be
+    served empty lists and any assertion about it would pass vacuously.
+    """
 
     def fake(repo):
-        seen["n"] += 1
-        return (list(prs), ok) if seen["n"] == 1 else ([], ok)
+        return (list(prs), ok) if repo == discover.FIX_PR_REPOS[0] else ([], ok)
 
     monkeypatch.setattr(discover, "open_fix_prs", fake)
 

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -498,6 +498,68 @@ def test_open_fix_pr_blocks_even_when_the_body_claims_nothing():
     assert result.dispatches == []
 
 
+def test_open_fix_pr_with_a_coverage_block_does_not_block_an_unclaimed_spec():
+    # Run 33605992250: c8-cross-component-e2e-tests#3267 claimed the cluster-creation
+    # setup specs on `main:saas-smoke-e2e`, and an unrelated smoke-test failure on the
+    # same surface was suppressed instead of dispatched.
+    claimed = _spec(name="Create AWS Cluster", file="tests/8.10/test-setup.spec.ts")
+    fresh = _spec(
+        name="Most Common Flow User Flow With All Apps",
+        file="tests/8.10/smoke-tests.spec.ts",
+    )
+    cand = _cand(surface=classify.SURFACE_SAAS_E2E, specs=[claimed, fresh])
+    claimed_fp = classify.spec_fingerprint(
+        "main", classify.SURFACE_SAAS_E2E, claimed.file, claimed.test_name
+    )
+
+    result = _plan(
+        [cand],
+        covered_fingerprints={claimed_fp},
+        open_pr_keys={"main:saas-smoke-e2e"},
+        open_pr_keys_with_coverage={"main:saas-smoke-e2e"},
+    )
+    assert len(result.dispatches) == 1
+    assert [s.test_name for s in result.dispatches[0].specs] == [fresh.test_name]
+
+
+def test_open_fix_pr_with_a_coverage_block_still_suppresses_the_specs_it_claims():
+    cand = _cand(surface=classify.SURFACE_SAAS_E2E)
+    result = _plan(
+        [cand],
+        covered_fingerprints=set(cand.spec_fingerprints),
+        open_pr_keys={"main:saas-smoke-e2e"},
+        open_pr_keys_with_coverage={"main:saas-smoke-e2e"},
+    )
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_PR_COVERED]
+
+
+def test_a_second_holder_without_a_coverage_block_keeps_the_surface_locked():
+    # `keys_with_coverage` is the intersection over holders, so one PR that published
+    # nothing still locks the surface even beside one that published a block.
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan(
+        [cand],
+        open_pr_keys={"main:sm-smoke-e2e"},
+        open_pr_keys_with_coverage=set(),
+    )
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_PR_OPEN]
+
+
+def test_in_flight_agent_still_blocks_a_coverage_declaring_surface():
+    # Narrowing the PR lock must not touch the concurrency rule: one agent per key.
+    cand = _cand(surface=classify.SURFACE_SM_E2E)
+    result = _plan(
+        [cand],
+        inflight_keys={"main:sm-smoke-e2e"},
+        open_pr_keys={"main:sm-smoke-e2e"},
+        open_pr_keys_with_coverage={"main:sm-smoke-e2e"},
+    )
+    assert result.dispatches == []
+    assert [s.reason for s in result.suppressed] == [plan.SUPPRESSED_IN_FLIGHT]
+
+
 # ---------------------------------------------------------------------------
 # PR lock expiry
 # ---------------------------------------------------------------------------

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -579,7 +579,7 @@ def _ago(**kw):
 
 
 def test_fresh_fix_pr_keeps_holding_its_key():
-    assert plan.pr_lock_expired(_ago(hours=6), NOW, 2) is False
+    assert plan.pr_lock_expired(_ago(minutes=30), NOW, 2) is False
 
 
 def test_fix_pr_past_the_ttl_releases_its_key():
@@ -588,9 +588,15 @@ def test_fix_pr_past_the_ttl_releases_its_key():
     assert plan.pr_lock_expired("2026-08-20T14:56:44Z", NOW, 2) is True
 
 
+def test_ttl_is_read_in_hours_not_days():
+    # The knob changed unit; a PR from this morning must not still hold its key.
+    assert plan.pr_lock_expired(_ago(hours=6), NOW, 2) is True
+    assert plan.pr_lock_expired(_ago(hours=6), NOW, plan.PR_LOCK_TTL_HOURS) is True
+
+
 def test_ttl_boundary_is_inclusive_of_the_lock():
-    assert plan.pr_lock_expired(_ago(days=2), NOW, 2) is False
-    assert plan.pr_lock_expired(_ago(days=2, minutes=1), NOW, 2) is True
+    assert plan.pr_lock_expired(_ago(hours=2), NOW, 2) is False
+    assert plan.pr_lock_expired(_ago(hours=2, minutes=1), NOW, 2) is True
 
 
 def test_unreadable_timestamp_keeps_the_lock():
@@ -605,7 +611,7 @@ def test_naive_created_at_is_read_as_utc():
 def test_naive_now_does_not_raise_against_an_offset_aware_created_at():
     naive_now = NOW.replace(tzinfo=None)
     assert plan.pr_lock_expired("2026-08-20T14:56:44Z", naive_now, 2) is True
-    assert plan.pr_lock_expired(_ago(hours=6), naive_now, 2) is False
+    assert plan.pr_lock_expired(_ago(minutes=30), naive_now, 2) is False
 
 
 def test_zero_ttl_restores_the_never_expiring_lock():

--- a/.github/scripts/alwaysgreen/test_plan.py
+++ b/.github/scripts/alwaysgreen/test_plan.py
@@ -446,6 +446,13 @@ def test_parse_returns_empty_when_absent():
     assert plan.parse_coverage_block(None) == set()
 
 
+def test_parse_returns_empty_for_a_block_that_claims_nothing():
+    # The marker alone is not a statement of remit: discover reads an empty result as
+    # "claims no specs" and keeps the coarse surface lock, same as a missing block.
+    assert plan.parse_coverage_block("Body\n\n<!-- alwaysgreen-fixed\n-->\n") == set()
+    assert plan.parse_coverage_block("Body\n\n<!-- alwaysgreen-fixed\nfp=\n-->\n") == set()
+
+
 def test_merge_appends_block_when_missing():
     merged = plan.merge_coverage_block("Body text", {"aaaaaaaa"})
     assert "fp=aaaaaaaa" in merged


### PR DESCRIPTION
## What

AlwaysGreen triage found a real, deterministic failure in [run 33605992250](https://github.com/camunda/camunda/actions/runs/33605992250) and dispatched **no** fix agent. The plan artifact says why:

```json
"dispatches": [],
"suppressed": [{"surface": "saas-smoke-e2e", "reason": "open-fix-pr-for-surface",
                "detail": "main:saas-smoke-e2e"}]
```

The holder was [c8-cross-component-e2e-tests#3267](https://github.com/camunda/c8-cross-component-e2e-tests/pull/3267), opened ~16 h earlier — well inside the 2-**day** lock this PR started from. Its coverage block claims three **cluster-creation setup** specs:

```
fp=771cc1a5  stable/8.10 :: tests/8.10/test-setup.spec.ts :: Create Default Cluster
fp=6b48db23  stable/8.10 :: tests/8.10/test-setup.spec.ts :: Create AWS Cluster
fp=080b6c34  main        :: tests/8.10/test-setup.spec.ts :: Create AWS Cluster
```

The failure in this run was a different test entirely — `tests/8.10/smoke-tests.spec.ts › Most Common Flow User Flow With All Apps` (`fp=619e4487`), failing `2/2` attempts on `Failed to click locator getByRole('button', {name: 'New project'})…`. Nothing claimed it, and nothing was dispatched for it.

## Why this is the right layer

`plan_dispatches` had three independent guards but the coarsest one ran first and short-circuited:

- `inflight_keys` — one agent per key. Concurrency. Correct as a blanket key lock.
- `open_pr_keys` — **any** open fix PR on the surface. Blanket, up to 2 days.
- `covered_fingerprints` — per-spec, exact.

The blanket `open_pr_keys` check exists for a real reason, stated in its own docstring: the coverage block is agent-written, so a PR that published none says nothing about its remit and the whole surface has to be assumed. That reason does not apply to a PR that *did* publish one — there the block is authoritative per spec, and locking the surface only hides the failure's neighbours.

So the check is now conditional: a key held solely by coverage-declaring PRs falls through to the per-spec accounting; a key with any holder that published no block keeps the coarse lock.

Not a loosening of concurrency — `inflight_keys` is untouched and still gates one agent per key.

**This PR does also change the TTL** (added after the first review round, commit `98e95e6`): `PR_LOCK_TTL_DAYS = 2` becomes `PR_LOCK_TTL_HOURS = 2`, and the override env var is renamed `ALWAYSGREEN_PR_LOCK_TTL_DAYS` → `ALWAYSGREEN_PR_LOCK_TTL_HOURS`. **Operators with the old variable set: it is refused, not converted** — reading a leftover `=2` as 48 h would restore exactly the window being replaced — and a `::warning::` names the new one in the run. Same treatment `ALWAYSGREEN_NO_FIX_COOLDOWN_DAYS` already got.

Two hours because the two changes divide the work: the coverage carve-out means a claim-nothing PR is the *only* case the TTL still governs, and for that case the window is how long an unrelated failure waits. Two hours is roughly three failing runs at the 20-40 minute pipeline cadence.

## Behaviour

| Situation | Before | After |
|---|---|---|
| Same spec fails again, PR claims it | `open-fix-pr-for-surface` | `open-pr-covers-all-specs` |
| New spec on a surface whose PR published a block | `open-fix-pr-for-surface` | **dispatched** |
| Any holding PR published no block | `open-fix-pr-for-surface` | `open-fix-pr-for-surface` |
| Agent still running on the key | `agent-already-running` | `agent-already-running` |
| PR lookup failed | suppress all | suppress all |

Replaying this run's candidate through the new planner dispatches 1 (was 0, `open-fix-pr-for-surface`). Against today's live open fix PRs, `open_fix_pr_keys()` returns 3 held keys, all 3 coverage-declaring, so none coarse-locks any more.

Consequence worth naming: two PRs can now hold one key label, for genuinely distinct specs. That is the shape `AGENTS.md` already asks for (different root causes → separate PRs), at the cost of two merges to free a key — the case `merge_by_key`'s docstring describes for #3071/#3073.

## Also

Each holding PR is now logged with the keys it holds and whether it locks the whole surface. Diagnosing this took downloading the plan artifact and cross-listing open fix PRs by label in three repos; the log line now says it outright.

## Testing

- `pytest .github/scripts/alwaysgreen` — 128 passed (4 new; `Scripts / Python Unit Tests` in `ci.yml` covers this path).
- New tests: unclaimed spec dispatches beside a coverage-declaring PR; claimed spec still suppressed as `open-pr-covers-all-specs`; a holder without a block keeps the surface locked; in-flight still wins.
- Existing `test_open_fix_pr_blocks_even_when_the_body_claims_nothing` unchanged and still passing — the new parameter defaults to empty, so the conservative path is the default.
- `open_fix_pr_keys()` run against live PRs in all three fix repos.

`main` only — the triage workflow checks the scripts out from `main` for this pipeline (`ref: inputs.tooling_ref || (inputs.run_id && github.ref_name) || 'main'`). `stable/8.10` carries its own copy of these scripts; not touched here, per branch-scoped fix convention.

The `smoke-tests.spec.ts` failure itself is a test-repo concern and is left for the agent this change unblocks.


## Related issues

<!-- CI/tooling fix with no tracked issue: the trigger is nightly run 33605992250. -->

- [x] This PR does not need a linked issue


---

## Review follow-ups

**`f823c4f` — wording.** Copilot flagged that "published a coverage block" overclaimed: the code keys off `parse_coverage_block()` returning at least one `fp=`, so a present-but-empty block behaves like a missing one. Reworded to "claims at least one fingerprint" / "claims no specs" in all four places, log line included, and pinned with a test.

**`fc4eb74` — a real hole this PR opened.** `covered_fingerprints()` fetched open fix PRs in its own `gh_json` call whose failure was swallowed into an empty set. That was survivable while every open fix PR locked its whole surface — the key layer caught what the empty set missed. Once a claiming PR's key stops locking, the two must agree: otherwise the key lookup succeeds and frees the key, the coverage lookup fails and reports nothing claimed, and the candidate dispatches a duplicate fix for a spec that PR already claims.

Both now come from one `dedupe_inputs()` behind one `ok`, so a partial read suppresses. Side effects: one fewer `gh pr list` per repo (it was fetching the same PRs twice, once for `body` and once for `labels`), and the name/shape now match `camunda-hub`'s equivalent.

**`fc4eb74` — `test_discover.py`.** The derivation had no tests, which is exactly why the above slipped through: the planner tests hand `open_pr_keys_with_coverage` in ready-made, so they assert what `plan` does with the answer, never how it is computed. Nine cases over a stubbed `open_fix_prs` seam, including multiple holders where one claims nothing, expired holders active and inactive, and lookup failure.

**`fc4eb74` — logging and an honest scope note.** The lock decision is logged once per key rather than per PR, since it is an intersection over holders that no single PR can state. The gate comment now records the residual it does not cover: a claim-nothing PR holds its surface only for `PR_LOCK_TTL_HOURS`, after which its key is released and it contributed no fingerprints. Deliberate — the alternative is the unbounded wedge the TTL removes — but bounded by `inflight_keys` and the dispatch caps, not by the gate.

Tests: **139 passing**.

