### PR TITLE
Restrict AGENT_INSTANCE:CREATE history items to CONFIGURATION and USER roles

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
@@ -86,7 +86,10 @@ public interface CreateAgentInstanceCommandStep1 {
      * Sets the batch of conversation history items to append to the agent instance at creation.
      * Always required — a CONFIGURATION item within the batch establishing model, provider, and
      * systemPrompt is the only way to create an agent instance. Every item's role must be
-     * CONFIGURATION or USER, and no item may carry metrics.
+     * CONFIGURATION or USER, and no item may carry positive usage-token metrics ({@code
+     * inputTokens}, {@code outputTokens}, {@code reasoningTokenCount}, {@code
+     * cacheCreationTokenCount}, {@code cacheReadTokenCount}); {@code durationMs} is exempt and may
+     * be positive.
      *
      * @param history the history items to append, in order. Must not be null or empty; elements
      *     must not be null.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
@@ -86,10 +86,10 @@ public interface CreateAgentInstanceCommandStep1 {
      * Sets the batch of conversation history items to append to the agent instance at creation.
      * Always required — a CONFIGURATION item within the batch establishing model, provider, and
      * systemPrompt is the only way to create an agent instance. Every item's role must be
-     * CONFIGURATION or USER, and no item may carry positive usage-token metrics ({@code
+     * CONFIGURATION or USER, and no item may carry non-zero usage-token metrics ({@code
      * inputTokens}, {@code outputTokens}, {@code reasoningTokenCount}, {@code
      * cacheCreationTokenCount}, {@code cacheReadTokenCount}); {@code durationMs} is exempt and may
-     * be positive.
+     * be non-zero.
      *
      * @param history the history items to append, in order. Must not be null or empty; elements
      *     must not be null.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentInstanceCommandStep1.java
@@ -85,7 +85,8 @@ public interface CreateAgentInstanceCommandStep1 {
     /**
      * Sets the batch of conversation history items to append to the agent instance at creation.
      * Always required — a CONFIGURATION item within the batch establishing model, provider, and
-     * systemPrompt is the only way to create an agent instance.
+     * systemPrompt is the only way to create an agent instance. Every item's role must be
+     * CONFIGURATION or USER, and no item may carry metrics.
      *
      * @param history the history items to append, in order. Must not be null or empty; elements
      *     must not be null.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -68,8 +68,8 @@ public final class AgentInstanceCreateProcessor
           + "roles are: %s.";
   private static final String ERROR_MSG_CREATE_METRICS_NOT_ALLOWED =
       "Expected to create agent instance with history item '%s', but it carries positive "
-          + "metrics. History items included when creating an agent instance must not carry "
-          + "metrics.";
+          + "token-usage metrics. History items included when creating an agent instance must "
+          + "not carry positive token-usage metrics; durationMs is exempt.";
 
   private static final Set<AgentHistoryRole> ALLOWED_CREATE_ROLES =
       Set.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
@@ -300,13 +300,15 @@ public final class AgentInstanceCreateProcessor
 
   /**
    * Validates that every item in a CREATE batch has an allowed role ({@link
-   * AgentHistoryRole#CONFIGURATION} or {@link AgentHistoryRole#USER}) and carries no metrics.
+   * AgentHistoryRole#CONFIGURATION} or {@link AgentHistoryRole#USER}) and carries no positive
+   * token-usage metrics ({@code inputTokens}, {@code outputTokens}, {@code reasoningTokenCount},
+   * {@code cacheCreationTokenCount}, {@code cacheReadTokenCount}); {@code durationMs} is exempt.
    * UPDATE keeps accepting every role, metrics included, since a rejected UPDATE still has a live
    * {@code AgentInstance} to apply metrics onto — a rejected CREATE does not, so this check is
    * CREATE-only.
    *
    * @return the rejection for the first invalid item found, or {@link Either#rightVoid()} if every
-   *     item is a CONFIGURATION or USER item without metrics
+   *     item is a CONFIGURATION or USER item without positive token-usage metrics
    */
   private static Either<Rejection, Void> validateCreateHistoryItems(
       final List<? extends AgentHistoryRecordValue> history) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -67,9 +67,13 @@ public final class AgentInstanceCreateProcessor
       "Expected to create agent instance with history item '%s', but its role is '%s'. Allowed "
           + "roles are: %s.";
   private static final String ERROR_MSG_CREATE_METRICS_NOT_ALLOWED =
-      "Expected to create agent instance with history item '%s', but it carries positive "
+      "Expected to create agent instance with history item '%s', but it carries non-zero "
           + "token-usage metrics. History items included when creating an agent instance must "
-          + "not carry positive token-usage metrics; durationMs is exempt.";
+          + "not carry non-zero token-usage metrics; durationMs is exempt.";
+
+  // AgentHistoryMetrics properties default to -1 to mean "not provided" — that sentinel, like 0,
+  // must not itself count as a non-zero metric.
+  private static final long METRIC_NOT_PROVIDED = -1L;
 
   private static final Set<AgentHistoryRole> ALLOWED_CREATE_ROLES =
       Set.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
@@ -300,7 +304,7 @@ public final class AgentInstanceCreateProcessor
 
   /**
    * Validates that every item in a CREATE batch has an allowed role ({@link
-   * AgentHistoryRole#CONFIGURATION} or {@link AgentHistoryRole#USER}) and carries no positive
+   * AgentHistoryRole#CONFIGURATION} or {@link AgentHistoryRole#USER}) and carries no non-zero
    * token-usage metrics ({@code inputTokens}, {@code outputTokens}, {@code reasoningTokenCount},
    * {@code cacheCreationTokenCount}, {@code cacheReadTokenCount}); {@code durationMs} is exempt.
    * UPDATE keeps accepting every role, metrics included, since a rejected UPDATE still has a live
@@ -308,7 +312,7 @@ public final class AgentInstanceCreateProcessor
    * CREATE-only.
    *
    * @return the rejection for the first invalid item found, or {@link Either#rightVoid()} if every
-   *     item is a CONFIGURATION or USER item without positive token-usage metrics
+   *     item is a CONFIGURATION or USER item without non-zero token-usage metrics
    */
   private static Either<Rejection, Void> validateCreateHistoryItems(
       final List<? extends AgentHistoryRecordValue> history) {
@@ -331,7 +335,7 @@ public final class AgentInstanceCreateProcessor
                     historyItemId, item.getRole(), sortedAllowedRoles)));
       }
 
-      if (hasPositiveMetrics(item.getMetrics())) {
+      if (hasNonZeroMetrics(item.getMetrics())) {
         return Either.left(
             new Rejection(
                 RejectionType.INVALID_ARGUMENT,
@@ -343,16 +347,20 @@ public final class AgentInstanceCreateProcessor
 
   /**
    * {@code durationMs} is deliberately excluded from this check: it isn't an accumulated
-   * conversation metric like the others, so it may be positive even on an otherwise-clean
+   * conversation metric like the others, so it may be non-zero even on an otherwise-clean
    * CONFIGURATION/USER item.
    */
-  private static boolean hasPositiveMetrics(
+  private static boolean hasNonZeroMetrics(
       final AgentHistoryRecordValue.AgentHistoryMetricsValue metrics) {
-    return metrics.getInputTokens() > 0
-        || metrics.getOutputTokens() > 0
-        || metrics.getReasoningTokenCount() > 0
-        || metrics.getCacheCreationTokenCount() > 0
-        || metrics.getCacheReadTokenCount() > 0;
+    return isNonZeroMetricValue(metrics.getInputTokens())
+        || isNonZeroMetricValue(metrics.getOutputTokens())
+        || isNonZeroMetricValue(metrics.getReasoningTokenCount())
+        || isNonZeroMetricValue(metrics.getCacheCreationTokenCount())
+        || isNonZeroMetricValue(metrics.getCacheReadTokenCount());
+  }
+
+  private static boolean isNonZeroMetricValue(final long value) {
+    return value != 0 && value != METRIC_NOT_PROVIDED;
   }
 
   private void writeRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -36,7 +36,9 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public final class AgentInstanceCreateProcessor
@@ -59,6 +61,17 @@ public final class AgentInstanceCreateProcessor
 
   private static final List<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
       List.of(BpmnElementType.AD_HOC_SUB_PROCESS, BpmnElementType.SERVICE_TASK);
+
+  private static final String ERROR_MSG_CREATE_ROLE_NOT_ALLOWED =
+      "Expected to create agent instance with history item '%s', but its role is '%s'. Allowed "
+          + "roles are: %s.";
+  private static final String ERROR_MSG_CREATE_METRICS_NOT_ALLOWED =
+      "Expected to create agent instance with history item '%s', but it carries positive "
+          + "metrics. History items included when creating an agent instance must not carry "
+          + "metrics.";
+
+  private static final Set<AgentHistoryRole> ALLOWED_CREATE_ROLES =
+      Set.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
@@ -189,6 +202,13 @@ public final class AgentInstanceCreateProcessor
       return;
     }
 
+    final var isCreateHistoryValid = validateCreateHistoryItems(commandValue.getHistory());
+    if (isCreateHistoryValid.isLeft()) {
+      final var rejection = isCreateHistoryValid.getLeft();
+      writeRejection(command, rejection.type(), rejection.reason());
+      return;
+    }
+
     final var deployedProcess =
         processState.getProcessByKeyAndTenant(
             elementInstanceValue.getProcessDefinitionKey(), elementInstanceValue.getTenantId());
@@ -275,6 +295,57 @@ public final class AgentInstanceCreateProcessor
 
     responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.CREATED, event, command);
+  }
+
+  /**
+   * Validates that every item in a CREATE batch has an allowed role ({@link
+   * AgentHistoryRole#CONFIGURATION} or {@link AgentHistoryRole#USER}) and carries no metrics.
+   * UPDATE keeps accepting every role, metrics included, since a rejected UPDATE still has a live
+   * {@code AgentInstance} to apply metrics onto — a rejected CREATE does not, so this check is
+   * CREATE-only.
+   *
+   * @return the rejection for the first invalid item found, or {@link Either#rightVoid()} if every
+   *     item is a CONFIGURATION or USER item without metrics
+   */
+  private static Either<Rejection, Void> validateCreateHistoryItems(
+      final List<? extends AgentHistoryRecordValue> history) {
+    if (history == null || history.isEmpty()) {
+      return Either.rightVoid();
+    }
+
+    for (final var item : history) {
+      final var historyItemId = item.getHistoryItemId();
+
+      if (!ALLOWED_CREATE_ROLES.contains(item.getRole())) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                ERROR_MSG_CREATE_ROLE_NOT_ALLOWED.formatted(
+                    historyItemId, item.getRole(), ALLOWED_CREATE_ROLES)));
+      }
+
+      if (hasPositiveMetrics(item.getMetrics())) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                ERROR_MSG_CREATE_METRICS_NOT_ALLOWED.formatted(historyItemId)));
+      }
+    }
+    return Either.rightVoid();
+  }
+
+  /**
+   * {@code durationMs} is deliberately excluded from this check: it isn't an accumulated
+   * conversation metric like the others, so it may be positive even on an otherwise-clean
+   * CONFIGURATION/USER item.
+   */
+  private static boolean hasPositiveMetrics(
+      final AgentHistoryRecordValue.AgentHistoryMetricsValue metrics) {
+    return metrics.getInputTokens() > 0
+        || metrics.getOutputTokens() > 0
+        || metrics.getReasoningTokenCount() > 0
+        || metrics.getCacheCreationTokenCount() > 0
+        || metrics.getCacheReadTokenCount() > 0;
   }
 
   private void writeRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -317,11 +318,15 @@ public final class AgentInstanceCreateProcessor
       final var historyItemId = item.getHistoryItemId();
 
       if (!ALLOWED_CREATE_ROLES.contains(item.getRole())) {
+        // sorted here, the only place the message's ordering matters: Set's own iteration order
+        // is seeded from a per-JVM salt, so its toString() would vary across JVM runs.
+        final var sortedAllowedRoles =
+            ALLOWED_CREATE_ROLES.stream().sorted(Comparator.comparing(Enum::name)).toList();
         return Either.left(
             new Rejection(
                 RejectionType.INVALID_ARGUMENT,
                 ERROR_MSG_CREATE_ROLE_NOT_ALLOWED.formatted(
-                    historyItemId, item.getRole(), ALLOWED_CREATE_ROLES)));
+                    historyItemId, item.getRole(), sortedAllowedRoles)));
       }
 
       if (hasPositiveMetrics(item.getMetrics())) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -426,8 +426,8 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
             "Expected to create agent instance with history item 'item-user', but it carries "
-                + "positive metrics. History items included when creating an agent instance must "
-                + "not carry metrics.");
+                + "positive token-usage metrics. History items included when creating an agent "
+                + "instance must not carry positive token-usage metrics; durationMs is exempt.");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -311,6 +311,64 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectCreateHistoryBatchWithUnspecifiedRole() {
+    // given — UNSPECIFIED is rejected by the shared validateHistory check, which runs before
+    // this CREATE-only check; pins that ordering so the CREATE-only check never masks it.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var item =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-unspecified")
+            .setRole(AgentHistoryRole.UNSPECIFIED)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("content"));
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(item))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            AgentHistoryBatchBehavior.ERROR_MSG_ROLE_UNSPECIFIED.formatted("item-unspecified"));
+  }
+
+  @Test
   public void shouldRejectCreateHistoryBatchWithPositiveMetricsOnUserItem() {
     // given — an allowed role (USER) is still rejected on CREATE if it carries metrics: metrics
     // are only ever meaningful on ASSISTANT/TOOL_RESULT items, which CREATE already disallows
@@ -370,6 +428,62 @@ public class AgentInstanceHistoryBatchProcessingTest {
             "Expected to create agent instance with history item 'item-user', but it carries "
                 + "positive metrics. History items included when creating an agent instance must "
                 + "not carry metrics.");
+  }
+
+  @Test
+  public void shouldAllowCreateHistoryBatchWithPositiveDurationMsOnUserItem() {
+    // given — durationMs isn't an accumulated conversation metric like the others, so it's
+    // exempt from the metrics check and may be positive even on a USER/CONFIGURATION item.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setDurationMs(5L);
+
+    // when
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .create();
+
+    // then
+    assertThat(created.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(created.getValue().getHistory()).hasSize(1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.client.AgentInstanceClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMetrics;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceTool;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -34,6 +35,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -184,74 +186,21 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
   @Test
   public void shouldRejectCreateHistoryBatchWithAssistantRole() {
-    // given — CREATE restricts history items to CONFIGURATION and USER roles; every other role
-    // is rejected (UNSPECIFIED is rejected separately, by the shared validateHistory check, which
-    // runs before this CREATE-only check).
-    final var role = AgentHistoryRole.ASSISTANT;
-    final var allowedRoles = List.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(
-                    SERVICE_TASK_ID,
-                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var elementInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .withElementId(SERVICE_TASK_ID)
-            .getFirst()
-            .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    final var jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .getFirst()
-            .getKey();
-    final var item =
-        new AgentHistoryRecord()
-            .setHistoryItemId("item-" + role)
-            .setRole(role)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText("content"));
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(elementInstanceKey)
-            .withJobKey(jobKey)
-            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(item))
-            .expectRejection()
-            .create();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            ("Expected to create agent instance with history item '%s', but its role is '%s'. "
-                    + "Allowed roles are: %s.")
-                .formatted(item.getHistoryItemId(), role, allowedRoles));
+    assertCreateRejectsDisallowedRole(AgentHistoryRole.ASSISTANT);
   }
 
   @Test
   public void shouldRejectCreateHistoryBatchWithToolResultRole() {
-    // given — CREATE restricts history items to CONFIGURATION and USER roles; every other role
-    // is rejected (UNSPECIFIED is rejected separately, by the shared validateHistory check, which
-    // runs before this CREATE-only check).
-    final var role = AgentHistoryRole.TOOL_RESULT;
+    assertCreateRejectsDisallowedRole(AgentHistoryRole.TOOL_RESULT);
+  }
+
+  /**
+   * CREATE restricts history items to CONFIGURATION and USER roles; every other role is rejected
+   * (UNSPECIFIED is rejected separately, by the shared validateHistory check, which runs before
+   * this CREATE-only check).
+   */
+  private void assertCreateRejectsDisallowedRole(final AgentHistoryRole role) {
+    // given
     final var allowedRoles = List.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
     ENGINE
         .deployment()
@@ -370,248 +319,43 @@ public class AgentInstanceHistoryBatchProcessingTest {
 
   @Test
   public void shouldRejectCreateHistoryBatchWithNonZeroInputTokensOnUserItem() {
-    // given — an allowed role (USER) is still rejected on CREATE if it carries metrics: metrics
-    // are only ever meaningful on ASSISTANT/TOOL_RESULT items, which CREATE already disallows
-    // entirely, so a USER/CONFIGURATION item reporting metrics is always a caller mistake.
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(
-                    SERVICE_TASK_ID,
-                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var elementInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .withElementId(SERVICE_TASK_ID)
-            .getFirst()
-            .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    final var jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .getFirst()
-            .getKey();
-    final var userItem =
-        new AgentHistoryRecord()
-            .setHistoryItemId("item-user")
-            .setRole(AgentHistoryRole.USER)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText("hi"));
-    userItem.getMetrics().setInputTokens(5L);
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(elementInstanceKey)
-            .withJobKey(jobKey)
-            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(userItem))
-            .expectRejection()
-            .create();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            "Expected to create agent instance with history item 'item-user', but it carries "
-                + "non-zero token-usage metrics. History items included when creating an agent "
-                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+    assertCreateRejectsUserItemWithMetric(metrics -> metrics.setInputTokens(5L));
   }
 
   @Test
   public void shouldRejectCreateHistoryBatchWithNonZeroOutputTokensOnUserItem() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(
-                    SERVICE_TASK_ID,
-                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var elementInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .withElementId(SERVICE_TASK_ID)
-            .getFirst()
-            .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    final var jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .getFirst()
-            .getKey();
-    final var userItem =
-        new AgentHistoryRecord()
-            .setHistoryItemId("item-user")
-            .setRole(AgentHistoryRole.USER)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText("hi"));
-    userItem.getMetrics().setOutputTokens(5L);
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(elementInstanceKey)
-            .withJobKey(jobKey)
-            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(userItem))
-            .expectRejection()
-            .create();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            "Expected to create agent instance with history item 'item-user', but it carries "
-                + "non-zero token-usage metrics. History items included when creating an agent "
-                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+    assertCreateRejectsUserItemWithMetric(metrics -> metrics.setOutputTokens(5L));
   }
 
   @Test
   public void shouldRejectCreateHistoryBatchWithNonZeroReasoningTokenCountOnUserItem() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(
-                    SERVICE_TASK_ID,
-                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var elementInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .withElementId(SERVICE_TASK_ID)
-            .getFirst()
-            .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    final var jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .getFirst()
-            .getKey();
-    final var userItem =
-        new AgentHistoryRecord()
-            .setHistoryItemId("item-user")
-            .setRole(AgentHistoryRole.USER)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText("hi"));
-    userItem.getMetrics().setReasoningTokenCount(5L);
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(elementInstanceKey)
-            .withJobKey(jobKey)
-            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(userItem))
-            .expectRejection()
-            .create();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            "Expected to create agent instance with history item 'item-user', but it carries "
-                + "non-zero token-usage metrics. History items included when creating an agent "
-                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+    assertCreateRejectsUserItemWithMetric(metrics -> metrics.setReasoningTokenCount(5L));
   }
 
   @Test
   public void shouldRejectCreateHistoryBatchWithNonZeroCacheCreationTokenCountOnUserItem() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(
-                    SERVICE_TASK_ID,
-                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var elementInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .withElementId(SERVICE_TASK_ID)
-            .getFirst()
-            .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    final var jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .getFirst()
-            .getKey();
-    final var userItem =
-        new AgentHistoryRecord()
-            .setHistoryItemId("item-user")
-            .setRole(AgentHistoryRole.USER)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText("hi"));
-    userItem.getMetrics().setCacheCreationTokenCount(5L);
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(elementInstanceKey)
-            .withJobKey(jobKey)
-            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(userItem))
-            .expectRejection()
-            .create();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            "Expected to create agent instance with history item 'item-user', but it carries "
-                + "non-zero token-usage metrics. History items included when creating an agent "
-                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+    assertCreateRejectsUserItemWithMetric(metrics -> metrics.setCacheCreationTokenCount(5L));
   }
 
   @Test
   public void shouldRejectCreateHistoryBatchWithNonZeroCacheReadTokenCountOnUserItem() {
+    assertCreateRejectsUserItemWithMetric(metrics -> metrics.setCacheReadTokenCount(5L));
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithNegativeInputTokensOnUserItem() {
+    // inputTokens defaults to -1 to mean "not provided"; any other negative value is not
+    // a valid token count and must still be rejected, not silently accepted because it isn't > 0.
+    assertCreateRejectsUserItemWithMetric(metrics -> metrics.setInputTokens(-2L));
+  }
+
+  /**
+   * An allowed role (USER) is still rejected on CREATE if it carries metrics: metrics are only ever
+   * meaningful on ASSISTANT/TOOL_RESULT items, which CREATE already disallows entirely, so a
+   * USER/CONFIGURATION item reporting metrics is always a caller mistake.
+   */
+  private void assertCreateRejectsUserItemWithMetric(
+      final Consumer<AgentHistoryMetrics> metricSetter) {
     // given
     ENGINE
         .deployment()
@@ -648,68 +392,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
                 new AgentHistoryMessageContent()
                     .setContentType(AgentHistoryContentType.TEXT)
                     .setText("hi"));
-    userItem.getMetrics().setCacheReadTokenCount(5L);
-
-    // when
-    final var rejection =
-        ENGINE
-            .agentInstances()
-            .withElementInstanceKey(elementInstanceKey)
-            .withJobKey(jobKey)
-            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
-            .withHistory(List.of(userItem))
-            .expectRejection()
-            .create();
-
-    // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            "Expected to create agent instance with history item 'item-user', but it carries "
-                + "non-zero token-usage metrics. History items included when creating an agent "
-                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
-  }
-
-  @Test
-  public void shouldRejectCreateHistoryBatchWithNegativeInputTokensOnUserItem() {
-    // given — inputTokens defaults to -1 to mean "not provided"; any other negative value is not
-    // a valid token count and must still be rejected, not silently accepted because it isn't > 0.
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(
-                    SERVICE_TASK_ID,
-                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
-                .endEvent()
-                .done())
-        .deploy();
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var elementInstanceKey =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .withElementId(SERVICE_TASK_ID)
-            .getFirst()
-            .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).activate();
-    final var jobKey =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(helper.getJobType())
-            .getFirst()
-            .getKey();
-    final var userItem =
-        new AgentHistoryRecord()
-            .setHistoryItemId("item-user")
-            .setRole(AgentHistoryRole.USER)
-            .setLoopIteration(1)
-            .addContent(
-                new AgentHistoryMessageContent()
-                    .setContentType(AgentHistoryContentType.TEXT)
-                    .setText("hi"));
-    userItem.getMetrics().setInputTokens(-2L);
+    metricSetter.accept(userItem.getMetrics());
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -369,7 +369,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
-  public void shouldRejectCreateHistoryBatchWithPositiveMetricsOnUserItem() {
+  public void shouldRejectCreateHistoryBatchWithNonZeroInputTokensOnUserItem() {
     // given — an allowed role (USER) is still rejected on CREATE if it carries metrics: metrics
     // are only ever meaningful on ASSISTANT/TOOL_RESULT items, which CREATE already disallows
     // entirely, so a USER/CONFIGURATION item reporting metrics is always a caller mistake.
@@ -426,8 +426,309 @@ public class AgentInstanceHistoryBatchProcessingTest {
     assertThat(rejection.getRejectionReason())
         .isEqualTo(
             "Expected to create agent instance with history item 'item-user', but it carries "
-                + "positive token-usage metrics. History items included when creating an agent "
-                + "instance must not carry positive token-usage metrics; durationMs is exempt.");
+                + "non-zero token-usage metrics. History items included when creating an agent "
+                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithNonZeroOutputTokensOnUserItem() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setOutputTokens(5L);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent instance with history item 'item-user', but it carries "
+                + "non-zero token-usage metrics. History items included when creating an agent "
+                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithNonZeroReasoningTokenCountOnUserItem() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setReasoningTokenCount(5L);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent instance with history item 'item-user', but it carries "
+                + "non-zero token-usage metrics. History items included when creating an agent "
+                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithNonZeroCacheCreationTokenCountOnUserItem() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setCacheCreationTokenCount(5L);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent instance with history item 'item-user', but it carries "
+                + "non-zero token-usage metrics. History items included when creating an agent "
+                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithNonZeroCacheReadTokenCountOnUserItem() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setCacheReadTokenCount(5L);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent instance with history item 'item-user', but it carries "
+                + "non-zero token-usage metrics. History items included when creating an agent "
+                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithNegativeInputTokensOnUserItem() {
+    // given — inputTokens defaults to -1 to mean "not provided"; any other negative value is not
+    // a valid token count and must still be rejected, not silently accepted because it isn't > 0.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setInputTokens(-2L);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent instance with history item 'item-user', but it carries "
+                + "non-zero token-usage metrics. History items included when creating an agent "
+                + "instance must not carry non-zero token-usage metrics; durationMs is exempt.");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -183,6 +183,257 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectCreateHistoryBatchWithAssistantRole() {
+    // given — CREATE restricts history items to CONFIGURATION and USER roles; every other role
+    // is rejected (UNSPECIFIED is rejected separately, by the shared validateHistory check, which
+    // runs before this CREATE-only check).
+    final var role = AgentHistoryRole.ASSISTANT;
+    final var allowedRoles = List.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var item =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-" + role)
+            .setRole(role)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("content"));
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(item))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            ("Expected to create agent instance with history item '%s', but its role is '%s'. "
+                    + "Allowed roles are: %s.")
+                .formatted(item.getHistoryItemId(), role, allowedRoles));
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithToolResultRole() {
+    // given — CREATE restricts history items to CONFIGURATION and USER roles; every other role
+    // is rejected (UNSPECIFIED is rejected separately, by the shared validateHistory check, which
+    // runs before this CREATE-only check).
+    final var role = AgentHistoryRole.TOOL_RESULT;
+    final var allowedRoles = List.of(AgentHistoryRole.CONFIGURATION, AgentHistoryRole.USER);
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var item =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-" + role)
+            .setRole(role)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("content"));
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(item))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            ("Expected to create agent instance with history item '%s', but its role is '%s'. "
+                    + "Allowed roles are: %s.")
+                .formatted(item.getHistoryItemId(), role, allowedRoles));
+  }
+
+  @Test
+  public void shouldRejectCreateHistoryBatchWithPositiveMetricsOnUserItem() {
+    // given — an allowed role (USER) is still rejected on CREATE if it carries metrics: metrics
+    // are only ever meaningful on ASSISTANT/TOOL_RESULT items, which CREATE already disallows
+    // entirely, so a USER/CONFIGURATION item reporting metrics is always a caller mistake.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    userItem.getMetrics().setInputTokens(5L);
+
+    // when
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(userItem))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent instance with history item 'item-user', but it carries "
+                + "positive metrics. History items included when creating an agent instance must "
+                + "not carry metrics.");
+  }
+
+  @Test
+  public void shouldAllowCreateHistoryBatchWithConfigurationAndUserRolesWithoutMetrics() {
+    // given — the positive case: CONFIGURATION and USER items with no metrics are exactly what
+    // CREATE is meant to accept.
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(helper.getJobType()).activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var configurationItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-configuration")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1)
+            .setChangedAttributes(List.of("model"));
+    final var userItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-user")
+            .setRole(AgentHistoryRole.USER)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+
+    // when
+    final var created =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(jobKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withHistory(List.of(configurationItem, userItem))
+            .create();
+
+    // then
+    assertThat(created.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(created.getValue().getHistory()).hasSize(2);
+  }
+
+  @Test
   public void shouldRejectWholeBatchWhenAnItemIsMissingHistoryItemId() {
     // given
     ENGINE

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -650,7 +650,8 @@ components:
             history, in request order. Each created item is echoed back in the
             response's createdHistory, positionally correlated. Must include a
             CONFIGURATION item establishing model, provider, and systemPrompt (and,
-            if needed, limits).
+            if needed, limits). Every item's role must be CONFIGURATION or USER, and
+            no item may carry metrics.
           type: array
           minItems: 1
           items:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -651,7 +651,9 @@ components:
             response's createdHistory, positionally correlated. Must include a
             CONFIGURATION item establishing model, provider, and systemPrompt (and,
             if needed, limits). Every item's role must be CONFIGURATION or USER, and
-            no item may carry metrics.
+            no item may carry positive usage-token metrics (inputTokens, outputTokens,
+            reasoningTokenCount, cacheCreationTokenCount, cacheReadTokenCount);
+            durationMs is exempt and may be positive.
           type: array
           minItems: 1
           items:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -651,9 +651,9 @@ components:
             response's createdHistory, positionally correlated. Must include a
             CONFIGURATION item establishing model, provider, and systemPrompt (and,
             if needed, limits). Every item's role must be CONFIGURATION or USER, and
-            no item may carry positive usage-token metrics (inputTokens, outputTokens,
+            no item may carry non-zero usage-token metrics (inputTokens, outputTokens,
             reasoningTokenCount, cacheCreationTokenCount, cacheReadTokenCount);
-            durationMs is exempt and may be positive.
+            durationMs is exempt and may be non-zero.
           type: array
           minItems: 1
           items:


### PR DESCRIPTION
## Summary

`AGENT_INSTANCE:CREATE` has no live `AgentInstance` to fall back on when its embedded history batch is rejected — unlike `UPDATE`, which always has one available to accumulate metrics onto even on rejection (established by #60715). That means anything wrong with a CREATE batch's contents is unrecoverable once rejected: there's no instance left to carry usage metrics that were genuinely incurred.

This PR closes that gap at the source by restricting CREATE's initial history batch to `CONFIGURATION` and `USER` role items only, and rejecting non-zero usage metrics on those items within a CREATE batch. `ASSISTANT` and `TOOL_RESULT` roles, and any accumulated conversation metric, only make sense once an instance already exists — CREATE's batch is meant to seed configuration and initial user context, not conversation turns or usage data. This is a breaking API-contract change: any caller submitting an `ASSISTANT`/`TOOL_RESULT` item or non-zero metrics in a CREATE batch today will start getting `INVALID_ARGUMENT` where it previously succeeded.

`AGENT_INSTANCE:UPDATE` is untouched by this change — the new validation is CREATE-only, implemented outside the shared `AgentHistoryBatchBehavior.validateHistory()` path both commands use.

Part of the Real-Time Agent Visibility epic (camunda/product-hub#3462).

## What's included

- New CREATE-only validation, `validateCreateHistoryItems(...)`, added directly to `AgentInstanceCreateProcessor` (not the shared `AgentHistoryBatchBehavior` class, since the check is CREATE-only) and called from `processRecord` right after the existing shared `validateHistory()`. Rejects `INVALID_ARGUMENT` for:
  - Any history item whose role isn't in the new private `ALLOWED_CREATE_ROLES` set (`CONFIGURATION`, `USER`) — so `ASSISTANT` and `TOOL_RESULT` are rejected. The rejection message takes the allowed roles as a formatted argument rather than hardcoding role names, so it stays in sync if the allowed set ever changes. `ALLOWED_CREATE_ROLES` stays a `Set` — it's checked via `contains()` on every history item in a CREATE batch — and is only sorted (alphabetically by role name) at the one place the message is actually built, since a `Set`'s own iteration order is JVM-salted and would otherwise vary the message text across runs.
  - Any `CONFIGURATION`/`USER` item whose metrics has a non-zero `inputTokens`, `outputTokens`, `reasoningTokenCount`, `cacheCreationTokenCount`, or `cacheReadTokenCount`, via a new private `hasNonZeroMetrics` helper. "Non-zero" is deliberate, not just "positive": each field defaults to `-1` to mean "not provided," so the check treats `0` and `-1` as the only values that don't carry a metric — a caller-supplied negative value other than the sentinel (e.g. `-2`) is rejected too, the same as a positive one. `durationMs` is deliberately excluded from this check even though it's also a metrics field: unlike the token/cache fields, nothing ever accumulates `durationMs` onto the live `AgentInstance` over its lifetime, so a stray `durationMs` on a CREATE item can't produce the unrecoverable-usage-data loss this PR exists to prevent, and rejecting it would add no real protection. Null/all-zero metrics are both accepted with no distinction between them.
- `AgentInstanceCreateProcessor` is the only caller of this new validation — `UPDATE`'s processor is untouched.
- 11 new engine-level test cases in `AgentInstanceHistoryBatchProcessingTest` (53 total in the class): `shouldRejectCreateHistoryBatchWithAssistantRole` and `shouldRejectCreateHistoryBatchWithToolResultRole`, `shouldRejectCreateHistoryBatchWithUnspecifiedRole` (pins that `UNSPECIFIED` is caught by the shared `validateHistory` check before this CREATE-only check ever runs), one rejection case per token-usage field (`shouldRejectCreateHistoryBatchWithNonZero{InputTokens,OutputTokens,ReasoningTokenCount,CacheCreationTokenCount,CacheReadTokenCount}OnUserItem`) so an omitted or swapped getter in the check can't silently pass, `shouldRejectCreateHistoryBatchWithNegativeInputTokensOnUserItem` (pins that a negative, non-sentinel value is rejected too), `shouldAllowCreateHistoryBatchWithPositiveDurationMsOnUserItem` (pins that `durationMs` stays exempt from the metrics check), and `shouldAllowCreateHistoryBatchWithConfigurationAndUserRolesWithoutMetrics`. The disallowed-role case is two separate, fully-inlined `@Test` methods rather than one `@ParameterizedTest`: the fixture (`EngineRule`) is a JUnit 4 `@ClassRule` whose broker startup only runs through the JUnit 4 vintage engine's `Statement` wrapping, and the Jupiter engine never triggers that for a `@ParameterizedTest` method — every `ENGINE` call in one throws immediately with the broker never started.
- Docs update to the `history` field description on `AgentInstanceCreationRequest` in `zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml`, and to the javadoc on `CreateAgentInstanceCommandStep1.CreateAgentInstanceCommandStep4.history(...)` in `clients/java`. Both now state the rule's shape precisely — every item's role must be `CONFIGURATION` or `USER`, and no item may carry non-zero `inputTokens`/`outputTokens`/`reasoningTokenCount`/`cacheCreationTokenCount`/`cacheReadTokenCount`, with `durationMs` named as the one exempt metrics field — without rationale/reasoning prose (`AgentInstanceUpdateRequest.history`, the shared `AgentInstanceHistoryItem` schema, and `UpdateAgentInstanceCommandStep1`'s javadoc are all deliberately untouched).

## Risk / open callout for reviewers

The real agent-runtime caller of `AGENT_INSTANCE:CREATE` lives outside this repo, and the blast radius of this restriction on that caller has not been verified — the originating issue calls this out explicitly as a risk to confirm before enforcing. This PR proceeds with enforcement anyway rather than blocking on that confirmation, per an explicit decision to flag it here for reviewer awareness rather than gate the change on it. Reviewers with visibility into the agent-runtime caller should double check it doesn't submit `ASSISTANT`/`TOOL_RESULT` items or non-zero metrics in its CREATE batches today.

## Alternative considered: role-based schema polymorphism

Explored on a separate branch (not part of this PR): splitting the shared `AgentInstanceHistoryItem` write-path schema into a `oneOf`/discriminator keyed on `role`, one variant per role, each exposing only the fields that role actually uses — the same pattern already used for `AgentInstanceMessageContent` (`contentType` discriminator). This is exactly the direction raised in #59785's "role-based polymorphism" update, which found the same underlying gap (`tools`/`model`/`provider`/`limits`/`systemPrompt`/`toolCalls`/`metrics` are documented as role-restricted but nothing enforces it) and proposed making the invalid combinations unrepresentable at the schema level instead of adding role-mismatch validation.

Confirmed feasible without changing the Java client's public interface — `CreateAgentInstanceCommandImpl` already decouples the hand-written public `AgentInstanceHistoryItem` from the generated wire type via `AgentInstanceHistoryMapper`, and already has precedent for client-side-only validation independent of schema shape (`ensureConfigurationEstablishesDefinition`). Not pursued here because the cost doesn't pay for itself yet: a CREATE-specific schema variant would duplicate most of the existing `AgentInstanceHistoryItem` shape and need to stay in sync with it on every future field change, and the mapper would fork into two near-duplicate builders. It also wouldn't remove the need for this PR's engine-level check — verified there is in fact no gRPC route or alternate client path to `AGENT_INSTANCE:CREATE`; the REST controller's OpenAPI-typed `AgentInstanceCreationRequest` is the sole production entry point, and the Java client SDK is REST-based end to end. But the engine is still the right enforcement point regardless: it's the layer that owns the command's actual invariants, and `AgentHistoryBatchBehavior`'s existing checks (empty `historyItemId`, `UNSPECIFIED` role, etc.) already enforce independently of the gateway/schema layer for the same reason. A schema-level restriction would be redundant with, not a replacement for, that. Worth revisiting if #59785's broader polymorphism direction gets picked up for other roles/fields at the same time, so the two write-path items are done once rather than twice.

## Test plan

- [x] Rebased onto current `main`; one conflict in `AgentInstanceHistoryBatchProcessingTest` (main added a new test at the same insertion point as this branch's first commit) resolved by keeping both tests, diff still scopes to the same 4 files.
- [x] `spotless:check`, `license:check`, and `checkstyle` all pass on touched modules (`zeebe/engine`, `clients/java`, `zeebe/gateway-protocol`).
- [ ] `AgentInstanceHistoryBatchProcessingTest` (55 tests incl. the 11 new CREATE-specific cases) could not be confirmed green locally — every test in the class, including ones unrelated to this change, timed out waiting for exported records; reproduced on an unrelated, unmodified engine test class too, confirming local machine resource contention rather than a real regression. Rely on CI for this class.

## Related issues

- Closes #61632

🤖 Generated with [Claude Code](https://claude.com/claude-code)