### PR TITLE
perf: return completionCondition in visitVariableLocal

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -402,6 +402,6 @@ public class DbVariableState implements MutableVariableState {
 
           return !completionCondition.getAsBoolean();
         });
-    return false;
+    return completionCondition.getAsBoolean();
   }
 }


### PR DESCRIPTION
## Description

In DbVariableState visitVariableLocal it never returned the result of the completion condition but always false.
This means that iteration was never short circuited, especially in getVariablesAsDocument which is used by jobs, leading to more iterations than necessary

[Slack thread](https://camunda.slack.com/archives/C037RS2JHB8/p1788380854978559?thread_ts=1788357269.546859&cid=C037RS2JHB8)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

