### PR TITLE
refactor: reduce the noisy logs of UserTaskZeebeRecordProcessor

### DIFF
--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/UserTaskZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/UserTaskZeebeRecordProcessor.java
@@ -23,6 +23,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -135,7 +136,7 @@ public class UserTaskZeebeRecordProcessor {
       final BatchRequest batchRequest, final Record<UserTaskRecordValue> userTaskRecord)
       throws PersistenceException {
     final Intent intent = userTaskRecord.getIntent();
-    LOGGER.info("Intent is: {}", intent);
+    LOGGER.debug("Intent is: {}", intent);
     final var userTaskValue = userTaskRecord.getValue();
     final UserTaskEntity userTaskEntity;
     try {
@@ -205,7 +206,7 @@ public class UserTaskZeebeRecordProcessor {
   }
 
   private OffsetDateTime toDateOrNull(final String dateString) {
-    if (dateString == null) {
+    if (StringUtils.isBlank(dateString)) {
       return null;
     }
     try {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
noticed that the importer's `UserTaskZeebeRecordProcessor` is logging too much noise

The warns are about empty `dueDate` and `followUpDate` fields, that are always exported by Zeebe as empty strings, not `null`

```
INFO
	io.camunda.operate.zeebeimport.processors.UserTaskZeebeRecordProcessor - Intent is: CREATING
WARN
	io.camunda.operate.zeebeimport.processors.UserTaskZeebeRecordProcessor - Could not parse  as OffsetDateTime. Use null.
WARN
	io.camunda.operate.zeebeimport.processors.UserTaskZeebeRecordProcessor - Could not parse  as OffsetDateTime. Use null.
```


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

