### PR TITLE
deps: bump hardened base image digest to 03f8879 (stable/optimize-8.7)

### DIFF
--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -4,7 +4,7 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:728ccf1d6dd2dc032e2e9f864f5ed29e324d459dc07569f8881f65d84b99b451"
+ARG BASE_DIGEST="sha256:03f8879ab01450363c4ee1224189ade068d66a37c15b9e0cb2652f82e36f7b29"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:728ccf1d6dd2dc032e2e9f864f5ed29e324d459dc07569f8881f65d84b99b451"
+ARG BASE_DIGEST="sha256:03f8879ab01450363c4ee1224189ade068d66a37c15b9e0cb2652f82e36f7b29"
 ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
 # If you don't have access to Minimus hardened base images, you can use public


### PR DESCRIPTION
## Summary
- Bumps the Minimus hardened base image digest (`reg.mini.dev/1212/openjre-base-compat:21-dev`) in `camunda.Dockerfile` and `optimize.Dockerfile` from `728ccf1d...` to `03f8879ab0...`.
- Picks up the Minimus rebuild that fixes the OpenSSL security advisory batch disclosed 2026-08-25: CVE-2026-63074, CVE-2026-63075, CVE-2026-75803 (all assessed as not-affected for Camunda's own code paths, but bumped defensively per policy).
- `stable/optimize-8.7` has no `.github/renovate.json5`, so this bump isn't automated on this branch — done manually here. The same digest was already applied on `stable/8.7` (#61735) and `stable/8.8` (#61683) via Renovate.

## Test plan
- [ ] CI build/image build passes on this branch