### PR TITLE
refactor: group cluster transports behind a managed network service

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -27,14 +27,12 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.ManagedClusterCommunicationService;
 import io.atomix.cluster.messaging.ManagedClusterEventService;
-import io.atomix.cluster.messaging.ManagedMessagingService;
-import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.cluster.messaging.ManagedNetworkService;
 import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.cluster.messaging.impl.DefaultClusterCommunicationService;
 import io.atomix.cluster.messaging.impl.DefaultClusterEventService;
-import io.atomix.cluster.messaging.impl.NettyMessagingService;
-import io.atomix.cluster.messaging.impl.NettyUnicastService;
+import io.atomix.cluster.messaging.impl.NettyNetworkService;
 import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.utils.Managed;
 import io.atomix.utils.Version;
@@ -44,6 +42,7 @@ import io.atomix.utils.net.Address;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,8 +91,7 @@ import org.slf4j.LoggerFactory;
 public class AtomixCluster implements BootstrapService, Managed<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AtomixCluster.class);
-  protected final ManagedMessagingService messagingService;
-  protected final ManagedUnicastService unicastService;
+  protected final ManagedNetworkService networkService;
   protected final NodeDiscoveryProvider discoveryProvider;
   protected final GroupMembershipProtocol membershipProtocol;
   protected final ManagedClusterMembershipService membershipService;
@@ -109,24 +107,19 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
       final Version version,
       final String actorSchedulerName,
       final MeterRegistry registry) {
-    this(config, version, null, null, actorSchedulerName, registry);
+    this(config, version, null, actorSchedulerName, registry);
   }
 
   protected AtomixCluster(
       final ClusterConfig config,
       final Version version,
-      final ManagedMessagingService messagingService,
-      final ManagedUnicastService unicastService,
+      final ManagedNetworkService networkService,
       final String actorSchedulerName,
       final MeterRegistry registry) {
-    this.messagingService =
-        messagingService != null
-            ? messagingService
-            : buildMessagingService(config, actorSchedulerName, registry);
-    this.unicastService =
-        unicastService != null
-            ? unicastService
-            : buildUnicastService(config, actorSchedulerName, registry);
+    this.networkService =
+        networkService != null
+            ? networkService
+            : buildNetworkService(config, actorSchedulerName, registry, threadContext);
 
     discoveryProvider = buildLocationProvider(config);
     membershipProtocol = buildMembershipProtocol(config, actorSchedulerName, registry);
@@ -170,7 +163,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
    */
   @Override
   public MessagingService getMessagingService() {
-    return messagingService;
+    return networkService.messagingService();
   }
 
   /**
@@ -184,7 +177,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
    */
   @Override
   public UnicastService getUnicastService() {
-    return unicastService;
+    return networkService.unicastService();
   }
 
   /**
@@ -254,9 +247,8 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   }
 
   protected CompletableFuture<Void> startServices() {
-    return messagingService
+    return networkService
         .start()
-        .thenComposeAsync(v -> unicastService.start(), threadContext)
         .thenComposeAsync(v -> membershipService.start(), threadContext)
         .thenComposeAsync(v -> communicationService.start(), threadContext)
         .thenComposeAsync(v -> eventService.start(), threadContext)
@@ -281,10 +273,8 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
         .exceptionally(e -> logServiceStopError("eventService", e))
         .thenComposeAsync(v -> membershipService.stop(), threadContext)
         .exceptionally(e -> logServiceStopError("membershipService", e))
-        .thenComposeAsync(v -> unicastService.stop(), threadContext)
-        .exceptionally(e -> logServiceStopError("unicastService", e))
-        .thenComposeAsync(v -> messagingService.stop(), threadContext)
-        .exceptionally(e -> logServiceStopError("messagingService", e));
+        .thenComposeAsync(v -> networkService.stop(), threadContext)
+        .exceptionally(e -> logServiceStopError("networkService", e));
   }
 
   protected CompletableFuture<Void> completeShutdown() {
@@ -299,26 +289,19 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
     return toStringHelper(this).toString();
   }
 
-  /** Builds a default messaging service. */
-  protected static ManagedMessagingService buildMessagingService(
-      final ClusterConfig config, final String actorSchedulerName, final MeterRegistry registry) {
-    return new NettyMessagingService(
+  /** Builds the default network service, i.e. the node's messaging and unicast transports. */
+  protected static ManagedNetworkService buildNetworkService(
+      final ClusterConfig config,
+      final String actorSchedulerName,
+      final MeterRegistry registry,
+      final Executor executor) {
+    return new NettyNetworkService(
         config.getClusterId(),
         config.getNodeConfig().getAddress(),
         config.getMessagingConfig(),
         actorSchedulerName,
-        registry);
-  }
-
-  /** Builds a default unicast service. */
-  protected static ManagedUnicastService buildUnicastService(
-      final ClusterConfig config, final String actorSchedulerName, final MeterRegistry registry) {
-    return new NettyUnicastService(
-        config.getClusterId(),
-        config.getNodeConfig().getAddress(),
-        config.getMessagingConfig(),
-        actorSchedulerName,
-        registry);
+        registry,
+        executor);
   }
 
   /** Builds a member location provider. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ManagedNetworkService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ManagedNetworkService.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging;
+
+import io.atomix.utils.Managed;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A {@link NetworkService} that also owns the lifecycle of the transports behind it.
+ *
+ * <p>This is the single point at which a node's peer-to-peer transports are started and stopped.
+ */
+@NullMarked
+public interface ManagedNetworkService extends NetworkService, Managed<NetworkService> {}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/NetworkService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/NetworkService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The set of transports a cluster node uses to talk to its peers, grouped behind a single owner.
+ *
+ * <p>A node communicates over two complementary primitives: {@link MessagingService} for reliable,
+ * addressed messages (requests, replies, fire-and-forget sends), and {@link UnicastService} for
+ * unreliable fire-and-forget messages.
+ *
+ * <p>Expected usage is for the caller to use the accessor (e.g. {@link #messagingService()})
+ * depending on the messaging semantics required.
+ */
+@NullMarked
+public interface NetworkService {
+
+  /**
+   * Returns the service for reliable, addressed messaging with peers.
+   *
+   * @return the messaging primitive
+   */
+  MessagingService messagingService();
+
+  /**
+   * Returns the service for unreliable, fire-and-forget messaging with peers.
+   *
+   * @return the unicast primitive
+   */
+  UnicastService unicastService();
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyNetworkService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyNetworkService.java
@@ -15,6 +15,7 @@ import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.NetworkService;
 import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -54,11 +55,20 @@ public final class NettyNetworkService implements ManagedNetworkService {
       final String actorSchedulerName,
       final MeterRegistry registry,
       final Executor executor) {
-    messagingService =
+    this(
         new NettyMessagingService(
-            clusterId, advertisedAddress, config, actorSchedulerName, registry);
-    unicastService =
-        new NettyUnicastService(clusterId, advertisedAddress, config, actorSchedulerName, registry);
+            clusterId, advertisedAddress, config, actorSchedulerName, registry),
+        new NettyUnicastService(clusterId, advertisedAddress, config, actorSchedulerName, registry),
+        executor);
+  }
+
+  @VisibleForTesting
+  NettyNetworkService(
+      final ManagedMessagingService messagingService,
+      final ManagedUnicastService unicastService,
+      final Executor executor) {
+    this.messagingService = messagingService;
+    this.unicastService = unicastService;
     this.executor = executor;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyNetworkService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyNetworkService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.atomix.cluster.messaging.ManagedNetworkService;
+import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.cluster.messaging.NetworkService;
+import io.atomix.cluster.messaging.UnicastService;
+import io.atomix.utils.net.Address;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link ManagedNetworkService} backed by Netty, pairing a TCP {@link NettyMessagingService} with
+ * a UDP {@link NettyUnicastService}.
+ *
+ * <p>Both transports are brought up here so that callers never have to order them: messaging starts
+ * first and stops last.
+ *
+ * <p>Note that we only expose the non-managed interfaces; this ensures the life cycle of the
+ * wrapped managed services are never controlled except in this class.
+ *
+ * <p>Both transitions are chained on a caller-provided {@link Executor}, so that neither transport
+ * is driven from a thread belonging to the other: the messaging service completes its start future
+ * on a Netty event loop, where binding the unicast transport would do set up work on a thread meant
+ * to stay free. The executor is borrowed, not owned, and must stay usable until {@link #stop()}
+ * completes.
+ */
+@NullMarked
+public final class NettyNetworkService implements ManagedNetworkService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NettyNetworkService.class);
+
+  private final ManagedMessagingService messagingService;
+  private final ManagedUnicastService unicastService;
+  private final Executor executor;
+
+  public NettyNetworkService(
+      final String clusterId,
+      final Address advertisedAddress,
+      final MessagingConfig config,
+      final String actorSchedulerName,
+      final MeterRegistry registry,
+      final Executor executor) {
+    messagingService =
+        new NettyMessagingService(
+            clusterId, advertisedAddress, config, actorSchedulerName, registry);
+    unicastService =
+        new NettyUnicastService(clusterId, advertisedAddress, config, actorSchedulerName, registry);
+    this.executor = executor;
+  }
+
+  @Override
+  public MessagingService messagingService() {
+    return messagingService;
+  }
+
+  @Override
+  public UnicastService unicastService() {
+    return unicastService;
+  }
+
+  @Override
+  public CompletableFuture<NetworkService> start() {
+    return messagingService
+        .start()
+        .thenComposeAsync(ignored -> unicastService.start(), executor)
+        .thenApply(ignored -> this);
+  }
+
+  @Override
+  public boolean isRunning() {
+    return messagingService.isRunning() && unicastService.isRunning();
+  }
+
+  @Override
+  public CompletableFuture<Void> stop() {
+    // recover from a failed unicast stop so the messaging transport is still torn down; leaking it
+    // would keep the node reachable after shutdown
+    return unicastService
+        .stop()
+        .exceptionally(
+            error -> {
+              LOGGER.error("Failed to stop the unicast service", error);
+              return null;
+            })
+        .thenComposeAsync(ignored -> messagingService.stop(), executor);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyNetworkServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyNetworkServiceTest.java
@@ -9,49 +9,73 @@ package io.atomix.cluster.messaging.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.ManagedUnicastService;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 final class NettyNetworkServiceTest {
+
+  private final AtomicBoolean messagingStarted = new AtomicBoolean();
+  private final AtomicBoolean messagingStopped = new AtomicBoolean();
+  private final AtomicBoolean unicastStarted = new AtomicBoolean();
+  private final AtomicBoolean unicastStopped = new AtomicBoolean();
 
   private final ManagedMessagingService messagingService = mock(ManagedMessagingService.class);
   private final ManagedUnicastService unicastService = mock(ManagedUnicastService.class);
   private final NettyNetworkService networkService =
       new NettyNetworkService(messagingService, unicastService, Runnable::run);
 
+  NettyNetworkServiceTest() {
+    when(messagingService.start())
+        .thenAnswer(
+            invocation -> {
+              messagingStarted.set(true);
+              return CompletableFuture.completedFuture(messagingService);
+            });
+    when(messagingService.stop())
+        .thenAnswer(
+            invocation -> {
+              messagingStopped.set(true);
+              return CompletableFuture.completedFuture(null);
+            });
+    when(unicastService.start())
+        .thenAnswer(
+            invocation -> {
+              unicastStarted.set(true);
+              return CompletableFuture.completedFuture(unicastService);
+            });
+    when(unicastService.stop())
+        .thenAnswer(
+            invocation -> {
+              unicastStopped.set(true);
+              return CompletableFuture.completedFuture(null);
+            });
+  }
+
   @Test
   void shouldStartBothTransports() {
-    // given
-    when(messagingService.start()).thenReturn(CompletableFuture.completedFuture(messagingService));
-    when(unicastService.start()).thenReturn(CompletableFuture.completedFuture(unicastService));
-
     // when
     final var started = networkService.start().join();
 
     // then
-    verify(messagingService).start();
-    verify(unicastService).start();
+    assertThat(messagingStarted).isTrue();
+    assertThat(unicastStarted).isTrue();
     assertThat(started).isSameAs(networkService);
   }
 
   @Test
   void shouldStopBothTransports() {
-    // given
-    when(unicastService.stop()).thenReturn(CompletableFuture.completedFuture(null));
-    when(messagingService.stop()).thenReturn(CompletableFuture.completedFuture(null));
-
     // when
     networkService.stop().join();
 
     // then
-    verify(unicastService).stop();
-    verify(messagingService).stop();
+    assertThat(messagingStopped).isTrue();
+    assertThat(unicastStopped).isTrue();
   }
 
   @Test
@@ -59,14 +83,13 @@ final class NettyNetworkServiceTest {
     // given
     when(unicastService.stop())
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("unicast stop failed")));
-    when(messagingService.stop()).thenReturn(CompletableFuture.completedFuture(null));
 
     // when
     final var stopped = networkService.stop();
 
     // then - leaving the messaging transport running would keep the node reachable after shutdown
     assertThat(stopped).succeedsWithin(Duration.ofSeconds(5));
-    verify(messagingService).stop();
+    assertThat(messagingStopped).isTrue();
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyNetworkServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyNetworkServiceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.atomix.cluster.messaging.ManagedUnicastService;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+final class NettyNetworkServiceTest {
+
+  private final ManagedMessagingService messagingService = mock(ManagedMessagingService.class);
+  private final ManagedUnicastService unicastService = mock(ManagedUnicastService.class);
+  private final NettyNetworkService networkService =
+      new NettyNetworkService(messagingService, unicastService, Runnable::run);
+
+  @Test
+  void shouldStartBothTransports() {
+    // given
+    when(messagingService.start()).thenReturn(CompletableFuture.completedFuture(messagingService));
+    when(unicastService.start()).thenReturn(CompletableFuture.completedFuture(unicastService));
+
+    // when
+    final var started = networkService.start().join();
+
+    // then
+    verify(messagingService).start();
+    verify(unicastService).start();
+    assertThat(started).isSameAs(networkService);
+  }
+
+  @Test
+  void shouldStopBothTransports() {
+    // given
+    when(unicastService.stop()).thenReturn(CompletableFuture.completedFuture(null));
+    when(messagingService.stop()).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    networkService.stop().join();
+
+    // then
+    verify(unicastService).stop();
+    verify(messagingService).stop();
+  }
+
+  @Test
+  void shouldStopMessagingWhenUnicastStopFails() {
+    // given
+    when(unicastService.stop())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("unicast stop failed")));
+    when(messagingService.stop()).thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    final var stopped = networkService.stop();
+
+    // then - leaving the messaging transport running would keep the node reachable after shutdown
+    assertThat(stopped).succeedsWithin(Duration.ofSeconds(5));
+    verify(messagingService).stop();
+  }
+
+  @Test
+  void shouldExposeBothTransports() {
+    // when - then
+    assertThat(networkService.messagingService()).isSameAs(messagingService);
+    assertThat(networkService.unicastService()).isSameAs(unicastService);
+  }
+}


### PR DESCRIPTION
## Description

Groups a cluster node's messaging service (TCP) and unicast
service (UDP) behind a single `NetworkService`, with a `Managed<?>` variant that owns their lifecycle, instead of
`AtomixCluster` holding two independent managed services and carrying the start/stop ordering itself.

This is preparation for the no-UDP mode in #61663, where unicast can be carried by the messaging transport. At that point "two independent managed services" stops being true: a service could report itself running while the transport behind it has stopped, and stopping one could silently disable the other.

Behaviour is otherwise preserved from the outside and by most consumers.

No new behaviour, so no new integration tests; the added unit test covers that starting and stopping the network service reaches both transports, and that a failed unicast stop still stops the messaging one.

## Related issues

relates to #61663
