### PR TITLE
fix: resolve Zeebe index prefix from the active search backend

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
@@ -219,9 +219,7 @@ public class ImportJob implements Callable<Boolean> {
 
   public void refreshZeebeIndices() {
     final String indexPattern =
-        importBatch
-            .getImportValueType()
-            .getIndicesPattern(operateProperties.getZeebeElasticsearch().getPrefix());
+        importBatch.getImportValueType().getIndicesPattern(zeebeStore.getZeebeIndexPrefix());
     zeebeStore.refreshIndex(indexPattern);
   }
 

--- a/operate/importer/src/test/java/io/camunda/operate/zeebeimport/ImportJobRefreshZeebeIndicesTest.java
+++ b/operate/importer/src/test/java/io/camunda/operate/zeebeimport/ImportJobRefreshZeebeIndicesTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebeimport;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.entities.meta.ImportPositionEntity;
+import io.camunda.operate.store.ZeebeStore;
+import io.camunda.operate.zeebe.ImportValueType;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import org.junit.Test;
+
+public class ImportJobRefreshZeebeIndicesTest {
+
+  @Test
+  public void refreshZeebeIndicesBuildsPatternFromZeebeStorePrefix() throws Exception {
+    final ZeebeStore zeebeStore = mock(ZeebeStore.class);
+    when(zeebeStore.getZeebeIndexPrefix()).thenReturn("custom-os-prefix");
+
+    final ImportBatch importBatch =
+        new ImportBatch(1, ImportValueType.PROCESS_INSTANCE, new ArrayList<>(), "some_name");
+    final ImportJob importJob = new ImportJob(importBatch, new ImportPositionEntity());
+    setField(importJob, "zeebeStore", zeebeStore);
+
+    importJob.refreshZeebeIndices();
+
+    verify(zeebeStore).getZeebeIndexPrefix();
+    verify(zeebeStore).refreshIndex(eq("custom-os-prefix*process-instance*"));
+  }
+
+  private static void setField(final Object target, final String fieldName, final Object value)
+      throws Exception {
+    final Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+}

--- a/operate/schema/src/main/java/io/camunda/operate/store/ZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/ZeebeStore.java
@@ -11,4 +11,7 @@ public interface ZeebeStore {
   void refreshIndex(String indexPattern);
 
   boolean zeebeIndicesExists(String indexPattern);
+
+  /** Returns the Zeebe-record index prefix configured for the backend currently in use. */
+  String getZeebeIndexPrefix();
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.store.elasticsearch;
 
 import io.camunda.operate.conditions.ElasticsearchCondition;
+import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ZeebeStore;
 import java.io.IOException;
@@ -39,15 +40,27 @@ public class ElasticsearchZeebeStore implements ZeebeStore {
   @Override
   public void refreshIndex(String indexPattern) {
     final RefreshRequest refreshRequest = new RefreshRequest(indexPattern);
+    final RefreshResponse refresh;
     try {
-      final RefreshResponse refresh =
-          zeebeEsClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
-      if (refresh.getFailedShards() > 0) {
-        LOGGER.warn("Unable to refresh indices: {}", indexPattern);
-      }
+      refresh = zeebeEsClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
     } catch (Exception ex) {
-      LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
+      throw new OperateRuntimeException(
+          String.format("Unable to refresh indices matching pattern %s", indexPattern), ex);
     }
+    if (refresh.getTotalShards() == 0) {
+      throw new OperateRuntimeException("Refresh matched no indices for pattern " + indexPattern);
+    }
+    if (refresh.getFailedShards() > 0) {
+      throw new OperateRuntimeException(
+          String.format(
+              "Unable to refresh indices matching pattern %s: %d of %d shards failed",
+              indexPattern, refresh.getFailedShards(), refresh.getTotalShards()));
+    }
+  }
+
+  @Override
+  public String getZeebeIndexPrefix() {
+    return operateProperties.getZeebeElasticsearch().getPrefix();
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
@@ -8,9 +8,12 @@
 package io.camunda.operate.store.opensearch;
 
 import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ZeebeStore;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.indices.RefreshResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,16 +31,33 @@ public class OpensearchZeebeStore implements ZeebeStore {
   @Qualifier("zeebeOpensearchClient")
   private OpenSearchClient openSearchClient;
 
+  @Autowired private OperateProperties operateProperties;
+
   @Override
   public void refreshIndex(String indexPattern) {
+    final RefreshResponse response;
     try {
-      final var response = openSearchClient.indices().refresh(r -> r.index(indexPattern));
-      if (!response.shards().failures().isEmpty()) {
-        LOGGER.warn("Unable to refresh indices: {}", indexPattern);
-      }
+      response = openSearchClient.indices().refresh(r -> r.index(indexPattern));
     } catch (Exception ex) {
-      LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
+      throw new OperateRuntimeException(
+          String.format("Unable to refresh indices matching pattern %s", indexPattern), ex);
     }
+    if (response.shards().total().intValue() == 0) {
+      throw new OperateRuntimeException("Refresh matched no indices for pattern " + indexPattern);
+    }
+    if (!response.shards().failures().isEmpty()) {
+      throw new OperateRuntimeException(
+          String.format(
+              "Unable to refresh indices matching pattern %s: %d of %d shards failed",
+              indexPattern,
+              response.shards().failures().size(),
+              response.shards().total().intValue()));
+    }
+  }
+
+  @Override
+  public String getZeebeIndexPrefix() {
+    return operateProperties.getZeebeOpensearch().getPrefix();
   }
 
   @Override

--- a/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStoreTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store.elasticsearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
+import java.io.IOException;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.client.IndicesClient;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElasticsearchZeebeStoreTest {
+
+  @Mock private RestHighLevelClient zeebeEsClient;
+  @Mock private IndicesClient indicesClient;
+  @Spy private OperateProperties operateProperties = new OperateProperties();
+
+  @InjectMocks private ElasticsearchZeebeStore zeebeStore;
+
+  @BeforeEach
+  void setUp() {
+    operateProperties.getZeebeElasticsearch().setPrefix("my-zeebe");
+  }
+
+  @Test
+  void shouldResolvePrefixFromZeebeElasticsearchProperties() {
+    assertThat(zeebeStore.getZeebeIndexPrefix()).isEqualTo("my-zeebe");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshMatchesNoIndices() throws Exception {
+    final RefreshResponse response = refreshResponse(0, 0);
+    when(zeebeEsClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenReturn(response);
+
+    assertThatThrownBy(() -> zeebeStore.refreshIndex("zeebe-record*process-instance*"))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining("zeebe-record*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshHasFailedShards() throws Exception {
+    final RefreshResponse response = refreshResponse(3, 1);
+    when(zeebeEsClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenReturn(response);
+
+    assertThatThrownBy(() -> zeebeStore.refreshIndex("my-zeebe*process-instance*"))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining("my-zeebe*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshRequestFails() throws Exception {
+    when(zeebeEsClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenThrow(new IOException("cluster unreachable"));
+
+    assertThatThrownBy(() -> zeebeStore.refreshIndex("my-zeebe*process-instance*"))
+        .isInstanceOf(OperateRuntimeException.class);
+  }
+
+  @Test
+  void shouldNotThrowWhenRefreshMatchesHealthyIndices() throws Exception {
+    final RefreshResponse response = refreshResponse(3, 0);
+    when(zeebeEsClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenReturn(response);
+
+    assertThatCode(() -> zeebeStore.refreshIndex("my-zeebe*process-instance*"))
+        .doesNotThrowAnyException();
+  }
+
+  private RefreshResponse refreshResponse(final int totalShards, final int failedShards) {
+    final RefreshResponse response = mock(RefreshResponse.class);
+    when(response.getTotalShards()).thenReturn(totalShards);
+    // unused once totalShards == 0, since refreshIndex throws before checking failed shards
+    lenient().when(response.getFailedShards()).thenReturn(failedShards);
+    return response;
+  }
+}

--- a/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchZeebeStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchZeebeStoreTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.store.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ShardFailure;
+import org.opensearch.client.opensearch._types.ShardStatistics;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.RefreshResponse;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class OpensearchZeebeStoreTest {
+
+  @Mock private OpenSearchClient openSearchClient;
+  @Mock private OpenSearchIndicesClient indicesClient;
+  @Spy private OperateProperties operateProperties = new OperateProperties();
+
+  @InjectMocks private OpensearchZeebeStore zeebeStore;
+
+  @BeforeEach
+  void setUp() {
+    operateProperties.getZeebeOpensearch().setPrefix("my-zeebe-os");
+  }
+
+  @Test
+  void shouldResolvePrefixFromZeebeOpensearchProperties() {
+    assertThat(zeebeStore.getZeebeIndexPrefix()).isEqualTo("my-zeebe-os");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshMatchesNoIndices() throws Exception {
+    final RefreshResponse response = refreshResponse(0, List.of());
+    when(openSearchClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(Function.class))).thenReturn(response);
+
+    assertThatThrownBy(() -> zeebeStore.refreshIndex("zeebe-record*process-instance*"))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining("zeebe-record*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshHasShardFailures() throws Exception {
+    final RefreshResponse response = refreshResponse(3, List.of(mock(ShardFailure.class)));
+    when(openSearchClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(Function.class))).thenReturn(response);
+
+    assertThatThrownBy(() -> zeebeStore.refreshIndex("my-zeebe-os*process-instance*"))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining("my-zeebe-os*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshRequestFails() throws Exception {
+    when(openSearchClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(Function.class)))
+        .thenThrow(new IOException("cluster unreachable"));
+
+    assertThatThrownBy(() -> zeebeStore.refreshIndex("my-zeebe-os*process-instance*"))
+        .isInstanceOf(OperateRuntimeException.class);
+  }
+
+  @Test
+  void shouldNotThrowWhenRefreshMatchesHealthyIndices() throws Exception {
+    final RefreshResponse response = refreshResponse(3, List.of());
+    when(openSearchClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(Function.class))).thenReturn(response);
+
+    assertThatCode(() -> zeebeStore.refreshIndex("my-zeebe-os*process-instance*"))
+        .doesNotThrowAnyException();
+  }
+
+  private RefreshResponse refreshResponse(
+      final int totalShards, final List<ShardFailure> failures) {
+    final RefreshResponse response = mock(RefreshResponse.class);
+    final ShardStatistics shards = mock(ShardStatistics.class);
+    when(shards.total()).thenReturn(totalShards);
+    // unused when totalShards == 0, since refreshIndex throws before checking failures
+    lenient().when(shards.failures()).thenReturn(failures);
+    when(response.shards()).thenReturn(shards);
+    return response;
+  }
+}

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -654,14 +654,21 @@ public abstract class ElasticsearchUtil {
   public static void refreshIndicesFor(
       final RestHighLevelClient esClient, final String indexPattern) {
     final var refreshRequest = new RefreshRequest(indexPattern);
+    final RefreshResponse refresh;
     try {
-      final RefreshResponse refresh =
-          esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
-      if (refresh.getFailedShards() > 0) {
-        LOGGER.warn("Unable to refresh indices: {}", indexPattern);
-      }
+      refresh = esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
     } catch (final Exception ex) {
-      LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
+      throw new TasklistRuntimeException(
+          String.format("Unable to refresh indices matching pattern %s", indexPattern), ex);
+    }
+    if (refresh.getTotalShards() == 0) {
+      throw new TasklistRuntimeException("Refresh matched no indices for pattern " + indexPattern);
+    }
+    if (refresh.getFailedShards() > 0) {
+      throw new TasklistRuntimeException(
+          String.format(
+              "Unable to refresh indices matching pattern %s: %d of %d shards failed",
+              indexPattern, refresh.getFailedShards(), refresh.getTotalShards()));
     }
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
@@ -240,13 +240,23 @@ public abstract class OpenSearchUtil {
 
   public static void refreshIndicesFor(final OpenSearchClient osClient, final String indexPattern) {
     final var refreshRequest = new RefreshRequest.Builder().index(List.of(indexPattern)).build();
+    final RefreshResponse refresh;
     try {
-      final RefreshResponse refresh = osClient.indices().refresh(refreshRequest);
-      if (refresh.shards().failures().size() > 0) {
-        LOGGER.warn("Unable to refresh indices: {}", indexPattern);
-      }
+      refresh = osClient.indices().refresh(refreshRequest);
     } catch (final Exception ex) {
-      LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
+      throw new TasklistRuntimeException(
+          String.format("Unable to refresh indices matching pattern %s", indexPattern), ex);
+    }
+    if (refresh.shards().total().intValue() == 0) {
+      throw new TasklistRuntimeException("Refresh matched no indices for pattern " + indexPattern);
+    }
+    if (!refresh.shards().failures().isEmpty()) {
+      throw new TasklistRuntimeException(
+          String.format(
+              "Unable to refresh indices matching pattern %s: %d of %d shards failed",
+              indexPattern,
+              refresh.shards().failures().size(),
+              refresh.shards().total().intValue()));
     }
   }
 

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/ElasticsearchUtilTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/ElasticsearchUtilTest.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,8 +19,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.exceptions.PersistenceException;
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import java.io.IOException;
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -28,6 +32,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
@@ -193,6 +198,68 @@ class ElasticsearchUtilTest {
         ArgumentCaptor.forClass(ClearScrollRequest.class);
     verify(esClient).clearScroll(clearCaptor.capture(), any());
     assertThat(clearCaptor.getValue().getScrollIds()).containsExactly("scroll-id-2");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshMatchesNoIndices() throws Exception {
+    final RestHighLevelClient esClient = mock(RestHighLevelClient.class);
+    final IndicesClient indicesClient = mock(IndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    when(refreshResponse.getTotalShards()).thenReturn(0);
+    when(esClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(refreshResponse);
+
+    assertThatThrownBy(
+            () -> ElasticsearchUtil.refreshIndicesFor(esClient, "zeebe-record*process-instance*"))
+        .isInstanceOf(TasklistRuntimeException.class)
+        .hasMessageContaining("zeebe-record*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshHasFailedShards() throws Exception {
+    final RestHighLevelClient esClient = mock(RestHighLevelClient.class);
+    final IndicesClient indicesClient = mock(IndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    when(refreshResponse.getTotalShards()).thenReturn(3);
+    when(refreshResponse.getFailedShards()).thenReturn(1);
+    when(esClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(refreshResponse);
+
+    assertThatThrownBy(
+            () -> ElasticsearchUtil.refreshIndicesFor(esClient, "my-zeebe*process-instance*"))
+        .isInstanceOf(TasklistRuntimeException.class)
+        .hasMessageContaining("my-zeebe*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshRequestFails() throws Exception {
+    final RestHighLevelClient esClient = mock(RestHighLevelClient.class);
+    final IndicesClient indicesClient = mock(IndicesClient.class);
+    when(esClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenThrow(new IOException("cluster unreachable"));
+
+    assertThatThrownBy(
+            () -> ElasticsearchUtil.refreshIndicesFor(esClient, "my-zeebe*process-instance*"))
+        .isInstanceOf(TasklistRuntimeException.class);
+  }
+
+  @Test
+  void shouldNotThrowWhenRefreshMatchesHealthyIndices() throws Exception {
+    final RestHighLevelClient esClient = mock(RestHighLevelClient.class);
+    final IndicesClient indicesClient = mock(IndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    when(refreshResponse.getTotalShards()).thenReturn(3);
+    when(refreshResponse.getFailedShards()).thenReturn(0);
+    when(esClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(refreshResponse);
+
+    assertThatCode(
+            () -> ElasticsearchUtil.refreshIndicesFor(esClient, "my-zeebe*process-instance*"))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/OpenSearchUtilTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/OpenSearchUtilTest.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -15,17 +16,23 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.entities.UserEntity;
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ShardFailure;
+import org.opensearch.client.opensearch._types.ShardStatistics;
 import org.opensearch.client.opensearch.core.ClearScrollRequest;
 import org.opensearch.client.opensearch.core.ScrollRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.RefreshRequest;
+import org.opensearch.client.opensearch.indices.RefreshResponse;
 
 class OpenSearchUtilTest {
 
@@ -53,5 +60,70 @@ class OpenSearchUtilTest {
         ArgumentCaptor.forClass(ClearScrollRequest.class);
     verify(osClient).clearScroll(clearCaptor.capture());
     assertThat(clearCaptor.getValue().scrollId()).contains("scroll-id-os");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshMatchesNoIndices() throws Exception {
+    final OpenSearchClient osClient = mock(OpenSearchClient.class);
+    final OpenSearchIndicesClient indicesClient = mock(OpenSearchIndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    final ShardStatistics shards = mock(ShardStatistics.class);
+    when(shards.total()).thenReturn(0);
+    when(refreshResponse.shards()).thenReturn(shards);
+    when(osClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class))).thenReturn(refreshResponse);
+
+    assertThatThrownBy(
+            () -> OpenSearchUtil.refreshIndicesFor(osClient, "zeebe-record*process-instance*"))
+        .isInstanceOf(TasklistRuntimeException.class)
+        .hasMessageContaining("zeebe-record*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshHasShardFailures() throws Exception {
+    final OpenSearchClient osClient = mock(OpenSearchClient.class);
+    final OpenSearchIndicesClient indicesClient = mock(OpenSearchIndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    final ShardStatistics shards = mock(ShardStatistics.class);
+    when(shards.total()).thenReturn(3);
+    when(shards.failures()).thenReturn(List.of(mock(ShardFailure.class)));
+    when(refreshResponse.shards()).thenReturn(shards);
+    when(osClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class))).thenReturn(refreshResponse);
+
+    assertThatThrownBy(
+            () -> OpenSearchUtil.refreshIndicesFor(osClient, "my-zeebe-os*process-instance*"))
+        .isInstanceOf(TasklistRuntimeException.class)
+        .hasMessageContaining("my-zeebe-os*process-instance*");
+  }
+
+  @Test
+  void shouldThrowWhenRefreshRequestFails() throws Exception {
+    final OpenSearchClient osClient = mock(OpenSearchClient.class);
+    final OpenSearchIndicesClient indicesClient = mock(OpenSearchIndicesClient.class);
+    when(osClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class)))
+        .thenThrow(new IOException("cluster unreachable"));
+
+    assertThatThrownBy(
+            () -> OpenSearchUtil.refreshIndicesFor(osClient, "my-zeebe-os*process-instance*"))
+        .isInstanceOf(TasklistRuntimeException.class);
+  }
+
+  @Test
+  void shouldNotThrowWhenRefreshMatchesHealthyIndices() throws Exception {
+    final OpenSearchClient osClient = mock(OpenSearchClient.class);
+    final OpenSearchIndicesClient indicesClient = mock(OpenSearchIndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    final ShardStatistics shards = mock(ShardStatistics.class);
+    when(shards.total()).thenReturn(3);
+    when(shards.failures()).thenReturn(List.of());
+    when(refreshResponse.shards()).thenReturn(shards);
+    when(osClient.indices()).thenReturn(indicesClient);
+    when(indicesClient.refresh(any(RefreshRequest.class))).thenReturn(refreshResponse);
+
+    assertThatCode(
+            () -> OpenSearchUtil.refreshIndicesFor(osClient, "my-zeebe-os*process-instance*"))
+        .doesNotThrowAnyException();
   }
 }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportJobOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportJobOpenSearch.java
@@ -46,7 +46,7 @@ public class ImportJobOpenSearch extends ImportJobAbstract {
     final String indexPattern =
         importBatch
             .getImportValueType()
-            .getIndicesPattern(tasklistProperties.getZeebeElasticsearch().getPrefix());
+            .getIndicesPattern(tasklistProperties.getZeebeOpenSearch().getPrefix());
     OpenSearchUtil.refreshIndicesFor(zeebeOsClient, indexPattern);
   }
 

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerOpenSearchTest.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerOpenSearchTest.java
@@ -41,7 +41,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ShardStatistics;
 import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.RefreshRequest;
+import org.opensearch.client.opensearch.indices.RefreshResponse;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -82,6 +86,40 @@ public class ImportListenerOpenSearchTest extends NoBeansTest {
   @BeforeEach
   public void before() {
     importListener.cancel();
+  }
+
+  @Test
+  public void refreshZeebeIndicesUsesOpenSearchPrefixNotElasticsearchPrefix() throws Exception {
+    // given - the Zeebe-record prefix is customised for OpenSearch and left at the (different)
+    // Elasticsearch default, as happens on a real OpenSearch deployment
+    tasklistProperties.getZeebeElasticsearch().setPrefix("wrong-es-prefix");
+    tasklistProperties.getZeebeOpenSearch().setPrefix("correct-os-prefix");
+
+    final OpenSearchIndicesClient indicesClient = mock(OpenSearchIndicesClient.class);
+    final RefreshResponse refreshResponse = mock(RefreshResponse.class);
+    final ShardStatistics shards = mock(ShardStatistics.class);
+    when(shards.total()).thenReturn(1);
+    when(shards.failures()).thenReturn(List.of());
+    when(refreshResponse.shards()).thenReturn(shards);
+    when(zeebeOsClient.indices()).thenReturn(indicesClient);
+    final ArgumentCaptor<RefreshRequest> refreshCaptor =
+        ArgumentCaptor.forClass(RefreshRequest.class);
+    when(indicesClient.refresh(refreshCaptor.capture())).thenReturn(refreshResponse);
+
+    final ImportBatch importBatchOpenSearch =
+        new ImportBatchOpenSearch(
+            1, ImportValueType.PROCESS_INSTANCE, new ArrayList<>(), "some_name");
+    final ImportPositionEntity previousPosition =
+        new ImportPositionEntity().setAliasName("alias").setPartitionId(1).setPosition(0);
+    final ImportJob importJob =
+        beanFactory.getBean(ImportJobOpenSearch.class, importBatchOpenSearch, previousPosition);
+
+    // when
+    importJob.refreshZeebeIndices();
+
+    // then - the refreshed pattern must be built from the OpenSearch prefix, not the
+    // Elasticsearch one (https://github.com/camunda/camunda/issues/61614)
+    assertEquals(List.of("correct-os-prefix*process-instance*"), refreshCaptor.getValue().index());
   }
 
   @Test


### PR DESCRIPTION
## Summary

On OpenSearch deployments with a customised Zeebe-record prefix, the importer's daily-rollover refresh always used the Elasticsearch prefix and silently matched no indices, with the failure swallowed. Impact: records written just before a daily index rollover could be permanently skipped with no error or log signal, and any later record depending on one of them (e.g. a called process instance referencing a flow node from the skipped batch) would then throw on every retry, permanently stalling that partition's importer for that value type until manually fixed.

## Related issues

closes #61614