### PR TITLE
ci: make infra-global-github-actions pins Renovate-readable

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -178,6 +178,16 @@
       ],
     },
     {
+      description: "infra-global-github-actions sub-actions come from a custom manager, so the matchManagers rule above does not reach them.",
+      matchDepNames: [
+        "/^camunda\\/infra-global-github-actions\\//",
+      ],
+      addLabels: [
+        "area/build",
+        "component/build-pipeline",
+      ],
+    },
+    {
       description: "Do not let Renovate edit generated agentic-workflow lock files *.lock.yml and managed upstream. Update by upgrading the gh-aw toolchain and recompiling, never via Renovate.",
       matchFileNames: [
         ".github/workflows/*.lock.yml",
@@ -955,18 +965,18 @@
     },
     {
       // Per-family extractVersion keeps each sub-action's tags from matching another family's release line.
-      description: "Track camunda/infra-global-github-actions sub-actions pinned to a per-action release tag (comment format '# <action>: vX.Y.Z'), which the default github-actions manager cannot version-track.",
+      description: "Track camunda/infra-global-github-actions sub-actions pinned to a per-action release tag (comment format '# <action>-X.Y.Z'), which the default github-actions manager cannot version-track because it drops the sub-action path from depName.",
       customType: "regex",
       managerFilePatterns: [
         "/^\\.github/.+\\.ya?ml$/",
       ],
       matchStrings: [
-        "uses:\\s*camunda/infra-global-github-actions/(?<actionPath>[\\w./-]+)@(?<currentDigest>[a-f0-9]{40})\\s*#\\s*(?<actionTag>[\\w-]+):\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
+        "uses:\\s*camunda/infra-global-github-actions/[\\w./-]+@(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<family>[a-z0-9-]+?)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
       ],
-      depNameTemplate: "camunda/infra-global-github-actions/{{{actionTag}}}",
+      depNameTemplate: "camunda/infra-global-github-actions/{{{family}}}",
       packageNameTemplate: "camunda/infra-global-github-actions",
       datasourceTemplate: "github-tags",
-      extractVersionTemplate: "^{{{actionTag}}}-(?<version>\\d+\\.\\d+\\.\\d+)$",
+      extractVersionTemplate: "^{{{family}}}-(?<version>\\d+\\.\\d+\\.\\d+)$",
     },
   ],
 }

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -224,7 +224,7 @@ jobs:
         # extracts the labels for component and severity and sets them in the project accordingly.
         # The action must be triggered for any label change to keep the project data up to date.
         name: Add issue to Quality Board
-        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@28e9ac0ffb3c71c7a1aaa989d5abdad0738c0436 # add-bug-to-quality-board: v1.0.3
+        uses: camunda/infra-global-github-actions/add-bug-to-quality-board@28e9ac0ffb3c71c7a1aaa989d5abdad0738c0436 # add-bug-to-quality-board-1.0.3
         with:
           github-token: ${{ steps.github-token.outputs.token }}
           project-number: "187"

--- a/.github/workflows/alwaysgreen-fix.yml
+++ b/.github/workflows/alwaysgreen-fix.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes

--- a/.github/workflows/alwaysgreen-triage.yml
+++ b/.github/workflows/alwaysgreen-triage.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Generate GitHub App Token
         if: ${{ steps.mode.outputs.active == 'true' }}
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes

--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/assign-urgency-to-issues-cron.yml
+++ b/.github/workflows/assign-urgency-to-issues-cron.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.10-api-rdbms.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs on runner shutdown
-        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run-1.1.0
         with:
           error-messages: |
             The runner has received a shutdown signal

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs on runner shutdown
-        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run-1.1.0
         with:
           error-messages: |
             The runner has received a shutdown signal

--- a/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rerun failed jobs on runner shutdown
-        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run-1.1.0
         with:
           error-messages: |
             The runner has received a shutdown signal

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Generate GitHub App token (qa-processes)
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/qa-processes

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Camunda Download Center - Upload artifact in own release
         if: inputs.publishToCamundaDownloadCenter
-        uses: camunda/infra-global-github-actions/download-center-upload@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # download-center-upload: v1.0.0
+        uses: camunda/infra-global-github-actions/download-center-upload@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # download-center-upload-1.0.0
         with:
           gcp_credentials: ${{ steps.secrets.outputs.GCP_CREDENTIALS_NAME }}
           version: ${{ inputs.camundaVersion }}
@@ -247,7 +247,7 @@ jobs:
 
       - name: Camunda Download Center - Upload artifact in Camunda apps version
         if: inputs.publishToCamundaDownloadCenter
-        uses: camunda/infra-global-github-actions/download-center-upload@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # download-center-upload: v1.0.0
+        uses: camunda/infra-global-github-actions/download-center-upload@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # download-center-upload-1.0.0
         with:
           gcp_credentials: ${{ steps.secrets.outputs.GCP_CREDENTIALS_NAME }}
           version: ${{ inputs.camundaAppsRelease }}

--- a/.github/workflows/camunda-load-test-smoke.yml
+++ b/.github/workflows/camunda-load-test-smoke.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
       - id: sanitize-author
         name: Sanitize author name
-        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name-1.0.0
         with:
           branch: ${{ github.event.pull_request.user.login || github.actor }}
           max_length: 10

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -113,7 +113,7 @@ jobs:
       # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -701,7 +701,7 @@ jobs:
       - name: Identify previous release version
         id: prev_version
         if: ${{ !inputs.dryRun }}
-        uses: camunda/infra-global-github-actions/previous-version@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # previous-version: v1.0.0
+        uses: camunda/infra-global-github-actions/previous-version@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # previous-version-1.0.0
         with:
           version: "${{ inputs.releaseVersion }}"
           verbose: 'false'
@@ -859,9 +859,9 @@ jobs:
             secret/data/products/camunda/ci/camunda FOSSA_API_KEY;
       - name: Get FOSSA context
         id: fossa-context
-        uses: camunda/infra-global-github-actions/fossa/info@fc4fa13813cbc1835129967f10a12f24aa7a393c
+        uses: camunda/infra-global-github-actions/fossa/info@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       - name: Wait for FOSSA scan completion
-        uses: camunda/infra-global-github-actions/fossa/wait-for-scan@fc4fa13813cbc1835129967f10a12f24aa7a393c
+        uses: camunda/infra-global-github-actions/fossa/wait-for-scan@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
         with:
           api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}
@@ -869,7 +869,7 @@ jobs:
           revision-id: ${{ needs.release.outputs.releaseTagCommitSha }}
           dry-run: ${{ inputs.dryRun || inputs.releaseProcessDryRun }}
       - name: Create FOSSA releases and generate reports
-        uses: camunda/infra-global-github-actions/fossa/release@fc4fa13813cbc1835129967f10a12f24aa7a393c
+        uses: camunda/infra-global-github-actions/fossa/release@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
         with:
           api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
           branch: ${{ steps.fossa-context.outputs.head-ref }}

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -60,14 +60,14 @@ jobs:
 
       - id: sanitize-author
         name: Sanitize author name
-        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name-1.0.0
         with:
           branch: ${{ github.event.pull_request.user.login }}
           max_length: 10
 
       - id: sanitize-db-type
         name: Sanitize db type
-        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name-1.0.0
         with:
           branch: ${{ inputs.secondary-storage-type }}
           max_length: 15

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -84,7 +84,7 @@ jobs:
       sanitized-name: ${{ steps.sanitize.outputs.branch_name }}
     steps:
       - id: sanitize
-        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name-1.0.0
         with:
           branch: ${{ inputs.name }}
           max_length: 50  # reduced to account for load-test prefix "c8-" and potential suffixes for uniqueness

--- a/.github/workflows/chatops-command-ci-problems.yml
+++ b/.github/workflows/chatops-command-ci-problems.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Generate a GitHub token
       id: github-token
-      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
       with:
         github-app-id-vault-key: GITHUB_OPTIMIZE_APP_ID
         github-app-id-vault-path: secret/data/products/optimize/ci/camunda-optimize

--- a/.github/workflows/chatops-command-disable-cache.yml
+++ b/.github/workflows/chatops-command-disable-cache.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Generate a GitHub token
       id: github-token
-      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
       with:
         github-app-id-vault-key: GITHUB_OPTIMIZE_APP_ID
         github-app-id-vault-path: secret/data/products/optimize/ci/camunda-optimize

--- a/.github/workflows/chatops-command-dispatch.yml
+++ b/.github/workflows/chatops-command-dispatch.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_OPTIMIZE_APP_ID
           github-app-id-vault-path: secret/data/products/optimize/ci/camunda-optimize

--- a/.github/workflows/check-licenses-active-issues.yml
+++ b/.github/workflows/check-licenses-active-issues.yml
@@ -40,21 +40,21 @@ jobs:
 
     - name: Get Issues for camunda/camunda@single-app (all tracked branches)
       # Tracked branches are defiened in FOSSA UI
-      uses: camunda/infra-global-github-actions/fossa/get-issues@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/get-issues@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       id: single-app
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         project-locator: custom+50756/camunda/camunda@single-app
 
     - name: Get Issues for camunda/camunda@optimize (all tracked branches)
-      uses: camunda/infra-global-github-actions/fossa/get-issues@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/get-issues@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       id: optimize
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         project-locator: custom+50756/camunda/camunda@optimize
 
     - name: Get Issues for camunda/camunda@c8run (all tracked branches)
-      uses: camunda/infra-global-github-actions/fossa/get-issues@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/get-issues@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       id: c8run
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -116,11 +116,11 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/setup@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
 
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/info@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
@@ -133,7 +133,7 @@ jobs:
       id: analyze1
       continue-on-error: true
       timeout-minutes: 30
-      uses: camunda/infra-global-github-actions/fossa/analyze@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/analyze@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -143,7 +143,7 @@ jobs:
     - name: Analyze project (attempt 2)
       if: steps.analyze1.outcome != 'success'
       timeout-minutes: 30
-      uses: camunda/infra-global-github-actions/fossa/analyze@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/analyze@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -155,7 +155,7 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/pr-check@fc4fa13813cbc1835129967f10a12f24aa7a393c # fossa-1.0.2
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Check all PRs for conflict
-      uses: camunda/infra-global-github-actions/preview-env/conflicts@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
     - name: Observe build status
       if: always()
       continue-on-error: true
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check PR for merge conflicts
-      uses: camunda/infra-global-github-actions/preview-env/conflicts@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
       with:
         pull-request-id: ${{ github.event.pull_request.number }}
     - name: Checkout

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -327,7 +327,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
-      - uses: camunda/infra-global-github-actions/setup-yarn-cache@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # setup-yarn-cache: v1.0.0
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # setup-yarn-cache-1.0.0
         with:
           directory: optimize/client
       - name: Install dependencies

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -560,7 +560,7 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         timeout-minutes: 1
         with:
           persist-credentials: false
-      - uses: camunda/infra-global-github-actions/actionlint@0077d059bb0d698e1086a4b46517cb7917fa8300 # actionlint: v1.0.2
+      - uses: camunda/infra-global-github-actions/actionlint@0077d059bb0d698e1086a4b46517cb7917fa8300 # actionlint-1.0.2
         with:
           version: ${{ env.ACTIONLINT_VERSION }}
           ignore: |-

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -790,7 +790,7 @@ jobs:
 
       - name: Generate GitHub App Token (for dispatch)
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci

--- a/.github/workflows/frontend-sbom-snyk-nightly.yml
+++ b/.github/workflows/frontend-sbom-snyk-nightly.yml
@@ -206,7 +206,7 @@ jobs:
         uses: YunaBraska/java-info-action@094dc70cf4050d156dded76d5574c962886c0b0a # 3.0.12
         with:
           work-dir: ./parent
-      - uses: camunda/infra-global-github-actions/setup-yarn-cache@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # setup-yarn-cache: v1.0.0
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # setup-yarn-cache-1.0.0
         with:
           directory: optimize/client
       - name: Import Snyk token from Vault

--- a/.github/workflows/load-test-golden-update.yml
+++ b/.github/workflows/load-test-golden-update.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Generate GitHub token
       id: github-token
-      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
       with:
         github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
         github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/optimize-ci-data-upgrade-nightly.yml
+++ b/.github/workflows/optimize-ci-data-upgrade-nightly.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrigger job
-        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run-1.1.0
         with:
           error-messages: |
             lost communication with the server

--- a/.github/workflows/optimize-create-release-branch.yml
+++ b/.github/workflows/optimize-create-release-branch.yml
@@ -22,7 +22,7 @@ jobs:
       # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/optimize-opened-issues-automation.yml
+++ b/.github/workflows/optimize-opened-issues-automation.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_OPTIMIZE_APP_ID
           github-app-id-vault-path: secret/data/products/optimize/ci/camunda-optimize

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -65,7 +65,7 @@ jobs:
         # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -174,7 +174,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Install common tooling (buildx) # required on self-hosted runners
-        uses: camunda/infra-global-github-actions/common-tooling@b20a0e8f64ea6554900bab2d3fb3906be613aa19 # common-tooling: v1.0.1
+        uses: camunda/infra-global-github-actions/common-tooling@b20a0e8f64ea6554900bab2d3fb3906be613aa19 # common-tooling-1.0.1
         with:
           buildx-enabled: true
           java-enabled: false

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -201,7 +201,7 @@ jobs:
     # Sanitize the branch name to remove dependabot/,renovate/ and transform the name
     - id: sanitize
       if: inputs.app-name == ''
-      uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
+      uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name-1.0.0
       with:
         branch: ${{ github.head_ref }}
         max_length: '15'
@@ -264,7 +264,7 @@ jobs:
     #########################################################################
     # Create a preview environment
     - name: Deploy Preview Environment for c8sm
-      uses: camunda/infra-global-github-actions/preview-env/create@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+      uses: camunda/infra-global-github-actions/preview-env/create@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
       with:
         revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
@@ -299,7 +299,7 @@ jobs:
     steps:
     - name: Check PR for merge conflicts
       if: github.event_name == 'pull_request'
-      uses: camunda/infra-global-github-actions/preview-env/conflicts@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
       with:
         pull-request-id: ${{ github.event.pull_request.number }}
 
@@ -343,7 +343,7 @@ jobs:
     timeout-minutes: 5
     needs: [deploy-preview]
     steps:
-    - uses: camunda/infra-global-github-actions/preview-env/comment@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+    - uses: camunda/infra-global-github-actions/preview-env/comment@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
 
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Generate a GitHub token
       id: github-token
-      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
       with:
         github-app-id-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_ID
         github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -50,7 +50,7 @@ jobs:
         vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
         vault-url: ${{ secrets.VAULT_ADDR }}
 
-    - uses: camunda/infra-global-github-actions/preview-env/clean@67d00e9260887361a31f6446252fffbecae4a02e # preview-env: v1.0.12
+    - uses: camunda/infra-global-github-actions/preview-env/clean@67d00e9260887361a31f6446252fffbecae4a02e # preview-env-1.0.12
       with:
         labels: deploy-preview
         pull-request: ${{ inputs.pull-request }}
@@ -70,7 +70,7 @@ jobs:
           secret/data/products/camunda/ci/camunda ARGOCD_TOKEN;
 
     # Clean up any (remaining) smoke-test preview environments older than 12 hours
-    - uses: camunda/infra-global-github-actions/argocd-delete-applications@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # argocd-delete-applications: v1.0.0
+    - uses: camunda/infra-global-github-actions/argocd-delete-applications@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # argocd-delete-applications-1.0.0
       with:
         argocd-token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         github-token: ${{ github.token }}

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -296,7 +296,7 @@ jobs:
 
       - name: Generate GitHub Token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -49,7 +49,7 @@ jobs:
     # Sanitize the branch name to remove dependabot/,renovate/ and transform the name
     - id: sanitize
       if: inputs.app-name == ''
-      uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
+      uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name-1.0.0
       with:
         branch: ${{ github.head_ref }} # head_ref = branch on PR
         max_length: '15'
@@ -71,7 +71,7 @@ jobs:
     # Setup: Generate Github Token for the Github App
     - name: Generate a GitHub token
       id: github-token
-      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
       with:
         github-app-id-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_ID
         github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -85,7 +85,7 @@ jobs:
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment
-      uses: camunda/infra-global-github-actions/preview-env/destroy@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+      uses: camunda/infra-global-github-actions/preview-env/destroy@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
       with:
         revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
     timeout-minutes: 5
     needs: [teardown-preview]
     steps:
-    - uses: camunda/infra-global-github-actions/preview-env/comment@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env: v1.0.8
+    - uses: camunda/infra-global-github-actions/preview-env/comment@a362d3abeb1f550f0269d74adf2fe343e24517ef # preview-env-1.0.8
 
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-rc-delta-slack-summary.yml
+++ b/.github/workflows/release-rc-delta-slack-summary.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Identify previous release version
         id: prev_version
-        uses: camunda/infra-global-github-actions/previous-version@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # previous-version: v1.0.0
+        uses: camunda/infra-global-github-actions/previous-version@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # previous-version-1.0.0
         with:
           version: ${{ inputs.rc_version }}
           verbose: 'false'

--- a/.github/workflows/renovate-daily.yml
+++ b/.github/workflows/renovate-daily.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate a GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RENOVATE_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -52,7 +52,7 @@ jobs:
     # failed required jobs.
     - name: Maintain Renovate PRs
       id: run-maintainer
-      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@d17726003bd01bcc7513556cc48005e8c6850938
+      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@e5e6668cef06b3ab76e94a8eb0045b9b16b33bd1 # renovate-pr-maintainer-1.1.0
       with:
         dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -196,7 +196,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -255,7 +255,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/trigger-c8run-e2e-tests.yml
+++ b/.github/workflows/trigger-c8run-e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Generate a GitHub token for camunda/camunda repo
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: GITHUB_APP_ID
           github-app-id-vault-path: secret/data/products/qa/ci/github.com/apps/camunda/quality-assurance-ci

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -150,7 +150,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets-1.1.0
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda


### PR DESCRIPTION
## 📌 What

Switches the 57 `camunda/infra-global-github-actions` pin comments from `# <action>: vX.Y.Z` to the literal upstream release tag `# <action>-X.Y.Z`, gives the 12 pins that had no comment one, and matches the Renovate custom manager on the new form. Adds a packageRule so the resulting PRs get the same labels as every other CI update.

## 🤔 Why

Renovate's `github-actions` manager reads the trailing pin comment with two patterns: a version-like token, or a single bare word ([`parse.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/github-actions/parse.ts)). `# preview-env: v1.0.8` matches neither, because the colon splits it into two tokens. The dependency then comes out with `currentValue: undefined` and `skipReason: unversioned-reference`, which is the `undefined` version showing against 69 of our action pins in the Mend dependency inventory. `# preview-env-1.0.8` parses cleanly: the version token accepts a `<name>-` prefix.

The same manager drops the sub-action path from `depName`, so all families in that repo collapse into one `camunda/infra-global-github-actions` dependency and cannot be version-tracked. The custom manager keeps that job, and with a parseable comment the built-in manager resolves the pin to its own tag digest and produces no competing update.

`fossa/*` and `renovate-pr-maintainer` carried no comment at all, so they were untracked and sit 14 and 2 releases behind. `fc4fa138` is exactly `fossa-1.0.2`, so those 11 comments are metadata only. `renovate-pr-maintainer` was pinned to an untagged commit; `renovate-pr-maintainer-1.1.0` is the release that contains it and differs from it only in `CHANGELOG.md`, which makes it the single SHA this PR changes.

Renovate will follow up with its own PRs for the 11 families that are behind. The `fossa` one carries FOSSA CLI 3.17.0 to 3.18.x, so it is a real upgrade to review rather than a rubber-stamp.

## 🔧 How

- Workflows: 57 comments reformatted, 11 `fossa/*` comments added, `renovate-pr-maintainer` repinned to `renovate-pr-maintainer-1.1.0`. No other SHA changes.
- `.github/renovate.json5`: custom manager matches `-` instead of `: v`; new packageRule labels `camunda/infra-global-github-actions/*` with `area/build` and `component/build-pipeline`, which the `matchManagers: ["github-actions"]` rule above cannot reach because these dependencies come from a custom manager.

Follows up on #61648, which added the custom manager but kept the comment format the built-in manager cannot read.

<details>
<summary>🧪 Validation</summary>

Proven end to end in [camunda/infra-github-demo](https://github.com/camunda/infra-github-demo) before touching this repo, so the behaviour comes from a live Renovate run rather than from reading the config.

**Sandbox, live Renovate.** [`b39c0d2`](https://github.com/camunda/infra-github-demo/commit/b39c0d2) puts this exact custom manager and label rule on `master`, plus a fixture workflow pinning four families deliberately behind, an old-format pin as a negative control, and a `# main` pin as an untouched control. Renovate opened four PRs and rewrote both halves of every line:

| PR | Rewrite |
|:---|:--------|
| [#655](https://github.com/camunda/infra-github-demo/pull/655) | `fossa/setup@fc4fa138 # fossa-1.0.2` → `@ee746fa6 # fossa-1.0.17` |
| [#656](https://github.com/camunda/infra-github-demo/pull/656) | `generate-github-app-token-from-vault-secrets@6c85c5de # …-1.1.0` → `@67d00e92 # …-1.1.1` |
| [#657](https://github.com/camunda/infra-github-demo/pull/657) | `preview-env/conflicts@a362d3ab # preview-env-1.0.8` → `@67d00e92 # preview-env-1.0.12` |
| [#658](https://github.com/camunda/infra-github-demo/pull/658) | `renovate-pr-maintainer@e5e6668c # …-1.1.0` → `@9d9d444b # …-1.2.0` |

Every new SHA matches its claimed tag (`git rev-parse <tag>^{commit}`). All four carry the label rule's labels, confirming it reaches custom-manager dependencies. The old-format control got no PR and still reports `undefined`; the `# main` control was left alone.

**This repo, extraction and lookup.** Renovate 44.57.1 (the version Mend runs) over all 53 workflow files here that reference the actions, with this branch's `renovate.json5` against live GitHub tags:

- `undefined` / `unversioned-reference`: 69 before, 0 after
- 11 families resolve real updates (`fossa` 1.0.2→1.0.16, `common-tooling` 1.0.1→1.0.5, `actionlint` 1.0.2→1.0.5, `preview-env` 1.0.8→1.0.12, `setup-yarn-cache` 1.0.0→1.0.2, `rerun-failed-run` 1.1.0→1.1.2, `renovate-pr-maintainer` 1.1.0→1.2.0, `add-bug-to-quality-board` 1.0.3→1.0.4, `argocd-delete-applications` 1.0.0→1.0.1, `download-center-upload` 1.0.0→1.0.1, `generate-github-app-token-from-vault-secrets` 1.1.0→1.1.1); 3 already at latest
- the 86 `# main` digest pins behave exactly as before
- every pin's SHA matches the tag its comment names, so the reformat triggers no digest PRs

`fossa` lands on 1.0.16 rather than 1.0.17 here because of this repo's `minimumReleaseAge: 3 days`.

**Linters.** `zizmor --config .github/zizmor.yml`: 0 `unpinned-uses`. `actionlint`: 41 findings before, 41 after.

</details>

## Checklist

- [ ] Enable backports when necessary. `stable/8.9` carries 39 of the same pins and Renovate runs against the stable base branches too, so backporting fixes the `undefined` reporting there as well. Reviewer call.

## Related issues

- [x] This PR does not need a linked issue
