### PR TITLE
feat: scale a non-default physical tenant while changing cluster membership

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -103,8 +103,8 @@ public sealed interface ClusterConfigurationManagementRequest {
    * @param brokerCount the target number of brokers. On a plain (non-zone-aware) cluster this is
    *     the total cluster size; when {@code zone} is set it is the target broker count <em>within
    *     that zone</em>, leaving the other zones untouched. Empty leaves the broker count unchanged.
-   *     Targets cluster membership, which has no tenant dimension, so it must not be combined with
-   *     {@code physicalTenantId}.
+   *     Targets cluster membership, which has no tenant dimension, so it is applied to every
+   *     physical tenant's partitions whatever {@code physicalTenantId} names.
    * @param newPartitionCount the target number of partitions of a single physical tenant — the one
    *     named by {@code physicalTenantId}, or the default tenant when none is named — or empty to
    *     leave it unchanged. Partitions can only be scaled up.
@@ -115,8 +115,10 @@ public sealed interface ClusterConfigurationManagementRequest {
    * @param zone the zone to scale, or empty to scale a plain cluster. Required when scaling a
    *     zone-aware cluster and rejected on a plain one.
    * @param physicalTenantId the physical tenant whose partition group {@code newPartitionCount}
-   *     applies to, or empty for the default physical tenant. Must not be combined with {@code
-   *     brokerCount} or {@code newReplicationFactor}.
+   *     applies to, or empty for the default physical tenant. Scopes {@code newPartitionCount}
+   *     alone, so it may accompany {@code brokerCount} but is rejected without a {@code
+   *     newPartitionCount} to scope, and rejected with {@code newReplicationFactor}, which is a
+   *     cluster-wide setting.
    * @param dryRun when true, the resulting plan is computed and returned without being applied.
    */
   record ClusterScaleRequest(
@@ -147,9 +149,11 @@ public sealed interface ClusterConfigurationManagementRequest {
 
   /**
    * @param physicalTenantId the physical tenant whose partition group {@code newPartitionCount}
-   *     applies to, or empty for the default physical tenant. Must not be combined with a non-empty
-   *     {@code membersToAdd}/{@code membersToRemove}, which change cluster membership and have no
-   *     tenant dimension, nor with {@code newReplicationFactor}, which is a cluster-wide setting.
+   *     applies to, or empty for the default physical tenant. Scopes {@code newPartitionCount}
+   *     alone, so it may accompany a non-empty {@code membersToAdd}/{@code membersToRemove} — those
+   *     change cluster membership, which has no tenant dimension — but is rejected without a {@code
+   *     newPartitionCount} to scope, and rejected with {@code newReplicationFactor}, which is a
+   *     cluster-wide setting.
    */
   record ClusterPatchRequest(
       Set<MemberId> membersToAdd,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -109,7 +109,12 @@ public final class ClusterConfigurationManagementRequestsHandler
       final BrokerScaleRequest scaleRequest) {
     return handleRequest(
         scaleRequest.dryRun(),
-        new ScaleRequestTransformer(scaleRequest.members(), scaleRequest.newReplicationFactor()));
+        // Resizes the cluster only: it carries no partition count, so it scales no physical tenant.
+        new ScaleRequestTransformer(
+            scaleRequest.members(),
+            scaleRequest.newReplicationFactor(),
+            Optional.empty(),
+            Optional.empty()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -52,19 +52,20 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
     final var changesMembership = !membersToAdd.isEmpty() || !membersToRemove.isEmpty();
-    if (physicalTenantId.isPresent()) {
-      if (changesMembership) {
-        return Either.left(
-            new InvalidRequest(
-                "membersToAdd/membersToRemove cannot be combined with physicalTenant: they change "
-                    + "cluster membership, which has no tenant dimension"));
-      }
-      if (newReplicationFactor.isPresent()) {
-        return Either.left(
-            new InvalidRequest(
-                "newReplicationFactor cannot be combined with physicalTenant: the replication "
-                    + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
-      }
+    if (physicalTenantId.isPresent() && newReplicationFactor.isPresent()) {
+      return Either.left(
+          new InvalidRequest(
+              "newReplicationFactor cannot be combined with physicalTenant: the replication "
+                  + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
+    }
+    if (physicalTenantId.isPresent() && newPartitionCount.isEmpty()) {
+      // Rejected rather than ignored: an operator who scopes a request to a tenant expects the
+      // scope to do something, and here there is nothing for it to apply to.
+      return Either.left(
+          new InvalidRequest(
+              "physicalTenant scopes newPartitionCount alone, and this request does not change "
+                  + "it: membersToAdd/membersToRemove change cluster membership, which has no "
+                  + "tenant dimension"));
     }
     // The replication factor of a zone-aware cluster follows from its zone specs, so it cannot be
     // set directly. Checked before anything else that could plan, so that a request combining a
@@ -75,6 +76,15 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
           new InvalidRequest(
               "Changing the replication factor is not supported on zone-aware clusters."));
     }
+    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
+    // Only the partition count targets a group; the replication factor and the membership span
+    // every tenant, so a request carrying only those has no group that has to exist.
+    if (newPartitionCount.isPresent() && !clusterConfiguration.hasPartitionGroup(groupId)) {
+      return Either.left(
+          new NotFound(
+              "Expected to patch physical tenant '%s', but there's no such tenant"
+                  .formatted(groupId)));
+    }
     if (changesMembership) {
       if (membersToAdd.stream().anyMatch(membersToRemove::contains)) {
         return Either.left(
@@ -84,35 +94,23 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
       }
       // Membership has no tenant dimension, but the partitions it moves do: every tenant's
       // partitions have to be redistributed over the new member set, not just the default
-      // tenant's, which is what ScaleRequestTransformer plans.
+      // tenant's, which is what ScaleRequestTransformer plans. The partition count keeps its
+      // tenant scope while it does so — the two dimensions are independent, so a request may
+      // change membership and grow one named tenant in the same plan.
       final var newSetOfMembers =
           new HashSet<>(clusterConfiguration.globalConfiguration().members().keySet());
       newSetOfMembers.addAll(membersToAdd);
       newSetOfMembers.removeAll(membersToRemove);
-      // A tenant-scoped request is rejected above, so a partition count reaching this path grows
-      // the default tenant.
       return new ScaleRequestTransformer(
               newSetOfMembers,
               newReplicationFactor,
-              newPartitionCount.map(
-                  count ->
-                      new TenantPartitionCount(CurrentClusterConfiguration.DEFAULT_GROUP, count)),
+              newPartitionCount.map(count -> new TenantPartitionCount(groupId, count)),
               Optional.empty())
           .phases(clusterConfiguration);
     }
     if (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
       // Changes neither membership nor a partition dimension, so there is nothing to plan.
       return Either.right(List.of());
-    }
-
-    final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
-    // Only the partition count targets a group; the replication factor spans every tenant, so a
-    // request carrying it alone has no group that has to exist.
-    if (newPartitionCount.isPresent() && !clusterConfiguration.hasPartitionGroup(groupId)) {
-      return Either.left(
-          new NotFound(
-              "Expected to patch physical tenant '%s', but there's no such tenant"
-                  .formatted(groupId)));
     }
     return PartitionGroupScalingPhases.phases(
         clusterConfiguration,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -89,7 +89,15 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
           new HashSet<>(clusterConfiguration.globalConfiguration().members().keySet());
       newSetOfMembers.addAll(membersToAdd);
       newSetOfMembers.removeAll(membersToRemove);
-      return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
+      // A tenant-scoped request is rejected above, so a partition count reaching this path grows
+      // the default tenant.
+      return new ScaleRequestTransformer(
+              newSetOfMembers,
+              newReplicationFactor,
+              newPartitionCount.map(
+                  count ->
+                      new TenantPartitionCount(CurrentClusterConfiguration.DEFAULT_GROUP, count)),
+              Optional.empty())
           .phases(clusterConfiguration);
     }
     if (newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
@@ -107,6 +115,8 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
                   .formatted(groupId)));
     }
     return PartitionGroupScalingPhases.phases(
-        groupId, clusterConfiguration, newPartitionCount, newReplicationFactor);
+        clusterConfiguration,
+        newPartitionCount.map(count -> new TenantPartitionCount(groupId, count)),
+        newReplicationFactor);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -87,10 +87,14 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
       // brokerCount has no tenant dimension, but the partitions it moves do: every tenant's
       // partitions have to be redistributed over the new member set, not just the default
       // tenant's, which is what ScaleRequestTransformer plans.
+      // A tenant-scoped request is rejected above, so a partition count reaching this path grows
+      // the default tenant.
       return new ScaleRequestTransformer(
               newSetOfMembers(clusterConfiguration.getMembers()),
               newReplicationFactor,
-              newPartitionCount,
+              newPartitionCount.map(
+                  count ->
+                      new TenantPartitionCount(CurrentClusterConfiguration.DEFAULT_GROUP, count)),
               zone)
           .phases(clusterConfiguration);
     }
@@ -106,7 +110,9 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
                   .formatted(groupId)));
     }
     return PartitionGroupScalingPhases.phases(
-        groupId, clusterConfiguration, newPartitionCount, newReplicationFactor);
+        clusterConfiguration,
+        newPartitionCount.map(count -> new TenantPartitionCount(groupId, count)),
+        newReplicationFactor);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -56,19 +56,19 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
   @Override
   public Either<Exception, List<Phase>> phases(
       final CurrentClusterConfiguration clusterConfiguration) {
-    if (physicalTenantId.isPresent()) {
-      if (brokerCount.isPresent()) {
-        return Either.left(
-            new InvalidRequest(
-                "brokerCount cannot be combined with physicalTenant: brokerCount changes cluster "
-                    + "membership, which has no tenant dimension"));
-      }
-      if (newReplicationFactor.isPresent()) {
-        return Either.left(
-            new InvalidRequest(
-                "newReplicationFactor cannot be combined with physicalTenant: the replication "
-                    + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
-      }
+    if (physicalTenantId.isPresent() && newReplicationFactor.isPresent()) {
+      return Either.left(
+          new InvalidRequest(
+              "newReplicationFactor cannot be combined with physicalTenant: the replication "
+                  + "factor is a cluster-wide setting, so it has no tenant to scope it to"));
+    }
+    if (physicalTenantId.isPresent() && newPartitionCount.isEmpty()) {
+      // Rejected rather than ignored: an operator who scopes a request to a tenant expects the
+      // scope to do something, and here there is nothing for it to apply to.
+      return Either.left(
+          new InvalidRequest(
+              "physicalTenant scopes newPartitionCount alone, and this request does not change "
+                  + "it: brokerCount changes cluster membership, which has no tenant dimension"));
     }
     if (brokerCount.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
       // Changes neither membership nor a partition dimension, so there is nothing to plan.
@@ -83,31 +83,28 @@ public final class ClusterScaleRequestTransformer implements ConfigurationChange
     if (invalidZone.isPresent()) {
       return Either.left(invalidZone.get());
     }
-    if (brokerCount.isPresent()) {
-      // brokerCount has no tenant dimension, but the partitions it moves do: every tenant's
-      // partitions have to be redistributed over the new member set, not just the default
-      // tenant's, which is what ScaleRequestTransformer plans.
-      // A tenant-scoped request is rejected above, so a partition count reaching this path grows
-      // the default tenant.
-      return new ScaleRequestTransformer(
-              newSetOfMembers(clusterConfiguration.getMembers()),
-              newReplicationFactor,
-              newPartitionCount.map(
-                  count ->
-                      new TenantPartitionCount(CurrentClusterConfiguration.DEFAULT_GROUP, count)),
-              zone)
-          .phases(clusterConfiguration);
-    }
-
     final var groupId = physicalTenantId.orElse(CurrentClusterConfiguration.DEFAULT_GROUP);
 
-    // Only the partition count targets a group; the replication factor spans every tenant, so a
-    // request carrying it alone has no group that has to exist.
+    // Only the partition count targets a group; the replication factor and the broker count span
+    // every tenant, so a request carrying only those has no group that has to exist.
     if (newPartitionCount.isPresent() && !clusterConfiguration.hasPartitionGroup(groupId)) {
       return Either.left(
           new NotFound(
               "Expected to scale physical tenant '%s', but there's no such tenant"
                   .formatted(groupId)));
+    }
+    if (brokerCount.isPresent()) {
+      // brokerCount has no tenant dimension, but the partitions it moves do: every tenant's
+      // partitions have to be redistributed over the new member set, not just the default
+      // tenant's, which is what ScaleRequestTransformer plans. The partition count keeps its
+      // tenant scope while it does so — the two dimensions are independent, so a request may
+      // resize the cluster and grow one named tenant in the same plan.
+      return new ScaleRequestTransformer(
+              newSetOfMembers(clusterConfiguration.getMembers()),
+              newReplicationFactor,
+              newPartitionCount.map(count -> new TenantPartitionCount(groupId, count)),
+              zone)
+          .phases(clusterConfiguration);
     }
     return PartitionGroupScalingPhases.phases(
         clusterConfiguration,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionGroupScalingPhases.java
@@ -74,12 +74,10 @@ final class PartitionGroupScalingPhases {
    * Plans the placement over the cluster's live members, for a request that does not change
    * membership.
    *
-   * @param targetGroupId the partition group whose partition count changes; must exist in {@code
-   *     clusterConfiguration} whenever {@code newPartitionCount} is present, and is unused
-   *     otherwise — the replication factor has no target group
    * @param clusterConfiguration the current multi-group configuration
-   * @param newPartitionCount the partition count {@code targetGroupId} should reach, or empty to
-   *     leave every group's partition count as it is
+   * @param newPartitionCount the partition count one named physical tenant should reach, or empty
+   *     to leave every group's partition count as it is. The tenant travels with the count because
+   *     it is the count alone that has a tenant dimension; see {@link TenantPartitionCount}.
    * @param newReplicationFactor the replication factor every partition of every group should reach,
    *     or empty to keep the one currently in use
    * @return a single {@link PartitionGroupPhase} covering every group whose partitions have to
@@ -88,15 +86,13 @@ final class PartitionGroupScalingPhases {
    *     the live brokers cannot satisfy the replication factor, or if no valid distribution exists.
    */
   static Either<Exception, List<Phase>> phases(
-      final String targetGroupId,
       final CurrentClusterConfiguration clusterConfiguration,
-      final Optional<Integer> newPartitionCount,
+      final Optional<TenantPartitionCount> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
     final var distributionByGroup =
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration);
-    final var currentPartitionCount = currentPartitionCount(distributionByGroup, targetGroupId);
     if (newReplicationFactor.isEmpty()
-        && newPartitionCount.orElse(currentPartitionCount) == currentPartitionCount) {
+        && changesNoPartitionCount(distributionByGroup, newPartitionCount)) {
       // Nothing is asked for that the cluster does not already have. Returning before the
       // distributor runs is what keeps such a request a no-op: a placement that has drifted from
       // what the distributor would compute now — after a manual reassignment through
@@ -110,7 +106,6 @@ final class PartitionGroupScalingPhases {
       return Either.right(List.of());
     }
     return phases(
-        targetGroupId,
         clusterConfiguration,
         distributionByGroup,
         clusterConfiguration.liveMembers(),
@@ -119,21 +114,19 @@ final class PartitionGroupScalingPhases {
   }
 
   /**
-   * As {@link #phases(String, CurrentClusterConfiguration, Optional, Optional)}, but places the
-   * partitions on {@code targetMembers} rather than on whichever members are currently live, and
-   * always runs the distributor.
+   * As {@link #phases(CurrentClusterConfiguration, Optional, Optional)}, but places the partitions
+   * on {@code targetMembers} rather than on whichever members are currently live, and always runs
+   * the distributor.
    *
    * @param targetMembers the members every partition of every group should end up on — the complete
    *     desired member set, so a member being removed from the cluster is simply absent from it
    */
   static Either<Exception, List<Phase>> phases(
-      final String targetGroupId,
       final CurrentClusterConfiguration clusterConfiguration,
       final Set<MemberId> targetMembers,
-      final Optional<Integer> newPartitionCount,
+      final Optional<TenantPartitionCount> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
     return phases(
-        targetGroupId,
         clusterConfiguration,
         ConfigurationUtil.getPartitionDistributionPerPhysicalTenant(clusterConfiguration),
         targetMembers,
@@ -142,37 +135,40 @@ final class PartitionGroupScalingPhases {
   }
 
   /**
+   * Whether {@code newPartitionCount} asks for a count the named tenant does not already have. A
+   * request that names no tenant changes no count.
+   */
+  private static boolean changesNoPartitionCount(
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Optional<TenantPartitionCount> newPartitionCount) {
+    return newPartitionCount
+        .map(
+            target ->
+                target.partitionCount()
+                    == currentPartitionCount(distributionByGroup, target.physicalTenantId()))
+        .orElse(true);
+  }
+
+  /**
    * Takes the current per-tenant distribution rather than scanning it out of {@code
    * clusterConfiguration}: the entry point above needs it to decide whether the request asks for
    * anything at all, and passes on what it already scanned.
    */
   private static Either<Exception, List<Phase>> phases(
-      final String targetGroupId,
       final CurrentClusterConfiguration clusterConfiguration,
       final Map<String, Set<PartitionMetadata>> distributionByGroup,
       final Set<MemberId> targetMembers,
-      final Optional<Integer> newPartitionCount,
+      final Optional<TenantPartitionCount> newPartitionCount,
       final Optional<Integer> newReplicationFactor) {
-    final var currentPartitionCount = currentPartitionCount(distributionByGroup, targetGroupId);
-    final int targetPartitionCount = newPartitionCount.orElse(currentPartitionCount);
-
     final int replicationFactor =
         newReplicationFactor.orElseGet(() -> currentReplicationFactor(distributionByGroup));
     final var rejection =
-        reject(
-            targetGroupId,
-            targetMembers,
-            currentPartitionCount,
-            targetPartitionCount,
-            replicationFactor);
+        reject(distributionByGroup, targetMembers, newPartitionCount, replicationFactor);
     if (rejection.isPresent()) {
       return Either.left(rejection.get());
     }
 
-    final var newPartitionIds =
-        IntStream.rangeClosed(currentPartitionCount + 1, targetPartitionCount)
-            .mapToObj(number -> new PartitionId(targetGroupId, number))
-            .toList();
+    final var newPartitionIds = newPartitionIds(distributionByGroup, newPartitionCount);
     final var targetPartitionIds =
         Stream.concat(
                 distributionByGroup.values().stream()
@@ -197,16 +193,17 @@ final class PartitionGroupScalingPhases {
       return Either.left(new InvalidRequest(e));
     }
 
-    if (!newPartitionIds.isEmpty()) {
+    if (newPartitionCount.isPresent() && !newPartitionIds.isEmpty()) {
+      final var target = newPartitionCount.get();
       final var newPartitionNumbers =
           new TreeSet<>(newPartitionIds.stream().map(PartitionId::number).toList());
       operationsByGroup.put(
-          targetGroupId,
+          target.physicalTenantId(),
           withScaleUpOperations(
-              operationsByGroup.getOrDefault(targetGroupId, List.of()),
+              operationsByGroup.getOrDefault(target.physicalTenantId(), List.of()),
               ClusterConfigurationCoordinatorSupplier.from(() -> clusterConfiguration)
                   .getDefaultCoordinator(),
-              targetPartitionCount,
+              target.partitionCount(),
               newPartitionNumbers));
     }
 
@@ -228,16 +225,23 @@ final class PartitionGroupScalingPhases {
    * @return the rejection to answer with, or empty if the request can be planned
    */
   private static Optional<Exception> reject(
-      final String targetGroupId,
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
       final Set<MemberId> targetMembers,
-      final int currentPartitionCount,
-      final int targetPartitionCount,
+      final Optional<TenantPartitionCount> newPartitionCount,
       final int replicationFactor) {
-    if (targetPartitionCount < currentPartitionCount) {
-      return Optional.of(
-          new InvalidRequest(
-              "New partition count [%d] of physical tenant '%s' must be greater than or equal to its current partition count [%d]"
-                  .formatted(targetPartitionCount, targetGroupId, currentPartitionCount)));
+    if (newPartitionCount.isPresent()) {
+      final var target = newPartitionCount.get();
+      final var currentPartitionCount =
+          currentPartitionCount(distributionByGroup, target.physicalTenantId());
+      if (target.partitionCount() < currentPartitionCount) {
+        return Optional.of(
+            new InvalidRequest(
+                "New partition count [%d] of physical tenant '%s' must be greater than or equal to its current partition count [%d]"
+                    .formatted(
+                        target.partitionCount(),
+                        target.physicalTenantId(),
+                        currentPartitionCount)));
+      }
     }
     if (replicationFactor <= 0) {
       return Optional.of(
@@ -251,6 +255,24 @@ final class PartitionGroupScalingPhases {
                   .formatted(targetMembers.size(), replicationFactor)));
     }
     return Optional.empty();
+  }
+
+  /**
+   * The ids of the partitions the request adds, in the named tenant's group. Empty when the request
+   * names no tenant, and also when it names one that already has the requested count.
+   */
+  private static List<PartitionId> newPartitionIds(
+      final Map<String, Set<PartitionMetadata>> distributionByGroup,
+      final Optional<TenantPartitionCount> newPartitionCount) {
+    return newPartitionCount
+        .map(
+            target ->
+                IntStream.rangeClosed(
+                        currentPartitionCount(distributionByGroup, target.physicalTenantId()) + 1,
+                        target.partitionCount())
+                    .mapToObj(number -> new PartitionId(target.physicalTenantId(), number))
+                    .toList())
+        .orElseGet(List::of);
   }
 
   private static int currentPartitionCount(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -30,31 +30,28 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
 
   private final Set<MemberId> members;
   private final Optional<Integer> newReplicationFactor;
-  private final Optional<Integer> newPartitionCount;
+  private final Optional<TenantPartitionCount> newPartitionCount;
   private final Optional<String> zone;
   private final ArrayList<ClusterConfigurationChangeOperation> generatedOperations =
       new ArrayList<>();
 
-  public ScaleRequestTransformer(final Set<MemberId> members) {
-    this(members, Optional.empty());
-  }
-
-  public ScaleRequestTransformer(
-      final Set<MemberId> members, final Optional<Integer> newReplicationFactor) {
-    this(members, newReplicationFactor, Optional.empty());
-  }
-
-  public ScaleRequestTransformer(
-      final Set<MemberId> members,
-      final Optional<Integer> newReplicationFactor,
-      final Optional<Integer> newPartitionCount) {
-    this(members, newReplicationFactor, newPartitionCount, Optional.empty());
-  }
-
+  /**
+   * @param members the complete member set the cluster should have once this request is applied, so
+   *     a member being removed is simply absent from it
+   * @param newReplicationFactor the replication factor every partition of every group should reach,
+   *     or empty to keep the one currently in use
+   * @param newPartitionCount the partition count one named physical tenant should reach, or empty
+   *     to scale no tenant. The count carries the tenant it applies to rather than defaulting to
+   *     the default group, so that a caller scaling no tenant names none and a caller scaling one
+   *     has to say which; see {@link TenantPartitionCount}.
+   * @param zone the zone whose brokers this request resizes, or empty on an unzoned cluster. Only
+   *     selects the member from which the pre/post-scaling callbacks run — the partition placement
+   *     spans the whole cluster either way.
+   */
   public ScaleRequestTransformer(
       final Set<MemberId> members,
       final Optional<Integer> newReplicationFactor,
-      final Optional<Integer> newPartitionCount,
+      final Optional<TenantPartitionCount> newPartitionCount,
       final Optional<String> zone) {
     this.members = members;
     this.newReplicationFactor = newReplicationFactor;
@@ -68,7 +65,8 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
    *
    * <p>{@link PartitionGroupScalingPhases} distributes every group's partitions together over
    * {@link #members}, rather than distributing the default group's alone. The member operations
-   * have no tenant dimension, so they are unchanged.
+   * have no tenant dimension, so they are unchanged. Only {@link #newPartitionCount} is scoped to
+   * one group — the one it names.
    *
    * <p>The resulting phases are the same three {@code toPhases} derives from the flat operation
    * list today — a global phase, a partition-group phase, a global phase — with the two global runs
@@ -119,11 +117,7 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
     scalingExecutor.ifPresent(id -> after.add(new PostScalingOperation(id, members)));
 
     return PartitionGroupScalingPhases.phases(
-            CurrentClusterConfiguration.DEFAULT_GROUP,
-            configuration,
-            members,
-            newPartitionCount,
-            newReplicationFactor)
+            configuration, members, newPartitionCount, newReplicationFactor)
         .map(partitionPhases -> assemble(before, partitionPhases, after));
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/TenantPartitionCount.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/TenantPartitionCount.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The partition count one physical tenant should reach, and the tenant it applies to.
+ *
+ * <p>The two travel together because neither says anything on its own. The partition count is the
+ * only dimension of a scaling request that has a tenant dimension — cluster membership and the
+ * replication factor are cluster-wide — so a request that leaves the partition count alone names no
+ * tenant at all, and one that changes it has to name the tenant it grows. Pairing them keeps a
+ * planner from having to invent a tenant for a request that scales none, which is what a default of
+ * {@code "default"} amounted to.
+ *
+ * @param physicalTenantId the tenant whose partition group grows. Must exist in the configuration
+ *     being planned against; the request transformer resolves it and rejects an unknown one,
+ *     because only it can say what the request named.
+ * @param partitionCount the count that tenant's partition group should reach. Partitions can only
+ *     be scaled up, so a count below the tenant's current one is rejected during planning.
+ */
+@NullMarked
+public record TenantPartitionCount(String physicalTenantId, int partitionCount) {}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -86,8 +86,9 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     // The placement must be computed with the new distributor, and the planner resolves it from the
     // configuration it is handed — so hand it a copy that already carries the new config. Only the
     // operation above really persists it.
+    // Redistributes every tenant's partitions under the new distributor without changing any
+    // tenant's partition count, so it scales no physical tenant.
     return PartitionGroupScalingPhases.phases(
-            CurrentClusterConfiguration.DEFAULT_GROUP,
             configuration.updateGlobalConfiguration(
                 global -> global.setPartitionDistributorConfig(newConfig)),
             targetMembers(configuration.getMembers()),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
@@ -470,8 +471,76 @@ final class ClusterPatchRequestTransformerTest {
   }
 
   @Test
-  void shouldRejectAddingMembersCombinedWithPhysicalTenant() {
-    // given — membersToAdd changes cluster membership, which has no tenant dimension
+  void shouldGrowOnlyTheRequestedTenantWhileAddingABroker() {
+    // given — tenant-b has 1 partition and the default tenant 2. The request adds a broker and
+    // grows tenant-b alone: membership has no tenant dimension, but the partition count does.
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(id3), Set.of(), Optional.of(2), Optional.empty(), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — the named tenant gains the partition, the default tenant keeps its count, and the
+    // broker joins before the partition work
+    assertThat(result).isRight();
+    final var partitionPhase =
+        (PartitionGroupPhase)
+            result.get().stream().filter(PartitionGroupPhase.class::isInstance).findFirst().get();
+    Assertions.assertThat(bootstraps(partitionPhase, TENANT_B))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(2));
+    Assertions.assertThat(bootstraps(partitionPhase, DEFAULT_GROUP)).isEmpty();
+    Assertions.assertThat(((GlobalPhase) result.get().getFirst()).operations())
+        .contains(new MemberJoinOperation(id3));
+  }
+
+  @Test
+  void shouldGrowOnlyTheRequestedTenantWhileRemovingABroker() {
+    // given — id1 holds the default tenant's partition 2, so removing it moves partitions of a
+    // tenant the request does not grow
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(), Set.of(id1), Optional.of(2), Optional.empty(), Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isRight();
+    final var partitionPhase =
+        (PartitionGroupPhase)
+            result.get().stream().filter(PartitionGroupPhase.class::isInstance).findFirst().get();
+    Assertions.assertThat(bootstraps(partitionPhase, TENANT_B))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(2));
+    Assertions.assertThat(bootstraps(partitionPhase, DEFAULT_GROUP)).isEmpty();
+    Assertions.assertThat(((GlobalPhase) result.get().getLast()).operations())
+        .describedAs("the broker leaves only after the partition work")
+        .contains(new MemberLeaveOperation(id1));
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantWhileChangingMembership() {
+    // given — the tenant is resolved on the membership path too, not only when the request plans
+    // the partition count on its own
+    final var transformer =
+        new ClusterPatchRequestTransformer(
+            Set.of(id3), Set.of(), Optional.of(2), Optional.empty(), Optional.of("unknown"));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown");
+  }
+
+  @Test
+  void shouldRejectPhysicalTenantWithoutAPartitionCountToScope() {
+    // given — membership is cluster-wide, so a tenant named alongside it scopes nothing
     final var transformer =
         new ClusterPatchRequestTransformer(
             Set.of(id3), Set.of(), Optional.empty(), Optional.empty(), Optional.of(TENANT_B));
@@ -480,21 +549,10 @@ final class ClusterPatchRequestTransformerTest {
     final var result = transformer.phases(twoTenantCluster());
 
     // then
-    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
-  }
-
-  @Test
-  void shouldRejectRemovingMembersCombinedWithPhysicalTenant() {
-    // given — membersToRemove changes cluster membership, which has no tenant dimension
-    final var transformer =
-        new ClusterPatchRequestTransformer(
-            Set.of(), Set.of(id1), Optional.empty(), Optional.empty(), Optional.of(TENANT_B));
-
-    // when
-    final var result = transformer.phases(twoTenantCluster());
-
-    // then
-    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("physicalTenant scopes newPartitionCount alone");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -612,8 +612,59 @@ final class ClusterScaleRequestTransformerTest {
   }
 
   @Test
-  void shouldRejectBrokerCountCombinedWithPhysicalTenant() {
-    // given — brokerCount changes cluster membership, which has no tenant dimension
+  void shouldGrowOnlyTheRequestedTenantWhileChangingTheBrokerCount() {
+    // given — the cluster shrinks from three brokers to two and tenant-b alone grows from one
+    // partition to two: the broker count has no tenant dimension, but the partition count does
+    final var transformer =
+        new ClusterScaleRequestTransformer(
+            Optional.of(2),
+            Optional.of(2),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(TENANT_B));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then — the named tenant gains the partition, the default tenant keeps its count, and the
+    // departing broker leaves only after the partition work
+    assertThat(result).isRight();
+    final var partitionPhase =
+        (PartitionGroupPhase)
+            result.get().stream().filter(PartitionGroupPhase.class::isInstance).findFirst().get();
+    Assertions.assertThat(bootstraps(partitionPhase, TENANT_B))
+        .singleElement()
+        .satisfies(op -> Assertions.assertThat(op.partitionId()).isEqualTo(2));
+    Assertions.assertThat(bootstraps(partitionPhase, DEFAULT_GROUP)).isEmpty();
+    Assertions.assertThat(((GlobalPhase) result.get().getLast()).operations())
+        .contains(new MemberLeaveOperation(id2));
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantWhileChangingTheBrokerCount() {
+    // given — the tenant is resolved on the broker-count path too, not only when the request plans
+    // the partition count on its own
+    final var transformer =
+        new ClusterScaleRequestTransformer(
+            Optional.of(2),
+            Optional.of(2),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of("unknown"));
+
+    // when
+    final var result = transformer.phases(twoTenantCluster());
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(NotFound.class)
+        .hasMessageContaining("unknown");
+  }
+
+  @Test
+  void shouldRejectPhysicalTenantWithoutAPartitionCountToScope() {
+    // given — the broker count is cluster-wide, so a tenant named alongside it scopes nothing
     final var transformer =
         new ClusterScaleRequestTransformer(
             Optional.of(3),
@@ -626,7 +677,10 @@ final class ClusterScaleRequestTransformerTest {
     final var result = transformer.phases(twoTenantCluster());
 
     // then
-    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("physicalTenant scopes newPartitionCount alone");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
+import static io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration.DEFAULT_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
@@ -80,6 +82,12 @@ class ScaleRequestTransformerTest {
     return IntStream.rangeClosed(1, partitionCount)
         .mapToObj(id -> new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, id))
         .toList();
+  }
+
+  /** A request that changes membership only: it scales no physical tenant. */
+  private static ScaleRequestTransformer membershipChange(final Set<MemberId> members) {
+    return new ScaleRequestTransformer(
+        members, Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   @Property(tries = 10)
@@ -190,7 +198,7 @@ class ScaleRequestTransformerTest {
 
     // when
     final var operationsEither =
-        plannedOperations(new ScaleRequestTransformer(newMembers), oldClusterTopology);
+        plannedOperations(membershipChange(newMembers), oldClusterTopology);
 
     // then
     EitherAssert.assertThat(operationsEither)
@@ -236,7 +244,7 @@ class ScaleRequestTransformerTest {
 
     // when
     final var operations =
-        plannedOperations(new ScaleRequestTransformer(newMembers), oldClusterTopology).get();
+        plannedOperations(membershipChange(newMembers), oldClusterTopology).get();
 
     // apply operations to generate new topology
     final ClusterConfiguration newTopology =
@@ -329,7 +337,12 @@ class ScaleRequestTransformerTest {
         ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
     final var transformer =
         new ScaleRequestTransformer(
-            getClusterMembers(clusterSize), Optional.of(3), Optional.of(desiredPartitionCount));
+            getClusterMembers(clusterSize),
+            Optional.of(3),
+            Optional.of(
+                new TenantPartitionCount(
+                    CurrentClusterConfiguration.DEFAULT_GROUP, desiredPartitionCount)),
+            Optional.empty());
     final var operations = plannedOperations(transformer, config);
     if (desiredPartitionCount < currentPartitionCount) {
       EitherAssert.assertThat(operations).isLeft();
@@ -384,8 +397,7 @@ class ScaleRequestTransformerTest {
 
       // when — broker 2 joins
       final var phases =
-          new ScaleRequestTransformer(
-                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")))
+          membershipChange(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")))
               .phases(configuration);
 
       // then — the joining broker receives a partition of both tenants
@@ -408,8 +420,7 @@ class ScaleRequestTransformerTest {
 
       // when — broker 2 leaves
       final var phases =
-          new ScaleRequestTransformer(Set.of(MemberId.from("0"), MemberId.from("1")))
-              .phases(configuration);
+          membershipChange(Set.of(MemberId.from("0"), MemberId.from("1"))).phases(configuration);
 
       // then — both tenants give up the partitions broker 2 held, and it receives nothing. The
       // distributor recomputes the whole placement, so partitions also move between the two
@@ -442,8 +453,7 @@ class ScaleRequestTransformerTest {
 
       // when — broker 3 joins as broker 2 leaves
       final var phases =
-          new ScaleRequestTransformer(
-                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("3")))
+          membershipChange(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("3")))
               .phases(configuration);
 
       // then
@@ -471,7 +481,9 @@ class ScaleRequestTransformerTest {
       final var phases =
           new ScaleRequestTransformer(
                   Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
-                  Optional.of(2))
+                  Optional.of(2),
+                  Optional.empty(),
+                  Optional.empty())
               .phases(configuration);
 
       // then — every partition of every tenant gains a replica
@@ -498,8 +510,7 @@ class ScaleRequestTransformerTest {
 
       // when
       final var phases =
-          new ScaleRequestTransformer(
-                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")))
+          membershipChange(Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")))
               .phases(configuration);
 
       // then — nothing separates the member join from the scaling callbacks, so one uninterrupted
@@ -548,9 +559,86 @@ class ScaleRequestTransformerTest {
     }
 
     @Test
+    void shouldGrowOnlyTheTargetedTenantWhileRedistributingEveryTenant() {
+      // given — both tenants run partitions 1-3 on brokers 0 and 1
+      final var configuration = twoTenantCluster();
+
+      // when — broker 2 joins and tenant-a alone grows to four partitions
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
+                  Optional.empty(),
+                  Optional.of(new TenantPartitionCount(TENANT_A, 4)),
+                  Optional.empty())
+              .phases(configuration);
+
+      // then — only the named tenant gains a partition, while both tenants are still redistributed
+      // over the joining broker
+      final var partitionPhase = partitionPhase(phases);
+      assertThat(bootstrappedPartitions(partitionPhase, TENANT_A))
+          .describedAs("tenant-a bootstraps its fourth partition")
+          .extracting(PartitionBootstrapOperation::partitionId)
+          .containsExactly(4);
+      assertThat(bootstrappedPartitions(partitionPhase, DEFAULT_GROUP))
+          .describedAs("the default tenant was not asked to grow")
+          .isEmpty();
+      assertThat(joinedPartitions(partitionPhase, DEFAULT_GROUP))
+          .describedAs("the default tenant still places a partition on the joining broker")
+          .isNotEmpty()
+          .allSatisfy(join -> assertThat(join.memberId()).isEqualTo(MemberId.from("2")));
+    }
+
+    @Test
+    void shouldGrowTheDefaultTenantWhenItIsTheTargetedTenant() {
+      // given — the same cluster, targeting the tenant that used to be the only one a scaling
+      // request could grow
+      final var configuration = twoTenantCluster();
+
+      // when — broker 2 joins and the default tenant alone grows to four partitions
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
+                  Optional.empty(),
+                  Optional.of(new TenantPartitionCount(DEFAULT_GROUP, 4)),
+                  Optional.empty())
+              .phases(configuration);
+
+      // then
+      final var partitionPhase = partitionPhase(phases);
+      assertThat(bootstrappedPartitions(partitionPhase, DEFAULT_GROUP))
+          .extracting(PartitionBootstrapOperation::partitionId)
+          .containsExactly(4);
+      assertThat(bootstrappedPartitions(partitionPhase, TENANT_A))
+          .describedAs("tenant-a was not asked to grow")
+          .isEmpty();
+    }
+
+    @Test
+    void shouldRejectAPartitionCountBelowTheTargetedTenantsCurrentCount() {
+      // given — both tenants have three partitions, and partitions can only be scaled up
+      final var configuration = twoTenantCluster();
+
+      // when
+      final var phases =
+          new ScaleRequestTransformer(
+                  Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2")),
+                  Optional.empty(),
+                  Optional.of(new TenantPartitionCount(TENANT_A, 2)),
+                  Optional.empty())
+              .phases(configuration);
+
+      // then — the rejection names the tenant that was asked to shrink, not the default one
+      EitherAssert.assertThat(phases)
+          .isLeft()
+          .left()
+          .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
+      assertThat(phases.getLeft()).hasMessageContaining(TENANT_A);
+    }
+
+    @Test
     void shouldRejectARequestWithoutAnyBroker() {
       // when
-      final var phases = new ScaleRequestTransformer(Set.of()).phases(twoTenantCluster());
+      final var phases = membershipChange(Set.of()).phases(twoTenantCluster());
 
       // then
       EitherAssert.assertThat(phases)
@@ -573,6 +661,14 @@ class ScaleRequestTransformerTest {
       return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
           .filter(PartitionJoinOperation.class::isInstance)
           .map(PartitionJoinOperation.class::cast)
+          .toList();
+    }
+
+    private List<PartitionBootstrapOperation> bootstrappedPartitions(
+        final PartitionGroupPhase phase, final String groupId) {
+      return phase.groupOperations().getOrDefault(groupId, List.of()).stream()
+          .filter(PartitionBootstrapOperation.class::isInstance)
+          .map(PartitionBootstrapOperation.class::cast)
           .toList();
     }
 
@@ -693,7 +789,7 @@ class ScaleRequestTransformerTest {
       newMembers.add(MemberId.from("3"));
 
       // when
-      final var phases = new ScaleRequestTransformer(newMembers).phases(configuration);
+      final var phases = membershipChange(newMembers).phases(configuration);
 
       // then
       EitherAssert.assertThat(phases)


### PR DESCRIPTION
A partition-count change could target a named physical tenant only in a request that changed
nothing else. Combined with a membership change it was rejected outright:

```
brokerCount cannot be combined with physicalTenant: brokerCount changes cluster membership,
which has no tenant dimension
```

The reasoning holds for the membership half and not for the request as a whole. Membership has no
tenant dimension, so it is applied to every tenant's partitions either way; the partition count
does have one, and the two dimensions are independent. Adding brokers and growing one tenant onto
them therefore took two requests and two configuration changes, though a single plan expresses it:
redistribute every tenant over the new member set, and grow the named tenant's group. Both request
shapes route through `PATCH /actuator/cluster`, so which of the two rejections an operator hit
depended only on whether they wrote `brokers.count` or `brokers.add`.

### What changed

- Both cluster-level transformers pass the resolved group to `ScaleRequestTransformer` instead of
  rejecting. The `NotFound` check for an unknown tenant moves ahead of the membership branch, so it
  covers that path too — previously a tenant was only ever resolved on the path that planned the
  partition count alone.
- `physicalTenant` without a partition count is now **rejected** rather than ignored. It was
  rejected before as part of the membership rejection, and scoping a request to a tenant that
  scopes nothing is far more likely a mistake than an intent. The one case that changes from a
  silent no-op to a rejection is a request naming a tenant and nothing else, which planned no
  operations anyway.
- `newReplicationFactor` stays incompatible with `physicalTenant`: it is cluster-wide, with no
  tenant to scope it to.

### Why the refactor comes first

`ScaleRequestTransformer` hardcoded `CurrentClusterConfiguration.DEFAULT_GROUP` as the scale-up
target. That was correct, but only by accident of its callers — they rejected the tenant, so a
partition count reaching the transformer could only have meant the default tenant. Nothing said so,
and nothing failed if it stopped holding.

The first commit pairs the count with the tenant it scales (`TenantPartitionCount`) and collapses
the four telescoping constructors that defaulted the tenant into one. The pairing removes the
default rather than relocating it: a required `String targetGroupId` would force the two callers
that carry no partition count — `BrokerScaleRequest` and a zone-migration stage — to name a tenant
they do not scale. With the count optional and the tenant inside it they name none, and
`PartitionGroupScalingPhases` loses the "unused when no count is present" caveat on its target-group
parameter. `UpdatePartitionDistributionTransformer` drops its own `DEFAULT_GROUP` argument the same
way. No behaviour change in that commit.

### Test coverage

The hardcoded group was previously indistinguishable from a correct per-tenant target: no test ever
passed a partition count through `ScaleRequestTransformer` on a multi-tenant cluster. New cases:

- `ScaleRequestTransformerTest` — a multi-tenant cluster growing a named tenant, growing the default
  one, and rejecting a count below the named tenant's current one.
- `ClusterPatchRequestTransformerTest` / `ClusterScaleRequestTransformerTest` — growing only the
  requested tenant while adding a broker, while removing one, and while changing the broker count;
  an unknown tenant rejected on the membership path; a tenant with no partition count to scope
  rejected.

Module suite green (`zeebe/dynamic-config`, 1161 tests). The 4 errors seen locally in
`ZoneAwareClusterConfigurationManagementApiTest` are port-binding noise on my machine — that class
passes 44/44 in isolation.

## Related issues

relates to #57007

Extends the per-tenant scaling added for #60077, which scoped the partition count only for requests
that changed nothing else.
