### PR TITLE
Bound historyItemId length in the schema and reject overlong values

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -37,7 +37,7 @@ import org.springframework.http.ProblemDetail;
 public class AgentInstanceRequestValidator {
 
   // Mirrors HistoryItemId#maxLength in identifiers.yaml.
-  public static final int MAX_HISTORY_ITEM_ID_LENGTH = 256;
+  private static final int MAX_HISTORY_ITEM_ID_LENGTH = 256;
 
   // Note: even if some properties are marked @NotNull in AgentInstanceCreationRequest,
   // no validation is performed during deserialization, so it is still necessary to validate it here

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidator.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mapping.http.validator;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_HISTORY_MISSING_CONFIGURATION_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateDate;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
@@ -34,6 +35,9 @@ import org.springframework.http.ProblemDetail;
 
 @NullMarked
 public class AgentInstanceRequestValidator {
+
+  // Mirrors HistoryItemId#maxLength in identifiers.yaml.
+  public static final int MAX_HISTORY_ITEM_ID_LENGTH = 256;
 
   // Note: even if some properties are marked @NotNull in AgentInstanceCreationRequest,
   // no validation is performed during deserialization, so it is still necessary to validate it here
@@ -118,6 +122,10 @@ public class AgentInstanceRequestValidator {
     if (historyItem.getHistoryItemId() == null || historyItem.getHistoryItemId().isBlank()) {
       violations.add(
           ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("history[" + index + "].historyItemId"));
+    } else if (historyItem.getHistoryItemId().length() > MAX_HISTORY_ITEM_ID_LENGTH) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(
+              "history[" + index + "].historyItemId", MAX_HISTORY_ITEM_ID_LENGTH));
     }
     if (historyItem.getLoopIteration() == null) {
       violations.add(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/validator/AgentInstanceRequestValidatorTest.java
@@ -190,6 +190,68 @@ class AgentInstanceRequestValidatorTest {
     }
 
     @Test
+    @DisplayName("Should reject a batch item with a historyItemId over 256 characters")
+    void shouldRejectHistoryItemWithTooLongHistoryItemId() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .jobKey(JOB_KEY)
+              .jobLease(JOB_LEASE)
+              .build();
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("a".repeat(257))
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isPresent();
+      assertThat(result.get().getDetail())
+          .isEqualTo("The provided history[0].historyItemId exceeds the limit of 256 characters.");
+    }
+
+    @Test
+    @DisplayName("Should accept a batch item with a historyItemId of exactly 256 characters")
+    void shouldAcceptHistoryItemWithMaxLengthHistoryItemId() {
+      final var request =
+          AgentInstanceUpdateRequest.Builder.create()
+              .elementInstanceKey(ELEMENT_INSTANCE_KEY)
+              .jobKey(JOB_KEY)
+              .jobLease(JOB_LEASE)
+              .build();
+      request.setHistory(
+          List.of(
+              AgentInstanceHistoryItem.Builder.create()
+                  .historyItemId("a".repeat(256))
+                  .loopIteration(1)
+                  .role(AgentInstanceHistoryRoleEnum.USER)
+                  .content(
+                      List.of(
+                          AgentInstanceTextContent.Builder.create()
+                              .contentType("TEXT")
+                              .text("hello")
+                              .build()))
+                  .producedAt("2025-06-01T12:00:00Z")
+                  .build()));
+
+      final Optional<ProblemDetail> result =
+          validator.validateUpdateRequest(AGENT_INSTANCE_KEY, request);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
     @DisplayName("Should report the correct index for a batch item beyond the first")
     void shouldReportCorrectIndexForSecondHistoryItem() {
       final var request =

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -735,7 +735,8 @@ components:
           description: |
             The historyItemId of the corresponding item in the request, echoed back
             so callers can correlate response entries with request items by id.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/HistoryItemId'
         historyItemKey:
           description: |
             The system-generated key for the history item. When isDuplicate is true,
@@ -804,7 +805,8 @@ components:
             item. For example, when a retried job activation resubmits history items
             it already sent in an earlier attempt, those items are not rejected; they
             are flagged via isDuplicate in the response instead. Must be non-blank.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/HistoryItemId'
         loopIteration:
           description: The loop iteration this item belongs to.
           allOf:
@@ -980,10 +982,9 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentHistoryItemKey'
         historyItemId:
-          description: |
-            The client-supplied identifier this item was created with. Empty for items that don't
-            carry one.
-          type: string
+          description: The historyItemId of this history item.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/HistoryItemId'
         agentInstanceKey:
           description: The key of the agent instance this item belongs to.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -219,6 +219,19 @@ components:
       x-semantic-client-minted: true
       example: 1
 
+    HistoryItemId:
+      description: The client-supplied identifier this item was created with.
+      type: string
+      format: HistoryItemId
+      x-semantic-type: HistoryItemId
+      x-semantic-client-minted: true
+      minLength: 1
+      maxLength: 256
+      # Opaque connector-generated content, not a Camunda-style id, so no `pattern`. Enforced
+      # at the REST layer (AgentInstanceRequestValidator), not via IdentifierValidator. 256
+      # matches the RDBMS secondary storage's varchar column size.
+      example: item-1
+
     ## Filters
 
     ElementIdFilterProperty:


### PR DESCRIPTION
## Summary
- Add a `HistoryItemId` schema in `identifiers.yaml`, non-blank and capped at 256 characters, referenced from all three `historyItemId` occurrences in `agent-instances.yaml`
- Reject `historyItemId` values over 256 characters in `AgentInstanceRequestValidator` at the REST layer, not in the engine, so the limit can change later without duplicating validation
- No `pattern` is applied: the value is opaque connector-generated content, not a Camunda-style id, so `IdentifierValidator` (which always couples a length bound to a pattern) doesn't fit here
- 256 matches the RDBMS secondary storage's varchar column size, keeping RocksDB (full value) and RDBMS (truncated) dedup identity aligned

## Test plan
- [x] `AgentInstanceRequestValidatorTest` (41/41 pass)
- [x] `AgentInstanceRequestValidatorSpecSyncTest` (unchanged, still 2/2 pass)
- [x] `zeebe/gateway-protocol` module builds clean with full checks

## Related issues
Closes camunda/camunda#61380