### PR TITLE
feat: add public cluster API for upgrade-completeness

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPaths.java
@@ -41,7 +41,8 @@ public final class SecurityPaths {
   // cluster-admin chain recognises only cluster-admin credentials — so a client migrating here from
   // /v2/status, which sends its ordinary API credentials on every request, would be answered 401 by
   // a health endpoint. Here the Authorization header is never inspected. The exact path is listed,
-  // so the rest of /cluster/v2/** stays with the cluster-admin chains.
+  // so the rest of /cluster/v2/** stays with the cluster-admin chains. /cluster/v2/status/upgrade
+  // is listed for the identical reason (camunda/camunda#61619).
   public static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           "/error",
@@ -50,7 +51,8 @@ public final class SecurityPaths {
           "/health",
           "/startup",
           "/favicon.ico",
-          "/cluster/v2/status");
+          "/cluster/v2/status",
+          "/cluster/v2/status/upgrade");
 
   private SecurityPaths() {}
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -53,7 +53,8 @@ class SecurityPathAdapterTest {
             "/health",
             "/startup",
             "/favicon.ico",
-            "/cluster/v2/status");
+            "/cluster/v2/status",
+            "/cluster/v2/status/upgrade");
   }
 
   @Test

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -39,6 +39,7 @@ import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterRuntimeBackupServices.PhysicalTenantBackupPort;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
+import io.camunda.service.ClusterUpgradeStatusServices;
 import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ConditionalServices;
 import io.camunda.service.DecisionDefinitionServices;
@@ -58,6 +59,7 @@ import io.camunda.service.ManagementServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.MessageServices;
 import io.camunda.service.MessageSubscriptionServices;
+import io.camunda.service.MigrationStatusAggregator;
 import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.RecoveryServices;
@@ -158,7 +160,8 @@ public class CamundaServicesConfiguration {
       final ObjectProvider<SecondaryStorageReadiness> secondaryStorageReadiness,
       final ObjectProvider<HistoryBackupApi> historyBackupApi,
       final ApiServicesExecutorProvider executor,
-      final SecretStoreRegistries secretStoreRegistries) {
+      final SecretStoreRegistries secretStoreRegistries,
+      final MigrationStatusAggregator migrationStatusAggregator) {
 
     final int maxNameFieldLength = gatewayRestConfiguration.getMaxNameFieldLength();
     final boolean secondaryStorageEnabled =
@@ -586,6 +589,8 @@ public class CamundaServicesConfiguration {
         new ClusterStatusServices(
             topologyServicesByTenant,
             physicalTenantId -> secondaryStorageReadiness.getObject().isReady(physicalTenantId)));
+    builder.clusterUpgradeStatusServices(
+        new ClusterUpgradeStatusServices(migrationStatusAggregator));
     builder.clusterTopologyServices(new ClusterTopologyServices(topologyServicesByTenant));
 
     builder.clusterRecoveryServices(

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/MigrationStatusAggregatorConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.service.MigrationStatusAggregator;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers the single {@link MigrationStatusAggregator} instance shared by the {@code
+ * upgradeReadiness} actuator endpoint ({@link UpgradeReadinessEndpoint}) and the public {@code GET
+ * /cluster/v2/status/upgrade} endpoint (camunda/camunda#61619). Both must read from one instance so
+ * their caching/backfill behavior can never diverge.
+ *
+ * <p>Deliberately not conditional on any HTTP gateway being enabled: the actuator endpoint must
+ * keep working on broker-only nodes with no REST gateway, matching the {@link
+ * MigrationStatusProvider} bean configurations it depends on (none of which are gateway-gated
+ * either).
+ */
+@Configuration(proxyBeanMethods = false)
+public class MigrationStatusAggregatorConfiguration {
+
+  @Bean
+  public MigrationStatusAggregator migrationStatusAggregator(
+      final List<MigrationStatusProvider> providers) {
+    return new MigrationStatusAggregator(providers);
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpoint.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
 import io.camunda.cluster.migration.MigrationStatusProvider;
-import java.util.List;
+import io.camunda.service.MigrationStatusAggregator;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.stereotype.Component;
@@ -18,10 +21,12 @@ import org.springframework.web.bind.annotation.GetMapping;
  * Reports whether this cluster has completed every condition required before the next minor-version
  * upgrade can safely be triggered (see camunda/product-hub#3067).
  *
- * <p>Collects every {@link MigrationStatusProvider} bean registered in this process. The response
- * only contains conditions for which a provider bean currently exists — {@code upgradeable} is
- * intentionally not meaningful until every planned provider (RDBMS schema, Elasticsearch/OpenSearch
- * schema, RocksDB snapshot, exporter flush) is registered; see {@link UpgradeReadinessResponse}.
+ * <p>Collects every {@link MigrationStatusProvider} bean registered in this process, via the shared
+ * {@link MigrationStatusAggregator} bean (also consumed by the public {@code GET
+ * /cluster/v2/status/upgrade} endpoint, see camunda/camunda#61619). The response only contains
+ * conditions for which a provider bean currently exists — {@code upgradeable} is intentionally not
+ * meaningful until every planned provider (RDBMS schema, Elasticsearch/OpenSearch schema, RocksDB
+ * snapshot, exporter flush) is registered; see {@link UpgradeReadinessResponse}.
  */
 @Component
 @RestControllerEndpoint(id = "upgradeReadiness")
@@ -30,12 +35,29 @@ public class UpgradeReadinessEndpoint {
   private final MigrationStatusAggregator aggregator;
 
   @Autowired
-  public UpgradeReadinessEndpoint(final List<MigrationStatusProvider> providers) {
-    aggregator = new MigrationStatusAggregator(providers);
+  public UpgradeReadinessEndpoint(final MigrationStatusAggregator aggregator) {
+    this.aggregator = aggregator;
   }
 
   @GetMapping(produces = "application/json")
   public UpgradeReadinessResponse getUpgradeReadiness() {
-    return aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
+    return new UpgradeReadinessResponse(isUpgradeable(physicalTenants), physicalTenants);
+  }
+
+  /**
+   * {@code true} only once every registered condition reports {@code MIGRATED} for every known
+   * physical tenant; {@code false} whenever nothing is known at all (see {@link
+   * UpgradeReadinessResponse}).
+   */
+  private static boolean isUpgradeable(
+      final Map<String, Map<String, MigrationConditionStatus>> physicalTenants) {
+    return !physicalTenants.isEmpty()
+        && physicalTenants.values().stream()
+            .allMatch(
+                conditions ->
+                    !conditions.isEmpty()
+                        && conditions.values().stream()
+                            .allMatch(status -> status.state() == MigrationState.MIGRATED));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -32,6 +32,7 @@ import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.ManagementServices;
+import io.camunda.service.MigrationStatusAggregator;
 import io.camunda.service.SecretServices.ResolvedSecret;
 import io.camunda.service.SecretServices.SecretErrorCode;
 import io.camunda.service.SecretServices.SecretResolutionError;
@@ -426,7 +427,8 @@ class CamundaServicesConfigurationTest {
         readinessProvider(),
         mock(ObjectProvider.class),
         new ApiServicesExecutorProvider(Executors.newSingleThreadExecutor()),
-        secretStoreRegistries);
+        secretStoreRegistries,
+        new MigrationStatusAggregator(List.of()));
   }
 
   /**

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/UpgradeReadinessEndpointTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.cluster.migration.MigrationConditionStatus;
 import io.camunda.cluster.migration.MigrationState;
 import io.camunda.cluster.migration.MigrationStatusProvider;
+import io.camunda.service.MigrationStatusAggregator;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,8 @@ final class UpgradeReadinessEndpointTest {
                 new MigrationConditionStatus(MigrationState.MIGRATED, "schema is current"));
           }
         };
-    final var endpoint = new UpgradeReadinessEndpoint(List.of(provider));
+    final var endpoint =
+        new UpgradeReadinessEndpoint(new MigrationStatusAggregator(List.of(provider)));
 
     // when
     final var response = endpoint.getUpgradeReadiness();
@@ -51,7 +53,7 @@ final class UpgradeReadinessEndpointTest {
   @Test
   void shouldReportNotUpgradeableWhenNoProviderIsRegisteredYet() {
     // given - staged rollout, before any MigrationStatusProvider bean exists
-    final var endpoint = new UpgradeReadinessEndpoint(List.of());
+    final var endpoint = new UpgradeReadinessEndpoint(new MigrationStatusAggregator(List.of()));
 
     // when
     final var response = endpoint.getUpgradeReadiness();
@@ -59,5 +61,35 @@ final class UpgradeReadinessEndpointTest {
     // then
     assertThat(response.upgradeable()).isFalse();
     assertThat(response.physicalTenants()).isEmpty();
+  }
+
+  @Test
+  void shouldReportNotUpgradeableWhenAConditionIsInProgress() {
+    // given
+    final MigrationStatusProvider provider =
+        new MigrationStatusProvider() {
+          @Override
+          public String conditionName() {
+            return "rdbmsSchemaMigrated";
+          }
+
+          @Override
+          public Map<String, MigrationConditionStatus> getMigrationStatus() {
+            return Map.of(
+                "default",
+                new MigrationConditionStatus(
+                    MigrationState.MIGRATION_IN_PROGRESS, "schema migration running"));
+          }
+        };
+    final var endpoint =
+        new UpgradeReadinessEndpoint(new MigrationStatusAggregator(List.of(provider)));
+
+    // when
+    final var response = endpoint.getUpgradeReadiness();
+
+    // then
+    assertThat(response.upgradeable()).isFalse();
+    assertThat(response.physicalTenants().get("default").get("rdbmsSchemaMigrated").state())
+        .isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.cluster.migration.MigrationState;
 import io.camunda.document.api.DocumentLink;
 import io.camunda.gateway.protocol.model.ActivatedJobResult;
 import io.camunda.gateway.protocol.model.AuthorizationCreateResult;
@@ -30,6 +31,7 @@ import io.camunda.gateway.protocol.model.ClusterBrokerInfo;
 import io.camunda.gateway.protocol.model.ClusterStatusResponse;
 import io.camunda.gateway.protocol.model.ClusterStatusResponse.StatusEnum;
 import io.camunda.gateway.protocol.model.ClusterTopologyResponse;
+import io.camunda.gateway.protocol.model.ClusterUpgradeStatusResponse;
 import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
@@ -949,6 +951,19 @@ public final class ResponseMapper {
               case HEALTHY -> StatusEnum.HEALTHY;
               case DEGRADED -> StatusEnum.DEGRADED;
               case DOWN -> StatusEnum.DOWN;
+            })
+        .build();
+  }
+
+  public static ClusterUpgradeStatusResponse toClusterUpgradeStatusResponse(
+      final MigrationState state) {
+    return ClusterUpgradeStatusResponse.Builder.create()
+        .status(
+            switch (state) {
+              case MIGRATED -> ClusterUpgradeStatusResponse.StatusEnum.MIGRATED;
+              case MIGRATION_IN_PROGRESS ->
+                  ClusterUpgradeStatusResponse.StatusEnum.MIGRATION_IN_PROGRESS;
+              case UNKNOWN -> ClusterUpgradeStatusResponse.StatusEnum.UNKNOWN;
             })
         .build();
   }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -175,7 +175,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-cluster</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/service/src/main/java/io/camunda/service/ClusterUpgradeStatusServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterUpgradeStatusServices.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Reports one overall {@link MigrationState} for the whole cluster, folded over every physical
+ * tenant and condition tracked by the shared {@link MigrationStatusAggregator} — the same instance
+ * backing the {@code GET /actuator/upgradeReadiness} endpoint, so both can never disagree due to
+ * independent caching.
+ *
+ * <p>Precedence: {@link MigrationState#MIGRATION_IN_PROGRESS} beats {@link MigrationState#UNKNOWN}
+ * beats {@link MigrationState#MIGRATED} — any confidently-not-yet-migrated tenant/condition wins
+ * over an inconclusive one, and only every known tenant/condition confirming {@code MIGRATED}
+ * yields {@code MIGRATED}. An empty result (nothing known yet, e.g. before the first poll) folds
+ * conservatively to {@link MigrationState#UNKNOWN}, never {@code MIGRATED}.
+ *
+ * <p>This service is cluster-wide, so it deliberately <b>exposes no physical tenant ids or
+ * condition names</b>: it backs the unauthenticated {@code GET /cluster/v2/status/upgrade}, the
+ * same concern {@link ClusterStatusServices} documents for {@code GET /cluster/v2/status} (see
+ * {@code docs/adr/management/001-physical-tenant-health-status-topology.md}).
+ */
+@NullMarked
+public final class ClusterUpgradeStatusServices {
+
+  private final MigrationStatusAggregator aggregator;
+
+  public ClusterUpgradeStatusServices(final MigrationStatusAggregator aggregator) {
+    this.aggregator = aggregator;
+  }
+
+  public CompletableFuture<MigrationState> getStatus() {
+    return CompletableFuture.completedFuture(fold(aggregator.aggregate()));
+  }
+
+  private static MigrationState fold(
+      final Map<String, Map<String, MigrationConditionStatus>> physicalTenants) {
+    if (physicalTenants.isEmpty()) {
+      return MigrationState.UNKNOWN;
+    }
+
+    var sawUnknown = false;
+    for (final var conditions : physicalTenants.values()) {
+      if (conditions.isEmpty()) {
+        sawUnknown = true;
+        continue;
+      }
+      for (final var status : conditions.values()) {
+        switch (status.state()) {
+          case MIGRATION_IN_PROGRESS -> {
+            return MigrationState.MIGRATION_IN_PROGRESS;
+          }
+          case UNKNOWN -> sawUnknown = true;
+          case MIGRATED -> {
+            // keep scanning; MIGRATED only wins if nothing worse is found
+          }
+        }
+      }
+    }
+    return sawUnknown ? MigrationState.UNKNOWN : MigrationState.MIGRATED;
+  }
+}

--- a/service/src/main/java/io/camunda/service/ClusterUpgradeStatusServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterUpgradeStatusServices.java
@@ -64,6 +64,8 @@ public final class ClusterUpgradeStatusServices {
           case MIGRATED -> {
             // keep scanning; MIGRATED only wins if nothing worse is found
           }
+          default ->
+              throw new IllegalStateException("Unexpected migration state: " + status.state());
         }
       }
     }

--- a/service/src/main/java/io/camunda/service/MigrationStatusAggregator.java
+++ b/service/src/main/java/io/camunda/service/MigrationStatusAggregator.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.shared.management;
+package io.camunda.service;
 
 import io.camunda.cluster.migration.MigrationConditionStatus;
 import io.camunda.cluster.migration.MigrationState;
@@ -20,7 +20,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Collects every registered {@link MigrationStatusProvider} and combines their per-physical-tenant
- * statuses into an {@link UpgradeReadinessResponse}.
+ * statuses into one {@code Map<physicalTenantId, Map<conditionName, MigrationConditionStatus>>}.
+ * Different consumers derive their own reduction over this shared, cache-smoothed map — the
+ * actuator's upgrade-readiness endpoint computes a boolean, the public {@code GET
+ * /cluster/v2/status/upgrade} endpoint ({@link ClusterUpgradeStatusServices}) computes one overall
+ * {@link MigrationState} — so both read from the same instance and can never disagree.
  *
  * <p>Keeps the last confirmed {@code MIGRATED} status per (physical tenant, condition) pair.
  */
@@ -37,7 +41,7 @@ public class MigrationStatusAggregator {
     this.providers = providers;
   }
 
-  public UpgradeReadinessResponse aggregate() {
+  public Map<String, Map<String, MigrationConditionStatus>> aggregate() {
     final var conditionNames =
         providers.stream().map(MigrationStatusProvider::conditionName).toList();
     final var physicalTenants = new LinkedHashMap<String, Map<String, MigrationConditionStatus>>();
@@ -57,15 +61,7 @@ public class MigrationStatusAggregator {
 
     backfillMissingPairs(physicalTenants, conditionNames);
 
-    final var upgradeable =
-        !physicalTenants.isEmpty()
-            && physicalTenants.values().stream()
-                .allMatch(
-                    conditions ->
-                        !conditions.isEmpty()
-                            && conditions.values().stream()
-                                .allMatch(status -> status.state() == MigrationState.MIGRATED));
-    return new UpgradeReadinessResponse(upgradeable, physicalTenants);
+    return physicalTenants;
   }
 
   private Map<String, MigrationConditionStatus> safeGetMigrationStatus(

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -22,6 +22,7 @@ import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
+import io.camunda.service.ClusterUpgradeStatusServices;
 import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ConditionalServices;
 import io.camunda.service.DecisionDefinitionServices;
@@ -112,6 +113,7 @@ public record DefaultServiceRegistry(
     ClusterRebalanceServices clusterRebalanceServices,
     ClusterRecoveryServices clusterRecoveryServices,
     ClusterStatusServices clusterStatusServices,
+    ClusterUpgradeStatusServices clusterUpgradeStatusServices,
     ClusterTopologyServices clusterTopologyServices,
     ClusterExportingServices clusterExportingServices,
     ManagementServices managementServices)
@@ -358,6 +360,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public ClusterUpgradeStatusServices clusterUpgradeStatusServices() {
+    return clusterUpgradeStatusServices;
+  }
+
+  @Override
   public ClusterTopologyServices clusterTopologyServices() {
     return clusterTopologyServices;
   }
@@ -461,6 +468,7 @@ public record DefaultServiceRegistry(
     private ClusterRebalanceServices clusterRebalanceServices;
     private ClusterRecoveryServices clusterRecoveryServices;
     private ClusterStatusServices clusterStatusServices;
+    private ClusterUpgradeStatusServices clusterUpgradeStatusServices;
     private ClusterTopologyServices clusterTopologyServices;
     private ClusterExportingServices clusterExportingServices;
     private ManagementServices managementServices;
@@ -705,6 +713,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder clusterUpgradeStatusServices(final ClusterUpgradeStatusServices service) {
+      clusterUpgradeStatusServices = service;
+      return this;
+    }
+
     public Builder clusterTopologyServices(final ClusterTopologyServices service) {
       clusterTopologyServices = service;
       return this;
@@ -767,6 +780,7 @@ public record DefaultServiceRegistry(
           clusterRebalanceServices,
           clusterRecoveryServices,
           clusterStatusServices,
+          clusterUpgradeStatusServices,
           clusterTopologyServices,
           clusterExportingServices,
           managementServices);

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -22,6 +22,7 @@ import io.camunda.service.ClusterRecoveryServices;
 import io.camunda.service.ClusterRuntimeBackupServices;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterTopologyServices;
+import io.camunda.service.ClusterUpgradeStatusServices;
 import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ConditionalServices;
 import io.camunda.service.DecisionDefinitionServices;
@@ -161,6 +162,8 @@ public interface ServiceRegistry {
   ClusterRuntimeBackupServices clusterRuntimeBackupServices();
 
   ClusterStatusServices clusterStatusServices();
+
+  ClusterUpgradeStatusServices clusterUpgradeStatusServices();
 
   ClusterTopologyServices clusterTopologyServices();
 

--- a/service/src/test/java/io/camunda/service/ClusterUpgradeStatusServicesTest.java
+++ b/service/src/test/java/io/camunda/service/ClusterUpgradeStatusServicesTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.migration.MigrationConditionStatus;
+import io.camunda.cluster.migration.MigrationState;
+import io.camunda.cluster.migration.MigrationStatusProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ClusterUpgradeStatusServicesTest {
+
+  @Test
+  void shouldReportUnknownWhenNoProviderIsRegistered() {
+    // given - staged rollout: not every provider exists yet
+    final var services = services();
+
+    // when / then
+    assertThat(statusOf(services)).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldReportMigratedWhenEveryConditionIsMigratedForEveryTenant() {
+    // given
+    final var services =
+        services(
+            provider("a", Map.of("default", migrated("a done"))),
+            provider("b", Map.of("default", migrated("b done"))));
+
+    // when / then
+    assertThat(statusOf(services)).isEqualTo(MigrationState.MIGRATED);
+  }
+
+  @Test
+  void shouldReportMigrationInProgressWhenOneConditionIsInProgress() {
+    // given - one condition confirmed migrated, another confidently not yet
+    final var services =
+        services(
+            provider("a", Map.of("default", migrated("a done"))),
+            provider("b", Map.of("default", inProgress("b behind"))));
+
+    // when / then
+    assertThat(statusOf(services)).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReportUnknownWhenOneConditionIsUnknownButNoneIsInProgress() {
+    // given - unknown beats migrated, but loses to migration-in-progress
+    final var services =
+        services(
+            provider("a", Map.of("default", migrated("a done"))),
+            provider("b", Map.of("default", unknown("b lookup failed"))));
+
+    // when / then
+    assertThat(statusOf(services)).isEqualTo(MigrationState.UNKNOWN);
+  }
+
+  @Test
+  void shouldPreferMigrationInProgressOverUnknown() {
+    // given - both an inconclusive and a confidently-incomplete condition are present
+    final var services =
+        services(
+            provider("a", Map.of("default", unknown("a lookup failed"))),
+            provider("b", Map.of("default", inProgress("b behind"))));
+
+    // when / then
+    assertThat(statusOf(services)).isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
+  }
+
+  private static MigrationConditionStatus migrated(final String detail) {
+    return new MigrationConditionStatus(MigrationState.MIGRATED, detail);
+  }
+
+  private static MigrationConditionStatus inProgress(final String detail) {
+    return new MigrationConditionStatus(MigrationState.MIGRATION_IN_PROGRESS, detail);
+  }
+
+  private static MigrationConditionStatus unknown(final String detail) {
+    return new MigrationConditionStatus(MigrationState.UNKNOWN, detail);
+  }
+
+  private static MigrationStatusProvider provider(
+      final String name, final Map<String, MigrationConditionStatus> statuses) {
+    return new MigrationStatusProvider() {
+      @Override
+      public String conditionName() {
+        return name;
+      }
+
+      @Override
+      public Map<String, MigrationConditionStatus> getMigrationStatus() {
+        return statuses;
+      }
+    };
+  }
+
+  private static ClusterUpgradeStatusServices services(final MigrationStatusProvider... providers) {
+    return new ClusterUpgradeStatusServices(new MigrationStatusAggregator(List.of(providers)));
+  }
+
+  private static MigrationState statusOf(final ClusterUpgradeStatusServices services) {
+    return services.getStatus().join();
+  }
+}

--- a/service/src/test/java/io/camunda/service/MigrationStatusAggregatorTest.java
+++ b/service/src/test/java/io/camunda/service/MigrationStatusAggregatorTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.shared.management;
+package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,20 +19,19 @@ import org.junit.jupiter.api.Test;
 final class MigrationStatusAggregatorTest {
 
   @Test
-  void shouldReportNotUpgradeableWhenNoProviderIsRegistered() {
+  void shouldReportNoPhysicalTenantsWhenNoProviderIsRegistered() {
     // given - staged rollout: not every provider exists yet
     final var aggregator = new MigrationStatusAggregator(List.of());
 
     // when
-    final var response = aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
 
     // then - an empty condition set must never be mistaken for readiness
-    assertThat(response.upgradeable()).isFalse();
-    assertThat(response.physicalTenants()).isEmpty();
+    assertThat(physicalTenants).isEmpty();
   }
 
   @Test
-  void shouldReportUpgradeableOnlyWhenEveryConditionIsMigratedForEveryTenant() {
+  void shouldReportEveryConditionForEveryPhysicalTenant() {
     // given
     final var aggregator =
         new MigrationStatusAggregator(
@@ -41,11 +40,10 @@ final class MigrationStatusAggregatorTest {
                 provider("b", Map.of("default", migrated("b done")))));
 
     // when
-    final var response = aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
 
     // then
-    assertThat(response.upgradeable()).isTrue();
-    assertThat(response.physicalTenants().get("default")).hasSize(2);
+    assertThat(physicalTenants.get("default")).hasSize(2);
   }
 
   @Test
@@ -61,18 +59,16 @@ final class MigrationStatusAggregatorTest {
                         "tenantB", inProgress("b behind")))));
 
     // when
-    final var response = aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
 
     // then
-    assertThat(response.upgradeable()).isFalse();
-    assertThat(response.physicalTenants().get("tenantA").get("a").state())
-        .isEqualTo(MigrationState.MIGRATED);
-    assertThat(response.physicalTenants().get("tenantB").get("a").state())
+    assertThat(physicalTenants.get("tenantA").get("a").state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(physicalTenants.get("tenantB").get("a").state())
         .isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
   }
 
   @Test
-  void shouldReportNotUpgradeableWhenOneConditionIsNotMigratedForOneTenant() {
+  void shouldKeepEachConditionIndependentPerTenant() {
     // given
     final var aggregator =
         new MigrationStatusAggregator(
@@ -81,11 +77,11 @@ final class MigrationStatusAggregatorTest {
                 provider("b", Map.of("default", inProgress("b behind")))));
 
     // when
-    final var response = aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
 
     // then
-    assertThat(response.upgradeable()).isFalse();
-    assertThat(response.physicalTenants().get("default").get("b").state())
+    assertThat(physicalTenants.get("default").get("a").state()).isEqualTo(MigrationState.MIGRATED);
+    assertThat(physicalTenants.get("default").get("b").state())
         .isEqualTo(MigrationState.MIGRATION_IN_PROGRESS);
   }
 
@@ -95,12 +91,11 @@ final class MigrationStatusAggregatorTest {
     final var aggregator = new MigrationStatusAggregator(List.of(throwingProvider("a", "boom")));
 
     // when
-    final var response = aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
 
     // then - a broken provider must never crash the endpoint; with no known tenant, there's
     // simply nothing to report yet
-    assertThat(response.upgradeable()).isFalse();
-    assertThat(response.physicalTenants()).isEmpty();
+    assertThat(physicalTenants).isEmpty();
   }
 
   @Test
@@ -113,11 +108,10 @@ final class MigrationStatusAggregatorTest {
                 throwingProvider("b", "boom")));
 
     // when
-    final var response = aggregator.aggregate();
+    final var physicalTenants = aggregator.aggregate();
 
     // then - "b" must not silently disappear for "default": a gap is UNKNOWN, never omission
-    assertThat(response.upgradeable()).isFalse();
-    final var conditions = response.physicalTenants().get("default");
+    final var conditions = physicalTenants.get("default");
     assertThat(conditions.get("a").state()).isEqualTo(MigrationState.MIGRATED);
     assertThat(conditions.get("b").state()).isEqualTo(MigrationState.UNKNOWN);
     assertThat(conditions.get("b").detail()).contains("no status reported");
@@ -131,13 +125,13 @@ final class MigrationStatusAggregatorTest {
     final var aggregator = new MigrationStatusAggregator(List.of(flakyProvider));
 
     // when - first poll confirms MIGRATED, second poll would otherwise lose the entry entirely
-    final var firstResponse = aggregator.aggregate();
-    final var secondResponse = aggregator.aggregate();
+    final var firstPhysicalTenants = aggregator.aggregate();
+    final var secondPhysicalTenants = aggregator.aggregate();
 
     // then - monotonicity is preserved via the backfill, even under total provider failure
-    assertThat(firstResponse.physicalTenants().get("default").get("a").state())
+    assertThat(firstPhysicalTenants.get("default").get("a").state())
         .isEqualTo(MigrationState.MIGRATED);
-    assertThat(secondResponse.physicalTenants().get("default").get("a").state())
+    assertThat(secondPhysicalTenants.get("default").get("a").state())
         .isEqualTo(MigrationState.MIGRATED);
   }
 
@@ -149,10 +143,10 @@ final class MigrationStatusAggregatorTest {
 
     // when
     aggregator.aggregate();
-    final var secondResponse = aggregator.aggregate();
+    final var secondPhysicalTenants = aggregator.aggregate();
 
     // then - nothing was ever confirmed MIGRATED, so the backfill falls back to UNKNOWN
-    assertThat(secondResponse.physicalTenants().get("default").get("a").state())
+    assertThat(secondPhysicalTenants.get("default").get("a").state())
         .isEqualTo(MigrationState.UNKNOWN);
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -119,7 +119,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ClusterUpgradeStatusResponse'
-      x-added-in-version: "8.11"
+      x-added-in-version: "8.10"
       x-scope: cluster-wide
 
   /cluster/v2/topology:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-admin.yaml
@@ -27,8 +27,9 @@
 # ClusterAdminBasicSecurityConfiguration / CLUSTER_ADMIN_API_PATTERN), a separate credential set
 # from the Orchestration Cluster API. Where an operation reuses the `bearerAuth` / `basicAuth`
 # scheme names from that API, it still resolves against different credentials — an Orchestration
-# Cluster user session cannot authenticate against it. `getClusterStatus` below is the one
-# exception: it is intentionally public (`security: []`), not cluster-admin-gated.
+# Cluster user session cannot authenticate against it. `getClusterStatus` and
+# `getClusterUpgradeStatus` below are the two exceptions: both are intentionally public
+# (`security: []`), not cluster-admin-gated.
 
 paths:
   /cluster/v2/status:
@@ -78,6 +79,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClusterStatusResponse'
       x-added-in-version: "8.10"
+      x-scope: cluster-wide
+
+  /cluster/v2/status/upgrade:
+    servers:
+      - url: "{schema}://{host}:{port}"
+        variables:
+          host:
+            default: localhost
+            description: The hostname of the Orchestration Cluster REST Gateway.
+          port:
+            default: "8080"
+            description: The port of the Orchestration Cluster REST API server.
+          schema:
+            default: http
+            description: The schema of the Orchestration Cluster REST API server.
+    get:
+      x-eventually-consistent: false
+      tags:
+        - Cluster
+      operationId: getClusterUpgradeStatus
+      x-required-permissions: [ ]
+      # Public — declared unauthenticated at runtime via SecurityPathAdapter, same as
+      # getClusterStatus above. security: [] overrides the conditional enforcement on the
+      # global schemes for this operation.
+      security: [ ]
+      summary: Get the upgrade-readiness status of the whole cluster
+      description: >-
+        Reports one overall upgrade-readiness status for the whole cluster, folded over every
+        physical tenant and condition. `MIGRATED` only once every known condition has migrated for
+        every known physical tenant; `MIGRATION_IN_PROGRESS` when at least one is confirmed not yet
+        migrated; `UNKNOWN` otherwise (including before anything has been reported yet). No
+        per-tenant or per-condition detail is reported here; see the `upgradeReadiness` actuator
+        endpoint for that.
+      responses:
+        "200":
+          description: The cluster's upgrade-readiness status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterUpgradeStatusResponse'
+      x-added-in-version: "8.11"
       x-scope: cluster-wide
 
   /cluster/v2/topology:
@@ -1549,6 +1591,23 @@ components:
             - HEALTHY
             - DEGRADED
             - DOWN
+    ClusterUpgradeStatusResponse:
+      description: The upgrade-readiness status of the whole cluster.
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: >-
+            `MIGRATED` once every known upgrade-readiness condition is met for every known
+            physical tenant; `MIGRATION_IN_PROGRESS` when at least one is confirmed not yet
+            migrated; `UNKNOWN` otherwise.
+          type: string
+          example: MIGRATED
+          enum:
+            - MIGRATED
+            - MIGRATION_IN_PROGRESS
+            - UNKNOWN
     ClusterRestoreRequest:
       description: >-
         Describes a restore request issued by a cluster admin. The backup selection at the top level

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -528,6 +528,8 @@ paths:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1restore'
   /cluster/v2/status:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1status'
+  /cluster/v2/status/upgrade:
+    $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1status~1upgrade'
   /cluster/v2/topology:
     $ref: 'cluster-admin.yaml#/paths/~1cluster~1v2~1topology'
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterStatusController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterStatusController.java
@@ -49,6 +49,23 @@ public class ClusterStatusController {
   }
 
   /**
+   * Reports one overall upgrade-readiness status for the whole cluster (see the {@code
+   * upgradeReadiness} actuator endpoint for full per-physical-tenant, per-condition detail). Public
+   * and unauthenticated, like {@link #getClusterStatus()} — see camunda/camunda#61619.
+   *
+   * <p>Always answers {@code 200}, even for {@code MIGRATION_IN_PROGRESS}/{@code UNKNOWN}: an
+   * in-progress upgrade is an expected condition the cluster keeps serving traffic through, unlike
+   * {@link #getClusterStatus()}'s {@code DOWN}, which is a genuine outage.
+   */
+  @CamundaGetMapping(path = "/status/upgrade")
+  public CompletableFuture<ResponseEntity<Object>> getClusterUpgradeStatus() {
+    return RequestExecutor.executeServiceMethod(
+        serviceRegistry.clusterUpgradeStatusServices()::getStatus,
+        ResponseMapper::toClusterUpgradeStatusResponse,
+        HttpStatus.OK);
+  }
+
+  /**
    * Only {@code DOWN} means the cluster cannot process work; a degraded cluster still serves
    * traffic, so it must not be signalled as unavailable.
    */

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterStatusControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterStatusControllerTest.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
+import io.camunda.cluster.migration.MigrationState;
 import io.camunda.service.ClusterStatusServices;
 import io.camunda.service.ClusterStatusServices.AggregatedStatus;
+import io.camunda.service.ClusterUpgradeStatusServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.concurrent.CompletableFuture;
@@ -27,13 +29,16 @@ import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 class ClusterStatusControllerTest extends RestControllerTest {
 
   static final String CLUSTER_STATUS_URL = "/cluster/v2/status";
+  static final String CLUSTER_UPGRADE_STATUS_URL = "/cluster/v2/status/upgrade";
 
   @MockitoBean ClusterStatusServices clusterStatusServices;
+  @MockitoBean ClusterUpgradeStatusServices clusterUpgradeStatusServices;
   @MockitoBean ServiceRegistry serviceRegistry;
 
   @BeforeEach
   void setup() {
     when(serviceRegistry.clusterStatusServices()).thenReturn(clusterStatusServices);
+    when(serviceRegistry.clusterUpgradeStatusServices()).thenReturn(clusterUpgradeStatusServices);
   }
 
   @Test
@@ -75,11 +80,63 @@ class ClusterStatusControllerTest extends RestControllerTest {
         .json("{\"status\":\"DOWN\"}", JsonCompareMode.STRICT);
   }
 
+  @Test
+  void shouldReturnOkWhenMigrated() {
+    // given
+    givenUpgradeStatus(MigrationState.MIGRATED);
+
+    // when / then
+    getClusterUpgradeStatus()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"status\":\"MIGRATED\"}", JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnOkWhenMigrationInProgress() {
+    // given — an in-progress upgrade is expected, not an outage, so it must still answer 200
+    givenUpgradeStatus(MigrationState.MIGRATION_IN_PROGRESS);
+
+    // when / then
+    getClusterUpgradeStatus()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"status\":\"MIGRATION_IN_PROGRESS\"}", JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnOkWhenUpgradeStatusUnknown() {
+    // given
+    givenUpgradeStatus(MigrationState.UNKNOWN);
+
+    // when / then
+    getClusterUpgradeStatus()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json("{\"status\":\"UNKNOWN\"}", JsonCompareMode.STRICT);
+  }
+
   private void givenStatus(final AggregatedStatus status) {
     when(clusterStatusServices.getStatus()).thenReturn(CompletableFuture.completedFuture(status));
   }
 
+  private void givenUpgradeStatus(final MigrationState status) {
+    when(clusterUpgradeStatusServices.getStatus())
+        .thenReturn(CompletableFuture.completedFuture(status));
+  }
+
   private ResponseSpec getClusterStatus() {
     return webClient.get().uri(CLUSTER_STATUS_URL).accept(MediaType.APPLICATION_JSON).exchange();
+  }
+
+  private ResponseSpec getClusterUpgradeStatus() {
+    return webClient
+        .get()
+        .uri(CLUSTER_UPGRADE_STATUS_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange();
   }
 }


### PR DESCRIPTION
## Summary

Adds `GET /cluster/v2/status/upgrade`, a public, unauthenticated endpoint reporting a coarse overall upgrade-readiness status for the whole cluster (`{"status": "MIGRATED"}`), built the same way as the existing `GET /cluster/v2/status`.

Today this data (`MigrationStatusProvider` beans — RocksDB, ES/OS schema, RDBMS schema) is only reachable via the actuator's `GET /actuator/upgradeReadiness`, which needs management-port access and returns full per-physical-tenant, per-condition detail. Customers need a simple "is the upgrade done" signal pollable from ordinary tooling.

## Approach

- Moved the actuator's `MigrationStatusAggregator` (the stateful engine that folds every `MigrationStatusProvider` into a per-tenant, per-condition map, with caching that prevents a transient provider failure from regressing a previously-confirmed `MIGRATED` condition) from `dist` into the `service` module, and registered it as a single shared Spring bean.
- Both the actuator endpoint and the new public endpoint now read from that one shared instance, so they can never disagree due to independent caching.
- New `ClusterUpgradeStatusServices` folds the shared map into one overall `MigrationState`, with precedence `MIGRATION_IN_PROGRESS` > `UNKNOWN` > `MIGRATED`.
- New endpoint always answers `200`, including for `MIGRATION_IN_PROGRESS`/`UNKNOWN` — an in-progress upgrade is expected and the cluster keeps serving traffic, unlike `GET /cluster/v2/status`'s `DOWN`.
- Public and unauthenticated, added to `SecurityPaths.UNPROTECTED_PATHS` for the same reason `/cluster/v2/status` is there.

Split into two commits: a pure refactor (moving/sharing the aggregator, no behavior change) followed by the new feature.

## Testing

- New/updated unit tests: `MigrationStatusAggregatorTest` (moved), `ClusterUpgradeStatusServicesTest` (new, 5 cases), `UpgradeReadinessEndpointTest` (+1 case), `ClusterStatusControllerTest` (+3 cases) — all green.
- Full repo compile (`./mvnw install -Dquickly -T1C`) green.
- `qa/archunit-tests` (69 tests, including `ServiceRegistryArchTest` which governs the exact registry pattern touched) green.
- `CsrfProtectionRequestMatcherTest` (consumes `SecurityPaths.UNPROTECTED_PATHS`) green.
- OpenAPI YAML structure sanity-checked with a YAML parser (Spectral CLI could not be run locally in this environment — no pinned version available, and the latest npx-fetched version is incompatible with this repo's ruleset schema).

Not included as it's optional per the design discussion: an end-to-end integration test in `zeebe/qa/integration-tests` proving the actuator and public endpoint agree. Happy to add if wanted.

## Related issues

closes #61619

## Reviewer notes

- The endpoint is intentionally unauthenticated, mirroring `GET /cluster/v2/status` — it leaks one bit of information to anonymous callers (whether the cluster is mid-upgrade), which is the explicit ask of the issue.
- `service/pom.xml`: promoted the existing `camunda-cluster` dependency from test- to compile-scope (it was already a declared intra-repo dependency, just not used by main code before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)