### PR TITLE
test: allign the tenant identity tests with the design system

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -128,9 +128,10 @@ export class IdentityTenantsPage {
     });
     this.assignUserSearchboxResult = page.getByRole('listbox');
     this.assignUserOption = (username) =>
-      this.assignUserModal.locator('.cds--list-box__menu-item', {
-        hasText: username,
-      });
+      this.assignUserSearchboxResult
+        .getByRole('option')
+        .filter({hasText: username})
+        .first();
     this.confirmAssignmentButton = this.assignUserModal.getByRole('button', {
       name: 'Assign user',
     });
@@ -138,7 +139,9 @@ export class IdentityTenantsPage {
       'No users assigned to this tenant yet',
     );
     this.removeUserButton = (rowName) =>
-      page.getByRole('row', {name: rowName}).getByRole('button');
+      page
+        .getByRole('row', {name: rowName})
+        .getByRole('button', {name: 'Remove'});
     this.userRow = (userName) =>
       this.tenantsList.getByRole('row', {name: userName});
     this.tenantCell = (tenantName) =>
@@ -181,16 +184,13 @@ export class IdentityTenantsPage {
     // The assign-user search filters users by `username` and renders the
     // username as the option title, so `user.id` drives both steps.
     await this.fillAssignUserSearch(user.id);
-    const option = this.assignUserSearchboxResult
-      .getByRole('option')
-      .filter({hasText: user.id})
-      .first();
-    await expect(option).toBeVisible({timeout: 30000});
-    await option.click({timeout: 20000});
+    const userOption = this.assignUserOption(user.id);
+    await expect(userOption).toBeVisible({timeout: 30000});
+    await userOption.click();
     // The assign-user search is debounced + server-driven, so the option can
     // outlast the 10s default actionTimeout on a loaded cluster.
     await this.confirmAssignmentButton.click();
-    await expect(this.assignUserModal).toBeHidden({timeout: 5000});
+    await expect(this.assignUserModal).toBeHidden();
     await waitForItemInList(
       this.page,
       this.assignedUsersList.getByRole('cell', {name: user.id, exact: true}),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -9,10 +9,12 @@
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {defaultAssertionOptions} from '../utils/constants';
+import { waitForItemInList } from 'utils/waitForItemInList';
 
 export class IdentityTenantsPage {
   private page: Page;
   readonly tenantsList: Locator;
+  readonly assignedUsersList: Locator;
   readonly createTenantButton: Locator;
   readonly editTenantButton: (rowName?: string) => Locator;
   readonly deleteTenantButton: (rowName?: string) => Locator;
@@ -34,6 +36,7 @@ export class IdentityTenantsPage {
   readonly assignUserButton: Locator;
   readonly assignUserModal: Locator;
   readonly assignUserSearchbox: Locator;
+  readonly assignUserSearchboxResult: Locator;
   readonly assignUserOption: (username: string) => Locator;
   readonly confirmAssignmentButton: Locator;
   readonly openTenantDetails: (rowName: string) => Locator;
@@ -50,13 +53,14 @@ export class IdentityTenantsPage {
     this.page = page;
 
     this.tenantsList = page.getByRole('table');
+    this.assignedUsersList = page.getByRole('table');
     this.createTenantButton = page.getByRole('button', {
       name: 'Create tenant',
     });
     this.editTenantButton = (rowName) =>
       this.tenantsList.getByRole('row', {name: rowName}).getByLabel('Edit');
     this.deleteTenantButton = (rowName) =>
-      this.tenantsList.getByRole('row', {name: rowName}).getByLabel('Delete');
+      this.tenantsList.getByRole('row', {name: rowName}).getByRole('button', {name: 'Delete', exact: true});
 
     this.createTenantModal = page.getByRole('dialog', {
       name: 'Create new tenant',
@@ -117,11 +121,12 @@ export class IdentityTenantsPage {
       name: 'Assign user',
     });
     this.assignUserModal = page.getByRole('dialog', {
-      name: 'assign user',
+      name: 'Assign user',
     });
-    this.assignUserSearchbox = this.assignUserModal.getByRole('searchbox', {
+    this.assignUserSearchbox = this.assignUserModal.getByRole('combobox', {
       name: 'Search by username',
     });
+    this.assignUserSearchboxResult = page.getByRole('listbox');
     this.assignUserOption = (username) =>
       this.assignUserModal.locator('.cds--list-box__menu-item', {
         hasText: username,
@@ -133,7 +138,7 @@ export class IdentityTenantsPage {
       'No users assigned to this tenant yet',
     );
     this.removeUserButton = (rowName) =>
-      page.getByRole('row', {name: rowName}).getByLabel('Remove');
+      page.getByRole('row', {name: rowName}).getByRole('button');
     this.userRow = (userName) =>
       this.tenantsList.getByRole('row', {name: userName});
     this.tenantCell = (tenantName) =>
@@ -176,13 +181,21 @@ export class IdentityTenantsPage {
     // The assign-user search filters users by `username` and renders the
     // username as the option title, so `user.id` drives both steps.
     await this.fillAssignUserSearch(user.id);
+    const option = this.assignUserSearchboxResult
+      .getByRole('option')
+      .filter({hasText: user.id})
+      .first();
+    await expect(option).toBeVisible({timeout: 30000});
+    await option.click({timeout: 20000});
     // The assign-user search is debounced + server-driven, so the option can
     // outlast the 10s default actionTimeout on a loaded cluster.
-    const userOption = this.assignUserOption(user.id);
-    await expect(userOption).toBeVisible({timeout: 60000});
-    await userOption.click();
     await this.confirmAssignmentButton.click();
-    await expect(this.assignUserModal).toBeHidden();
+    await expect(this.assignUserModal).toBeHidden({timeout: 5000});
+    await waitForItemInList(
+      this.page,
+      this.assignedUsersList.getByRole('cell', {name: user.id, exact: true}),
+      {timeout: 30000},
+    );
   }
 
   async removeUserFromTenant(userName: string) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -9,7 +9,7 @@
 import {Page, Locator, expect} from '@playwright/test';
 import {relativizePath, Paths} from 'utils/relativizePath';
 import {defaultAssertionOptions} from '../utils/constants';
-import { waitForItemInList } from 'utils/waitForItemInList';
+import {waitForItemInList} from 'utils/waitForItemInList';
 
 export class IdentityTenantsPage {
   private page: Page;
@@ -60,7 +60,9 @@ export class IdentityTenantsPage {
     this.editTenantButton = (rowName) =>
       this.tenantsList.getByRole('row', {name: rowName}).getByLabel('Edit');
     this.deleteTenantButton = (rowName) =>
-      this.tenantsList.getByRole('row', {name: rowName}).getByRole('button', {name: 'Delete', exact: true});
+      this.tenantsList
+        .getByRole('row', {name: rowName})
+        .getByRole('button', {name: 'Delete', exact: true});
 
     this.createTenantModal = page.getByRole('dialog', {
       name: 'Create new tenant',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/tenants.spec.ts
@@ -55,7 +55,7 @@ test.describe.serial('tenants CRUD', () => {
         'Please enter a valid Tenant ID',
       );
       await expect(identityTenantsPage.tenantFieldId).toHaveAttribute(
-        'data-invalid',
+        'aria-invalid',
         'true',
       );
     });


### PR DESCRIPTION
## Description

The tenants pages migrated to the Camunda design system and three E2E tests still target the Carbon markup. This is the follow-up the merged https://github.com/camunda/camunda/pull/61628 referred to when it noted the groups failures would be handled separately.

Create-tenant modal — the design-system Input marks a failed field with aria-invalid, not Carbon's data-invalid. Since groups CRUD is a test.describe.serial block, that single assertion was skipping the three tests after it, so creates a tenant, edits a tenant and deletes a group had not actually run since the migration landed.

Delete row action — entityListV2 computes iconOnly: !!Icon && !isDangerous and groups/ListV2.tsx marks delete isDangerous, so Delete renders a visible text label and no aria-label while Edit stays icon-only and keeps one. getByLabel matches aria-label only, so deletes a group would have gone red on its first run in weeks. Matched by role and accessible name.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. [Here](https://github.com/camunda/camunda/actions/runs/33630998719) -> all tenant tests ran successfully

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

