### PR TITLE
feat: let camunda.security.saas.* alone configure CCSaaS org and cluster id

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/SaasOrgAndClusterIdBackfill.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/SaasOrgAndClusterIdBackfill.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.security.api.model.config.SaasConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * Makes {@code camunda.security.saas.cluster-id} and {@code camunda.security.saas.organization-id}
+ * sufficient on their own, so a CCSaaS deployment no longer has to set the legacy {@code
+ * CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID} / {@code CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION} pair as well
+ * (camunda/camunda#61604).
+ *
+ * <p>Three blocks of {@code service-config.yaml} read the legacy pair: {@code security.auth.cloud},
+ * {@code analytics.mixpanel.properties} and {@code onboarding.properties}. Without the legacy keys
+ * the first resolves to an empty string, which fails startup in {@link
+ * OptimizeCloudSecurityConfiguration}, while the other two fall back to their {@code dev} defaults
+ * and report a wrong organization and cluster id to the UI.
+ *
+ * <p>The fallback cannot live in {@code service-config.yaml}: its {@code ${...}} placeholders are
+ * resolved by Optimize's own {@code ConfigurationParser} against system properties and environment
+ * variables only, in a single pass, so the inner placeholder of a {@code
+ * ${LEGACY:${camunda.security.saas.cluster-id:}}} chain would be stored verbatim.
+ *
+ * <p>Binds CSL's own {@link SaasConfiguration} under CSL's own prefix rather than looking the two
+ * properties up by name. Relaxed binding accepts spellings {@code Environment#getProperty} does
+ * not, and the SaaS control plane emits one of them ({@code CAMUNDA_SECURITY_SAAS_CLUSTERID}, with
+ * no underscore before {@code ID}). Binding what CSL binds keeps the two in agreement whatever the
+ * operator sets.
+ *
+ * <p>A legacy key that is set still wins, so existing CCSaaS deployments are unaffected, and the
+ * {@code dev} defaults still apply when neither pair is set. "Set" is checked the same way {@code
+ * ConfigurationParser} resolves it, {@code System.getProperty} then {@code System.getenv}, not
+ * {@code Environment#getProperty}, which also sees command-line args, {@code application.yaml} and
+ * {@code spring.config.import} — sources {@code ConfigurationParser} never reads, so a legacy key
+ * set only through one of those would otherwise look "set" here while the value never actually
+ * reached {@code ConfigurationService}.
+ *
+ * <p>Independent of {@link OptimizeSecurityConfigCompatibilityPostProcessor}, so it outlives that
+ * bridge's removal in 8.11 (camunda/camunda#58485).
+ */
+@Component
+public class SaasOrgAndClusterIdBackfill implements BeanPostProcessor {
+
+  static final String LEGACY_CLUSTER_ID_KEY = "CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID";
+  static final String LEGACY_ORGANIZATION_ID_KEY = "CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION";
+
+  private static final String SAAS_PREFIX = "camunda.security.saas";
+
+  private static final Logger LOG = LoggerFactory.getLogger(SaasOrgAndClusterIdBackfill.class);
+
+  private final Environment environment;
+
+  public SaasOrgAndClusterIdBackfill(final Environment environment) {
+    this.environment = environment;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(final Object bean, final String beanName) {
+    if (bean instanceof final ConfigurationService configurationService) {
+      backfill(configurationService);
+    }
+    return bean;
+  }
+
+  private void backfill(final ConfigurationService configurationService) {
+    final SaasConfiguration saas =
+        Binder.get(environment).bind(SAAS_PREFIX, SaasConfiguration.class).orElse(null);
+    if (saas == null) {
+      return;
+    }
+    if (isBackfillable(saas.getClusterId(), LEGACY_CLUSTER_ID_KEY)) {
+      setClusterId(configurationService, saas.getClusterId());
+      LOG.info(
+          "Optimize's cluster id was not set via '{}', backfilling it from '{}'",
+          LEGACY_CLUSTER_ID_KEY,
+          SAAS_PREFIX + ".cluster-id");
+    }
+    if (isBackfillable(saas.getOrganizationId(), LEGACY_ORGANIZATION_ID_KEY)) {
+      setOrganizationId(configurationService, saas.getOrganizationId());
+      LOG.info(
+          "Optimize's organization id was not set via '{}', backfilling it from '{}'",
+          LEGACY_ORGANIZATION_ID_KEY,
+          SAAS_PREFIX + ".organization-id");
+    }
+  }
+
+  private static void setClusterId(
+      final ConfigurationService configurationService, final String clusterId) {
+    configurationService.getAuthConfiguration().getCloudAuthConfiguration().setClusterId(clusterId);
+    configurationService.getAnalytics().getMixpanel().getProperties().setClusterId(clusterId);
+    configurationService.getOnboarding().getProperties().setClusterId(clusterId);
+  }
+
+  private static void setOrganizationId(
+      final ConfigurationService configurationService, final String organizationId) {
+    configurationService
+        .getAuthConfiguration()
+        .getCloudAuthConfiguration()
+        .setOrganizationId(organizationId);
+    configurationService
+        .getAnalytics()
+        .getMixpanel()
+        .getProperties()
+        .setOrganizationId(organizationId);
+    configurationService.getOnboarding().getProperties().setOrganizationId(organizationId);
+  }
+
+  // Mirrors how ConfigurationParser resolves the legacy placeholders: System.getProperty, then
+  // System.getenv, nothing else. environment.getProperty also sees command-line args,
+  // application.yaml and spring.config.import, none of which ConfigurationParser reads, so a
+  // legacy key set through one of those would make this treat the key as set while
+  // ConfigurationService never actually received the value.
+  private static boolean isBackfillable(final String saasValue, final String legacyKey) {
+    return !isBlank(saasValue) && isBlank(legacyValue(legacyKey));
+  }
+
+  private static String legacyValue(final String legacyKey) {
+    final String systemProperty = System.getProperty(legacyKey);
+    return systemProperty != null ? systemProperty : System.getenv(legacyKey);
+  }
+
+  private static boolean isBlank(final String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/SaasOrgAndClusterIdBackfillTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/SaasOrgAndClusterIdBackfillTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static io.camunda.optimize.rest.security.csl.SaasOrgAndClusterIdBackfill.LEGACY_CLUSTER_ID_KEY;
+import static io.camunda.optimize.rest.security.csl.SaasOrgAndClusterIdBackfill.LEGACY_ORGANIZATION_ID_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import io.camunda.optimize.service.util.configuration.security.CloudAuthConfiguration;
+import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.oidc.TokenValidatorFactory;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Pins the CSL-only CCSaaS configuration: {@code camunda.security.saas.*} alone must drive every
+ * consumer of the legacy cluster id and organization id, so the legacy pair can be dropped from the
+ * SaaS control plane and the behaviour survives the removal of {@link
+ * OptimizeSecurityConfigCompatibilityPostProcessor} in 8.11 (camunda/camunda#58485).
+ */
+class SaasOrgAndClusterIdBackfillTest {
+
+  private static final String CLUSTER_ID = "cluster-from-csl";
+  private static final String ORGANIZATION_ID = "org-from-csl";
+  private static final String DEV_DEFAULT = "dev";
+
+  @AfterEach
+  void clearLegacySystemProperties() {
+    System.clearProperty(LEGACY_CLUSTER_ID_KEY);
+    System.clearProperty(LEGACY_ORGANIZATION_ID_KEY);
+  }
+
+  @Test
+  void shouldBackfillEveryConsumerFromCamundaSecuritySaas() {
+    // given
+    final ConfigurableEnvironment environment =
+        environmentWith(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.saas.cluster-id", CLUSTER_ID,
+                    "camunda.security.saas.organization-id", ORGANIZATION_ID)));
+
+    // when
+    final ConfigurationService configuration = backfilledConfiguration(environment);
+
+    // then
+    assertThat(cloudAuth(configuration).getClusterId()).isEqualTo(CLUSTER_ID);
+    assertThat(cloudAuth(configuration).getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+    assertThat(configuration.getAnalytics().getMixpanel().getProperties().getClusterId())
+        .isEqualTo(CLUSTER_ID);
+    assertThat(configuration.getAnalytics().getMixpanel().getProperties().getOrganizationId())
+        .isEqualTo(ORGANIZATION_ID);
+    assertThat(configuration.getOnboarding().getProperties().getClusterId()).isEqualTo(CLUSTER_ID);
+    assertThat(configuration.getOnboarding().getProperties().getOrganizationId())
+        .isEqualTo(ORGANIZATION_ID);
+  }
+
+  @Test
+  void shouldBackfillFromTheEnvironmentVariableSpellingTheControlPlaneEmits() {
+    // given the spelling camunda/camunda-operator emits, which only relaxed binding resolves
+    final ConfigurableEnvironment environment =
+        environmentWith(
+            new SystemEnvironmentPropertySource(
+                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                Map.of(
+                    "CAMUNDA_SECURITY_SAAS_CLUSTERID", CLUSTER_ID,
+                    "CAMUNDA_SECURITY_SAAS_ORGANIZATIONID", ORGANIZATION_ID)));
+
+    // when
+    final ConfigurationService configuration = backfilledConfiguration(environment);
+
+    // then
+    assertThat(cloudAuth(configuration).getClusterId()).isEqualTo(CLUSTER_ID);
+    assertThat(cloudAuth(configuration).getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+  }
+
+  @Test
+  void shouldKeepLegacyValuesWhenBothPairsAreSet() {
+    // given
+    System.setProperty(LEGACY_CLUSTER_ID_KEY, "cluster-from-legacy");
+    System.setProperty(LEGACY_ORGANIZATION_ID_KEY, "org-from-legacy");
+    final ConfigurableEnvironment environment =
+        environmentWith(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.saas.cluster-id", CLUSTER_ID,
+                    "camunda.security.saas.organization-id", ORGANIZATION_ID)));
+
+    // when
+    final ConfigurationService configuration = backfilledConfiguration(environment);
+
+    // then
+    assertThat(cloudAuth(configuration).getClusterId()).isEqualTo("cluster-from-legacy");
+    assertThat(cloudAuth(configuration).getOrganizationId()).isEqualTo("org-from-legacy");
+    assertThat(configuration.getAnalytics().getMixpanel().getProperties().getClusterId())
+        .isEqualTo("cluster-from-legacy");
+    assertThat(configuration.getOnboarding().getProperties().getOrganizationId())
+        .isEqualTo("org-from-legacy");
+  }
+
+  @Test
+  void shouldKeepShippedDefaultsWhenNeitherPairIsSet() {
+    // given
+    final ConfigurableEnvironment environment =
+        environmentWith(new MapPropertySource("test", Map.of()));
+
+    // when
+    final ConfigurationService configuration = backfilledConfiguration(environment);
+
+    // then
+    assertThat(cloudAuth(configuration).getClusterId()).isEmpty();
+    assertThat(cloudAuth(configuration).getOrganizationId()).isEmpty();
+    assertThat(configuration.getAnalytics().getMixpanel().getProperties().getClusterId())
+        .isEqualTo(DEV_DEFAULT);
+    assertThat(configuration.getOnboarding().getProperties().getOrganizationId())
+        .isEqualTo(DEV_DEFAULT);
+  }
+
+  @Test
+  void shouldRejectForeignClusterTokenWhenConfiguredOnlyByCamundaSecuritySaas() {
+    // given
+    final ConfigurableEnvironment environment =
+        environmentWith(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.saas.cluster-id", CLUSTER_ID,
+                    "camunda.security.saas.organization-id", ORGANIZATION_ID)));
+    final ConfigurationService configuration = backfilledConfiguration(environment);
+
+    // when
+    final OAuth2TokenValidator<Jwt> validator = clusterValidator(configuration);
+
+    // then
+    assertThat(
+            validator
+                .validate(jwt(Map.of(OptimizeCloudClusterValidator.CLUSTER_CLAIM, CLUSTER_ID)))
+                .hasErrors())
+        .isFalse();
+    assertThat(
+            validator
+                .validate(jwt(Map.of(OptimizeCloudClusterValidator.CLUSTER_CLAIM, "other-cluster")))
+                .hasErrors())
+        .isTrue();
+  }
+
+  @Test
+  void shouldApplyTheBackfillToTheConfigurationServiceBeanTheApplicationUses() {
+    // given the real bean factory and the backfill registered as a BeanPostProcessor, so this
+    // covers what the other tests cannot: that Spring runs the backfill against the
+    // ConfigurationService every consumer is injected with, rather than a hand-built one
+    new ApplicationContextRunner()
+        .withUserConfiguration(ConfigurationServiceBuilder.class, SaasOrgAndClusterIdBackfill.class)
+        .withPropertyValues(
+            "camunda.security.saas.cluster-id=" + CLUSTER_ID,
+            "camunda.security.saas.organization-id=" + ORGANIZATION_ID)
+
+        // when
+        .run(
+            context -> {
+              // then
+              assertThat(context).hasNotFailed();
+              final ConfigurationService configuration =
+                  context.getBean(ConfigurationService.class);
+              assertThat(cloudAuth(configuration).getClusterId()).isEqualTo(CLUSTER_ID);
+              assertThat(cloudAuth(configuration).getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+              assertThat(configuration.getOnboarding().getProperties().getClusterId())
+                  .isEqualTo(CLUSTER_ID);
+            });
+  }
+
+  private static ConfigurationService backfilledConfiguration(
+      final ConfigurableEnvironment environment) {
+    final ConfigurationService configuration =
+        ConfigurationServiceBuilder.createDefaultConfiguration();
+    new SaasOrgAndClusterIdBackfill(environment)
+        .postProcessAfterInitialization(configuration, "configurationService");
+    return configuration;
+  }
+
+  // The real system environment is dropped so a CAMUNDA_SECURITY_SAAS_* variable set on the machine
+  // running the tests cannot decide the outcome. System properties stay, because they are how a
+  // test feeds the legacy keys to both ConfigurationParser and the backfill.
+  private static ConfigurableEnvironment environmentWith(final PropertySource<?> source) {
+    final StandardEnvironment environment = new StandardEnvironment();
+    environment
+        .getPropertySources()
+        .remove(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME);
+    environment.getPropertySources().addFirst(source);
+    return environment;
+  }
+
+  private static CloudAuthConfiguration cloudAuth(final ConfigurationService configuration) {
+    return configuration.getAuthConfiguration().getCloudAuthConfiguration();
+  }
+
+  private static OAuth2TokenValidator<Jwt> clusterValidator(
+      final ConfigurationService configuration) {
+    final OidcProviderConfigurationPort oidcProviderConfigurationPort =
+        mock(OidcProviderConfigurationPort.class);
+    when(oidcProviderConfigurationPort.getOidcAuthenticationConfigurations()).thenReturn(Map.of());
+    final TokenValidatorFactory factory =
+        new OptimizeCloudSecurityConfiguration()
+            .tokenValidatorFactory(
+                oidcProviderConfigurationPort,
+                configuration,
+                new CamundaSecurityLibraryProperties());
+    return factory.createTokenValidator(clientRegistration());
+  }
+
+  private static ClientRegistration clientRegistration() {
+    return ClientRegistration.withRegistrationId("oidc")
+        .clientId("optimize")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/api/authentication/callback")
+        .authorizationUri("http://idp/authorize")
+        .tokenUri("http://idp/token")
+        .build();
+  }
+
+  private static Jwt jwt(final Map<String, Object> claims) {
+    final Instant now = Instant.now();
+    final Jwt.Builder builder =
+        Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .issuedAt(now)
+            .expiresAt(now.plusSeconds(300))
+            .subject("user");
+    claims.forEach(builder::claim);
+    return builder.build();
+  }
+}

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -52,10 +52,7 @@ const cloudEnv = {
   SPRING_PROFILES_ACTIVE: 'cloud',
   ZEEBE_IMPORT_ENABLED: 'true',
 
-  // Not auth config. Optimize's own SaaS access control reads these and fails startup on a
-  // blank value, and the M2M Accounts client needs the token url and audience.
-  CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID: 'optimize-e2e-cloud',
-  CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION: 'f4e522a8-f642-4293-b5cb-1d14e1730534',
+  // Not auth config. The M2M Accounts client needs the token url and audience.
   CAMUNDA_OPTIMIZE_AUTH0_TOKEN_URL: 'https://login.cloud.dev.ultrawombat.com/oauth/token',
   CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_URL: 'https://accounts.cloud.dev.ultrawombat.com',
   CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_AUTH0_AUDIENCE: 'cloud.dev.ultrawombat.com',


### PR DESCRIPTION
Makes `camunda.security.saas.cluster-id` and
`camunda.security.saas.organization-id` sufficient on their own, so the SaaS
control plane can stop emitting `CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID` and
`CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION` alongside them.

Three blocks of `service-config.yaml` read the legacy pair
(`security.auth.cloud`, `analytics.mixpanel.properties`,
`onboarding.properties`). Without it, the first resolves to an empty string and
fails startup in `OptimizeCloudSecurityConfiguration`, and the other two
silently report a wrong organization and cluster id to the UI.

### Approach, and one correction to the issue

The issue proposed a nested placeholder default in `service-config.yaml`. That
does not work: those placeholders are resolved by Optimize's own
`ConfigurationParser`, not by Spring, and it neither accepts dots in a variable
name nor re-resolves a default, so the inner placeholder would be stored
verbatim.

The values are therefore back-filled in Java, by binding CSL's own
`SaasConfiguration` under CSL's own prefix. Looking the properties up by name
would not do: the operator emits `CAMUNDA_SECURITY_SAAS_CLUSTERID`, with no
underscore before `ID`, which only relaxed binding resolves. Binding what CSL
binds keeps the two in agreement whatever an operator sets.

The back-fill runs as a `BeanPostProcessor` on the `ConfigurationService` bean,
which guarantees it happens before any consumer is injected. Calling it
directly from the bean factory in `optimize-commons` would have been simpler,
but `Binder` comes from `org.springframework.boot:spring-boot`, which that
module does not declare; `optimize-backend` already does, so placing it there
avoids a pom change entirely. `dependency:analyze` is clean.

Legacy keys still win when both pairs are set, and the `dev` defaults still
apply when neither is. Nothing depends on the compat bridge, so this survives
its removal in #58485.

### Testing

Six tests pinning the CSL-only configuration, including a foreign cluster id
being rejected by the validator and an `ApplicationContextRunner` test proving
Spring actually applies the back-fill to the bean the application uses. Full
`optimize-backend` suite green (1225 tests).

Not covered here: dev-cluster verification. The `camunda/camunda-operator`
change that drops the legacy pair is separate and later: the operator keeps
emitting both pairs for now, and only stops emitting the legacy two once the
8.11 compat-bridge cleanup lands.

## Related issues

closes #61604
relates to #58486