### PR TITLE
perf: size the membership outage map by configured tenants, not by traffic

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -54,15 +54,23 @@ public class DefaultMembershipService implements MembershipPort {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultMembershipService.class);
   private static final Retry MEMBERSHIP_LOOKUP_RETRY = TransientRetry.of("membership-lookup");
 
-  private final ServiceRegistry serviceRegistry;
-  private final OidcGroupsExtractor oidcGroupsExtractor;
-  private final boolean isGroupsClaimConfigured;
-
   // This service is a singleton shared by every physical tenant, and each lookup routes to the
   // store of the tenant in context. An outage therefore belongs to the (tenant, lookup) pair: keyed
   // by lookup alone, a healthy call for one tenant would close another tenant's outage and make the
   // next failure report it again.
-  private final Map<String, OutageLog> lookupOutages = new ConcurrentHashMap<>();
+  //
+  // Only a transient failure puts an entry in here. The key carries the physical tenant taken from
+  // the request path, which PhysicalTenantFilter stamps without validating (ADR-0003), so
+  // populating this on the success path would size the map by the tenant ids that reach the
+  // service rather than by the ones that are configured.
+  //
+  // Package-private so the test can assert what is retained, which is the whole point of the
+  // field's lifecycle and is not observable from any of this class's outputs.
+  final Map<String, OutageLog> lookupOutages = new ConcurrentHashMap<>();
+
+  private final ServiceRegistry serviceRegistry;
+  private final OidcGroupsExtractor oidcGroupsExtractor;
+  private final boolean isGroupsClaimConfigured;
 
   public DefaultMembershipService(
       final ServiceRegistry serviceRegistry, final CamundaSecurityLibraryProperties cslProperties) {
@@ -173,19 +181,23 @@ public class DefaultMembershipService implements MembershipPort {
     // no tenant bound is already doomed — the lookup itself resolves the tenant and throws.
     final var subject =
         requireNonNullElse(PhysicalTenantContext.currentOrNull(), "unknown") + "/" + label;
-    final var outage = lookupOutages.computeIfAbsent(subject, s -> new OutageLog(LOG));
     try {
       final var ids = Retry.decorateSupplier(MEMBERSHIP_LOOKUP_RETRY, lookup).get();
-      outage.recovery("Resolving {} works again", subject);
+      final var outage = lookupOutages.get(subject);
+      if (outage != null) {
+        outage.recovery("Resolving {} works again", subject);
+      }
       return ids;
     } catch (final RuntimeException e) {
       if (TransientRetry.isTransient(e)) {
-        outage.failure(
-            "Failed to resolve {} after {} attempts, falling back to empty: {}",
-            subject,
-            TransientRetry.MAX_ATTEMPTS,
-            e.getMessage(),
-            e);
+        lookupOutages
+            .computeIfAbsent(subject, s -> new OutageLog(LOG))
+            .failure(
+                "Failed to resolve {} after {} attempts, falling back to empty: {}",
+                subject,
+                TransientRetry.MAX_ATTEMPTS,
+                e.getMessage(),
+                e);
         return List.of();
       }
       throw e;

--- a/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/DefaultMembershipService.java
@@ -59,10 +59,16 @@ public class DefaultMembershipService implements MembershipPort {
   // by lookup alone, a healthy call for one tenant would close another tenant's outage and make the
   // next failure report it again.
   //
-  // Only a transient failure puts an entry in here. The key carries the physical tenant taken from
-  // the request path, which PhysicalTenantFilter stamps without validating (ADR-0003), so
-  // populating this on the success path would size the map by the tenant ids that reach the
-  // service rather than by the ones that are configured.
+  // Only a transient failure puts an entry in here, which is what keeps the map sized by the
+  // configured tenants rather than by traffic. The key carries the physical tenant taken from the
+  // request path, and PhysicalTenantFilter stamps that without validating it (ADR-0003) — but an
+  // id no tenant matches cannot get this far: every lookup below opens by resolving its services
+  // through ServiceRegistry, which throws IllegalArgumentException for an unknown tenant before
+  // any search runs. That is not a transient failure, so it propagates without allocating.
+  //
+  // ServiceRegistry rejecting an unknown tenant is therefore load-bearing here, and is pinned by
+  // DefaultServiceRegistryTest. Were it ever to fall back to a default tenant instead, this map
+  // would silently become traffic-bounded again.
   //
   // Package-private so the test can assert what is retained, which is the whole point of the
   // field's lifecycle and is not observable from any of this class's outputs.

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -460,18 +460,21 @@ class DefaultMembershipServiceTest {
   }
 
   @Test
-  void shouldNotRetainAnOutageEntryForALookupThatFailedNonTransiently() {
-    // given — a deterministic failure, which is the shape an unconfigured physical tenant takes:
-    // resolving its store throws rather than returning one
-    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
-        .thenThrow(new IllegalArgumentException("unknown physical tenant"));
+  void shouldNotRetainAnOutageEntryForAnUnconfiguredPhysicalTenant() {
+    // given — a physical tenant this registry does not know. PhysicalTenantFilter stamps the id
+    // from the request path without validating it, so an arbitrary one does reach this service;
+    // what stops it is the lookup opening by resolving that tenant's services.
     final var query = baseQuery().withMappingRuleIds(List.of("mr1"));
 
-    // when / then — it propagates, as before
-    assertThatThrownBy(() -> inPhysicalTenant("default", () -> service.groupIds(query)))
-        .isInstanceOf(IllegalArgumentException.class);
+    // when / then — the registry rejects it before any search runs, and a rejection is not a
+    // transient failure, so it propagates
+    assertThatThrownBy(() -> inPhysicalTenant("tenantz", () -> service.groupIds(query)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantz");
 
-    // and nothing is retained, so a request that cannot resolve a store cannot cost memory either
+    // and nothing is retained. This is what bounds the map by the configured tenants rather than
+    // by the ids that arrive: an id no tenant matches cannot reach the failure branch that
+    // allocates.
     assertThat(service.lookupOutages).isEmpty();
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/DefaultMembershipServiceTest.java
@@ -442,6 +442,39 @@ class DefaultMembershipServiceTest {
                     .contains("groupIds"));
   }
 
+  @Test
+  void shouldNotRetainAnOutageEntryForALookupThatNeverFailed() {
+    // given — a healthy group store
+    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
+        .thenReturn(List.of(new GroupEntity(1L, "g1", "group", null)));
+    final var query = baseQuery().withMappingRuleIds(List.of("mr1"));
+
+    // when — the lookup succeeds
+    inPhysicalTenant("default", () -> service.groupIds(query));
+
+    // then — nothing is retained. The key is derived from the physical tenant on the request, which
+    // PhysicalTenantFilter stamps without validating, so anything retained on the success path
+    // would tie this service's memory to the set of tenant ids that reach it rather than to the set
+    // that is configured.
+    assertThat(service.lookupOutages).isEmpty();
+  }
+
+  @Test
+  void shouldNotRetainAnOutageEntryForALookupThatFailedNonTransiently() {
+    // given — a deterministic failure, which is the shape an unconfigured physical tenant takes:
+    // resolving its store throws rather than returning one
+    when(groupServices.getGroupsByMemberTypeAndMemberIds(any(), any()))
+        .thenThrow(new IllegalArgumentException("unknown physical tenant"));
+    final var query = baseQuery().withMappingRuleIds(List.of("mr1"));
+
+    // when / then — it propagates, as before
+    assertThatThrownBy(() -> inPhysicalTenant("default", () -> service.groupIds(query)))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // and nothing is retained, so a request that cannot resolve a store cannot cost memory either
+    assertThat(service.lookupOutages).isEmpty();
+  }
+
   private void inPhysicalTenant(final String physicalTenantId, final Runnable call) {
     final var request = new MockHttpServletRequest();
     PhysicalTenantContext.setPhysicalTenantId(request, physicalTenantId);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/EncodedTenantPaths.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/EncodedTenantPaths.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.physicaltenant;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+
+/**
+ * The two spellings of one physical tenant, and a request that reaches the server with the spelling
+ * intact, shared by {@link PhysicalTenantEncodedPathRoutingIT} and {@link
+ * PhysicalTenantEncodedPathOidcRoutingIT}.
+ *
+ * <p>The pair of spellings belongs in one place: they only mean anything relative to each other,
+ * and a change to one that missed the other would leave a test that still passes while no longer
+ * testing an encoded path at all.
+ */
+final class EncodedTenantPaths {
+
+  /** A configured physical tenant. */
+  static final String TENANT_ID = "tenanta";
+
+  /** {@link #TENANT_ID} with its last character written as {@code %61}. */
+  static final String ENCODED_TENANT_ID = "tenant%61";
+
+  /** An endpoint that resolves the caller's memberships, so the stamped tenant is acted on. */
+  static final String ME_ENDPOINT = "/v2/authentication/me";
+
+  private EncodedTenantPaths() {}
+
+  /** The tenant-prefixed path to {@link #ME_ENDPOINT}, with {@code tenantId} spelled verbatim. */
+  static String meEndpointFor(final String tenantId) {
+    return "/physical-tenants/" + tenantId + ME_ENDPOINT;
+  }
+
+  /**
+   * Sends {@code rawPath} to {@code baseAddress} without touching its encoding. A {@code
+   * CamundaClient} builds the tenant prefix itself and would normalize away the very thing under
+   * test, so these tests go direct.
+   *
+   * @param authorization the value of the {@code Authorization} header, which is where the two
+   *     callers differ
+   */
+  static HttpResponse<String> get(
+      final String baseAddress, final String rawPath, final String authorization) throws Exception {
+    final var base = baseAddress.replaceAll("/+$", "");
+    try (final var client = HttpClient.newHttpClient()) {
+      return client.send(
+          HttpRequest.newBuilder(URI.create(base + rawPath))
+              .header("Authorization", authorization)
+              .GET()
+              .build(),
+          BodyHandlers.ofString());
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathOidcRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathOidcRoutingIT.java
@@ -62,23 +62,16 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
   @Container
   static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
 
-  private static final String TENANT_A = "tenanta";
-
-  /** {@code tenanta} with its last character written as {@code %61}. */
-  private static final String ENCODED_TENANT_ID = "tenant%61";
-
   private static final String REALM = "realm-a";
   private static final String CLIENT_ID = "client-a";
   private static final String CLIENT_SECRET = "secret-a";
-  private static final String AUDIENCE = "zeebe";
-  private static final String ME_ENDPOINT = "/v2/authentication/me";
   private static final Pattern ACCESS_TOKEN =
       Pattern.compile("\"access_token\"\\s*:\\s*\"([^\"]+)\"");
 
   private static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
           .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.rdbmsH2("default"))
-          .withTenant(TENANT_A, Storage.rdbmsH2(TENANT_A))
+          .withTenant(EncodedTenantPaths.TENANT_ID, Storage.rdbmsH2(EncodedTenantPaths.TENANT_ID))
           .build();
 
   @TestZeebe(autoStart = false, purgeAfterEach = false)
@@ -102,7 +95,7 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
           c.getAuthentication().getOidc().setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
         });
     BROKER.withPtConfig(
-        TENANT_A,
+        EncodedTenantPaths.TENANT_ID,
         c -> {
           final var oidc = c.getSecurity().getAuthentication().getOidc();
           oidc.setIssuerUri(issuer);
@@ -110,7 +103,9 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
           oidc.setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
         });
     BROKER.withProperty(
-        "camunda.physical-tenants." + TENANT_A + ".security.authentication.providers.assigned[0]",
+        "camunda.physical-tenants."
+            + EncodedTenantPaths.TENANT_ID
+            + ".security.authentication.providers.assigned[0]",
         "oidc");
 
     BROKER.start();
@@ -121,7 +116,9 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
         .ignoreExceptions()
         .untilAsserted(
             () ->
-                assertThat(get("/physical-tenants/" + TENANT_A + ME_ENDPOINT).statusCode())
+                assertThat(
+                        get(EncodedTenantPaths.meEndpointFor(EncodedTenantPaths.TENANT_ID))
+                            .statusCode())
                     .isEqualTo(200));
   }
 
@@ -130,8 +127,8 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
     // given — a token the configured tenant's chain accepts, proven by the baseline above
 
     // when — the same endpoint and the same token, with the tenant spelled two ways
-    final var plain = get("/physical-tenants/" + TENANT_A + ME_ENDPOINT);
-    final var encoded = get("/physical-tenants/" + ENCODED_TENANT_ID + ME_ENDPOINT);
+    final var plain = get(EncodedTenantPaths.meEndpointFor(EncodedTenantPaths.TENANT_ID));
+    final var encoded = get(EncodedTenantPaths.meEndpointFor(EncodedTenantPaths.ENCODED_TENANT_ID));
 
     // then
     assertThat(plain.statusCode())
@@ -151,17 +148,8 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
   }
 
   private static HttpResponse<String> get(final String rawPath) throws Exception {
-    final var base = BROKER.restAddress().toString().replaceAll("/+$", "");
-    // A raw request: a CamundaClient builds the tenant prefix itself and would normalize away the
-    // encoding under test.
-    try (final var client = HttpClient.newHttpClient()) {
-      return client.send(
-          HttpRequest.newBuilder(URI.create(base + rawPath))
-              .header("Authorization", "Bearer " + bearerToken)
-              .GET()
-              .build(),
-          BodyHandlers.ofString());
-    }
+    return EncodedTenantPaths.get(
+        BROKER.restAddress().toString(), rawPath, "Bearer " + bearerToken);
   }
 
   private static String fetchToken() throws Exception {
@@ -169,9 +157,7 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
         "grant_type=client_credentials&client_id="
             + URLEncoder.encode(CLIENT_ID, StandardCharsets.UTF_8)
             + "&client_secret="
-            + URLEncoder.encode(CLIENT_SECRET, StandardCharsets.UTF_8)
-            + "&audience="
-            + URLEncoder.encode(AUDIENCE, StandardCharsets.UTF_8);
+            + URLEncoder.encode(CLIENT_SECRET, StandardCharsets.UTF_8);
     try (final var client = HttpClient.newHttpClient()) {
       final var response =
           client.send(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathOidcRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathOidcRoutingIT.java
@@ -48,12 +48,18 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * stamped id, and a token valid for the configured tenant is a valid token here.
  *
  * <p>Whether the request is then refused therefore rests on a different step than it does for basic
- * auth, which is why it needs its own test rather than an argument by analogy. It is refused, and
- * the different status — 400 here against 401 there — is the visible sign that a different step
- * does it.
+ * auth, which is why it needs its own test rather than an argument by analogy. It is refused: the
+ * stamped id is acted on, by a physical-tenant-scoped lookup that fails hard rather than falling
+ * back to a shared default, since resolving one tenant's request against another's storage would
+ * break isolation. Hence 400 here against 401 for basic auth, where authentication never succeeds
+ * in the first place.
  *
- * <p>Secondary storage is provisioned per tenant because membership resolution — the first thing
- * downstream to act on the stamped id — is only active when it is.
+ * <p>What matters for the caller is that every such lookup on an unknown id fails this way —
+ * deliberately and deterministically. None of them is the transient failure that would make {@code
+ * DefaultMembershipService} retain an outage entry.
+ *
+ * <p>Secondary storage is provisioned per tenant so those scoped lookups exist at all; without it
+ * the request would be refused for an unrelated reason and prove nothing.
  */
 @Testcontainers
 @ZeebeIntegration
@@ -139,9 +145,10 @@ final class PhysicalTenantEncodedPathOidcRoutingIT {
     // 404, and the token validated there. It must still not be served: the id handed downstream
     // matches no configured tenant. A 200 would mean it was served as some tenant; a 5xx would mean
     // the mismatched id travelled past authentication and failed on a store it cannot resolve.
-    // The status differs from the basic-auth case, which answers 401 when it cannot resolve the
-    // user under the mismatched id. What matters is shared: not 200, so it was not served, and not
-    // 5xx, which is what acting on an id that resolves to no store would produce.
+    // 400, not the 401 of the basic-auth case: the token is valid, so the refusal comes from a
+    // scoped lookup rejecting the stamped id — "No ResourceAccessProvider registered for physical
+    // tenant 'tenant%61'; refusing to fall back to a shared default". A deliberate rejection, not
+    // an accident of something unprepared for the id, which is what a 5xx would indicate.
     assertThat(encoded.statusCode())
         .as("an encoded spelling of a configured tenant must not be served")
         .isEqualTo(400);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathOidcRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathOidcRoutingIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * The OIDC counterpart of {@link PhysicalTenantEncodedPathRoutingIT}, which pins the same property
+ * under basic authentication.
+ *
+ * <p>The two authentication methods validate credentials against different things, so the
+ * basic-auth result does not carry over. Basic auth resolves the user from the physical tenant the
+ * request was stamped with, which is exactly the mismatched id, so it fails there. An OIDC bearer
+ * token is validated by the decoder bound to the <em>filter chain</em> the request matched, and
+ * that chain was selected from the decoded path — so nothing in the validation step consults the
+ * stamped id, and a token valid for the configured tenant is a valid token here.
+ *
+ * <p>Whether the request is then refused therefore rests on a different step than it does for basic
+ * auth, which is why it needs its own test rather than an argument by analogy. It is refused, and
+ * the different status — 400 here against 401 there — is the visible sign that a different step
+ * does it.
+ *
+ * <p>Secondary storage is provisioned per tenant because membership resolution — the first thing
+ * downstream to act on the stamped id — is only active when it is.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class PhysicalTenantEncodedPathOidcRoutingIT {
+
+  @Container
+  static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  private static final String TENANT_A = "tenanta";
+
+  /** {@code tenanta} with its last character written as {@code %61}. */
+  private static final String ENCODED_TENANT_ID = "tenant%61";
+
+  private static final String REALM = "realm-a";
+  private static final String CLIENT_ID = "client-a";
+  private static final String CLIENT_SECRET = "secret-a";
+  private static final String AUDIENCE = "zeebe";
+  private static final String ME_ENDPOINT = "/v2/authentication/me";
+  private static final Pattern ACCESS_TOKEN =
+      Pattern.compile("\"access_token\"\\s*:\\s*\"([^\"]+)\"");
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.rdbmsH2("default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2(TENANT_A))
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withAuthenticatedAccess()
+              .withAuthenticationMethod(AuthenticationMethod.OIDC));
+
+  private static String bearerToken;
+
+  @BeforeAll
+  static void start() throws Exception {
+    configureRealm();
+    final var issuer = KEYCLOAK.getAuthServerUrl() + "/realms/" + REALM;
+    // redirectUri is mandatory for Spring's client registration even in resource-server mode.
+    BROKER.withSecurityConfig(
+        c -> {
+          c.getAuthentication().getOidc().setIssuerUri(issuer);
+          c.getAuthentication().getOidc().setClientId(CLIENT_ID);
+          c.getAuthentication().getOidc().setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    BROKER.withPtConfig(
+        TENANT_A,
+        c -> {
+          final var oidc = c.getSecurity().getAuthentication().getOidc();
+          oidc.setIssuerUri(issuer);
+          oidc.setClientId(CLIENT_ID);
+          oidc.setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    BROKER.withProperty(
+        "camunda.physical-tenants." + TENANT_A + ".security.authentication.providers.assigned[0]",
+        "oidc");
+
+    BROKER.start();
+    bearerToken = fetchToken();
+
+    Awaitility.await("the configured tenant's own path is served")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(get("/physical-tenants/" + TENANT_A + ME_ENDPOINT).statusCode())
+                    .isEqualTo(200));
+  }
+
+  @Test
+  void shouldNotServeAPercentEncodedTenantPath() throws Exception {
+    // given — a token the configured tenant's chain accepts, proven by the baseline above
+
+    // when — the same endpoint and the same token, with the tenant spelled two ways
+    final var plain = get("/physical-tenants/" + TENANT_A + ME_ENDPOINT);
+    final var encoded = get("/physical-tenants/" + ENCODED_TENANT_ID + ME_ENDPOINT);
+
+    // then
+    assertThat(plain.statusCode())
+        .as("a configured tenant's own path must authenticate and serve")
+        .isEqualTo(200);
+
+    // and — the encoded spelling reached the same chain, since the catch-all would have answered
+    // 404, and the token validated there. It must still not be served: the id handed downstream
+    // matches no configured tenant. A 200 would mean it was served as some tenant; a 5xx would mean
+    // the mismatched id travelled past authentication and failed on a store it cannot resolve.
+    // The status differs from the basic-auth case, which answers 401 when it cannot resolve the
+    // user under the mismatched id. What matters is shared: not 200, so it was not served, and not
+    // 5xx, which is what acting on an id that resolves to no store would produce.
+    assertThat(encoded.statusCode())
+        .as("an encoded spelling of a configured tenant must not be served")
+        .isEqualTo(400);
+  }
+
+  private static HttpResponse<String> get(final String rawPath) throws Exception {
+    final var base = BROKER.restAddress().toString().replaceAll("/+$", "");
+    // A raw request: a CamundaClient builds the tenant prefix itself and would normalize away the
+    // encoding under test.
+    try (final var client = HttpClient.newHttpClient()) {
+      return client.send(
+          HttpRequest.newBuilder(URI.create(base + rawPath))
+              .header("Authorization", "Bearer " + bearerToken)
+              .GET()
+              .build(),
+          BodyHandlers.ofString());
+    }
+  }
+
+  private static String fetchToken() throws Exception {
+    final var form =
+        "grant_type=client_credentials&client_id="
+            + URLEncoder.encode(CLIENT_ID, StandardCharsets.UTF_8)
+            + "&client_secret="
+            + URLEncoder.encode(CLIENT_SECRET, StandardCharsets.UTF_8)
+            + "&audience="
+            + URLEncoder.encode(AUDIENCE, StandardCharsets.UTF_8);
+    try (final var client = HttpClient.newHttpClient()) {
+      final var response =
+          client.send(
+              HttpRequest.newBuilder(
+                      URI.create(
+                          KEYCLOAK.getAuthServerUrl()
+                              + "/realms/"
+                              + REALM
+                              + "/protocol/openid-connect/token"))
+                  .header("Content-Type", "application/x-www-form-urlencoded")
+                  .POST(BodyPublishers.ofString(form))
+                  .build(),
+              BodyHandlers.ofString());
+      final var matcher = ACCESS_TOKEN.matcher(response.body());
+      assertThat(matcher.find()).as("Keycloak returned a token: %s", response.body()).isTrue();
+      return matcher.group(1);
+    }
+  }
+
+  private static void configureRealm() {
+    final var client = new ClientRepresentation();
+    client.setClientId(CLIENT_ID);
+    client.setEnabled(true);
+    client.setClientAuthenticatorType("client-secret");
+    client.setSecret(CLIENT_SECRET);
+    client.setServiceAccountsEnabled(true);
+
+    final var realm = new RealmRepresentation();
+    realm.setRealm(REALM);
+    realm.setEnabled(true);
+    realm.setClients(List.of(client));
+
+    try (final var admin = KEYCLOAK.getKeycloakAdminClient()) {
+      admin.realms().create(realm);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathRoutingIT.java
@@ -38,12 +38,14 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  *
  * <p>The catch-all that rejects unconfigured tenants with 404 does not cover this: it too matches
  * on the decoded path, where this request is a valid tenant's. What stops it is one layer further
- * in — per-physical-tenant credential resolution, which finds no tenant under the encoded id and
- * answers 401. Authentication therefore fails before anything downstream acts on the mismatched id.
+ * in — authentication itself, which under basic auth resolves the caller against the physical
+ * tenant that was stamped, and so answers 401 for an id no tenant matches.
  *
- * <p>That ordering is what this test pins. It is load-bearing and not self-evident from either
- * layer alone: the security chains admit the request, and the filter hands on an id no
- * configuration matches, so only the credential step keeps the two from meeting.
+ * <p>That is what this test pins, and it is not self-evident from either layer alone: the security
+ * chains admit the request and the filter hands on a bogus id, so only the credential step keeps
+ * the two from meeting. It is also specific to this authentication method — see {@link
+ * PhysicalTenantEncodedPathOidcRoutingIT}, where a valid token gets further and a different scoped
+ * lookup does the refusing.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants(EncodedTenantPaths.TENANT_ID)
@@ -67,8 +69,9 @@ final class PhysicalTenantEncodedPathRoutingIT {
 
   @Test
   void shouldNotServeAPercentEncodedTenantPath() throws Exception {
-    // given — a user that exists in the configured tenant, so the request gets past authentication
-    // and reaches membership resolution rather than stopping at a 401
+    // given — a user that exists in the configured tenant. Only the baseline needs it: without a
+    // user, both spellings would be refused and the test would pass while proving nothing about
+    // the encoding.
     final var username = createUser();
 
     // when — the same endpoint and the same credentials, spelled two ways
@@ -81,10 +84,10 @@ final class PhysicalTenantEncodedPathRoutingIT {
         .as("a configured tenant's own path must authenticate and serve")
         .isEqualTo(200);
 
-    // and — the encoded spelling is refused. It reached the tenant's chain, since the catch-all
-    // would have answered 404, but the credentials could not be resolved under an id no tenant
-    // matches. A 200 would mean it was served as some tenant; a 5xx would mean the mismatched id
-    // travelled past authentication and failed somewhere downstream on an unresolvable store.
+    // and — the encoded spelling is refused, having reached the tenant's chain: the catch-all
+    // would have answered 404. The same credentials that just worked do not authenticate here,
+    // because they are resolved against the stamped id. A 200 would mean it was served as some
+    // tenant; a 5xx would mean something met the id without being prepared for it.
     assertThat(encoded.statusCode())
         .as("an encoded spelling of a configured tenant must not be served")
         .isEqualTo(401);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathRoutingIT.java
@@ -16,11 +16,7 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.qa.util.multidb.MultiPhysicalTenantClients;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.UUID;
@@ -50,14 +46,12 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * configuration matches, so only the credential step keeps the two from meeting.
  */
 @MultiDbTest
-@MultiDbPhysicalTenants(PhysicalTenantEncodedPathRoutingIT.TENANT_ID)
+@MultiDbPhysicalTenants(EncodedTenantPaths.TENANT_ID)
 @EnabledIfSystemProperty(
     named = "test.integration.camunda.database.type",
     matches = "rdbms.*$",
     disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class PhysicalTenantEncodedPathRoutingIT {
-
-  static final String TENANT_ID = "tenanta";
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
@@ -68,10 +62,6 @@ final class PhysicalTenantEncodedPathRoutingIT {
 
   static MultiPhysicalTenantClients ptClients;
 
-  /** {@code tenanta} with its last character written as {@code %61}. */
-  private static final String ENCODED_TENANT_ID = "tenant%61";
-
-  private static final String ME_ENDPOINT = "/v2/authentication/me";
   private static final String PASSWORD = "encoded-path-probe";
   private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
 
@@ -82,8 +72,9 @@ final class PhysicalTenantEncodedPathRoutingIT {
     final var username = createUser();
 
     // when — the same endpoint and the same credentials, spelled two ways
-    final var plain = get("/physical-tenants/" + TENANT_ID + ME_ENDPOINT, username);
-    final var encoded = get("/physical-tenants/" + ENCODED_TENANT_ID + ME_ENDPOINT, username);
+    final var plain = get(EncodedTenantPaths.meEndpointFor(EncodedTenantPaths.TENANT_ID), username);
+    final var encoded =
+        get(EncodedTenantPaths.meEndpointFor(EncodedTenantPaths.ENCODED_TENANT_ID), username);
 
     // then — the plain spelling is the baseline: authenticated and served
     assertThat(plain.statusCode())
@@ -100,7 +91,7 @@ final class PhysicalTenantEncodedPathRoutingIT {
   }
 
   private String createUser() {
-    final CamundaClient admin = ptClients.admin(TENANT_ID);
+    final CamundaClient admin = ptClients.admin(EncodedTenantPaths.TENANT_ID);
     final var username = "probe-" + UUID.randomUUID().toString().substring(0, 8);
     admin
         .newCreateUserCommand()
@@ -128,18 +119,8 @@ final class PhysicalTenantEncodedPathRoutingIT {
 
   private static HttpResponse<String> get(final String rawPath, final String username)
       throws Exception {
-    final var base = BROKER.restAddress().toString().replaceAll("/+$", "");
     final var credentials =
         Base64.getEncoder().encodeToString((username + ":" + PASSWORD).getBytes());
-    // A raw java.net.http request: a CamundaClient builds the prefix itself and would normalize the
-    // encoding away, which is the very thing under test.
-    try (final var client = HttpClient.newHttpClient()) {
-      return client.send(
-          HttpRequest.newBuilder(URI.create(base + rawPath))
-              .header("Authorization", "Basic " + credentials)
-              .GET()
-              .build(),
-          BodyHandlers.ofString());
-    }
+    return EncodedTenantPaths.get(BROKER.restAddress().toString(), rawPath, "Basic " + credentials);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/PhysicalTenantEncodedPathRoutingIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.qa.util.multidb.MultiPhysicalTenantClients;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Pins how the assembled application treats a percent-encoded spelling of a configured physical
+ * tenant, end to end: through CSL's scoped security chains, real credential validation, and the
+ * authentication converter that resolves memberships.
+ *
+ * <p>Two path parsers meet on this route. CSL selects a scoped chain with {@code
+ * http.securityMatcher(String...)}, which matches the parsed, decoded path, while {@code
+ * PhysicalTenantFilter} derives the tenant id the application acts on from the request path. If the
+ * filter reads the encoded form, {@code /physical-tenants/tenant%61/...} is routed as the
+ * configured tenant {@code tenanta} but acted on as {@code tenant%61} — an id no configuration
+ * matches, and one a caller varies freely without changing how the request is routed.
+ *
+ * <p>The catch-all that rejects unconfigured tenants with 404 does not cover this: it too matches
+ * on the decoded path, where this request is a valid tenant's. What stops it is one layer further
+ * in — per-physical-tenant credential resolution, which finds no tenant under the encoded id and
+ * answers 401. Authentication therefore fails before anything downstream acts on the mismatched id.
+ *
+ * <p>That ordering is what this test pins. It is load-bearing and not self-evident from either
+ * layer alone: the security chains admit the request, and the filter hands on an id no
+ * configuration matches, so only the credential step keeps the two from meeting.
+ */
+@MultiDbTest
+@MultiDbPhysicalTenants(PhysicalTenantEncodedPathRoutingIT.TENANT_ID)
+@EnabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
+final class PhysicalTenantEncodedPathRoutingIT {
+
+  static final String TENANT_ID = "tenanta";
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+
+  static MultiPhysicalTenantClients ptClients;
+
+  /** {@code tenanta} with its last character written as {@code %61}. */
+  private static final String ENCODED_TENANT_ID = "tenant%61";
+
+  private static final String ME_ENDPOINT = "/v2/authentication/me";
+  private static final String PASSWORD = "encoded-path-probe";
+  private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  @Test
+  void shouldNotServeAPercentEncodedTenantPath() throws Exception {
+    // given — a user that exists in the configured tenant, so the request gets past authentication
+    // and reaches membership resolution rather than stopping at a 401
+    final var username = createUser();
+
+    // when — the same endpoint and the same credentials, spelled two ways
+    final var plain = get("/physical-tenants/" + TENANT_ID + ME_ENDPOINT, username);
+    final var encoded = get("/physical-tenants/" + ENCODED_TENANT_ID + ME_ENDPOINT, username);
+
+    // then — the plain spelling is the baseline: authenticated and served
+    assertThat(plain.statusCode())
+        .as("a configured tenant's own path must authenticate and serve")
+        .isEqualTo(200);
+
+    // and — the encoded spelling is refused. It reached the tenant's chain, since the catch-all
+    // would have answered 404, but the credentials could not be resolved under an id no tenant
+    // matches. A 200 would mean it was served as some tenant; a 5xx would mean the mismatched id
+    // travelled past authentication and failed somewhere downstream on an unresolvable store.
+    assertThat(encoded.statusCode())
+        .as("an encoded spelling of a configured tenant must not be served")
+        .isEqualTo(401);
+  }
+
+  private String createUser() {
+    final CamundaClient admin = ptClients.admin(TENANT_ID);
+    final var username = "probe-" + UUID.randomUUID().toString().substring(0, 8);
+    admin
+        .newCreateUserCommand()
+        .username(username)
+        .password(PASSWORD)
+        .name(username)
+        .email(username + "@example.com")
+        .send()
+        .join();
+    Awaitility.await("user '" + username + "' exists")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        admin
+                            .newUsersSearchRequest()
+                            .filter(f -> f.username(username))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+    return username;
+  }
+
+  private static HttpResponse<String> get(final String rawPath, final String username)
+      throws Exception {
+    final var base = BROKER.restAddress().toString().replaceAll("/+$", "");
+    final var credentials =
+        Base64.getEncoder().encodeToString((username + ":" + PASSWORD).getBytes());
+    // A raw java.net.http request: a CamundaClient builds the prefix itself and would normalize the
+    // encoding away, which is the very thing under test.
+    try (final var client = HttpClient.newHttpClient()) {
+      return client.send(
+          HttpRequest.newBuilder(URI.create(base + rawPath))
+              .header("Authorization", "Basic " + credentials)
+              .GET()
+              .build(),
+          BodyHandlers.ofString());
+    }
+  }
+}

--- a/service/src/test/java/io/camunda/service/registry/DefaultServiceRegistryTest.java
+++ b/service/src/test/java/io/camunda/service/registry/DefaultServiceRegistryTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.service.ClusterHistoryBackupServices;
+import io.camunda.service.GroupServices;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import org.junit.jupiter.api.Test;
@@ -48,5 +49,44 @@ class DefaultServiceRegistryTest {
 
     // when / then
     assertThat(registry.clusterHistoryBackupServices()).isSameAs(services);
+  }
+
+  /**
+   * A tenant-scoped accessor is reached with whatever physical tenant id was stamped on the
+   * request, and that id is taken from the request path without being validated against the
+   * configured tenants (ADR-0003). Rejecting an unknown one here is therefore the point at which an
+   * arbitrary id stops, and callers rely on that: {@code DefaultMembershipService} keys a
+   * per-outage map by the tenant in context, and only stays bounded by the configured tenants
+   * because an unknown one never gets past this accessor to fail transiently.
+   *
+   * <p>Falling back to the default tenant instead would also be an isolation fault in its own
+   * right, serving one tenant's data under another's id.
+   */
+  @Test
+  void shouldRejectAnUnknownPhysicalTenant() {
+    // given a registry that knows one tenant
+    final var registry =
+        DefaultServiceRegistry.of(
+            builder -> builder.groupServices("tenanta", mock(GroupServices.class)));
+
+    // when / then — asking for another is an error, not a fallback
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> registry.groupServices("tenantz"))
+        .withMessageContaining("tenantz");
+  }
+
+  @Test
+  void shouldReturnTheServicesOfTheRequestedPhysicalTenant() {
+    // given two tenants with distinct instances
+    final var tenantA = mock(GroupServices.class);
+    final var tenantB = mock(GroupServices.class);
+    final var registry =
+        DefaultServiceRegistry.of(
+            builder -> builder.groupServices("tenanta", tenantA).groupServices("tenantb", tenantB));
+
+    // when / then — each id resolves to its own, so a rejection above cannot be mistaken for the
+    // accessor simply never returning anything
+    assertThat(registry.groupServices("tenanta")).isSameAs(tenantA);
+    assertThat(registry.groupServices("tenantb")).isSameAs(tenantB);
   }
 }


### PR DESCRIPTION
## Summary

`DefaultMembershipService.resolveWithRetry` allocated an `OutageLog` before running the lookup, so every call retained one — successes and deterministic failures included. The map has no eviction, and its key carries the physical tenant id taken from the request path, which `PhysicalTenantFilter` deliberately does not validate (ADR-0003).

The entry is now created only in the transient-failure branch. A success reports a recovery only if an entry already exists; a non-transient failure allocates nothing.

## Not a fix

An id that reaches this method but matches no configured tenant is refused deterministically — 401 under basic auth, where the caller is resolved against the stamped tenant, and 400 under OIDC, where a scoped lookup rejects the id rather than falling back to a shared default. Neither is a transient failure, so nothing can currently grow the map. This removes a legitimate deployment's four permanent entries per tenant, and drops the map's dependence on an invariant two layers away in another repository.

## Related issues

relates to #51873

Hardening of code delivered for that issue, so it links rather than closes. Reported by Copilot on the stable/8.10 backport, https://github.com/camunda/camunda/pull/61744#discussion_r3913788500.

