### PR TITLE
perf: skip variable lookups for scopes without local variables

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -693,7 +693,10 @@ public final class BpmnStateTransitionBehavior {
   }
 
   public long createChildProcessInstance(
-      final DeployedProcess process, final BpmnElementContext context, final String businessId) {
+      final DeployedProcess process,
+      final BpmnElementContext context,
+      final String businessId,
+      final boolean propagatesVariables) {
 
     final var processInstanceKey = keyGenerator.nextKey();
 
@@ -709,7 +712,11 @@ public final class BpmnStateTransitionBehavior {
         .setBpmnElementType(process.getProcess().getElementType())
         .setTenantId(context.getTenantId())
         .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
-        .setBusinessId(businessId);
+        .setBusinessId(businessId)
+        // when the call activity propagates variables it copies them into this scope right after
+        // this command is written, i.e. before the scope is created; flag it so that the scope is
+        // not created as empty
+        .setHasVariables(propagatesVariables);
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -106,13 +106,16 @@ public final class CallActivityProcessor
               final var activated =
                   stateTransitionBehavior.transitionToActivated(context, element.getEventType());
 
-              final var childProcessInstanceKey =
-                  stateTransitionBehavior.createChildProcessInstance(
-                      process, context, calledProcess.businessId());
-
               final var propagateAllParentVariablesEnabled =
                   element.isPropagateAllParentVariablesEnabled();
               final var inputMappings = element.getInputMappings();
+
+              final var childProcessInstanceKey =
+                  stateTransitionBehavior.createChildProcessInstance(
+                      process,
+                      context,
+                      calledProcess.businessId(),
+                      propagateAllParentVariablesEnabled || inputMappings.isPresent());
               final var callActivityInstanceKey = activated.getElementInstanceKey();
               final var rootProcessInstanceKey = context.getRootProcessInstanceKey();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -417,6 +417,9 @@ public final class ElementActivationBehavior {
 
     final var elementRecord =
         createElementRecord(processInstanceRecord, elementToActivate, elementFlowScopeKey);
+    // the caller merges the variables of its activate instruction right after this command is
+    // written, i.e. before the scope is created; flag it so that the scope is not created as empty
+    elementRecord.setHasVariables(true);
     commandWriter.appendFollowUpCommand(
         elementInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, elementRecord);
     return elementInstanceKey;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -256,14 +256,19 @@ public class ProcessInstanceCreationHelper {
   public void setVariablesFromDocument(
       final ProcessInstanceRecord processInstance, final DirectBuffer variablesBuffer)
       throws VariableValidationException {
-    variableBehavior.mergeLocalDocument(
-        processInstance.getProcessInstanceKey(),
-        processInstance.getProcessDefinitionKey(),
-        processInstance.getProcessInstanceKey(),
-        processInstance.getRootProcessInstanceKey(),
-        processInstance.getBpmnProcessIdBuffer(),
-        processInstance.getTenantId(),
-        variablesBuffer);
+    final boolean wroteVariables =
+        variableBehavior.mergeLocalDocument(
+            processInstance.getProcessInstanceKey(),
+            processInstance.getProcessDefinitionKey(),
+            processInstance.getProcessInstanceKey(),
+            processInstance.getRootProcessInstanceKey(),
+            processInstance.getBpmnProcessIdBuffer(),
+            processInstance.getTenantId(),
+            variablesBuffer);
+
+    // the scope is only created when the follow-up ACTIVATE_ELEMENT command is processed, so the
+    // record has to carry that these variables already exist
+    processInstance.setHasVariables(wroteVariables);
   }
 
   public void activateElementsForStartInstructions(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -90,8 +90,11 @@ public final class VariableBehavior {
    * @param processDefinitionKey the process key to be associated with each variable
    * @param processInstanceKey the process instance key to be associated with each variable
    * @param document the document to merge
+   * @return whether the scope holds local variables after the merge, i.e. whether the document was
+   *     not empty. Note this is not the same as "something changed": re-merging an unchanged value
+   *     emits no event but the variable is still there.
    */
-  public void mergeLocalDocument(
+  public boolean mergeLocalDocument(
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
@@ -103,7 +106,7 @@ public final class VariableBehavior {
     validateBuffer(scopeKey, document);
     indexedDocument.index(document);
     if (indexedDocument.isEmpty()) {
-      return;
+      return false;
     }
     variableRecord
         .setScopeKey(scopeKey)
@@ -121,6 +124,7 @@ public final class VariableBehavior {
     }
 
     conditionalBehavior.evaluateConditionals(processInstanceKey, variableEvents);
+    return true;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -250,9 +250,10 @@ public final class DbElementInstanceState implements MutableElementInstanceState
 
     elementInstanceColumnFamily.insert(elementInstanceKey, instance);
     parentChildColumnFamily.insert(parentChildKey, DbNil.INSTANCE);
-    variableState.createScope(elementInstanceKey.getValue(), parentKey.inner().getValue());
-
     final var recordValue = instance.getValue();
+    variableState.createScope(
+        elementInstanceKey.getValue(), parentKey.inner().getValue(), recordValue.hasVariables());
+
     if (recordValue.getBpmnElementType() == BpmnElementType.PROCESS) {
       processDefinitionKey.wrapLong(recordValue.getProcessDefinitionKey());
       processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ParentScopeKey.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ParentScopeKey.java
@@ -9,21 +9,35 @@ package io.camunda.zeebe.engine.state.instance;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 
 public class ParentScopeKey extends UnpackedObject implements DbValue {
   private final LongProperty keyProp = new LongProperty("parentScopeKey", -1L);
 
+  /**
+   * Whether the scope has no variables of its own, in which case reading them can be skipped
+   * without hitting the VARIABLES column family. Defaults to {@code false} so that records written
+   * before this property existed are read as "may have local variables", which is correct, just
+   * unoptimized.
+   */
+  private final BooleanProperty emptyProp = new BooleanProperty("empty", false);
+
   public ParentScopeKey() {
-    super(1);
-    declareProperty(keyProp);
+    super(2);
+    declareProperty(keyProp).declareProperty(emptyProp);
   }
 
-  public void set(final long key) {
+  public void set(final long key, final boolean empty) {
     keyProp.setValue(key);
+    emptyProp.setValue(empty);
   }
 
   public long get() {
     return keyProp.getValue();
+  }
+
+  public boolean isEmpty() {
+    return emptyProp.getValue();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableVariableState.java
@@ -57,7 +57,13 @@ public interface MutableVariableState extends VariableState {
       int valueOffset,
       int valueLength);
 
-  void createScope(long childKey, long parentKey);
+  /**
+   * Creates the variable scope of an element instance.
+   *
+   * @param hasVariables whether variables were already written for this scope before it was
+   *     created; when false the scope is recorded as empty so that reads can skip it
+   */
+  void createScope(long childKey, long parentKey, boolean hasVariables);
 
   void removeScope(long scopeKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -40,10 +40,13 @@ public class DbVariableState implements MutableVariableState {
   private final ExpandableArrayBuffer documentResultBuffer = new ExpandableArrayBuffer();
   private final DirectBuffer resultView = new UnsafeBuffer(0, 0);
 
-  // (child scope key) => (parent scope key)
+  // (child scope key) => (parent scope key, whether the scope has no local variables)
+  // we need two separate wrapper to not interfere with get and put
+  // see https://github.com/zeebe-io/zeebe/issues/1914
   private final ColumnFamily<DbLong, ParentScopeKey> childParentColumnFamily;
   private final DbLong childKey;
-  private final ParentScopeKey parentKey = new ParentScopeKey();
+  private final ParentScopeKey scopeToRead = new ParentScopeKey();
+  private final ParentScopeKey scopeToWrite = new ParentScopeKey();
 
   // (scope key, variable name) => (variable value)
   private final ColumnFamily<DbCompositeKey<DbLong, DbString>, VariableInstance>
@@ -75,7 +78,7 @@ public class DbVariableState implements MutableVariableState {
             ZbColumnFamilies.ELEMENT_INSTANCE_CHILD_PARENT,
             transactionContext,
             childKey,
-            parentKey);
+            scopeToRead);
 
     scopeKey = new DbLong();
     variableName = new DbString();
@@ -127,21 +130,27 @@ public class DbVariableState implements MutableVariableState {
     variableName.wrapBuffer(variableNameView);
 
     variablesColumnFamily.upsert(scopeKeyVariableNameKey, newVariable);
+
+    setScopeEmpty(scopeKey, false);
   }
 
   @Override
-  public void createScope(final long childKey, final long parentKey) {
+  public void createScope(final long childKey, final long parentKey, final boolean hasVariables) {
     this.childKey.wrapLong(childKey);
-    this.parentKey.set(parentKey);
+    // Variables can be written before their scope exists: the create-instance payload, modification
+    // variable instructions and call activity propagation all merge variables while the element is
+    // only activated by a follow-up ACTIVATE_ELEMENT command. Those callers flag it on the record,
+    // because marking such a scope empty would hide the variables from every later read.
+    scopeToWrite.set(parentKey, !hasVariables);
 
-    childParentColumnFamily.insert(this.childKey, this.parentKey);
+    childParentColumnFamily.insert(this.childKey, scopeToWrite);
   }
 
   @Override
   public void removeScope(final long scopeKey) {
-    this.scopeKey.wrapLong(scopeKey);
-
-    removeAllVariables(scopeKey);
+    if (!isScopeEmpty(scopeKey)) {
+      deleteAllVariablesLocal(scopeKey);
+    }
 
     childKey.wrapLong(scopeKey);
     // TODO: Could be deleteExisting except for tests
@@ -150,11 +159,12 @@ public class DbVariableState implements MutableVariableState {
 
   @Override
   public void removeAllVariables(final long scopeKey) {
-    visitVariablesLocal(
-        scopeKey,
-        dbString -> true,
-        (dbString, variable1) -> variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey),
-        () -> false);
+    if (isScopeEmpty(scopeKey)) {
+      return;
+    }
+
+    deleteAllVariablesLocal(scopeKey);
+    setScopeEmpty(scopeKey, true);
   }
 
   @Override
@@ -195,17 +205,31 @@ public class DbVariableState implements MutableVariableState {
   public DirectBuffer getVariable(
       final long scopeKey, final DirectBuffer name, final int nameOffset, final int nameLength) {
 
-    long currentScopeKey = scopeKey;
-    do {
-      final VariableInstance variable =
-          getVariableLocal(currentScopeKey, name, nameOffset, nameLength);
+    // the given scope is read without looking up its scope record first: on a local hit that saves
+    // the lookup entirely, and otherwise the record is needed anyway to find the parent
+    VariableInstance variable = getVariableLocal(scopeKey, name, nameOffset, nameLength);
+    if (variable != null) {
+      return variable.getValue();
+    }
 
-      if (variable != null) {
-        return variable.getValue();
+    long currentScopeKey = getParentScopeKey(scopeKey);
+    while (currentScopeKey >= 0) {
+      childKey.wrapLong(currentScopeKey);
+      final ParentScopeKey scope = childParentColumnFamily.get(childKey);
+      if (scope == null) {
+        return null;
       }
 
-      currentScopeKey = getParentScopeKey(currentScopeKey);
-    } while (currentScopeKey >= 0);
+      final long parentScopeKey = scope.get();
+      if (!scope.isEmpty()) {
+        variable = getVariableLocal(currentScopeKey, name, nameOffset, nameLength);
+        if (variable != null) {
+          return variable.getValue();
+        }
+      }
+
+      currentScopeKey = parentScopeKey;
+    }
 
     return null;
   }
@@ -366,13 +390,20 @@ public class DbVariableState implements MutableVariableState {
       final BooleanSupplier completionCondition) {
     long currentScope = scopeKey;
 
-    boolean completed;
-    do {
-      completed = visitVariablesLocal(currentScope, filter, variableConsumer, completionCondition);
+    boolean completed = false;
+    while (!completed && currentScope >= 0) {
+      childKey.wrapLong(currentScope);
+      final ParentScopeKey scope = childParentColumnFamily.get(childKey);
+      // an unknown scope has no parent to continue with, but it may still hold variables
+      final boolean empty = scope != null && scope.isEmpty();
+      final long parentScope = scope != null ? scope.get() : NO_PARENT;
 
-      currentScope = getParentScopeKey(currentScope);
+      if (!empty) {
+        completed = seekVariablesLocal(currentScope, filter, variableConsumer, completionCondition);
+      }
 
-    } while (!completed && currentScope >= 0);
+      currentScope = parentScope;
+    }
   }
 
   /**
@@ -385,6 +416,22 @@ public class DbVariableState implements MutableVariableState {
    * @return true if the completion condition was met
    */
   private boolean visitVariablesLocal(
+      final long scopeKey,
+      final Predicate<DbString> variableFilter,
+      final BiConsumer<DbString, VariableInstance> variableConsumer,
+      final BooleanSupplier completionCondition) {
+    if (isScopeEmpty(scopeKey)) {
+      return false;
+    }
+
+    return seekVariablesLocal(scopeKey, variableFilter, variableConsumer, completionCondition);
+  }
+
+  /**
+   * Like {@link #visitVariablesLocal(long, Predicate, BiConsumer, BooleanSupplier)}, but without
+   * checking first whether the scope is empty. Only for callers that already know it is not.
+   */
+  private boolean seekVariablesLocal(
       final long scopeKey,
       final Predicate<DbString> variableFilter,
       final BiConsumer<DbString, VariableInstance> variableConsumer,
@@ -403,5 +450,32 @@ public class DbVariableState implements MutableVariableState {
           return !completionCondition.getAsBoolean();
         });
     return false;
+  }
+
+  private void deleteAllVariablesLocal(final long scopeKey) {
+    seekVariablesLocal(
+        scopeKey,
+        dbString -> true,
+        (dbString, variable) -> variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey),
+        () -> false);
+  }
+
+  /** Returns true only if the scope is known to have no variables of its own. */
+  private boolean isScopeEmpty(final long scopeKey) {
+    childKey.wrapLong(scopeKey);
+    final ParentScopeKey scope = childParentColumnFamily.get(childKey);
+    return scope != null && scope.isEmpty();
+  }
+
+  private void setScopeEmpty(final long scopeKey, final boolean empty) {
+    childKey.wrapLong(scopeKey);
+    final ParentScopeKey scope = childParentColumnFamily.get(childKey);
+
+    if (scope == null || scope.isEmpty() == empty) {
+      return;
+    }
+
+    scopeToWrite.set(scope.get(), empty);
+    childParentColumnFamily.update(childKey, scopeToWrite);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -217,7 +217,9 @@ public class DbVariableState implements MutableVariableState {
       childKey.wrapLong(currentScopeKey);
       final ParentScopeKey scope = childParentColumnFamily.get(childKey);
       if (scope == null) {
-        return null;
+        // The scope record may not exist yet even though variables have already been written to it.
+        variable = getVariableLocal(currentScopeKey, name, nameOffset, nameLength);
+        return variable != null ? variable.getValue() : null;
       }
 
       final long parentScopeKey = scope.get();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -91,8 +91,8 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(childFooKey, childScopeKey, processDefinitionKey, "foo", "qux");
 
     // when
@@ -172,9 +172,9 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar");
-    state.createScope(rootScopeKey, VariableState.NO_PARENT);
-    state.createScope(parentScopeKey, rootScopeKey);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(rootScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(parentScopeKey, rootScopeKey, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(parentFooKey, parentScopeKey, processDefinitionKey, "foo", "qux");
     setVariable(5, rootScopeKey, processDefinitionKey, "foo", "biz");
 
@@ -216,9 +216,9 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
-    state.createScope(rootScopeKey, VariableState.NO_PARENT);
-    state.createScope(parentScopeKey, rootScopeKey);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(rootScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(parentScopeKey, rootScopeKey, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
 
     // when
     behavior.mergeDocument(
@@ -268,9 +268,9 @@ final class VariableBehaviorTest {
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
-    state.createScope(rootScopeKey, VariableState.NO_PARENT);
-    state.createScope(parentScopeKey, rootScopeKey);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(rootScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(parentScopeKey, rootScopeKey, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(4, rootScopeKey, processDefinitionKey, "foo", "bar");
 
     // when
@@ -311,8 +311,8 @@ final class VariableBehaviorTest {
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar");
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(childFooKey, childScopeKey, processDefinitionKey, "foo", "qux");
     setVariable(4, parentScopeKey, processDefinitionKey, "foo", "biz");
 
@@ -354,8 +354,8 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of();
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(3, parentScopeKey, processDefinitionKey, "foo", "qux");
     setVariable(4, childScopeKey, processDefinitionKey, "foo", "bar");
 
@@ -385,8 +385,8 @@ final class VariableBehaviorTest {
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
 
     // when
     behavior.setLocalVariable(
@@ -431,8 +431,8 @@ final class VariableBehaviorTest {
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(parentFooKey, parentScopeKey, processDefinitionKey, "foo", "qux");
 
     // when
@@ -479,8 +479,8 @@ final class VariableBehaviorTest {
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     setVariable(parentFooKey, parentScopeKey, processDefinitionKey, "foo", "bar");
 
     // when
@@ -515,8 +515,8 @@ final class VariableBehaviorTest {
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
 
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
 
     // when
     behavior.setLocalVariable(
@@ -564,8 +564,8 @@ final class VariableBehaviorTest {
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
 
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
 
     setVariable(parentFooKey, parentScopeKey, processDefinitionKey, "foo", "qux");
 
@@ -615,8 +615,8 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
 
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
 
     setVariable(childFooKey, childScopeKey, processDefinitionKey, "foo", "qux");
 
@@ -672,9 +672,9 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
 
-    state.createScope(rootScopeKey, VariableState.NO_PARENT);
-    state.createScope(parentScopeKey, rootScopeKey);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(rootScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(parentScopeKey, rootScopeKey, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
 
     setVariable(123456L, parentScopeKey, processDefinitionKey, "foo", "qux");
 
@@ -728,9 +728,9 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar");
-    state.createScope(rootScopeKey, VariableState.NO_PARENT);
-    state.createScope(parentScopeKey, rootScopeKey);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(rootScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(parentScopeKey, rootScopeKey, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     final var variableSource =
         isApiSource ? VariableSourceRecord.api() : VariableSourceRecord.none();
     final var behavior = this.behavior.withVariableSource(variableSource);
@@ -772,8 +772,8 @@ final class VariableBehaviorTest {
     final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final String tenantId = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     final Map<String, Object> document = Map.of("foo", "bar");
-    state.createScope(parentScopeKey, VariableState.NO_PARENT);
-    state.createScope(childScopeKey, parentScopeKey);
+    state.createScope(parentScopeKey, VariableState.NO_PARENT, false);
+    state.createScope(childScopeKey, parentScopeKey, false);
     final var variableSource =
         isApiSource ? VariableSourceRecord.api() : VariableSourceRecord.none();
     final var behavior = this.behavior.withVariableSource(variableSource);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ParentScopeKeyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/ParentScopeKeyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import org.agrona.ExpandableArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+final class ParentScopeKeyTest {
+
+  @Test
+  void shouldReadScopeWrittenWithoutEmptyFlagAsNotEmpty() {
+    // given a record as written before the empty flag existed, e.g. from an older snapshot
+    final var legacy = new LegacyParentScopeKey();
+    legacy.keyProp.setValue(1234L);
+    final var buffer = new ExpandableArrayBuffer();
+    final int length = legacy.write(buffer, 0);
+
+    // when
+    final var scope = new ParentScopeKey();
+    scope.wrap(buffer, 0, length);
+
+    // then the scope must be treated as possibly holding variables
+    assertThat(scope.get()).isEqualTo(1234L);
+    assertThat(scope.isEmpty()).isFalse();
+  }
+
+  private static final class LegacyParentScopeKey extends UnpackedObject {
+    private final LongProperty keyProp = new LongProperty("parentScopeKey", -1L);
+
+    LegacyParentScopeKey() {
+      super(1);
+      declareProperty(keyProp);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
@@ -536,6 +536,24 @@ public final class VariableStateTest {
     assertThat(variableState.getParentScopeKey(child)).isEqualTo(parent);
   }
 
+  @Test
+  public void shouldGetVariableFromParentScopeThatWasNotCreatedYet() {
+    // given
+    setVariableLocal(parent, wrapString("a"), asMsgPack("1"));
+    variableState.createScope(child, parent, false);
+
+    try {
+      // when
+      final DirectBuffer variable = variableState.getVariable(child, wrapString("a"));
+
+      // then
+      assertEquality(variable, "1");
+    } finally {
+      variableState.removeScope(child);
+      variableState.removeScope(parent);
+    }
+  }
+
   private void declareScope(final long key) {
     declareScope(-1, key);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/variable/VariableStateTest.java
@@ -479,20 +479,83 @@ public final class VariableStateTest {
             tuple(keyVariableC, child, wrapString("c"), wrapString("3")));
   }
 
+  @Test
+  public void shouldCollectVariablesSetAfterRemovingAllVariablesOfScope() {
+    // given
+    declareScope(parent);
+    declareScope(parent, child);
+
+    setVariableLocal(child, wrapString("a"), asMsgPack("1"));
+    variableState.removeAllVariables(child);
+
+    // when
+    setVariableLocal(child, wrapString("b"), asMsgPack("2"));
+
+    // then
+    assertEquality(variableState.getVariablesAsDocument(child), "{'b': 2}");
+    assertEquality(variableState.getVariablesLocalAsDocument(child), "{'b': 2}");
+    assertEquality(variableState.getVariable(child, wrapString("b")), "2");
+  }
+
+  @Test
+  public void shouldCollectVariablesFromGrandparentWhenIntermediateScopesAreEmpty() {
+    // given
+    final long grandparent = parent;
+    final long parent = child;
+    final long child = child2;
+    declareScope(grandparent);
+    declareScope(grandparent, parent);
+    declareScope(parent, child);
+
+    setVariableLocal(grandparent, wrapString("a"), asMsgPack("1"));
+
+    // when
+    final DirectBuffer variablesDocument = variableState.getVariablesAsDocument(child);
+
+    // then
+    assertEquality(variablesDocument, "{'a': 1}");
+    assertEquality(variableState.getVariable(child, wrapString("a")), "1");
+  }
+
+  @Test
+  public void shouldCollectVariablesSetBeforeTheScopeWasCreated() {
+    // given - the create-instance payload, modification variable instructions and call activity
+    // propagation all write variables before the element instance of that scope exists
+    declareScope(parent);
+    setVariableLocal(parent, wrapString("a"), asMsgPack("1"));
+    setVariableLocal(child, wrapString("b"), asMsgPack("2"));
+
+    // when the scope is created with the flag the activating record carries
+    declareScope(parent, child, true);
+
+    // then
+    assertEquality(variableState.getVariablesLocalAsDocument(child), "{'b': 2}");
+    assertEquality(variableState.getVariablesAsDocument(child), "{'a': 1, 'b': 2}");
+    assertEquality(variableState.getVariable(child, wrapString("b")), "2");
+    assertEquality(variableState.getVariable(child, wrapString("a")), "1");
+    assertThat(variableState.getParentScopeKey(child)).isEqualTo(parent);
+  }
+
   private void declareScope(final long key) {
     declareScope(-1, key);
   }
 
   private void declareScope(final long parentKey, final long key) {
+    declareScope(parentKey, key, false);
+  }
+
+  private void declareScope(final long parentKey, final long key, final boolean hasVariables) {
     final ElementInstance parent = elementInstanceState.getInstance(parentKey);
 
-    final TypedRecord<ProcessInstanceRecord> record = mockTypedRecord(key, parentKey);
+    final TypedRecord<ProcessInstanceRecord> record = mockTypedRecord(key, parentKey, hasVariables);
     elementInstanceState.newInstance(
         parent, key, record.getValue(), ProcessInstanceIntent.ELEMENT_ACTIVATING);
   }
 
-  private TypedRecord<ProcessInstanceRecord> mockTypedRecord(final long key, final long parentKey) {
-    final ProcessInstanceRecord processInstanceRecord = createProcessInstanceRecord(parentKey);
+  private TypedRecord<ProcessInstanceRecord> mockTypedRecord(
+      final long key, final long parentKey, final boolean hasVariables) {
+    final ProcessInstanceRecord processInstanceRecord =
+        createProcessInstanceRecord(parentKey, hasVariables);
 
     final TypedRecord<ProcessInstanceRecord> typedRecord = mock(TypedRecord.class);
     when(typedRecord.getKey()).thenReturn(key);
@@ -501,8 +564,10 @@ public final class VariableStateTest {
     return typedRecord;
   }
 
-  private ProcessInstanceRecord createProcessInstanceRecord(final long parentKey) {
+  private ProcessInstanceRecord createProcessInstanceRecord(
+      final long parentKey, final boolean hasVariables) {
     final ProcessInstanceRecord processInstanceRecord = new ProcessInstanceRecord();
+    processInstanceRecord.setHasVariables(hasVariables);
 
     if (parentKey >= 0) {
       processInstanceRecord.setFlowScopeKey(parentKey);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -61,6 +62,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   public static final StringValue RESUME_FROM_JOB_KEY_KEY = new StringValue("resumeFromJobKey");
+  public static final StringValue HAS_VARIABLES_KEY = new StringValue("hasVars");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -106,8 +108,15 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   private final LongProperty resumeFromJobKeyProp = new LongProperty(RESUME_FROM_JOB_KEY_KEY, -1L);
 
+  /**
+   * Whether variables have already been written for this element instance's scope before the scope
+   * itself is created. Engine-internal: it lets the ELEMENT_ACTIVATING applier create the scope
+   * with the right "has local variables" state instead of looking it up.
+   */
+  private final BooleanProperty hasVariablesProp = new BooleanProperty(HAS_VARIABLES_KEY, false);
+
   public ProcessInstanceRecord() {
-    super(19);
+    super(20);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -126,7 +135,8 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
-        .declareProperty(resumeFromJobKeyProp);
+        .declareProperty(resumeFromJobKeyProp)
+        .declareProperty(hasVariablesProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -145,6 +155,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     businessIdProp.setValue(record.getBusinessId());
     resumeFromJobKeyProp.setValue(record.getResumeFromJobKey());
+    hasVariablesProp.setValue(record.hasVariables());
+  }
+
+  public boolean hasVariables() {
+    return hasVariablesProp.getValue();
+  }
+
+  public ProcessInstanceRecord setHasVariables(final boolean hasVariables) {
+    hasVariablesProp.setValue(hasVariables);
+    return this;
   }
 
   @JsonIgnore


### PR DESCRIPTION

## Description

Reading variables walks the scope chain and issues a prefix seek on the VARIABLES column family for every scope on the way up. Each seek allocates a fresh RocksIterator off the transaction (WriteBatchWithIndex iterator + DB iterator merge + superversion ref) and crosses JNI. In a simple 1 job process, most scopes  hold no variables of their own, so 91.5% of those seeks found nothing: 13.3k seeks/s against 1.1k seek-hits/s, which is 367 ms/s of cluster-wide RocksDB time and 58% of the read cost in the processing hot path.

Adding a property `empty` in the scope allows us to avoid creating an iterator when the scope is empty.
However, we don't know if a scope has any variable associated to it beforehand, we only know when we create the first variable. That forces us to perform an additional write when the scope is not empty. 

We could have created a new column family but then we would trade a write for a get and backward compatibility would be complex.



## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

