### PR TITLE
Stop double-counting metrics on a resent history item

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -274,9 +274,9 @@ public final class AgentHistoryBatchBehavior {
       // A duplicate is skipped entirely: no metrics accumulation — re-applying values the
       // instance already reflects would be unobservable, so the durable signal that it was
       // skipped is the isDuplicate flag on the echoed item alone.
-      final var alreadyAccumulated =
-          agentHistoryState.hasAccumulatedMetrics(target.getAgentInstanceKey(), historyItemId);
-      if (!isDuplicate && !alreadyAccumulated && applyMetrics(target.getMetrics(), item)) {
+      if (!isDuplicate
+          && !agentHistoryState.hasAccumulatedMetrics(target.getAgentInstanceKey(), historyItemId)
+          && applyMetrics(target.getMetrics(), item)) {
         changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
       }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -274,7 +274,9 @@ public final class AgentHistoryBatchBehavior {
       // A duplicate is skipped entirely: no metrics accumulation — re-applying values the
       // instance already reflects would be unobservable, so the durable signal that it was
       // skipped is the isDuplicate flag on the echoed item alone.
-      if (!isDuplicate && applyMetrics(target.getMetrics(), item)) {
+      final var alreadyAccumulated =
+          agentHistoryState.hasAccumulatedMetrics(target.getAgentInstanceKey(), historyItemId);
+      if (!isDuplicate && !alreadyAccumulated && applyMetrics(target.getMetrics(), item)) {
         changedAttributes.add(AgentInstanceRecord.ATTR_METRICS);
       }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
@@ -50,10 +50,10 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
       committedHistoryItemIdsColumnFamily;
 
   // Metrics-accumulated ids: (agentInstanceKey, historyItemId) -> nil
-  // Composite key supports prefix search by agentInstanceKey alone. Kept separate from
-  // committedHistoryItemIdsColumnFamily: that store's value is echoed back as the item's
-  // agentHistoryKey, so writing an entry there at creation time would make a created-then-
-  // discarded item look committed on resend.
+  // Supports prefix search by agentInstanceKey alone, for the one-shot delete on instance
+  // completion. Kept separate from committedHistoryItemIdsColumnFamily: that store's value is
+  // echoed back as the item's agentHistoryKey, so writing an entry there at creation time would
+  // make a created-then-discarded item look committed on resend.
   private final DbLong metricsAccumulatedAgentInstanceKey = new DbLong();
   private final DbString metricsAccumulatedHistoryItemId = new DbString();
   private final DbCompositeKey<DbLong, DbString> metricsAccumulatedKey =
@@ -195,5 +195,22 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
     metricsAccumulatedAgentInstanceKey.wrapLong(agentInstanceKey);
     metricsAccumulatedHistoryItemId.wrapString(historyItemId);
     metricsAccumulatedIdsColumnFamily.upsert(metricsAccumulatedKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void deleteMetricsAccumulatedIds(final long agentInstanceKey) {
+    metricsAccumulatedAgentInstanceKey.wrapLong(agentInstanceKey);
+    // Collect the ids in one pass, then delete in a second: mutating the column family while its
+    // own iterator is still open is unsafe (RocksDB explicitly warns against it), so this must not
+    // call deleteExisting from inside the whileEqualPrefix visitor below.
+    final var historyItemIds = new ArrayList<String>();
+    final Consumer<DbCompositeKey<DbLong, DbString>> collectHistoryItemId =
+        key -> historyItemIds.add(key.second().toString());
+    metricsAccumulatedIdsColumnFamily.whileEqualPrefix(
+        metricsAccumulatedAgentInstanceKey, collectHistoryItemId);
+    for (final var historyItemId : historyItemIds) {
+      metricsAccumulatedHistoryItemId.wrapString(historyItemId);
+      metricsAccumulatedIdsColumnFamily.deleteExisting(metricsAccumulatedKey);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
@@ -49,6 +49,18 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
   private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbLong>
       committedHistoryItemIdsColumnFamily;
 
+  // Metrics-accumulated ids: (agentInstanceKey, historyItemId) -> nil
+  // Composite key supports prefix search by agentInstanceKey alone. Kept separate from
+  // committedHistoryItemIdsColumnFamily: that store's value is echoed back as the item's
+  // agentHistoryKey, so writing an entry there at creation time would make a created-then-
+  // discarded item look committed on resend.
+  private final DbLong metricsAccumulatedAgentInstanceKey = new DbLong();
+  private final DbString metricsAccumulatedHistoryItemId = new DbString();
+  private final DbCompositeKey<DbLong, DbString> metricsAccumulatedKey =
+      new DbCompositeKey<>(metricsAccumulatedAgentInstanceKey, metricsAccumulatedHistoryItemId);
+  private final ColumnFamily<DbCompositeKey<DbLong, DbString>, DbNil>
+      metricsAccumulatedIdsColumnFamily;
+
   public DbAgentHistoryState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     agentHistoryColumnFamily =
@@ -66,6 +78,12 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
             transactionContext,
             committedKey,
             committedAgentHistoryKey);
+    metricsAccumulatedIdsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.AGENT_HISTORY_METRICS_ACCUMULATED_IDS,
+            transactionContext,
+            metricsAccumulatedKey,
+            DbNil.INSTANCE);
   }
 
   @Override
@@ -163,5 +181,19 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
       committedHistoryItemId.wrapString(historyItemId);
       committedHistoryItemIdsColumnFamily.deleteExisting(committedKey);
     }
+  }
+
+  @Override
+  public boolean hasAccumulatedMetrics(final long agentInstanceKey, final String historyItemId) {
+    metricsAccumulatedAgentInstanceKey.wrapLong(agentInstanceKey);
+    metricsAccumulatedHistoryItemId.wrapString(historyItemId);
+    return metricsAccumulatedIdsColumnFamily.exists(metricsAccumulatedKey);
+  }
+
+  @Override
+  public void markMetricsAccumulated(final long agentInstanceKey, final String historyItemId) {
+    metricsAccumulatedAgentInstanceKey.wrapLong(agentInstanceKey);
+    metricsAccumulatedHistoryItemId.wrapString(historyItemId);
+    metricsAccumulatedIdsColumnFamily.upsert(metricsAccumulatedKey, DbNil.INSTANCE);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
@@ -87,5 +87,8 @@ public final class AgentHistoryCreatedApplier
       }
     }
     agentHistoryState.insert(key, storedRecord);
+    // Marks the id as having had its metrics accumulated, independent of the pending record above
+    // (which is deleted on commit/discard) — see AGENT_HISTORY_METRICS_ACCUMULATED_IDS.
+    agentHistoryState.markMetricsAccumulated(value.getAgentInstanceKey(), value.getHistoryItemId());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplier.java
@@ -31,5 +31,6 @@ public final class AgentInstanceCompletedApplier
     agentInstanceState.delete(key, value);
     // Only removal path for an agent instance; any new one needs this same cleanup call.
     agentHistoryState.deleteCommittedHistoryItemKeys(key);
+    agentHistoryState.deleteMetricsAccumulatedIds(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AgentHistoryState.java
@@ -40,6 +40,13 @@ public interface AgentHistoryState {
    */
   Long getCommittedHistoryItemKey(long agentInstanceKey, String historyItemId);
 
+  /**
+   * @return whether metrics were already accumulated for {@code historyItemId} on {@code
+   *     agentInstanceKey}, whether or not that item's copy is still pending, committed, or was
+   *     discarded
+   */
+  boolean hasAccumulatedMetrics(long agentInstanceKey, String historyItemId);
+
   @FunctionalInterface
   interface AgentHistoryVisitor {
     void visit(AgentHistoryRecord record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
@@ -39,4 +39,11 @@ public interface MutableAgentHistoryState extends AgentHistoryState {
    * agent instance completes.
    */
   void deleteCommittedHistoryItemKeys(long agentInstanceKey);
+
+  /**
+   * Records that metrics were accumulated for {@code historyItemId} on {@code agentInstanceKey}, so
+   * a later resend of the same id — even one whose earlier copy was discarded — does not accumulate
+   * its metrics again.
+   */
+  void markMetricsAccumulated(long agentInstanceKey, String historyItemId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
@@ -46,4 +46,10 @@ public interface MutableAgentHistoryState extends AgentHistoryState {
    * its metrics again.
    */
   void markMetricsAccumulated(long agentInstanceKey, String historyItemId);
+
+  /**
+   * Deletes every metrics-accumulated-id entry recorded for {@code agentInstanceKey}. Called once,
+   * when the agent instance completes.
+   */
+  void deleteMetricsAccumulatedIds(long agentInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -3416,7 +3416,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
   @Test
   public void shouldNotTreatDiscardedItemAsDuplicateWhenResent() {
     // given — one job pushes two items under two different leases: "item-committed" under
-    // lease-1, "item-discarded" under lease-2
+    // lease-1, "item-discarded" under lease-2. Both carry non-zero token deltas so a later
+    // re-accumulation would be visible rather than passing vacuously.
     ENGINE
         .deployment()
         .withXmlResource(
@@ -3451,6 +3452,16 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .getFirst()
             .getKey();
 
+    final var committedItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-committed")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    committedItem.getMetrics().setInputTokens(10L).setOutputTokens(5L);
     final var firstUpdate =
         ENGINE
             .agentInstances()
@@ -3458,37 +3469,41 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
             .withJobLease("lease-1")
-            .withHistory(
-                List.of(
-                    new AgentHistoryRecord()
-                        .setHistoryItemId("item-committed")
-                        .setRole(AgentHistoryRole.USER)
-                        .setLoopIteration(1)
-                        .addContent(
-                            new AgentHistoryMessageContent()
-                                .setContentType(AgentHistoryContentType.TEXT)
-                                .setText("hi"))))
+            .withHistory(List.of(committedItem))
             .update();
     final var committedOriginalKey =
         firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
 
-    ENGINE
-        .agentInstances()
-        .withAgentInstanceKey(agentInstanceKey)
-        .withElementInstanceKey(elementInstanceKey)
-        .withJobKey(jobKey)
-        .withJobLease("lease-2")
-        .withHistory(
-            List.of(
-                new AgentHistoryRecord()
-                    .setHistoryItemId("item-discarded")
-                    .setRole(AgentHistoryRole.USER)
-                    .setLoopIteration(1)
-                    .addContent(
-                        new AgentHistoryMessageContent()
-                            .setContentType(AgentHistoryContentType.TEXT)
-                            .setText("hey"))))
-        .update();
+    final var discardedItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-discarded")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hey"));
+    discardedItem.getMetrics().setInputTokens(7L).setOutputTokens(3L);
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease("lease-2")
+            .withHistory(List.of(discardedItem))
+            .update();
+
+    assertThat(secondUpdate.getValue().getMetrics().getInputTokens())
+        .describedAs(
+            "metrics apply at accept time, not commit time — both items' deltas are already on"
+                + " the instance before either is committed or discarded")
+        .isEqualTo(10L + 7L);
+    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens())
+        .describedAs(
+            "metrics apply at accept time, not commit time — both items' deltas are already on"
+                + " the instance before either is committed or discarded")
+        .isEqualTo(5L + 3L);
 
     // when — COMMIT with lease-1: "item-committed" is committed, "item-discarded" (lease-2, a
     // superseded activation) is discarded
@@ -3500,7 +3515,19 @@ public class AgentInstanceHistoryBatchProcessingTest {
         .withJobKey(jobKey)
         .getFirst();
 
-    // when — a later request resends both historyItemIds
+    // when — a later request resends both historyItemIds, this time with different (larger)
+    // metrics on the resent "item-discarded" — if it were re-accumulated, the totals below would
+    // include it a second time.
+    final var resentDiscardedItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-discarded")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hey again"));
+    resentDiscardedItem.getMetrics().setInputTokens(100L).setOutputTokens(50L);
     final var resend =
         ENGINE
             .agentInstances()
@@ -3517,17 +3544,11 @@ public class AgentInstanceHistoryBatchProcessingTest {
                             new AgentHistoryMessageContent()
                                 .setContentType(AgentHistoryContentType.TEXT)
                                 .setText("hi again")),
-                    new AgentHistoryRecord()
-                        .setHistoryItemId("item-discarded")
-                        .setRole(AgentHistoryRole.USER)
-                        .setLoopIteration(1)
-                        .addContent(
-                            new AgentHistoryMessageContent()
-                                .setContentType(AgentHistoryContentType.TEXT)
-                                .setText("hey again"))))
+                    resentDiscardedItem))
             .update();
 
-    // then
+    // then — the content half: resending still recreates "item-discarded" fresh (it is not a
+    // duplicate), exactly as before this change.
     final var echoed = resend.getValue().getHistory();
     assertThat(echoed).hasSize(2);
     assertThat(echoed.get(0).isDuplicate())
@@ -3556,6 +3577,20 @@ public class AgentInstanceHistoryBatchProcessingTest {
             "two CREATED events exist for item-discarded in total: one from the first push, one"
                 + " from this resend")
         .hasSize(2);
+
+    // then — the metrics half: "item-discarded"'s earlier copy was discarded, but its metrics
+    // were already accumulated when it was first created, so this resend must not pay for them a
+    // second time — the totals stay exactly where they were before the resend, and the resend's
+    // own changedAttributes omits "metrics" as the observable signal that it was skipped.
+    assertThat(resend.getValue().getMetrics().getInputTokens())
+        .as("item-discarded's metrics were already accumulated on its first creation")
+        .isEqualTo(10L + 7L);
+    assertThat(resend.getValue().getMetrics().getOutputTokens())
+        .as("item-discarded's metrics were already accumulated on its first creation")
+        .isEqualTo(5L + 3L);
+    assertThat(resend.getValue().getChangedAttributes())
+        .as("metrics were skipped for both the duplicate and the resent-but-discarded item")
+        .doesNotContain("metrics");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -3541,6 +3541,126 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldAccumulateMetricsPerAgentInstanceForSameHistoryItemId() {
+    // given — agent instance A receives "item-shared" with non-zero metrics
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKeyA = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKeyA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyA)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKeyA =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobAKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKeyA)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    final var itemForA =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-shared")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    itemForA.getMetrics().setInputTokens(10L).setOutputTokens(5L);
+    final var updateA =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyA)
+            .withElementInstanceKey(elementInstanceKeyA)
+            .withJobKey(jobAKey)
+            .withHistory(List.of(itemForA))
+            .update();
+
+    // then — instance A's metrics reflect its own item
+    assertThat(updateA.getValue().getMetrics().getInputTokens()).isEqualTo(10L);
+    assertThat(updateA.getValue().getMetrics().getOutputTokens()).isEqualTo(5L);
+
+    // given — a second, unrelated agent instance B
+    final var processInstanceKeyB = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKeyB =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKeyB)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKeyB =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobBKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKeyB)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+
+    // when — the SAME historyItemId ("item-shared") is sent to agent instance B for the first
+    // time, carrying its own (different) non-zero metrics
+    final var itemForB =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-shared")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    itemForB.getMetrics().setInputTokens(20L).setOutputTokens(8L);
+    final var updateB =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKeyB)
+            .withElementInstanceKey(elementInstanceKeyB)
+            .withJobKey(jobBKey)
+            .withHistory(List.of(itemForB))
+            .update();
+
+    // then — instance B accumulates its own metrics; the same historyItemId already accumulated
+    // on instance A does not cause B's accumulation to be skipped, because the
+    // metrics-accumulated-ids store is keyed by (agentInstanceKey, historyItemId), not by
+    // historyItemId alone.
+    assertThat(updateB.getValue().getMetrics().getInputTokens())
+        .as("instance B accumulates its own metrics for item-shared, unaffected by instance A")
+        .isEqualTo(20L);
+    assertThat(updateB.getValue().getMetrics().getOutputTokens())
+        .as("instance B accumulates its own metrics for item-shared, unaffected by instance A")
+        .isEqualTo(8L);
+    assertThat(updateB.getValue().getChangedAttributes())
+        .as("metrics were not skipped for instance B's first-ever item-shared")
+        .contains("metrics");
+  }
+
+  @Test
   public void shouldNotTreatDiscardedItemAsDuplicateWhenResent() {
     // given — one job pushes two items under two different leases: "item-committed" under
     // lease-1, "item-discarded" under lease-2. Both carry non-zero token deltas so a later

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -3047,6 +3047,133 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldAccumulateMetricsOnceForSameItemIdPendingUnderTwoLeases() {
+    // given — the same historyItemId arrives under a second lease while the first lease's copy
+    // is still pending (the job has not completed, so neither copy is committed or discarded
+    // yet). The metrics-accumulated-ids mechanism keys on historyItemId alone, so it must
+    // recognize the second copy as the same id and skip re-accumulating its metrics, even though
+    // the two copies live under different leases and neither has won yet.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    final var agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    // Activation 1 (superseded): push the item under lease1, carrying non-zero token/tool-call
+    // deltas, then fail the job to trigger re-activation. Its copy stays pending — never
+    // committed, never discarded.
+    final var batch1 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
+    final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
+
+    final var firstItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-pending-under-two-leases")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    firstItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
+    firstItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease1)
+            .withHistory(List.of(firstItem))
+            .update();
+    assertThat(firstUpdate.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(firstUpdate.getValue().getMetrics().getOutputTokens()).isEqualTo(40L);
+    assertThat(firstUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(firstUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(lease1)
+        .withRetries(1)
+        .fail();
+
+    // Activation 2: re-activate under a new lease — lease1's copy is still pending, the job has
+    // not completed — then resend the same historyItemId with its own (different) deltas.
+    final var batch2 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex2 = batch2.getValue().getJobKeys().indexOf(jobKey);
+    final var lease2 = batch2.getValue().getJobs().get(jobIndex2).getLeaseToken();
+    assertThat(lease2).as("re-activation must advance the lease token").isNotEqualTo(lease1);
+
+    final var secondItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-pending-under-two-leases")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    secondItem.getMetrics().setInputTokens(200L).setOutputTokens(80L);
+    secondItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-2").setToolName("lookup"));
+
+    // when
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withJobLease(lease2)
+            .withHistory(List.of(secondItem))
+            .update();
+
+    // then — the second copy shares the first copy's historyItemId, so its metrics must not be
+    // counted again: totals stay exactly where the first (still-pending) copy left them.
+    assertThat(secondUpdate.getValue().getMetrics().getInputTokens())
+        .as("item-pending-under-two-leases' metrics were already accumulated under lease1")
+        .isEqualTo(100L);
+    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens())
+        .as("item-pending-under-two-leases' metrics were already accumulated under lease1")
+        .isEqualTo(40L);
+    assertThat(secondUpdate.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(secondUpdate.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+    assertThat(secondUpdate.getValue().getChangedAttributes())
+        .as("metrics were skipped for the item already accumulated under lease1")
+        .doesNotContain("metrics");
+  }
+
+  @Test
   public void shouldAcceptPushFromSecondElementInstanceAfterFirstCompletes() {
     // given — a sequential multi-instance AI-agent service task: EI1 activates, completes, then
     // EI2 activates. This is the counter-case to the second-active-writer rejection above: it

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceCompletedApplierTest.java
@@ -198,4 +198,61 @@ public class AgentInstanceCompletedApplierTest {
             agentHistoryState.getCommittedHistoryItemKey(secondAgentInstanceKey, "history-item-1"))
         .isEqualTo(201L);
   }
+
+  @Test
+  void shouldDeleteMetricsAccumulatedIdsOnCompletion() {
+    // given — a completed agent instance with metrics-accumulated ids recorded against it.
+    final long agentInstanceKey = 31L;
+    final long processInstanceKey = 5L;
+    createdApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentHistoryState.markMetricsAccumulated(agentInstanceKey, "history-item-1");
+    agentHistoryState.markMetricsAccumulated(agentInstanceKey, "history-item-2");
+
+    // when — the agent instance completes.
+    completedApplier.applyState(
+        agentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(agentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — every metrics-accumulated id recorded for this agent instance is gone.
+    assertThat(agentHistoryState.hasAccumulatedMetrics(agentInstanceKey, "history-item-1"))
+        .isFalse();
+    assertThat(agentHistoryState.hasAccumulatedMetrics(agentInstanceKey, "history-item-2"))
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotAffectMetricsAccumulatedIdsOfOtherAgentInstances() {
+    // given — metrics-accumulated ids for two different agent instances.
+    final long processInstanceKey = 5L;
+    final long firstAgentInstanceKey = 32L;
+    final long secondAgentInstanceKey = 33L;
+    createdApplier.applyState(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.INITIALIZING));
+    agentHistoryState.markMetricsAccumulated(firstAgentInstanceKey, "history-item-1");
+    agentHistoryState.markMetricsAccumulated(secondAgentInstanceKey, "history-item-1");
+
+    // when — only the first agent instance completes.
+    completedApplier.applyState(
+        firstAgentInstanceKey,
+        new AgentInstanceRecord()
+            .setAgentInstanceKey(firstAgentInstanceKey)
+            .setProcessInstanceKey(processInstanceKey)
+            .setStatus(AgentInstanceStatus.COMPLETED));
+
+    // then — the second agent instance's metrics-accumulated id is untouched.
+    assertThat(agentHistoryState.hasAccumulatedMetrics(secondAgentInstanceKey, "history-item-1"))
+        .isTrue();
+  }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
@@ -87,5 +87,8 @@ public final class AgentHistoryCreatedApplier
       }
     }
     agentHistoryState.insert(key, storedRecord);
+    // Marks the id as having had its metrics accumulated, independent of the pending record above
+    // (which is deleted on commit/discard) — see AGENT_HISTORY_METRICS_ACCUMULATED_IDS.
+    agentHistoryState.markMetricsAccumulated(value.getAgentInstanceKey(), value.getHistoryItemId());
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_COMPLETED_v1.golden
@@ -31,5 +31,6 @@ public final class AgentInstanceCompletedApplier
     agentInstanceState.delete(key, value);
     // Only removal path for an agent instance; any new one needs this same cleanup call.
     agentHistoryState.deleteCommittedHistoryItemKeys(key);
+    agentHistoryState.deleteMetricsAccumulatedIds(key);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -397,7 +397,8 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // accumulated for an agent instance, independent of AGENT_HISTORY_COMMITTED_IDS: a discarded
   // item leaves no trace in that store, so a later job resending the same id would otherwise
   // re-accumulate its metrics. Written when an item is first created (see
-  // AgentHistoryCreatedApplier), and survives commit/discard.
+  // AgentHistoryCreatedApplier), survives commit/discard, and is deleted in one pass when the
+  // instance completes (see AgentInstanceCompletedApplier).
   AGENT_HISTORY_METRICS_ACCUMULATED_IDS(165, PARTITION_LOCAL);
 
   private final int value;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -391,7 +391,14 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   // this, since a committed item is deleted from it. Retained for the agent instance's whole
   // lifetime and deleted in one pass when the instance completes (see
   // AgentInstanceCompletedApplier).
-  AGENT_HISTORY_COMMITTED_IDS(164, PARTITION_LOCAL);
+  AGENT_HISTORY_COMMITTED_IDS(164, PARTITION_LOCAL),
+
+  // (agentInstanceKey, historyItemId) -> ∅. Records every history item whose metrics were ever
+  // accumulated for an agent instance, independent of AGENT_HISTORY_COMMITTED_IDS: a discarded
+  // item leaves no trace in that store, so a later job resending the same id would otherwise
+  // re-accumulate its metrics. Written when an item is first created (see
+  // AgentHistoryCreatedApplier), and survives commit/discard.
+  AGENT_HISTORY_METRICS_ACCUMULATED_IDS(165, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

Fixes one piece of #60715: a resent history item no longer double-counts its metrics once its earlier copy was discarded. For example, after its job was cancelled or errored out.

#60715 asks for metrics to survive when an update is rejected only because its `jobLease` is superseded. The real fix for that is to stop rejecting such updates and accept them instead — that's the next PR in this stack. But accepting a superseded-lease update means its history item gets created and, later, discarded (the losing side of the race). Today, a discarded item leaves no trace anywhere in state: the only dedup entry, the committed-ids store, is written when an item commits and never when it is discarded. So a later resend of the same `historyItemId` (after the previous was already discarded) looks brand new, and its metrics get applied a second time. This bug already exists today, independent of the lease work, whenever a job is cancelled or errors out. Fixing it first means the next PR can start accepting superseded-lease updates without turning today's lost-metrics bug into a double-accumulation bug.

This PR adds a second, independent store of metrics-accumulated ids, keyed by `(agentInstanceKey, historyItemId)`. It is written the first time an item is created, survives commit and discard, and is only cleaned up when the agent instance completes. Duplicate detection for content is untouched: a resent item's content can still be created fresh and still commit. Only its metrics are now charged exactly once, no matter how many times its id is discarded and resent.

**Out of scope:** this PR changes nothing about accept-vs-reject. An update whose only problem is a superseded `jobLease`, or whose job is not `ACTIVATED`, is still rejected outright, exactly as today. That's the two follow-up PRs stacked on this one — they close #60715 itself. This PR only lays the groundwork they need.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Relates to #60715
