### PR TITLE
fix: resolve create-by-id to the latest active process version

### DIFF
--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -408,7 +408,7 @@
           "processDefinitionVersion": {
             "type": "integer",
             "format": "int32",
-            "description": "The version of the process. By default, the latest version of the process is used. "
+            "description": "The version of the process. If omitted, the latest active version is used. "
           },
           "requestTimeout": {
             "type": "integer",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -154,7 +154,7 @@ public class ProcessInstanceCreationHelper {
   private Either<Rejection, DeployedProcess> getProcess(
       final DirectBuffer bpmnProcessId, final String tenantId) {
     final DeployedProcess process =
-        processState.getLatestProcessVersionByProcessId(bpmnProcessId, tenantId);
+        processState.getLatestActiveProcessVersionByProcessId(bpmnProcessId, tenantId);
     if (process != null) {
       return Either.right(process);
     } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -481,21 +481,29 @@ public class ResourceDeletionDeleteProcessor
     resourceDeletionRecord.setBatchOperationType(BatchOperationType.DELETE_DECISION_INSTANCE);
   }
 
-  // Skip DRAINING/deleted versions — they must not hold start-event subscriptions.
+  /**
+   * Latest {@code ACTIVE} version strictly below {@code version}. Skips draining and
+   * pending-deletion versions so they do not hold start-event subscriptions.
+   *
+   * <p>Loads known versions once and scans newest-first. {@code version >=} the deleted latest is
+   * skipped because that version is already draining.
+   */
   private Optional<DeployedProcess> findLatestActiveVersionBelow(
       final DirectBuffer processIdBuffer,
       final String processId,
       final int version,
       final String tenantId) {
-    var candidate = processState.findProcessVersionBefore(processId, version, tenantId);
-    while (candidate.isPresent()) {
-      final int candidateVersion = candidate.get();
+    final var knownVersions = processState.getKnownProcessVersions(processId, tenantId);
+    for (int i = knownVersions.size() - 1; i >= 0; i--) {
+      final int candidateVersion = knownVersions.get(i).intValue();
+      if (candidateVersion >= version) {
+        continue;
+      }
       final var process =
           processState.getProcessByProcessIdAndVersion(processIdBuffer, candidateVersion, tenantId);
       if (process != null && process.getState() == PersistedProcessState.ACTIVE) {
         return Optional.of(process);
       }
-      candidate = processState.findProcessVersionBefore(processId, candidateVersion, tenantId);
     }
     return Optional.empty();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -487,6 +487,13 @@ public final class DbProcessState implements MutableProcessState {
     return cachedProcess;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When the highest version is {@code ACTIVE}, it is returned immediately without loading known
+   * versions. The reverse scan only runs when that version is not {@code ACTIVE}, and it skips
+   * {@code version >= latestVersion} because that version was already checked.
+   */
   @Override
   public DeployedProcess getLatestActiveProcessVersionByProcessId(
       final DirectBuffer processIdBuffer, final String tenantId) {
@@ -498,15 +505,17 @@ public final class DbProcessState implements MutableProcessState {
       return process;
     }
 
-    final String processId = bufferAsString(processIdBuffer);
-    var candidate = findProcessVersionBefore(processId, process.getVersion(), tenantId);
-    while (candidate.isPresent()) {
-      final int candidateVersion = candidate.get();
-      process = getProcessByProcessIdAndVersion(processIdBuffer, candidateVersion, tenantId);
+    final int latestVersion = process.getVersion();
+    final var knownVersions = getKnownProcessVersions(bufferAsString(processIdBuffer), tenantId);
+    for (int i = knownVersions.size() - 1; i >= 0; i--) {
+      final int version = knownVersions.get(i).intValue();
+      if (version >= latestVersion) {
+        continue;
+      }
+      process = getProcessByProcessIdAndVersion(processIdBuffer, version, tenantId);
       if (process != null && process.getState() == PersistedProcessState.ACTIVE) {
         return process;
       }
-      candidate = findProcessVersionBefore(processId, candidateVersion, tenantId);
     }
     return null;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -488,6 +488,30 @@ public final class DbProcessState implements MutableProcessState {
   }
 
   @Override
+  public DeployedProcess getLatestActiveProcessVersionByProcessId(
+      final DirectBuffer processIdBuffer, final String tenantId) {
+    DeployedProcess process = getLatestProcessVersionByProcessId(processIdBuffer, tenantId);
+    if (process == null) {
+      return null;
+    }
+    if (process.getState() == PersistedProcessState.ACTIVE) {
+      return process;
+    }
+
+    final String processId = bufferAsString(processIdBuffer);
+    var candidate = findProcessVersionBefore(processId, process.getVersion(), tenantId);
+    while (candidate.isPresent()) {
+      final int candidateVersion = candidate.get();
+      process = getProcessByProcessIdAndVersion(processIdBuffer, candidateVersion, tenantId);
+      if (process != null && process.getState() == PersistedProcessState.ACTIVE) {
+        return process;
+      }
+      candidate = findProcessVersionBefore(processId, candidateVersion, tenantId);
+    }
+    return null;
+  }
+
+  @Override
   public DeployedProcess getProcessByProcessIdAndVersion(
       final DirectBuffer processId, final int version, final String tenantId) {
     final var tenantIdAndProcessIdAndVersion =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -18,6 +18,13 @@ public interface ProcessState {
 
   DeployedProcess getLatestProcessVersionByProcessId(DirectBuffer processId, final String tenantId);
 
+  /**
+   * Latest {@code ACTIVE} version of this process id. Skips draining and pending-deletion versions.
+   * {@link #getLatestProcessVersionByProcessId} still returns the highest version in state.
+   */
+  DeployedProcess getLatestActiveProcessVersionByProcessId(
+      DirectBuffer processId, final String tenantId);
+
   DeployedProcess getProcessByProcessIdAndVersion(
       DirectBuffer processId, int version, final String tenantId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -20,7 +20,10 @@ public interface ProcessState {
 
   /**
    * Latest {@code ACTIVE} version of this process id. Skips draining and pending-deletion versions.
-   * {@link #getLatestProcessVersionByProcessId} still returns the highest version in state.
+   *
+   * <p>If the highest version in state is already {@code ACTIVE}, that process is returned and
+   * older versions are not inspected. {@link #getLatestProcessVersionByProcessId} still returns the
+   * highest version in state regardless of lifecycle.
    */
   DeployedProcess getLatestActiveProcessVersionByProcessId(
       DirectBuffer processId, final String tenantId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -97,8 +97,8 @@ public class DrainingProcessDefinitionTest {
   }
 
   @Test
-  public void shouldRejectCreateInstanceByProcessIdWhenDraining() {
-    // given - a definition kept draining by a still-running instance
+  public void shouldRejectCreateInstanceByProcessIdWhenNoActiveVersionRemains() {
+    // given - the only version is kept draining by a still-running instance
     final var processId = helper.getBpmnProcessId();
     final var metadata = deployWithJob(processId);
     awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
@@ -107,14 +107,37 @@ public class DrainingProcessDefinitionTest {
     // when
     engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
 
-    // then
+    // then - create-by-id skips draining versions; with none left this is not-found, not draining
     final var rejection =
         RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
     assertThat(rejection)
-        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
-                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            "Expected to find process definition with process ID '%s', but none found"
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldCreateInstanceByProcessIdOnLatestActiveVersionWhenLatestIsDraining() {
+    // given - v1 stays ACTIVE while v2 is kept draining by a still-running instance
+    final var processId = helper.getBpmnProcessId();
+    final var v1 = deployWithJob(processId);
+    final var v2 = deployWithJob(processId, "end-v2");
+    awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
+    drainViaDeletion(v2.getProcessDefinitionKey());
+
+    // when
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final var started =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    assertThat(started.getValue().getProcessDefinitionKey())
+        .isEqualTo(v1.getProcessDefinitionKey());
+    assertThat(started.getValue().getVersion()).isEqualTo(v1.getVersion());
   }
 
   @Test
@@ -156,10 +179,10 @@ public class DrainingProcessDefinitionTest {
             .onlyCommandRejections()
             .getFirst();
     assertThat(rejection)
-        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
-                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            "Expected to find process definition with process ID '%s', but none found"
+                .formatted(processId));
   }
 
   @Test
@@ -170,10 +193,12 @@ public class DrainingProcessDefinitionTest {
     awaitJobCreated(engine.processInstance().ofBpmnProcessId(processId).create());
     drainViaDeletion(metadata.getProcessDefinitionKey());
 
-    // when - bogus element id: proves the draining guard runs before start-instruction validation
+    // when - explicit version plus a bogus element id: proves the draining guard runs before
+    // start-instruction validation
     engine
         .processInstance()
         .ofBpmnProcessId(processId)
+        .withVersion(1)
         .withStartInstruction("nonExistentElement")
         .expectRejection()
         .create();
@@ -608,8 +633,9 @@ public class DrainingProcessDefinitionTest {
     // when - only the first instance completes
     engine.job().ofInstance(firstInstanceKey).withType(JOB_TYPE).complete();
 
-    // then - still draining: a new instance is still rejected, proving it is not yet drained
-    engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
+    // then - still draining: an explicit-version create is still rejected, proving it is not yet
+    // drained
+    engine.processInstance().ofBpmnProcessId(processId).withVersion(1).expectRejection().create();
     final var rejection =
         RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
     assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
@@ -831,8 +857,8 @@ public class DrainingProcessDefinitionTest {
     migrateToTarget(migratingInstanceKey, target.getProcessDefinitionKey(), "task");
 
     // then - the source is not finalized while the other instance still references it: it stays
-    // DRAINING, so a new instance is still rejected for that reason (not "not found")
-    engine.processInstance().ofBpmnProcessId(sourceId).expectRejection().create();
+    // DRAINING, so an explicit-version create is still rejected for that reason (not "not found")
+    engine.processInstance().ofBpmnProcessId(sourceId).withVersion(1).expectRejection().create();
     final var rejection =
         RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
     assertThat(rejection)
@@ -1264,13 +1290,17 @@ public class DrainingProcessDefinitionTest {
   }
 
   private ProcessMetadataValue deployWithJob(final String processId) {
+    return deployWithJob(processId, "end");
+  }
+
+  private ProcessMetadataValue deployWithJob(final String processId, final String endEventId) {
     return engine
         .deployment()
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
-                .endEvent()
+                .endEvent(endEventId)
                 .done())
         .deploy()
         .getValue()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -844,6 +844,61 @@ public final class ProcessStateTest {
   }
 
   @Test
+  public void shouldGetLatestActiveProcessSkippingDrainingLatest() {
+    // given
+    final var v1 = creatingProcessRecord(processingState, "processId", 1);
+    final var v2 = creatingProcessRecord(processingState, "processId", 2);
+    processState.putProcess(v1.getKey(), v1);
+    processState.putProcess(v2.getKey(), v2);
+    processState.markDraining(v2);
+
+    // when
+    final var latest =
+        processState.getLatestProcessVersionByProcessId(wrapString("processId"), TENANT_ID);
+    final var latestActive =
+        processState.getLatestActiveProcessVersionByProcessId(wrapString("processId"), TENANT_ID);
+
+    // then
+    assertThat(latest.getKey()).isEqualTo(v2.getKey());
+    assertThat(latestActive.getKey()).isEqualTo(v1.getKey());
+  }
+
+  @Test
+  public void shouldSkipDrainingAndPendingDeletionWhenLookingUpLatestActiveProcess() {
+    // given - v3 is draining, v2 is pending deletion, v1 is the only ACTIVE version
+    final var v1 = creatingProcessRecord(processingState, "processId", 1);
+    final var v2 = creatingProcessRecord(processingState, "processId", 2);
+    final var v3 = creatingProcessRecord(processingState, "processId", 3);
+    processState.putProcess(v1.getKey(), v1);
+    processState.putProcess(v2.getKey(), v2);
+    processState.putProcess(v3.getKey(), v3);
+    processState.updateProcessState(v2, PersistedProcessState.PENDING_DELETION);
+    processState.markDraining(v3);
+
+    // when
+    final var latestActive =
+        processState.getLatestActiveProcessVersionByProcessId(wrapString("processId"), TENANT_ID);
+
+    // then
+    assertThat(latestActive.getKey()).isEqualTo(v1.getKey());
+  }
+
+  @Test
+  public void shouldReturnNullLatestActiveProcessWhenNoActiveVersionRemains() {
+    // given
+    final var processRecord = creatingProcessRecord(processingState);
+    processState.putProcess(processRecord.getKey(), processRecord);
+    processState.markDraining(processRecord);
+
+    // when
+    final var latestActive =
+        processState.getLatestActiveProcessVersionByProcessId(wrapString("processId"), TENANT_ID);
+
+    // then
+    assertThat(latestActive).isNull();
+  }
+
+  @Test
   public void shouldRememberDeleteHistoryIntentWhileDraining() {
     // given
     final long processDefinitionKey = 100L;

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -17,6 +17,8 @@ paths:
         Creates and starts an instance of the specified process.
         The process definition to use to create the instance can be specified either using its unique key
         (as returned by Deploy resources), or using the BPMN process id and a version.
+        If only the process definition id is given, the latest ACTIVE version is used.
+        If no ACTIVE version exists, the request is rejected as not found.
 
         Waits for the completion of the process instance before returning a result
         when awaitCompletion is enabled.
@@ -1179,7 +1181,7 @@ components:
             - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
         processDefinitionVersion:
           description: |
-            The version of the process. By default, the latest version of the process is used.
+            The version of the process. If omitted, the latest active version is used.
           type: integer
           format: int32
           default: -1


### PR DESCRIPTION
When the latest process definition is `DRAINING`, `POST /v2/process-instances` with only `processDefinitionId` was partition-dependent: a partition still holding the draining version rejected the request (`409 INVALID_STATE`), while a partition that had already finalized it started the older `ACTIVE` version.

Create-by-id now resolves to the latest `ACTIVE` version on that partition. That matches start-event handover (#56978) and is the only contract that stays consistent with per-partition drain finalization (#56972). Blocking is unchanged: a draining definition is never started.

## Approach

- Add `ProcessState.getLatestActiveProcessVersionByProcessId`, which walks down from the highest version in state and skips `DRAINING` / `PENDING_DELETION`.
- Use it only in unversioned create-by-id (`ProcessInstanceCreationHelper.getProcess(id)`).
- Leave `getLatestProcessVersionByProcessId` as “highest version still in this partition’s state”. Changing that would break deploy duplicate detection (`BpmnResourceTransformer` pairs it with `getLatestVersionDigest` and already refuses to treat a draining definition as a duplicate), start-event “is this the latest?”, and scale-up start-event resubscribe (null if the only version is draining).
- Explicit `processDefinitionVersion` / `processDefinitionKey` still reject with `INVALID_STATE` while that definition is draining.

## Out of scope

- Call-activity `latest` binding has the same lookup-then-reject pattern; left unchanged in this PR.
- Explicit version/key can still mix `409` and `404` across partitions after local finalization. That follows from per-partition deletion and is not solved here.
- Consistently rejecting create-by-id while *any* partition is still draining would need cluster-wide “true latest is draining” knowledge, which we do not have after a partition has deleted the version.

## Related issues

closes #61719
relates to #56995