### PR TITLE
fix: fall back to legacy timeouts when unified values are unset

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -344,13 +344,18 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.dateFormat = dateFormat;
   }
 
+  /**
+   * See {@link #getMaxConnections()} for why this is resolved as {@code SUPPORTED}. The field is
+   * unset by default, so comparing a legacy timeout against the unified {@code null} would fail
+   * startup.
+   */
   public Duration getSocketTimeout() {
     final var socketTimeout =
         UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix() + ".socket-timeout",
             this.socketTimeout != null ? Math.toIntExact(this.socketTimeout.toMillis()) : null,
             Integer.class,
-            BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+            BackwardsCompatibilityMode.SUPPORTED,
             legacySocketTimeoutProperties());
     return socketTimeout != null ? Duration.ofMillis(socketTimeout) : null;
   }
@@ -359,13 +364,18 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     this.socketTimeout = socketTimeout;
   }
 
+  /**
+   * See {@link #getMaxConnections()} for why this is resolved as {@code SUPPORTED}. The field is
+   * unset by default, so comparing a legacy timeout against the unified {@code null} would fail
+   * startup.
+   */
   public Duration getConnectionTimeout() {
     final var connectionTimeoutInt =
         UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix() + ".connection-timeout",
             connectionTimeout != null ? Math.toIntExact(connectionTimeout.toMillis()) : null,
             Integer.class,
-            BackwardsCompatibilityMode.SUPPORTED_ONLY_IF_VALUES_MATCH,
+            BackwardsCompatibilityMode.SUPPORTED,
             legacyConnectionTimeoutProperties());
     return connectionTimeoutInt != null ? Duration.ofMillis(connectionTimeoutInt) : null;
   }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -849,6 +849,61 @@ public class SecondaryStorageElasticsearchTest {
   @Nested
   @TestPropertySource(
       properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.secondary-storage.elasticsearch.url=http://expected-url:4321",
+        "camunda.database.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.tasklist.elasticsearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.operate.elasticsearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "zeebe.broker.exporters.camundaexporter.class-name=io.camunda.exporter.CamundaExporter",
+        "zeebe.broker.exporters.camundaexporter.args.connect.socketTimeout="
+            + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.database.connectionTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.tasklist.elasticsearch.connectionTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.operate.elasticsearch.connectionTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "zeebe.broker.exporters.camundaexporter.args.connect.connectionTimeout="
+            + EXPECTED_CONNECTION_TIMEOUT,
+      })
+  class WithOnlyLegacyTimeoutsSet {
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithOnlyLegacyTimeoutsSet(
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void shouldFallBackToTheLegacyTimeoutsForTheCamundaExporter() {
+      // given
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      // when
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+
+      // then
+      assertThat(exporterConfiguration.getConnect())
+          .returns(EXPECTED_SOCKET_TIMEOUT, ConnectConfiguration::getSocketTimeout)
+          .returns(EXPECTED_CONNECTION_TIMEOUT, ConnectConfiguration::getConnectTimeout);
+    }
+
+    @Test
+    void shouldFallBackToTheLegacyTimeoutsForTheSearchEngineConnectProperties() {
+      // then
+      assertThat(searchEngineConnectProperties)
+          .returns(EXPECTED_SOCKET_TIMEOUT, SearchEngineConnectProperties::getSocketTimeout)
+          .returns(EXPECTED_CONNECTION_TIMEOUT, SearchEngineConnectProperties::getConnectTimeout);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
         "camunda.data.secondary-storage.autoconfigure-camunda-exporter=false",
         "camunda.data.secondary-storage.elasticsearch.url=http://unwanted-url:4321",
       })

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -443,6 +443,61 @@ public class SecondaryStorageOpensearchTest {
   @Nested
   @TestPropertySource(
       properties = {
+        "camunda.data.secondary-storage.type=opensearch",
+        "camunda.data.secondary-storage.opensearch.url=http://expected-url:4321",
+        "camunda.database.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.tasklist.opensearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.operate.opensearch.socketTimeout=" + EXPECTED_SOCKET_TIMEOUT,
+        "zeebe.broker.exporters.camundaexporter.class-name=io.camunda.exporter.CamundaExporter",
+        "zeebe.broker.exporters.camundaexporter.args.connect.socketTimeout="
+            + EXPECTED_SOCKET_TIMEOUT,
+        "camunda.database.connectionTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.tasklist.opensearch.connectionTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "camunda.operate.opensearch.connectionTimeout=" + EXPECTED_CONNECTION_TIMEOUT,
+        "zeebe.broker.exporters.camundaexporter.args.connect.connectionTimeout="
+            + EXPECTED_CONNECTION_TIMEOUT,
+      })
+  class WithOnlyLegacyTimeoutsSet {
+    final BrokerBasedProperties brokerBasedProperties;
+    final SearchEngineConnectProperties searchEngineConnectProperties;
+
+    WithOnlyLegacyTimeoutsSet(
+        @Autowired final BrokerBasedProperties brokerBasedProperties,
+        @Autowired final SearchEngineConnectProperties searchEngineConnectProperties) {
+      this.brokerBasedProperties = brokerBasedProperties;
+      this.searchEngineConnectProperties = searchEngineConnectProperties;
+    }
+
+    @Test
+    void shouldFallBackToTheLegacyTimeoutsForTheCamundaExporter() {
+      // given
+      final ExporterCfg camundaExporter = brokerBasedProperties.getCamundaExporter();
+      assertThat(camundaExporter).isNotNull();
+      final Map<String, Object> args = camundaExporter.getArgs();
+      assertThat(args).isNotNull();
+
+      // when
+      final ExporterConfiguration exporterConfiguration =
+          UnifiedConfigurationHelper.argsToCamundaExporterConfiguration(args);
+
+      // then
+      assertThat(exporterConfiguration.getConnect())
+          .returns(EXPECTED_SOCKET_TIMEOUT, ConnectConfiguration::getSocketTimeout)
+          .returns(EXPECTED_CONNECTION_TIMEOUT, ConnectConfiguration::getConnectTimeout);
+    }
+
+    @Test
+    void shouldFallBackToTheLegacyTimeoutsForTheSearchEngineConnectProperties() {
+      // then
+      assertThat(searchEngineConnectProperties)
+          .returns(EXPECTED_SOCKET_TIMEOUT, SearchEngineConnectProperties::getSocketTimeout)
+          .returns(EXPECTED_CONNECTION_TIMEOUT, SearchEngineConnectProperties::getConnectTimeout);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
         // type
         "camunda.data.secondary-storage.type=opensearch",
         "camunda.database.type=opensearch",


### PR DESCRIPTION
## Description

When only the legacy `socketTimeout` / `connectionTimeout` properties are set, unified configuration treated the unset unified values (`null`) as a conflict and aborted broker startup with `UnifiedConfigurationException: Ambiguous configuration`.

`getSocketTimeout()` and `getConnectionTimeout()` now use `BackwardsCompatibilityMode.SUPPORTED`, matching `getMaxConnections()`, so an unset unified property falls back to the legacy timeout instead of failing `BrokerBasedProperties`.

Tests cover Elasticsearch and OpenSearch when only the legacy timeouts are set.

## Checklist

- [ ] Enable backports when necessary (see [backporting](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #61202