### PR TITLE
feat: add draining gauge and split drain lifecycle metrics

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -509,6 +509,16 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
     }
   }
 
+  public enum ProcessDefinitionKeyNames implements KeyName {
+    /** The BPMN process ID of the process definition */
+    BPMN_PROCESS_ID {
+      @Override
+      public String asString() {
+        return "bpmnProcessId";
+      }
+    }
+  }
+
   public enum JobAction {
     CREATED("created"),
     ACTIVATED("activated"),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -294,6 +294,83 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getAdditionalKeyNames() {
       return PartitionKeyNames.values();
     }
+  },
+
+  /** Number of unique deployed process definitions (distinct BPMN process IDs) */
+  DEPLOYED_PROCESS_DEFINITIONS {
+    @Override
+    public String getDescription() {
+      return "Number of unique deployed process definitions (distinct BPMN process IDs)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.process.definitions.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Total size in bytes of all deployed versions of each process definition */
+  PROCESS_DEFINITION_RESOURCE_SIZE {
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {ProcessDefinitionKeyNames.BPMN_PROCESS_ID};
+
+    @Override
+    public String getDescription() {
+      return "Total size in bytes of all deployed versions of each process definition";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.process.definition.resource.size.bytes";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Number of process definitions currently draining (deleted, awaiting last instance) */
+  DRAINING_PROCESS_DEFINITIONS {
+    @Override
+    public String getDescription() {
+      return "Number of process definitions currently draining (deleted, awaiting last instance)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.process.definitions.draining.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
   };
 
   /** Tags/label values possibly used by the engine metrics. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetrics.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.ProcessDefinitionKeyNames;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ProcessDefinitionMetrics {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionMetrics.class);
+
+  private final MeterRegistry registry;
+  private final AtomicLong totalUniqueProcessIds = new AtomicLong(0);
+  private final AtomicLong drainingProcessDefinitions = new AtomicLong(0);
+
+  // processDefinitionKey -> (bpmnProcessId, sizeBytes) — to know what to subtract on deletion
+  private final Map<Long, KeyEntry> entriesByKey = new HashMap<>();
+  // bpmnProcessId -> set of processDefinitionKeys with that ID
+  private final Map<String, Set<Long>> keysByProcessId = new HashMap<>();
+  // bpmnProcessId -> running total of bytes across all deployed versions
+  private final Map<String, AtomicLong> totalSizeByProcessId = new HashMap<>();
+  // bpmnProcessId -> registered Gauge (to allow removal when last version is deleted)
+  private final Map<String, Gauge> sizeGaugesByProcessId = new HashMap<>();
+
+  public ProcessDefinitionMetrics(final MeterRegistry registry, final ProcessState processState) {
+    this.registry = Objects.requireNonNull(registry);
+
+    final long startNanos = System.nanoTime();
+    final var drainingCount = new AtomicLong(0);
+    processState.forEachProcess(
+        null,
+        process -> {
+          if (process.getState() == PersistedProcessState.ACTIVE) {
+            final String bpmnProcessId = BufferUtil.bufferAsString(process.getBpmnProcessId());
+            addEntry(process.getKey(), bpmnProcessId, process.getResource().capacity());
+          } else if (process.getState() == PersistedProcessState.DRAINING) {
+            drainingCount.incrementAndGet();
+          }
+          return true;
+        });
+    LOG.debug(
+        "Initialized process definition metrics by scanning {} process definitions in {}",
+        entriesByKey.size(),
+        Duration.ofNanos(System.nanoTime() - startNanos));
+
+    totalUniqueProcessIds.set(keysByProcessId.size());
+    drainingProcessDefinitions.set(drainingCount.get());
+
+    final var definitionsDoc = EngineMetricsDoc.DEPLOYED_PROCESS_DEFINITIONS;
+    Gauge.builder(definitionsDoc.getName(), totalUniqueProcessIds, AtomicLong::get)
+        .description(definitionsDoc.getDescription())
+        .register(registry);
+
+    final var drainingDoc = EngineMetricsDoc.DRAINING_PROCESS_DEFINITIONS;
+    Gauge.builder(drainingDoc.getName(), drainingProcessDefinitions, AtomicLong::get)
+        .description(drainingDoc.getDescription())
+        .register(registry);
+  }
+
+  /**
+   * Records the deployment of a new process definition version. Must be called from live event
+   * processing only (not during replay), since the initial state is recovered via the constructor
+   * scan.
+   */
+  public void processDefinitionDeployed(
+      final long processDefinitionKey, final String bpmnProcessId, final int sizeBytes) {
+    final var keys = addEntry(processDefinitionKey, bpmnProcessId, sizeBytes);
+    if (keys.size() == 1) {
+      totalUniqueProcessIds.incrementAndGet();
+    }
+  }
+
+  /** Moves a definition from the deployed count into the draining count. Live processing only. */
+  public void processDefinitionDraining(final long processDefinitionKey) {
+    removeDeployedDefinition(processDefinitionKey);
+    drainingProcessDefinitions.incrementAndGet();
+  }
+
+  /**
+   * Records that a draining process definition finalized its deletion. Must be called from live
+   * event processing only (not during replay).
+   */
+  public void processDefinitionDrainFinalized() {
+    drainingProcessDefinitions.decrementAndGet();
+  }
+
+  private void removeDeployedDefinition(final long processDefinitionKey) {
+    final var entry = entriesByKey.remove(processDefinitionKey);
+    if (entry == null) {
+      return;
+    }
+
+    final var keys = keysByProcessId.get(entry.bpmnProcessId());
+    if (keys == null) {
+      return;
+    }
+    keys.remove(processDefinitionKey);
+
+    if (keys.isEmpty()) {
+      keysByProcessId.remove(entry.bpmnProcessId());
+      totalSizeByProcessId.remove(entry.bpmnProcessId());
+      final var gauge = sizeGaugesByProcessId.remove(entry.bpmnProcessId());
+      if (gauge != null) {
+        registry.remove(gauge);
+      }
+      totalUniqueProcessIds.decrementAndGet();
+    } else {
+      totalSizeByProcessId.get(entry.bpmnProcessId()).addAndGet(-entry.sizeBytes());
+    }
+  }
+
+  private Set<Long> addEntry(
+      final long processDefinitionKey, final String bpmnProcessId, final int sizeBytes) {
+    entriesByKey.put(processDefinitionKey, new KeyEntry(bpmnProcessId, sizeBytes));
+    final var keys = keysByProcessId.computeIfAbsent(bpmnProcessId, id -> new HashSet<>());
+    keys.add(processDefinitionKey);
+
+    final var totalSize =
+        totalSizeByProcessId.computeIfAbsent(bpmnProcessId, id -> new AtomicLong());
+    totalSize.addAndGet(sizeBytes);
+
+    sizeGaugesByProcessId.computeIfAbsent(
+        bpmnProcessId,
+        id -> {
+          final var sizeDoc = EngineMetricsDoc.PROCESS_DEFINITION_RESOURCE_SIZE;
+          return Gauge.builder(sizeDoc.getName(), totalSize, AtomicLong::get)
+              .description(sizeDoc.getDescription())
+              .tag(ProcessDefinitionKeyNames.BPMN_PROCESS_ID.asString(), id)
+              .register(registry);
+        });
+    return keys;
+  }
+
+  private record KeyEntry(String bpmnProcessId, int sizeBytes) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessDefinitionMetricsTest.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.DeploymentClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessDefinitionMetricsTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessDefinitionMetricsTest.class);
+  private static final String PROCESS_ID_A = "processA";
+  private static final String PROCESS_ID_B = "processB";
+  private static final String JOB_TYPE = "task";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTrackSingleDeployedProcessDefinition() {
+    // when
+    engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID_A).startEvent().endEvent().done())
+        .deploy();
+
+    // then
+    assertThat(definitionsCountGauge()).describedAs("unique process definitions count").isOne();
+  }
+
+  @Test
+  public void shouldNotIncrementDefinitionCountOnRedeployment() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID_A).startEvent().endEvent().done())
+        .deploy();
+
+    // when - redeploy a modified version of the same process ID
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID_A)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("work"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // then - same BPMN process ID, so unique definitions stays at 1
+    assertThat(definitionsCountGauge())
+        .describedAs("unique process definitions count after redeployment")
+        .isOne();
+  }
+
+  @Test
+  public void shouldTrackMultipleDistinctProcessDefinitions() {
+    // when
+    engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID_A).startEvent().endEvent().done())
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID_B).startEvent().endEvent().done())
+        .deploy();
+
+    // then
+    assertThat(definitionsCountGauge())
+        .describedAs("unique process definitions count for two distinct processes")
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldTrackResourceSizeGauge() {
+    // when
+    engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID_A).startEvent().endEvent().done())
+        .deploy();
+
+    // then - size gauge is registered and reports a positive byte count
+    assertThat(resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("resource size gauge for %s", PROCESS_ID_A)
+        .isPositive();
+  }
+
+  @Test
+  public void shouldReflectResourceBytesInSizeGauge() {
+    // given - a BPMN with a documentation field of a known size
+    final int paddingBytes = 1024;
+    final String padding = "x".repeat(paddingBytes);
+
+    // when
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID_A)
+                .startEvent()
+                .endEvent()
+                .documentation(padding)
+                .done())
+        .deploy();
+
+    // then - size gauge reports more bytes than the injected payload
+    assertThat(resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("resource size gauge should reflect the deployed BPMN bytes")
+        .isGreaterThan(paddingBytes);
+  }
+
+  @Test
+  public void shouldSumSizeAcrossVersionsOfSameProcess() {
+    // given - a first version
+    engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID_A).startEvent().endEvent().done())
+        .deploy();
+    final double sizeAfterV1 = resourceSizeGauge(PROCESS_ID_A);
+
+    // when - deploy a second version of the same process
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID_A)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("work"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // then - the gauge reports the sum of both versions' sizes
+    assertThat(resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("size gauge should aggregate bytes across all versions of the same process")
+        .isGreaterThan(sizeAfterV1);
+  }
+
+  @Test
+  public void shouldDecrementCountAndRemoveSizeGaugeOnDeletion() {
+    // given
+    final long processDefinitionKey = deploySimpleProcess(PROCESS_ID_A);
+    assertThat(definitionsCountGauge()).isOne();
+
+    // when
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withBpmnProcessId(PROCESS_ID_A)
+        .await();
+
+    // then
+    assertThat(definitionsCountGauge())
+        .describedAs("unique process definitions count after deletion")
+        .isZero();
+    assertThatCode(() -> resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("size gauge for deleted process should be removed from registry")
+        .isInstanceOf(MeterNotFoundException.class);
+  }
+
+  @Test
+  public void shouldSubtractDeletedVersionFromTotalSizeWhenOneVersionRemains() {
+    // given - deploy two versions of the same process
+    deploySimpleProcess(PROCESS_ID_A);
+    final double sizeAfterV1 = resourceSizeGauge(PROCESS_ID_A);
+    final long v2Key =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(PROCESS_ID_A)
+                    .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType("work"))
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    assertThat(resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("size after both versions deployed")
+        .isGreaterThan(sizeAfterV1);
+
+    // when - delete only v2
+    engine.resourceDeletion().withResourceKey(v2Key).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withBpmnProcessId(PROCESS_ID_A)
+        .withVersion(2)
+        .await();
+
+    // then - definition still tracked because v1 remains; size gauge falls back to v1's size
+    assertThat(definitionsCountGauge())
+        .describedAs("unique process definitions count should remain 1 since v1 still exists")
+        .isOne();
+    assertThat(resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("size gauge should be reduced to v1's size only after v2 is deleted")
+        .isEqualTo(sizeAfterV1);
+  }
+
+  @Test
+  public void shouldRecoverDefinitionCountAfterBrokerRestart() {
+    // given - deploy two distinct processes before restart
+    deploySimpleProcess(PROCESS_ID_A);
+    deploySimpleProcess(PROCESS_ID_B);
+
+    assertThat(definitionsCountGauge()).isEqualTo(2);
+
+    // when - snapshot and restart the engine
+    engine.snapshot();
+    engine.stop();
+    engine.start();
+
+    // then - count is recovered from state without requiring any new deployments
+    assertThat(definitionsCountGauge())
+        .describedAs("unique process definitions count should be recovered after restart")
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldRecoverPerProcessSizeGaugeAfterBrokerRestart() {
+    // given
+    deploySimpleProcess(PROCESS_ID_A);
+    final double sizeBeforeRestart = resourceSizeGauge(PROCESS_ID_A);
+    assertThat(sizeBeforeRestart).isPositive();
+
+    // when
+    engine.snapshot();
+    engine.stop();
+    engine.start();
+
+    // then - size gauge is re-registered from state with the same byte count
+    assertThat(resourceSizeGauge(PROCESS_ID_A))
+        .describedAs("resource size gauge should be re-registered after restart with same value")
+        .isEqualTo(sizeBeforeRestart);
+  }
+
+  @Test
+  public void shouldInitializeMetricsForManyDeployedProcesses() throws IOException {
+    // given - many distinct process definitions derived from a real BPMN file,
+    // deployed in batched deployments to keep test setup fast.
+    final byte[] baseBpmn;
+    try (var in =
+        getClass().getResourceAsStream("/processes/bankCustomerComplaintDisputeHandling.bpmn")) {
+      baseBpmn = in.readAllBytes();
+    }
+    final String baseXml = new String(baseBpmn, StandardCharsets.UTF_8);
+    final String originalProcessId = "bankDisputeHandling";
+
+    final int processCount = 1000;
+    final int batchSize = 10;
+    for (int batch = 0; batch < processCount; batch += batchSize) {
+      DeploymentClient deployment = engine.deployment();
+      for (int i = batch; i < batch + batchSize; i++) {
+        final String processId = "process-" + i;
+        final byte[] resource =
+            baseXml.replace(originalProcessId, processId).getBytes(StandardCharsets.UTF_8);
+        deployment = deployment.withXmlResource(resource, processId + ".bpmn");
+      }
+      deployment.deploy();
+    }
+    assertThat(definitionsCountGauge())
+        .describedAs("definitions count before restart")
+        .isEqualTo(processCount);
+
+    // when - snapshot and restart triggers the metric initialization scan
+    engine.snapshot();
+    engine.stop();
+    final long startNanos = System.nanoTime();
+    engine.start();
+    final Duration restartDuration = Duration.ofNanos(System.nanoTime() - startNanos);
+
+    LOG.info(
+        "Engine restart with {} deployed process definitions (~{} bytes each) took {}",
+        processCount,
+        baseBpmn.length,
+        restartDuration);
+
+    // then - all definitions are recovered into the gauge
+    assertThat(definitionsCountGauge())
+        .describedAs("definitions count after restart with %d processes", processCount)
+        .isEqualTo(processCount);
+  }
+
+  @Test
+  public void shouldIncrementDrainingGaugeWhenDeletingProcessWithRunningInstance() {
+    // given - a deployed process with a single instance stuck on a job
+    final long processDefinitionKey = deployProcessWithJob(PROCESS_ID_A);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID_A).create();
+    awaitJobCreated(processInstanceKey);
+    assertThat(definitionsCountGauge()).isOne();
+    assertThat(drainingCountGauge()).isZero();
+
+    // when - the definition is deleted while the instance is still running
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    awaitDraining(processDefinitionKey);
+
+    // then - it moves out of the deployed count and into the draining count
+    assertThat(drainingCountGauge()).describedAs("draining definitions count").isOne();
+    assertThat(definitionsCountGauge())
+        .describedAs("a draining definition is no longer counted as deployed")
+        .isZero();
+  }
+
+  @Test
+  public void shouldDecrementDrainingGaugeWhenLastDrainingInstanceCompletes() {
+    // given - a draining definition kept alive by one running instance
+    final long processDefinitionKey = deployProcessWithJob(PROCESS_ID_A);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID_A).create();
+    awaitJobCreated(processInstanceKey);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    awaitDraining(processDefinitionKey);
+    assertThat(drainingCountGauge()).isOne();
+
+    // when - the last active instance completes and the deletion is finalized
+    engine.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // then - the draining count returns to zero
+    assertThat(drainingCountGauge())
+        .describedAs("draining count returns to zero once the definition is finalized")
+        .isZero();
+  }
+
+  @Test
+  public void shouldNotLeaveDrainingGaugeElevatedWhenDeletingProcessWithoutRunningInstances() {
+    // given - a deployed process with no running instances
+    final long processDefinitionKey = deploySimpleProcess(PROCESS_ID_A);
+    assertThat(definitionsCountGauge()).isOne();
+    assertThat(drainingCountGauge()).isZero();
+
+    // when - the definition is deleted; with no instances it drains and finalizes in one step
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DELETED)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+
+    // then - the draining gauge was incremented then decremented within the same finalize, so it
+    // never stays elevated, and the definition leaves the deployed count
+    assertThat(drainingCountGauge())
+        .describedAs("immediate finalize increments then decrements the draining gauge, net zero")
+        .isZero();
+    assertThat(definitionsCountGauge())
+        .describedAs("the deleted definition is no longer counted as deployed")
+        .isZero();
+  }
+
+  @Test
+  public void shouldRecoverDrainingCountAfterBrokerRestart() {
+    // given - a draining definition
+    final long processDefinitionKey = deployProcessWithJob(PROCESS_ID_A);
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID_A).create();
+    awaitJobCreated(processInstanceKey);
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete();
+    awaitDraining(processDefinitionKey);
+    assertThat(drainingCountGauge()).isOne();
+
+    // when - snapshot and restart triggers the metric initialization scan
+    engine.snapshot();
+    engine.stop();
+    engine.start();
+
+    // then - the draining count is recovered from state, not just from live processing
+    assertThat(drainingCountGauge())
+        .describedAs("draining count should be recovered from state after restart")
+        .isOne();
+  }
+
+  private long deployProcessWithJob(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private void awaitJobCreated(final long processInstanceKey) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .await();
+  }
+
+  private void awaitDraining(final long processDefinitionKey) {
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
+  }
+
+  private double drainingCountGauge() {
+    return engine
+        .getMeterRegistry()
+        .get("zeebe.process.definitions.draining.count")
+        .gauge()
+        .value();
+  }
+
+  private long deploySimpleProcess(final String processId) {
+    return engine
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private double definitionsCountGauge() {
+    return engine.getMeterRegistry().get("zeebe.process.definitions.count").gauge().value();
+  }
+
+  private double resourceSizeGauge(final String bpmnProcessId) {
+    return engine
+        .getMeterRegistry()
+        .get("zeebe.process.definition.resource.size.bytes")
+        .tag("bpmnProcessId", bpmnProcessId)
+        .gauge()
+        .value();
+  }
+}


### PR DESCRIPTION
Operators need to see how many definitions are currently draining (deleted but with instances still running) versus rejected outright, so the drain backlog is observable and does not silently pile up.

Add a `zeebe.process.definitions.draining.count` gauge and split the former single deletion metric into `processDefinitionDraining` (incremented when a definition enters DRAINING) and `processDefinitionDrainFinalized` (decremented once the last instance completes and the definition is physically removed). Incrementing before decrementing keeps the gauge from dipping transiently negative when a definition finalizes immediately.

These methods have no callers yet; the core switch to DRAINING wires them in a later commit.

(cherry picked from commit 8ceffb153e22b831a52c8fc857238de7431a929c)