### PR TITLE
fix: Broken AWS OS ITs Nightly Run

### DIFF
--- a/.github/actions/setup-aws-opensearch-env/action.yml
+++ b/.github/actions/setup-aws-opensearch-env/action.yml
@@ -4,7 +4,7 @@ name: Setup AWS OpenSearch env
 # owner: @camunda/data-layer
 
 description: |
-  Imports OpenSearch endpoints from Vault, resolves OS URL for a selected 
+  Imports OpenSearch endpoints from Vault, resolves OS URL for a selected
   version, and configures AWS credentials.
 
 inputs:
@@ -75,3 +75,7 @@ runs:
         aws-region: ${{ env.AWS_REGION }}
         web-identity-token-file: ${{ env.AWS_WEB_IDENTITY_TOKEN_FILE }}
         role-to-assume: ${{ env.AWS_ROLE_ARN }}
+        # AWS OpenSearch tests take longer because we opted out of parallelizing them to avoid
+        # overloading the underlying infrastructure. Keep this credential live longer to avoid
+        # token expiry errors (set TTL to 6 hours).
+        role-duration-seconds: 21600

--- a/.github/scripts/clean-up-aws-opensearch-indices.py
+++ b/.github/scripts/clean-up-aws-opensearch-indices.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+"""Delete leftover test artifacts from the shared AWS OpenSearch CI cluster.
+
+Integration tests create indices, index templates, component templates and ISM
+policies under a per-test prefix, and nothing removes them when a run ends.
+
+Indices are checked for their creation age and deleted appropriately. Templates
+and policies carry no creation timestamp so there is nothing to age them by, but
+this is a dedicated CI cluster, so everything that is not plugin-owned is dropped
+instead. Dropping a template does not affect existing indices, since templates
+only apply at index creation, and every run recreates what it needs during schema
+startup. This runs as a PRE step behind the workflow's concurrency group, so no
+pipeline test is in flight while it wipes them.
+"""
 import os
 import sys
 import time
@@ -52,6 +65,8 @@ client = OpenSearch(
     connection_class=RequestsHttpConnection,
 )
 
+prefix = "[DRY RUN] " if DRY_RUN else ""
+
 try:
     all_indices = client.cat.indices(h="index,creation.date", format="json")
 except Exception as exc:
@@ -59,10 +74,6 @@ except Exception as exc:
     sys.exit(1)
 
 indices = [idx for idx in all_indices if not idx.get("index", "").startswith(".")]
-if not indices:
-    print("INFO: No user indices found, nothing to delete.")
-    sys.exit(0)
-
 now = int(time.time())
 deleted = skipped_young = skipped_already_gone = skipped_error = 0
 
@@ -98,7 +109,126 @@ for idx in indices:
             skipped_error += 1
             print(f"  WARN: Failed to delete {idx_name}: {exc}")
 
-prefix = "[DRY RUN] " if DRY_RUN else ""
+
+# Most index/component template a Camunda app creates carries its app name
+# somewhere in the name (e.g. "<prefix>-operate-list-view-8.3.0_"), so one
+# wildcard delete clears the bulk of them in a single cluster state update.
+APP_NAME_WORDS = ("camunda", "operate", "tasklist", "optimize", "zeebe")
+
+# Dotted names are system-owned; the rest are prefixes OpenSearch plugins (ISM,
+# observability, security analytics) register on install. Nothing here is created
+# by a test run, and dropping one may breaks the cluster for every later run.
+PROTECTED_NAME_PREFIXES = (".", "ss4o_", "ism_", "opensearch", "security-auditlog", "sample-")
+
+
+def wipe(label, path, key):
+    """Delete the test-created artifacts under path, returning (deleted, errors).
+
+    Wildcard deletes clear everything carrying a camunda specific name in bulk
+    (one request per app word — OpenSearch binds the template name as a single
+    pattern, so comma-separated patterns are not supported), then stragglers are
+    deleted by name. Not using bare "*", although the cluster is dedicated to CI,
+    it's technically not exclusively ours. In addition, installed OpenSearch
+    plugins may register templates of their own that a bare wildcard would delete.
+    Note: Bulk deletions are not counted individually (the wildcard response
+    carries no count).
+    """
+    deleted = errors = 0
+
+    # Bulk pass first, before any listing: with tens of thousands of leftover
+    # app-named templates, listing up front would page through them all just to
+    # classify names the wildcards already cover.
+    for word in APP_NAME_WORDS:
+        if DRY_RUN:
+            print(f"  [DRY RUN] Would bulk-delete {path}/*{word}*")
+            continue
+        try:
+            client.transport.perform_request("DELETE", f"{path}/*{word}*")
+        except NotFoundError:
+            pass  # nothing matched this word
+        except Exception as exc:
+            errors += 1
+            print(f"  WARN: Failed to bulk-delete {label} matching *{word}*: {exc}")
+
+    # Straggler pass: whatever survived the wildcards.
+    try:
+        listing = client.transport.perform_request("GET", path, params={"filter_path": f"{key}.name"})
+        names = [entry["name"] for entry in listing.get(key, [])]
+    except Exception as exc:
+        errors += 1
+        print(f"  WARN: Failed to list {label}: {exc}")
+        return deleted, errors
+
+    app_named = [name for name in names if any(word in name for word in APP_NAME_WORDS)]
+    if DRY_RUN:
+        # The bulk pass did not run, so every app-named entry is still listed;
+        # count them as the deletions that pass would have made.
+        deleted += len(app_named)
+    elif app_named:
+        # A bulk delete must have failed; deleting tens of thousands serially
+        # would run for hours, so surface the leftovers instead of retrying.
+        errors += 1
+        print(f"  WARN: {len(app_named)} app-named {label} survived the bulk pass")
+
+    stragglers = [
+        name
+        for name in names
+        if not any(word in name for word in APP_NAME_WORDS)
+        and not name.startswith(PROTECTED_NAME_PREFIXES)
+    ]
+
+    for name in stragglers:
+        if DRY_RUN:
+            print(f"  [DRY RUN] Would delete {label} {name}")
+            deleted += 1
+            continue
+        try:
+            client.transport.perform_request("DELETE", f"{path}/{name}")
+            deleted += 1
+        except NotFoundError:
+            deleted += 1
+        except Exception as exc:
+            errors += 1
+            print(f"  WARN: Failed to delete {label} {name}: {exc}")
+    return deleted, errors
+
+
+# Index templates must go before component templates: OpenSearch refuses to drop
+# a component template while an index template still composes it.
+index_templates, index_template_errors = wipe("index templates", "/_index_template", "index_templates")
+component_templates, component_template_errors = wipe(
+    "component templates", "/_component_template", "component_templates"
+)
+
+ism_policies = ism_errors = 0
+try:
+    response = client.transport.perform_request("GET", "/_plugins/_ism/policies", params={"size": "10000"})
+    # Test policies don't consistently carry an app name (e.g. "<uniqueId>-default-policy"
+    # from OpenSearchArchiverRepositoryIT), so guard with the plugin-owned denylist
+    # instead of an app-name allowlist.
+    policies = [
+        policy.get("_id", "")
+        for policy in response.get("policies", [])
+        if not policy.get("_id", "").startswith(PROTECTED_NAME_PREFIXES)
+    ]
+    for policy_id in policies:
+        if DRY_RUN:
+            ism_policies += 1
+            print(f"  [DRY RUN] Would delete ISM policy: {policy_id}")
+            continue
+        try:
+            client.transport.perform_request("DELETE", f"/_plugins/_ism/policies/{policy_id}")
+            ism_policies += 1
+        except NotFoundError:
+            ism_policies += 1
+        except Exception as exc:
+            ism_errors += 1
+            print(f"  WARN: Failed to delete ISM policy {policy_id}: {exc}")
+except Exception as exc:
+    print(f"  WARN: Failed to list ISM policies: {exc}")
+
+template_errors = index_template_errors + component_template_errors + ism_errors
+
 print(
     f"\n{prefix}Summary:"
     f"\n{prefix}indices_found={len(indices)}"
@@ -106,5 +236,20 @@ print(
     f"\n{prefix}too_young={skipped_young}"
     f"\n{prefix}already_gone={skipped_already_gone}"
     f"\n{prefix}errors={skipped_error}"
+    f"\n{prefix}index_templates_deleted={index_templates}"
+    f"\n{prefix}component_templates_deleted={component_templates}"
+    f"\n{prefix}ism_policies_deleted={ism_policies}"
+    f"\n{prefix}template_errors={template_errors}"
 )
+
+# The job stays green even when cleanup partially fails - a red PRE step would
+# block the test run over leftovers the next night retries anyway. A workflow
+# annotation keeps the failure visible so recurring ones don't refill the
+# cluster unnoticed (that is how it previously grew to 65k stale templates).
+if skipped_error + template_errors > 0:
+    print(
+        f"::warning title=AWS OpenSearch cleanup incomplete::"
+        f"{skipped_error} index and {template_errors} template/policy deletions failed; "
+        f"see the step log for details"
+    )
 sys.exit(0)

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -222,6 +222,7 @@ jobs:
           -D test.integration.opensearch.aws.url="${{ env.OPENSEARCH_URL }}"
           -D test.integration.camunda.database.type=AWS_OS
           -D test.integration.opensearch.aws.timeout.seconds=180
+          -D test.integration.camunda.app.startup.timeout.seconds=600
           -P parallel-tests,extract-flaky-tests,${{ matrix.maven-test-profiles }}
           -pl ${{ matrix.maven-modules }}
           verify

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -747,6 +747,7 @@
             <identity.docker.image.version>${version.identity}</identity.docker.image.version>
           </systemPropertyVariables>
           <excludedGroups>rdbms, rdbms-aurora, rdbms-aurora-mysql, multi-db-test, compatibility-test, dl-nightly, async-repl</excludedGroups>
+          <forkedProcessTimeoutInSeconds>10800</forkedProcessTimeoutInSeconds>
         </configuration>
         <dependencies>
           <dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -32,6 +32,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -403,7 +404,7 @@ class AgentInstanceAuthorizationIT {
   private static void waitForHistoryItemsToBeIndexed(
       final CamundaClient client, final long agentInstanceKey, final int expectedCount) {
     Awaitility.await("agent history indexed for key " + agentInstanceKey)
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
@@ -28,6 +28,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -81,6 +82,7 @@ class AuthorizationSearchIT {
             .join();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -158,6 +160,7 @@ class AuthorizationSearchIT {
 
     // then
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThat(
@@ -192,6 +195,7 @@ class AuthorizationSearchIT {
 
     // Verify it was created
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThat(
@@ -215,6 +219,7 @@ class AuthorizationSearchIT {
 
     // then
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThat(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -528,6 +528,7 @@ class BatchOperationAuthorizationIT {
       final String batchOperationKey,
       final Consumer<List<BatchOperationItem>> assertions) {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 camundaClient

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -37,6 +37,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -345,7 +346,7 @@ class BatchOperationAuthorizationIT {
 
     // then we should find nothing with our restricted user
     Awaitility.await("should not return batch operation")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofMillis(100))
         .untilAsserted(
             () -> {
@@ -377,7 +378,7 @@ class BatchOperationAuthorizationIT {
 
     // then we should find nothing with our restricted user
     Awaitility.await("should not return batch operation")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofMillis(100))
         .untilAsserted(
             () -> {
@@ -471,7 +472,7 @@ class BatchOperationAuthorizationIT {
   private static void waitForProcessesToBeDeployed(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy processes and import in Operate")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -483,7 +484,7 @@ class BatchOperationAuthorizationIT {
   public static void waitForBatchOperation(
       final CamundaClient camundaClient, final String batchOperationKey, final long itemsCount) {
     Awaitility.await("should wait for started batch operation")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofMillis(100))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
@@ -501,7 +502,7 @@ class BatchOperationAuthorizationIT {
       final long totalItemsCount,
       final BatchOperationState expectedState) {
     Awaitility.await("should wait for started batch operation")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofMillis(100))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
@@ -553,7 +554,7 @@ class BatchOperationAuthorizationIT {
       final long processInstanceKey,
       final boolean shouldBeInactive) {
     Awaitility.await("should wait for incident to be created")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofMillis(100))
         .ignoreExceptions()
         .until(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterVariableAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterVariableAuthorizationIT.java
@@ -21,10 +21,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -800,7 +800,7 @@ class ClusterVariableAuthorizationIT {
   private static void waitForClusterVariablesToBeAvailable(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should have cluster variables available")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -812,7 +812,7 @@ class ClusterVariableAuthorizationIT {
   private static void waitForClusterVariableToBeDeleted(
       final CamundaClient camundaClient, final String variableName, final String tenantId) {
     Awaitility.await("should have cluster variable deleted")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -20,10 +20,10 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
@@ -215,7 +215,7 @@ class DecisionAuthorizationIT {
   private static void waitForDecisionDefinitionsToBeDeployed(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy decision definitions and import in Operate")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -227,7 +227,7 @@ class DecisionAuthorizationIT {
   private static void waitForDecisionRequirementsToBeDeployed(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy decision requirements and import in Operate")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -22,10 +22,10 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
@@ -161,7 +161,7 @@ class DecisionInstanceAuthorizationIT {
   private static void waitForDecisionsToBeEvaluated(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy decision definitions and import in Operate")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
@@ -25,10 +25,10 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -121,7 +121,7 @@ class ExpressionAuthorizationIT {
             .getProcessInstanceKey();
 
     Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
@@ -117,6 +117,7 @@ class GlobalTaskListenerAuthorizationIT {
 
     // then the global listener is correctly created
     Awaitility.await("global listener should become available in search layer")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .until(() -> adminClient.newGlobalTaskListenerGetRequest(listenerId).send().join() != null);
   }
@@ -169,6 +170,7 @@ class GlobalTaskListenerAuthorizationIT {
 
     // then the global listener is correctly updated
     Awaitility.await("global listener should have data updated in search layer")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .until(
             () -> {
@@ -198,6 +200,7 @@ class GlobalTaskListenerAuthorizationIT {
 
     // then the global listener is correctly deleted
     Awaitility.await("global listener should become unavailable in search layer")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GlobalTaskListenerAuthorizationIT.java
@@ -22,6 +22,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -411,7 +412,7 @@ class GlobalTaskListenerAuthorizationIT {
   public static void waitForCreatedGlobalListener(
       final CamundaClient camundaClient, final String globalListenerId) {
     Awaitility.await("should wait for global listener to be available in search layer")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofMillis(100))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .until(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -29,6 +29,7 @@ import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
@@ -201,6 +202,7 @@ class GroupAuthorizationIT {
 
     // then
     Awaitility.await("Client is assigned to the group")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -253,6 +255,7 @@ class GroupAuthorizationIT {
         .join();
 
     Awaitility.await("Client is assigned to the group")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -271,6 +274,7 @@ class GroupAuthorizationIT {
 
     // then
     Awaitility.await("Client is unassigned from the group")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -309,6 +313,7 @@ class GroupAuthorizationIT {
 
     // then
     Awaitility.await("Clients are assigned to the group and can be searched")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -23,6 +23,7 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -30,7 +31,6 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -378,7 +378,7 @@ public class JobStreamAuthorizationIT {
       final JobState state,
       final String... resourceIds) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MappingRuleAuthorizationIT.java
@@ -24,6 +24,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -86,6 +87,7 @@ class MappingRuleAuthorizationIT {
 
     // when / then
     Awaitility.await("until the rule is visible in the search results")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThat(
@@ -227,6 +229,7 @@ class MappingRuleAuthorizationIT {
 
     // make sure it's available for get/search afterwards
     Awaitility.await("Mapping rule exists in secondary storage")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(IOException.class)
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsIT.java
@@ -30,6 +30,7 @@ import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
@@ -114,6 +115,7 @@ class MeAuthorizationsIT {
   void shouldReturnAuthorizationsGrantedDirectlyViaGroupAndViaRole(
       @Authenticated(ME) final CamundaClient meClient) throws Exception {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final SearchResponse<Authorization> response =
@@ -159,6 +161,7 @@ class MeAuthorizationsIT {
   void shouldFilterOwnAuthorizationsByResourceType(@Authenticated(ME) final CamundaClient meClient)
       throws Exception {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final SearchResponse<Authorization> response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsOidcIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MeAuthorizationsOidcIT.java
@@ -30,6 +30,7 @@ import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestMappingRule;
 import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.multidb.CamundaClientTestFactory;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
@@ -120,6 +121,7 @@ class MeAuthorizationsOidcIT {
   @Test
   void shouldReturnAuthorizationsForMappingRuleDirectlyViaGroupAndViaRole() {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final CamundaClient client = clientFactory.getCamundaClient(ME_MAPPING_RULE.id());
@@ -167,6 +169,7 @@ class MeAuthorizationsOidcIT {
   @Test
   void shouldFilterMappingRuleAuthorizationsByResourceType() {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final CamundaClient client = clientFactory.getCamundaClient(ME_MAPPING_RULE.id());
@@ -193,6 +196,7 @@ class MeAuthorizationsOidcIT {
   @Test
   void shouldReturnAuthorizationsForClientDirectlyAndViaGroup() {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final CamundaClient client = clientFactory.getCamundaClient(ME_CLIENT.clientId());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -22,6 +22,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -178,7 +179,7 @@ class ProcessAuthorizationIT {
   private static void waitForProcessesToBeDeployed(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy processes and make them searchable")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -191,7 +192,7 @@ class ProcessAuthorizationIT {
         getProcessDefinitionKey(camundaClient, PROCESS_DEFINITION_ID_WITH_START_FORM);
 
     Awaitility.await("should deploy start form and make it searchable")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -23,6 +23,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -33,7 +34,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.stream.StreamSupport;
@@ -456,7 +456,7 @@ class ProcessInstanceAuthorizationIT {
 
   private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from ES")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -27,6 +27,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -282,6 +283,7 @@ class RoleAuthorizationIT {
         .join();
 
     Awaitility.await("Mapping rule is assigned to the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -373,6 +375,7 @@ class RoleAuthorizationIT {
 
     // then
     Awaitility.await("Role is unassigned from the client")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -408,6 +411,7 @@ class RoleAuthorizationIT {
         .join();
 
     Awaitility.await("Role is unassigned from the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -456,6 +460,7 @@ class RoleAuthorizationIT {
     adminClient.newAssignRoleToGroupCommand().roleId(roleId).groupId(groupId).send().join();
 
     Awaitility.await("Group is assigned to the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -479,6 +484,7 @@ class RoleAuthorizationIT {
     adminClient.newAssignRoleToTenantCommand().roleId(ROLE_ID_1).tenantId(tenantId).send().join();
 
     Awaitility.await("Role is assigned to the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -531,6 +537,7 @@ class RoleAuthorizationIT {
         .join();
 
     Awaitility.await("Mapping rule is unassigned from the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -583,6 +590,7 @@ class RoleAuthorizationIT {
     adminClient.newUnassignRoleFromGroupCommand().roleId(ROLE_ID_1).groupId(groupId).send().join();
 
     Awaitility.await("Group is unassigned from the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -617,6 +625,7 @@ class RoleAuthorizationIT {
 
     // then
     Awaitility.await("Role is assigned to the client")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -657,6 +666,7 @@ class RoleAuthorizationIT {
 
     // when/then
     Awaitility.await("Search returns correct client ID")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -696,6 +706,7 @@ class RoleAuthorizationIT {
 
     // when/then
     Awaitility.await("Group is searchable by role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -734,6 +745,7 @@ class RoleAuthorizationIT {
 
     // verify
     Awaitility.await("Authorization is searchable")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -773,6 +785,7 @@ class RoleAuthorizationIT {
 
     // verify
     Awaitility.await("Authorization is searchable")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -30,6 +30,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -181,6 +182,7 @@ class TenantAuthorizationIT {
 
     // when/then
     Awaitility.await("Search returns correct users")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -201,6 +203,7 @@ class TenantAuthorizationIT {
 
     // when/then
     Awaitility.await("Search returns groups by tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -234,6 +237,7 @@ class TenantAuthorizationIT {
 
     // when/then
     Awaitility.await("Search returns clients by tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -281,6 +285,7 @@ class TenantAuthorizationIT {
 
     // then
     Awaitility.await("Client is assigned to the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -320,6 +325,7 @@ class TenantAuthorizationIT {
 
     // verify client is assigned
     Awaitility.await("Client is assigned to the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -339,6 +345,7 @@ class TenantAuthorizationIT {
 
     // then - verify client is no longer assigned
     Awaitility.await("Client is unassigned from the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UniqueEntityIdentifiersIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UniqueEntityIdentifiersIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ public class UniqueEntityIdentifiersIT {
     // assign group to tenant
     client.newAssignGroupToTenantCommand().groupId(conflictingId).tenantId(tenantId).send().join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -48,6 +50,7 @@ public class UniqueEntityIdentifiersIT {
     // assign role to tenant with the same ID
     client.newAssignRoleToTenantCommand().roleId(conflictingId).tenantId(tenantId).send().join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -89,6 +92,7 @@ public class UniqueEntityIdentifiersIT {
     // assign user to group
     client.newAssignUserToGroupCommand().username(conflictingId).groupId(groupId).send().join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -106,6 +110,7 @@ public class UniqueEntityIdentifiersIT {
         .send()
         .join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -141,6 +146,7 @@ public class UniqueEntityIdentifiersIT {
     // assign user to role
     client.newAssignRoleToUserCommand().roleId(roleId).username(conflictingId).send().join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -153,6 +159,7 @@ public class UniqueEntityIdentifiersIT {
     // assign group to role with the same ID
     client.newAssignRoleToGroupCommand().roleId(roleId).groupId(conflictingId).send().join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
@@ -31,6 +31,7 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -122,7 +123,7 @@ public class UsageMetricAuthorizationIT {
   private static void waitForUsageMetrics(
       final CamundaClient camundaClient, final Consumer<UsageMetricsStatistics> fnRequirements) {
     Awaitility.await("should export metrics to secondary storage")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () ->
@@ -140,7 +141,7 @@ public class UsageMetricAuthorizationIT {
   private static void waitForUsersAssignedToTenant(
       final CamundaClient camundaClient, final String tenant, final String... usernames) {
     Awaitility.await("users " + Arrays.asList(usernames) + " assigned to tenant " + tenant)
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -30,11 +30,11 @@ import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -515,7 +515,7 @@ class UserTaskAuthorizationIT {
 
   private static void waitForProcessAndTasksBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from ES")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -578,7 +578,7 @@ class UserTaskAuthorizationIT {
             .getAuthorizationKey();
 
     Awaitility.await("authorization with key '" + authorizationKey + "' to be created")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskCandidateGroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskCandidateGroupAuthorizationIT.java
@@ -22,11 +22,11 @@ import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.authz.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -123,7 +123,7 @@ class UserTaskCandidateGroupAuthorizationIT {
 
   private static void waitForProcessAndTasksBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from ES")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.auth.Authorization;
@@ -66,9 +67,10 @@ public class ActivateJobIT {
   @BeforeAll
   static void setup() {
     // The CamundaMultiDBExtension resets RecordingExporter (maximumWaitTime → 5s) in its
-    // beforeAll, which runs before this method. Override to 30s to tolerate slow CI runners
-    // where gateway-issued FAIL commands can take longer to propagate.
-    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
+    // beforeAll, which runs before this method. Override to use the data availability time
+    // to tolerate slow CI runners where gateway-issued FAIL commands can take longer to propagate.
+    RecordingExporter.setMaximumWaitTime(
+        CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY.toMillis());
     grpcClient = BROKER.newClientBuilder().preferRestOverGrpc(false).build();
     // gRPC calls are not retried and basic auth validates the demo user against secondary
     // storage, whose export can lag behind broker start on a loaded cluster — retry until

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -28,6 +28,7 @@ import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.response.AgentInstance;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import java.time.Duration;
@@ -266,7 +267,7 @@ public class AgentHistoryCommitLifecycleIT {
 
     // then
     Awaitility.await("resent history item deduped, not double-applied")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -444,7 +445,7 @@ public class AgentHistoryCommitLifecycleIT {
 
     // then
     Awaitility.await("resent history item deduped across job activations, not double-applied")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -547,7 +548,7 @@ public class AgentHistoryCommitLifecycleIT {
     // Without this, the baseline check below could pass purely because it ran before the write
     // was even indexed, not because the CONFIGURATION change is genuinely deferred until commit.
     Awaitility.await("CONFIGURATION history item indexed as PENDING")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -600,7 +601,7 @@ public class AgentHistoryCommitLifecycleIT {
     camundaClient.newCompleteCommand(activatedJob).execute();
 
     Awaitility.await("agent instance definition reflects committed CONFIGURATION change")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -770,7 +771,7 @@ public class AgentHistoryCommitLifecycleIT {
   private void awaitHistoryStatuses(
       final long agentInstanceKey, final String description, final Tuple... expected) {
     Awaitility.await(description)
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import java.time.Duration;
@@ -591,7 +592,7 @@ public class AgentInstanceHistorySearchIT {
       final Consumer<AgentInstanceHistoryFilter> filter,
       final int expectedCount) {
     Awaitility.await("agent history indexed")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIT.java
@@ -31,6 +31,7 @@ import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
@@ -90,6 +91,7 @@ public class AuthorizationIT {
 
     // then
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -155,6 +157,7 @@ public class AuthorizationIT {
 
     // then
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -168,6 +171,7 @@ public class AuthorizationIT {
     updateAuthorization(authorizationKey, request);
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -270,6 +274,7 @@ public class AuthorizationIT {
 
     // when
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -312,6 +317,7 @@ public class AuthorizationIT {
         .join();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -356,6 +362,7 @@ public class AuthorizationIT {
         .join();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -398,6 +405,7 @@ public class AuthorizationIT {
         .execute();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -442,6 +450,7 @@ public class AuthorizationIT {
         .join();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -497,6 +506,7 @@ public class AuthorizationIT {
         .join();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -557,6 +567,7 @@ public class AuthorizationIT {
         .join();
 
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -602,6 +613,7 @@ public class AuthorizationIT {
     // when / then — sort by ownerType (tied), paginate with limit 1
     // the authorization key should break the tie and cursors should work
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -662,6 +674,7 @@ public class AuthorizationIT {
 
     // when / then — a search with no explicit sort should still return cursors
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -706,6 +719,7 @@ public class AuthorizationIT {
 
     // when / then — paginate with limit 1 and use cursors to navigate
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
@@ -14,11 +14,11 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -161,7 +161,7 @@ public class CallActivityBusinessIdIT {
     // then - the child is retrievable by filtering the search API on its resolved Business ID
     // (scoped by parentProcessInstanceKey so an inherited id could never match the parent instead)
     Awaitility.await("child instance is queryable by its business id")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -256,7 +256,7 @@ public class CallActivityBusinessIdIT {
   private static ProcessInstance awaitChild(final long parentProcessInstanceKey) {
     final AtomicReference<ProcessInstance> child = new AtomicReference<>();
     Awaitility.await("child process instance is exported to the search index")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -276,7 +276,7 @@ public class CallActivityBusinessIdIT {
   private static long awaitIncidentKey(final long processInstanceKey) {
     final AtomicLong incidentKey = new AtomicLong();
     Awaitility.await("incident is exported to the search index")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByGroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByGroupIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -48,6 +49,7 @@ public class ClientsByGroupIT {
 
     // then
     Awaitility.await("Client is assigned to the group")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -86,6 +88,7 @@ public class ClientsByGroupIT {
         .join();
 
     Awaitility.await("Client is assigned to the group")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -104,6 +107,7 @@ public class ClientsByGroupIT {
 
     // then
     Awaitility.await("Client is unassigned from the group")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -182,6 +186,7 @@ public class ClientsByGroupIT {
 
     // then
     Awaitility.await("Clients are assigned to the group and can be searched")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -218,6 +223,7 @@ public class ClientsByGroupIT {
 
     // then
     Awaitility.await("Clients are assigned to the group and can be searched")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientsByTenantIT.java
@@ -17,6 +17,7 @@ import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -54,6 +55,7 @@ public class ClientsByTenantIT {
 
     // then
     Awaitility.await("Clients are assigned to the tenant and can be searched")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CompleteJobBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CompleteJobBusinessIdAssignmentIT.java
@@ -17,6 +17,7 @@ import static org.awaitility.Awaitility.await;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -185,7 +186,7 @@ class CompleteJobBusinessIdAssignmentIT {
 
   private void awaitBusinessId(final long processInstanceKey, final String businessId) {
     await("business id is reflected in secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(() -> assertThat(getBusinessId(processInstanceKey)).isEqualTo(businessId));
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -1172,7 +1173,7 @@ public class ExpressionEvaluationIT {
 
   private long waitForActiveElementInstance(final long processInstanceKey, final String elementId) {
     Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GetMappingRuleIT.java
@@ -14,6 +14,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.net.http.HttpClient;
@@ -49,6 +50,7 @@ public class GetMappingRuleIT {
 
     // wait for the mapping rule to be created and indexed
     Awaitility.await("Mapping rule is created and indexed")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobBusinessIdIT.java
@@ -16,10 +16,10 @@ import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.Job;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -134,7 +134,7 @@ public class JobBusinessIdIT {
   private static void waitForJob(final long processInstanceKey) {
     Awaitility.await()
         .ignoreExceptions()
-        .timeout(Duration.ofSeconds(30))
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .until(
             () ->
                 !client

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTagsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobTagsIT.java
@@ -13,9 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.Process;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import java.time.Duration;
 import java.util.Set;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -73,7 +73,7 @@ public class JobTagsIT {
   private void waitForJobs(final Long... processInstanceKeys) {
     Awaitility.await()
         .ignoreExceptions()
-        .timeout(Duration.ofSeconds(30))
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .until(
             () ->
                 client

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRuleIT.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.net.http.HttpClient;
@@ -99,6 +100,7 @@ public class MappingRuleIT {
       final String claimName,
       final String claimValue) {
     Awaitility.await("Mapping rule exists in the secondary storage system")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingRulesSearchIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
@@ -159,6 +160,7 @@ public class MappingRulesSearchIT {
 
   private static void assertMappingRuleCreated(final String mappingRuleId) {
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final var mappingRuleSearchResponse =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
@@ -830,6 +830,7 @@ public class ProcessDefinitionStatisticsIT {
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE), 2);
 
     Awaitility.await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               // when
@@ -898,6 +899,7 @@ public class ProcessDefinitionStatisticsIT {
     waitForProcessInstances(camundaClient, f -> f.processDefinitionKey(processDefinitionKey), 2);
 
     Awaitility.await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               // when

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
@@ -16,10 +16,10 @@ import static org.awaitility.Awaitility.await;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1.AssignProcessInstanceBusinessIdCommandStep2;
 import io.camunda.client.api.command.ClientException;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
-import java.time.Duration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -125,7 +125,7 @@ class ProcessInstanceBusinessIdAssignmentIT {
 
   private void awaitBusinessId(final long processInstanceKey, final String businessId) {
     await("business id is reflected in secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -33,6 +33,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -718,6 +719,7 @@ public class ProcessInstanceSearchIT {
   @Test
   void shouldQueryProcessInstancesByStateCompleted() {
     await("process is completed")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendedSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendedSearchIT.java
@@ -17,8 +17,8 @@ import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -48,7 +48,7 @@ public class ProcessInstanceSuspendedSearchIT {
 
     // wait until the suspension is visible in secondary storage
     await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final ProcessInstance instance =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIT.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.filter.AuthorizationFilter;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.UUID;
@@ -145,6 +146,7 @@ public class RoleIT {
 
     // then
     Awaitility.await("Role is deleted")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThatThrownBy(() -> camundaClient.newRoleGetRequest(roleId).send().join())
@@ -212,6 +214,7 @@ public class RoleIT {
                 .ownerId(roleId);
 
     Awaitility.await("Authorization was created")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThat(
@@ -226,6 +229,7 @@ public class RoleIT {
 
     // then
     Awaitility.await("Role is deleted")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThatThrownBy(() -> camundaClient.newRoleGetRequest(roleId).send().join())
@@ -233,6 +237,7 @@ public class RoleIT {
                     .hasMessageContaining("Failed with code 404: 'Not Found'"));
 
     Awaitility.await("Authorization is deleted")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () ->
                 assertThat(
@@ -281,6 +286,7 @@ public class RoleIT {
 
     // then
     Awaitility.await("Role is updated")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -314,6 +320,7 @@ public class RoleIT {
   private static void assertRoleCreated(
       final String roleId, final String roleName, final String description) {
     Awaitility.await("Role is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByClientIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByClientIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Client;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -33,6 +34,7 @@ public class RolesByClientIT {
     createRole(EXISTING_ROLE_ID, "ARoleName", "description");
 
     Awaitility.await("Role is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -59,6 +61,7 @@ public class RolesByClientIT {
 
     // then
     Awaitility.await("Role is assigned to the client")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -79,6 +82,7 @@ public class RolesByClientIT {
     camundaClient.newAssignRoleToClientCommand().roleId(roleId).clientId(clientId).send().join();
 
     Awaitility.await("Role is assigned to the client")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -98,6 +102,7 @@ public class RolesByClientIT {
 
     // then
     Awaitility.await("Role is unassigned from the client")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -115,6 +120,7 @@ public class RolesByClientIT {
 
     // when/then
     Awaitility.await("Empty list is returned")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -138,6 +144,7 @@ public class RolesByClientIT {
 
     // when/then
     Awaitility.await("Both client IDs are returned")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -163,6 +170,7 @@ public class RolesByClientIT {
 
     // then
     Awaitility.await("Role is unassigned from the client")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Role;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.UUID;
@@ -35,6 +36,7 @@ public class RolesByGroupIT {
     createRole(EXISTING_ROLE_ID, "ARoleName", "description");
 
     Awaitility.await("Role is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -120,6 +122,7 @@ public class RolesByGroupIT {
 
     // then
     Awaitility.await("Role was deleted and unassigned")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(() -> assertThat(searchRolesByGroupId(groupId).items()).isEmpty());
   }
@@ -140,6 +143,7 @@ public class RolesByGroupIT {
         .join();
 
     Awaitility.await("Group is assigned to the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -156,6 +160,7 @@ public class RolesByGroupIT {
 
     // then
     Awaitility.await("Group is unassigned from the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(() -> assertThat(searchRolesByGroupId(groupId).items()).isEmpty());
   }
@@ -355,6 +360,7 @@ public class RolesByGroupIT {
         .join();
 
     Awaitility.await("Group is assigned to the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
@@ -371,6 +377,7 @@ public class RolesByGroupIT {
 
     // then
     Awaitility.await("Group is unassigned from the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(() -> assertThat(searchRolesByGroupId(groupId).items()).isEmpty());
   }
@@ -399,6 +406,7 @@ public class RolesByGroupIT {
 
   private static void assertRoleAssignedToGroup(final String roleId, final String groupId) {
     Awaitility.await("Group is assigned to the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingRuleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingRuleIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -34,6 +35,7 @@ public class RolesByMappingRuleIT {
     createRole(EXISTING_ROLE_ID, "ARoleName", "description");
 
     Awaitility.await("Role is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -94,6 +96,7 @@ public class RolesByMappingRuleIT {
 
     // then
     Awaitility.await("Mapping rule is unassigned from the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(() -> assertThat(searchMappingRuleByRole(roleId).items()).isEmpty());
   }
@@ -121,6 +124,7 @@ public class RolesByMappingRuleIT {
 
     // then
     Awaitility.await("Mapping rule is unassigned from deleted role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(() -> assertThat(searchMappingRuleByRole(roleId).items()).isEmpty());
   }
@@ -279,6 +283,7 @@ public class RolesByMappingRuleIT {
         .join();
     // when / then
     Awaitility.await("Mapping rule should be found by role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -352,6 +357,7 @@ public class RolesByMappingRuleIT {
         .join();
 
     Awaitility.await("Mapping rules are sorted by name")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -403,6 +409,7 @@ public class RolesByMappingRuleIT {
         .join();
 
     Awaitility.await("Mapping rules are sorted by claimName")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -454,6 +461,7 @@ public class RolesByMappingRuleIT {
         .join();
 
     Awaitility.await("Mapping rules are sorted by claimValue")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -503,6 +511,7 @@ public class RolesByMappingRuleIT {
         .join();
 
     Awaitility.await("Mapping rule is filtered by name")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -552,6 +561,7 @@ public class RolesByMappingRuleIT {
         .join();
 
     Awaitility.await("Mapping rule is filtered by claimName")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -600,6 +610,7 @@ public class RolesByMappingRuleIT {
         .join();
 
     Awaitility.await("Mapping rule is filtered by claimValue")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -634,6 +645,7 @@ public class RolesByMappingRuleIT {
   private static void verifyRoleIsAssignedToMappingRule(
       final String roleId, final String mappingRuleId) {
     Awaitility.await("Mapping rule is assigned to the role")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIT.java
@@ -19,7 +19,6 @@ import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.net.http.HttpClient;
-import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
@@ -293,7 +292,7 @@ public class RolesByTenantIT {
 
   private void waitForTenantsToBeCreated(final String tenantId) {
     Awaitility.await("should create tenants and import in ES")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchIT.java
@@ -13,6 +13,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Role;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
@@ -119,6 +120,7 @@ public class RolesSearchIT {
   private static void assertRoleCreated(
       final String roleId, final String roleName, final String description) {
     Awaitility.await("Role is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.UUID;
@@ -43,6 +44,7 @@ public class TenantIT {
 
     // then
     Awaitility.await("Tenant is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantsSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TenantsSearchIT.java
@@ -13,6 +13,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Tenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -114,6 +115,7 @@ public class TenantsSearchIT {
   private static void assertTenantCreated(
       final String tenantId, final String tenantName, final String description) {
     Awaitility.await("Tenant is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIT.java
@@ -17,6 +17,7 @@ import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -47,6 +48,7 @@ public class UnassignClientFromTenantIT {
 
     // verify client is assigned
     Awaitility.await("Client is assigned to the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -65,6 +67,7 @@ public class UnassignClientFromTenantIT {
 
     // then - verify client is no longer assigned
     Awaitility.await("Client is unassigned from the tenant")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -45,6 +46,7 @@ public class UserIT {
 
     // then
     Awaitility.await("User is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -80,6 +82,7 @@ public class UserIT {
 
     // then
     Awaitility.await("User is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIT.java
@@ -16,6 +16,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.List;
 import org.awaitility.Awaitility;
@@ -185,6 +186,7 @@ public class UsersSearchIT {
 
   private static void assertUserCreated(final String userName) {
     Awaitility.await("User is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIT.java
@@ -16,6 +16,7 @@ import io.camunda.client.api.response.UpdateUserResponse;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,7 @@ public class UsersUpdateIT {
     assertThat(updateUserResponse.getEmail()).isEqualTo(updatedEmail);
 
     Awaitility.await("User is updated")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -98,6 +100,7 @@ public class UsersUpdateIT {
 
     // then
     Awaitility.await("User is updated")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {
@@ -134,6 +137,7 @@ public class UsersUpdateIT {
 
   private static void assertUserCreated(final String userName) {
     Awaitility.await("User is created and exported")
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/ProcessInstanceHistoryCleanupIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.HistoryMultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
@@ -226,7 +227,7 @@ public class ProcessInstanceHistoryCleanupIT {
       final long processInstanceKey,
       final ProcessInstanceState expectedState) {
     Awaitility.await("Wait for process instance state: " + expectedState)
-        .timeout(TIMEOUT)
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final var processInstances =
@@ -246,7 +247,7 @@ public class ProcessInstanceHistoryCleanupIT {
 
   private long getChildProcessInstanceKey(final CamundaClient client, final long rootPiKey) {
     return Awaitility.await()
-        .timeout(TIMEOUT)
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .until(
             () ->
                 client
@@ -365,7 +366,7 @@ public class ProcessInstanceHistoryCleanupIT {
     // Wait for user task to appear then complete it
     final var userTaskKey =
         Awaitility.await()
-            .atMost(TIMEOUT)
+            .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
             .ignoreExceptions()
             .until(
                 () ->
@@ -397,6 +398,7 @@ public class ProcessInstanceHistoryCleanupIT {
         .send()
         .join();
     Awaitility.await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .until(
             () ->
                 !client
@@ -411,7 +413,7 @@ public class ProcessInstanceHistoryCleanupIT {
   private void handleIncident(final CamundaClient client, final long processInstanceKey) {
     // Wait for incident
     Awaitility.await()
-        .atMost(TIMEOUT)
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .until(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/mcp/authentication/AuthenticatedMcpServerTest.java
@@ -20,12 +20,12 @@ import io.camunda.gateway.protocol.model.ProcessDefinitionSearchQueryResult;
 import io.camunda.it.util.TestHelper;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -133,7 +133,7 @@ abstract class AuthenticatedMcpServerTest extends McpServerAuthenticationTest {
                 processDefinitionId + ".bpmn"));
 
     await("should make deployed processes searchable")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final var visibleProcessDefinitionIds =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentIT.java
@@ -149,6 +149,7 @@ public class IncidentIT {
   private void assertIncidentState(
       final CamundaClient client, final long key, final IncidentState expected) {
     Awaitility.await("until incident %d state is = %s".formatted(key, expected))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -166,6 +167,7 @@ public class IncidentIT {
   private void assertProcessInstanceIncidentState(
       final CamundaClient client, final long key, final boolean expected) {
     Awaitility.await("until process instance %d incident state = %s".formatted(key, expected))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -184,6 +186,7 @@ public class IncidentIT {
     Awaitility.await(
             "until element %s in process instance %d incident state = %s"
                 .formatted(elementId, processInstanceKey, expected))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentIT.java
@@ -18,6 +18,7 @@ import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.test.util.Strings;
@@ -217,7 +218,7 @@ public class IncidentIT {
 
   private long getChildProcessInstanceKey(final CamundaClient client) {
     return Awaitility.await("until one element exists in the child process instance")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .until(
             () ->
@@ -324,7 +325,7 @@ public class IncidentIT {
       final CamundaClient client, final Consumer<IncidentFilter> filterFn) {
     return Awaitility.await()
         .ignoreExceptions()
-        .timeout(Duration.ofSeconds(30))
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .until(
             () -> client.newIncidentSearchRequest().filter(filterFn).send().join().items(),
             Predicate.not(List::isEmpty))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.config.AuthenticationMethod;
@@ -107,7 +108,7 @@ public class IncidentNotifierIT {
     }
 
     await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               // get all webhook requests received by WireMock
@@ -141,7 +142,7 @@ public class IncidentNotifierIT {
     }
 
     await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               final var requests = getRequestsToWebhook();
@@ -172,7 +173,7 @@ public class IncidentNotifierIT {
   private void waitForIncidentToExist(
       final ProcessInstanceEvent incident, final CamundaClient camundaClient) {
     await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .pollInterval(Duration.ofSeconds(1))
         .until(
             () -> getIncidents(camundaClient),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/VariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/VariableIT.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.filter.VariableFilter;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
@@ -267,7 +267,7 @@ public class VariableIT {
       final CamundaClient client, final Consumer<VariableFilter> filterFn) {
     Awaitility.await()
         .ignoreExceptions()
-        .timeout(Duration.ofSeconds(30))
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .until(
             () ->
                 !client

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -348,7 +349,7 @@ public class AgentInstanceTenancyIT {
   private static void waitForHistoryItemsToBeIndexed(
       final CamundaClient client, final long agentInstanceKey, final int expectedCount) {
     Awaitility.await("agent history indexed for key " + agentInstanceKey)
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AuthorizationTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AuthorizationTenancyIT.java
@@ -19,10 +19,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -112,7 +112,7 @@ public class AuthorizationTenancyIT {
 
   private static void waitForAuthorizationsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ClusterVariableTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ClusterVariableTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -448,7 +448,7 @@ public class ClusterVariableTenancyIT {
 
   private static void waitForClusterVariablesBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive cluster variables from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () ->
@@ -458,7 +458,7 @@ public class ClusterVariableTenancyIT {
 
   private static void waitForBaselineClusterVariablesForUser1(final CamundaClient camundaClient) {
     Awaitility.await("should receive baseline cluster variables for USER1")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
@@ -473,7 +473,7 @@ public class ClusterVariableTenancyIT {
   private static void waitForClusterVariableToBeDeleted(
       final CamundaClient camundaClient, final String variableName, final String tenantId) {
     Awaitility.await("should have cluster variable deleted")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionDefinitionTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -186,7 +186,7 @@ public class DecisionDefinitionTenancyIT {
   private static void waitForDecisionDefinitionsToBeDeployed(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy decision definitions")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionInstanceTenancyIT.java
@@ -19,10 +19,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -198,7 +198,7 @@ public class DecisionInstanceTenancyIT {
   private static void waitForDecisionsToBeEvaluated(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should evaluate decision definitions")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/DecisionRequirementsTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -192,7 +192,7 @@ public class DecisionRequirementsTenancyIT {
       final CamundaClient client, final String tenant, final int numOfAssignments) {
 
     Awaitility.await("should assign users to tenant " + tenant)
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -204,7 +204,7 @@ public class DecisionRequirementsTenancyIT {
   private static void waitForDecisionRequirementsToBeDeployed(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy decision definitions")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ElementInstanceTenancyIT.java
@@ -19,10 +19,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -167,7 +167,7 @@ public class ElementInstanceTenancyIT {
 
   private static void waitForElementInstancesBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GroupTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/GroupTenancyIT.java
@@ -17,10 +17,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -123,7 +123,7 @@ public class GroupTenancyIT {
 
   private static void waitForGroupsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -133,7 +133,7 @@ public class GroupTenancyIT {
 
   private static void waitForGroupMembershipsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/IncidentTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -162,7 +162,7 @@ public class IncidentTenancyIT {
 
   private static void waitForIncidentsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/JobTenancyIT.java
@@ -16,10 +16,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -124,7 +124,7 @@ public class JobTenancyIT {
 
   private static void waitForJobsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MappingRuleTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MappingRuleTenancyIT.java
@@ -16,10 +16,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -101,7 +101,7 @@ public class MappingRuleTenancyIT {
 
   private static void waitForMappingRulesBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MessageSubscriptionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/MessageSubscriptionTenancyIT.java
@@ -16,10 +16,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -132,7 +132,7 @@ public class MessageSubscriptionTenancyIT {
 
   private static void waitForMessageSubscriptionsExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessDefinitionTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -168,7 +168,7 @@ public class ProcessDefinitionTenancyIT {
 
   private static void waitForProcessBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/ProcessInstanceTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -102,7 +102,7 @@ public class ProcessInstanceTenancyIT {
     deleteTenant(camundaClient, tenantToBeDeleted);
 
     Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
             () -> {
               // then
@@ -224,7 +224,7 @@ public class ProcessInstanceTenancyIT {
   private static void waitForProcessBeingExported(
       final CamundaClient camundaClient, final int expectedProcessDefinitions) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/RoleTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/RoleTenancyIT.java
@@ -17,10 +17,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -125,7 +125,7 @@ public class RoleTenancyIT {
 
   private static void waitForRolesBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -142,7 +142,7 @@ public class RoleTenancyIT {
 
   private static void waitForRoleMembershipBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/SequenceFlowTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/SequenceFlowTenancyIT.java
@@ -17,10 +17,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -121,7 +121,7 @@ public class SequenceFlowTenancyIT {
   private static void waitForSequenceFlowsExported(
       final CamundaClient camundaClient, final long processInstanceKey) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/TenantTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/TenantTenancyIT.java
@@ -15,11 +15,11 @@ import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -113,7 +113,7 @@ public class TenantTenancyIT {
 
   private static void waitForTenantsBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -123,7 +123,7 @@ public class TenantTenancyIT {
 
   private static void waitForTenantMembershipBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTaskTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTaskTenancyIT.java
@@ -18,10 +18,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -163,7 +163,7 @@ public class UserTaskTenancyIT {
 
   private static void waitForUserTasksBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/UserTenancyIT.java
@@ -16,10 +16,10 @@ import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -85,7 +85,7 @@ public class UserTenancyIT {
 
   private static void waitForTenantMembershipBeingExported(final CamundaClient camundaClient) {
     Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -716,7 +716,7 @@ public final class TestHelper {
   public static void waitForProcessInstanceToBeTerminated(
       final CamundaClient camundaClient, final Long processInstanceKey) {
     Awaitility.await("should wait until process is terminated")
-        .atMost(Duration.ofSeconds(60))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -1489,7 +1489,7 @@ public final class TestHelper {
       final long processInstanceKey,
       final int expectedDecisionInstances) {
     Awaitility.await("should deploy decision definitions and wait for import")
-        .atMost(Duration.ofSeconds(15))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
@@ -90,13 +90,20 @@ public abstract class SearchDBExtension implements BeforeAllCallback, AfterAllCa
     if (openSearchAwsInstanceUrl.isEmpty()) {
       return new ContainerizedSearchDBExtension();
     } else {
-      final Duration dataAvailabilityTimeout =
-          Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
-              .map(val -> Duration.ofSeconds(Long.parseLong(val)))
-              .orElse(Duration.ofSeconds(60));
-
-      return new AWSSearchDBExtension(openSearchAwsInstanceUrl, dataAvailabilityTimeout);
+      return new AWSSearchDBExtension(
+          openSearchAwsInstanceUrl, awsDataAvailabilityTimeout(Duration.ofSeconds(60)));
     }
+  }
+
+  /**
+   * Timeout for data to become available in the AWS OpenSearch instance, read from the {@value
+   * #TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT} system property with the given fallback when unset.
+   * Single parse point for the property — callers pick their own fallback.
+   */
+  public static Duration awsDataAvailabilityTimeout(final Duration fallback) {
+    return Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
+        .map(val -> Duration.ofSeconds(Long.parseLong(val)))
+        .orElse(fallback);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -23,6 +23,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
+import io.camunda.exporter.utils.CamundaExporterSchemaUtils;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.SchemaManager;
@@ -1711,13 +1712,14 @@ final class OpenSearchArchiverRepositoryIT {
                     .connect(connectConfig)
                     .retention(retention)
                     .schemaManager(schemaManagerConfig));
-    new SchemaManager(
+
+    CamundaExporterSchemaUtils.startupSchemaWithRetries(
+        new SchemaManager(
             searchEngineClient,
             resourceProvider.getIndexDescriptors(),
             resourceProvider.getIndexTemplateDescriptors(),
             searchEngineConfiguration,
-            MAPPER)
-        .startupOnce();
+            MAPPER));
   }
 
   private void createBatchOperationIndex() throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
@@ -15,7 +15,6 @@ import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Optional;
 import org.awaitility.Awaitility;
 
 public final class CamundaExporterSchemaUtils {
@@ -27,10 +26,7 @@ public final class CamundaExporterSchemaUtils {
    * will control how/long we would retry.
    */
   private static final Duration SCHEMA_CREATION_TIMEOUT =
-      Optional.ofNullable(
-              System.getProperty(SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
-          .map(val -> Duration.ofSeconds(Long.parseLong(val)))
-          .orElse(Duration.ofSeconds(120));
+      SearchDBExtension.awsDataAvailabilityTimeout(Duration.ofSeconds(120));
 
   private CamundaExporterSchemaUtils() {}
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
@@ -11,10 +11,27 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import org.awaitility.Awaitility;
 
 public final class CamundaExporterSchemaUtils {
+
+  /**
+   * SchemaManager.startupOnce() is a single attempt by design; on prod we retry schema creation
+   * with backoff so we can complete initialization in a loaded managed cluster taking more than one
+   * attempt. Similarly, we will retry schema creation in tests to avoid flakiness and the timeout
+   * will control how/long we would retry.
+   */
+  private static final Duration SCHEMA_CREATION_TIMEOUT =
+      Optional.ofNullable(
+              System.getProperty(SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
+          .map(val -> Duration.ofSeconds(Long.parseLong(val)))
+          .orElse(Duration.ofSeconds(120));
+
   private CamundaExporterSchemaUtils() {}
 
   public static void createSchemas(final ExporterConfiguration config) throws IOException {
@@ -23,7 +40,8 @@ public final class CamundaExporterSchemaUtils {
             config.getConnect().getIndexPrefix(),
             config.getConnect().getTypeEnum().isElasticSearch());
     try (final ClientAdapter clientAdapter = ClientAdapter.of(config.getConnect())) {
-      new SchemaManager(
+      startupSchemaWithRetries(
+          new SchemaManager(
               clientAdapter.getSearchEngineClient(),
               indexDescriptors.indices(),
               indexDescriptors.templates(),
@@ -32,8 +50,18 @@ public final class CamundaExporterSchemaUtils {
                       b.connect(config.getConnect())
                           .index(config.getIndex())
                           .retention(config.getHistory().getRetention())),
-              clientAdapter.objectMapper())
-          .startupOnce();
+              clientAdapter.objectMapper()));
     }
+  }
+
+  public static void startupSchemaWithRetries(final SchemaManager schemaManager) {
+    Awaitility.await("schema manager startup & initialization completes")
+        .ignoreExceptions()
+        .atMost(SCHEMA_CREATION_TIMEOUT)
+        .until(
+            () -> {
+              schemaManager.startupOnce();
+              return true;
+            });
   }
 }


### PR DESCRIPTION
## Description

The nightly AWS OpenSearch pipeline has been failing across every matrix leg.
Three independent causes, diagnosed from runs 31993784962, 32331080051 and
their predecessors.

### 1. AWS credentials expired mid-job (`ci:`)

`setup-aws-opensearch-env` pre-logs in with `configure-aws-credentials`, which
exports static `AWS_ACCESS_KEY_ID`/`SECRET`/`SESSION_TOKEN`. Those take
precedence over the web identity provider in the SDK's default chain and never
refresh, so the STS default of one hour became a hard deadline for jobs whose
timeout is six. The correlation is exact — the three jobs that ran 63-77
minutes each started failing every OpenSearch request at roughly the 60 minute
mark with `[security_exception] The security token included in the request is
expired`; the one that finished in 55 minutes passed.

Request a session that outlives the job.

### 2. Waits sized for a local database (`fix:`, `test:`)

80 waits across 48 acceptance test files gave secondary storage 3-60 seconds to
make data queryable — budgets calibrated for a container on the same host. They
now read `CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY`, which defaults to
two minutes and is overridable per environment via
`test.integration.opensearch.aws.timeout.seconds` (the pipeline sets it), so the
waits track the environment instead of encoding a local-database assumption.

Only secondary-storage reads in `@MultiDbTest` classes changed, and only where
the budget was below the constant. Deliberately left alone: `IncidentIT`'s
negative assertion, `StandaloneSchemaManagerIT` (not multi-db, own container),
engine-side waits such as job activation, and the job lock durations on
`newActivateJobsCommand` — which read as `.timeout(Duration)` but are command
parameters, not test waits.

### 3. A hung test could run out the job (`test:`)

Two runs went silent and burned over three hours each before the runner was reaped, producing no test reports. Failsafe now kills the fork at three hours, so the build fails with artifacts while job time remains. This bounds the whole fork rather than one test, because CI runs `forkCount=1` with `reuseForks=true`.

### Reviewer notes

- [x] `role-duration-seconds` is capped by the IAM role's `max-session-duration`. If that is still at the AWS default of one hour, the first run fails fast at credential setup instead of an hour in, and the role needs raising to match. Worth a check by whoever owns `AWS_ROLE_ARN` before merge (note: extended to 6 hours https://github.com/camunda/infra-core/pull/14141)
- [x] The fork timeout is a backstop, not a diagnosis: it caps wasted runner time but still will not name the hung test.
- [ ] Not verified end to end yet — the credential fix only proves out on a job that runs past 60 minutes, so the pipeline needs a re-run after merge.


## Related issues

relates to #52892

