### PR TITLE
docs: update load tests deprecation message for stable/8.8

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
-> This folder in the branch `stable/8.7` is unused and should not be updated.
-> To deploy a load test for the Camunda Platform 8.7, use the `stable-87` folder from the `main` branch instead.
+> The `setup` folder in the branch `stable/8.8` does not exist.
+> To deploy a load test for the Camunda Platform 8.8, use the `stable-88` folder from the `main` branch instead.
 
 ---
 


### PR DESCRIPTION
## Description

Follow-up https://github.com/camunda/camunda/pull/61293

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

