### PR TITLE
Accept agent instance update with a superseded job lease

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior.LeaseMismatchHandling;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -105,7 +106,7 @@ public final class AgentHistoryCreateProcessor
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
             List.of(commandValue),
-            true);
+            LeaseMismatchHandling.REJECT);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -104,7 +104,8 @@ public final class AgentHistoryCreateProcessor
             commandValue.getJobKey(),
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
-            List.of(commandValue));
+            List.of(commandValue),
+            true);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -88,6 +88,24 @@ public final class AgentHistoryBatchBehavior {
   }
 
   /**
+   * Whether {@link #validateJobContext} rejects a command whose {@code jobLease} does not match the
+   * job's current lease, or accepts it as stale.
+   */
+  public enum LeaseMismatchHandling {
+    /**
+     * Reject on a lease mismatch. For callers whose effects apply immediately and can't be deferred
+     * to a later commit step (e.g. {@code AGENT_INSTANCE:CREATE}, which applies a CONFIGURATION
+     * item's changes and commits it right away).
+     */
+    REJECT,
+    /**
+     * Accept a stale lease. For callers that store the batch as PENDING under its own lease —
+     * resolved later by the commit/discard machinery.
+     */
+    ALLOW_STALE
+  }
+
+  /**
    * Validates the job context a command carries. {@code jobKey} may be omitted only when no history
    * batch is present; once a batch is attached to the command, {@code jobKey} becomes required — a
    * batch must always be attributed to the active job that produced it. When a job is supplied
@@ -95,10 +113,8 @@ public final class AgentHistoryBatchBehavior {
    * {@code elementInstanceKey}.
    *
    * <p>{@code jobLease} is a fencing token, not an authorization check (see ADR 0005-810): whether
-   * a mismatch is fatal depends on {@code rejectOnLeaseMismatch}. Callers that persist the batch
-   * directly against the current lease (e.g. standalone {@code AGENT_HISTORY:CREATE}) must reject
-   * on mismatch. Callers that instead store the batch as PENDING under its own lease — resolved
-   * later by the commit/discard machinery — may pass {@code false} to accept a stale lease.
+   * a mismatch is fatal depends on {@code leaseMismatchHandling}, see {@link
+   * LeaseMismatchHandling}.
    *
    * @return the active {@link JobRecord} if a job was supplied and is valid, {@code null} wrapped
    *     in {@link Either#right} if no job was supplied and none was required, otherwise the {@link
@@ -109,7 +125,7 @@ public final class AgentHistoryBatchBehavior {
       final String jobLease,
       final long elementInstanceKey,
       final List<? extends AgentHistoryRecordValue> history,
-      final boolean rejectOnLeaseMismatch) {
+      final LeaseMismatchHandling leaseMismatchHandling) {
 
     if (jobKey == -1L) {
       if (history != null && !history.isEmpty()) {
@@ -127,7 +143,7 @@ public final class AgentHistoryBatchBehavior {
     }
 
     final var job = jobState.getJob(jobKey);
-    if (rejectOnLeaseMismatch
+    if (leaseMismatchHandling == LeaseMismatchHandling.REJECT
         && job.hasLeaseToken()
         && !Objects.equals(jobLease, job.getLeaseToken())) {
       return Either.left(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentHistoryBatchBehavior.java
@@ -91,8 +91,14 @@ public final class AgentHistoryBatchBehavior {
    * Validates the job context a command carries. {@code jobKey} may be omitted only when no history
    * batch is present; once a batch is attached to the command, {@code jobKey} becomes required — a
    * batch must always be attributed to the active job that produced it. When a job is supplied
-   * (with or without a batch), it must refer to a currently-active job, that job's lease token (if
-   * any) must match {@code jobLease}, and the job must belong to {@code elementInstanceKey}.
+   * (with or without a batch), it must refer to a currently-active job, and the job must belong to
+   * {@code elementInstanceKey}.
+   *
+   * <p>{@code jobLease} is a fencing token, not an authorization check (see ADR 0005-810): whether
+   * a mismatch is fatal depends on {@code rejectOnLeaseMismatch}. Callers that persist the batch
+   * directly against the current lease (e.g. standalone {@code AGENT_HISTORY:CREATE}) must reject
+   * on mismatch. Callers that instead store the batch as PENDING under its own lease — resolved
+   * later by the commit/discard machinery — may pass {@code false} to accept a stale lease.
    *
    * @return the active {@link JobRecord} if a job was supplied and is valid, {@code null} wrapped
    *     in {@link Either#right} if no job was supplied and none was required, otherwise the {@link
@@ -102,7 +108,8 @@ public final class AgentHistoryBatchBehavior {
       final long jobKey,
       final String jobLease,
       final long elementInstanceKey,
-      final List<? extends AgentHistoryRecordValue> history) {
+      final List<? extends AgentHistoryRecordValue> history,
+      final boolean rejectOnLeaseMismatch) {
 
     if (jobKey == -1L) {
       if (history != null && !history.isEmpty()) {
@@ -120,7 +127,9 @@ public final class AgentHistoryBatchBehavior {
     }
 
     final var job = jobState.getJob(jobKey);
-    if (job.hasLeaseToken() && !Objects.equals(jobLease, job.getLeaseToken())) {
+    if (rejectOnLeaseMismatch
+        && job.hasLeaseToken()
+        && !Objects.equals(jobLease, job.getLeaseToken())) {
       return Either.left(
           new Rejection(RejectionType.NOT_FOUND, ERROR_MSG_JOB_LEASE_MISMATCH.formatted(jobKey)));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior.LeaseMismatchHandling;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -174,7 +175,7 @@ public final class AgentInstanceCreateProcessor
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
             commandValue.getHistory(),
-            true);
+            LeaseMismatchHandling.REJECT);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -173,7 +173,8 @@ public final class AgentInstanceCreateProcessor
             commandValue.getJobKey(),
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
-            commandValue.getHistory());
+            commandValue.getHistory(),
+            true);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior.LeaseMismatchHandling;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
@@ -221,7 +222,7 @@ public final class AgentInstanceUpdateProcessor
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
             commandValue.getHistory(),
-            false);
+            LeaseMismatchHandling.ALLOW_STALE);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -220,7 +220,8 @@ public final class AgentInstanceUpdateProcessor
             commandValue.getJobKey(),
             commandValue.getJobLease(),
             commandValue.getElementInstanceKey(),
-            commandValue.getHistory());
+            commandValue.getHistory(),
+            false);
     if (validJob.isLeft()) {
       final var rejection = validJob.getLeft();
       writeRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -559,6 +559,83 @@ public class AgentHistoryCommitTest {
         .isEqualTo(2);
   }
 
+  @Test
+  public void shouldNotApplyConfigurationChangeFromDiscardedItemAfterJobCompletion() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+
+    // Activation 1 (superseded): an AGENT_INSTANCE:UPDATE queues a CONFIGURATION item that
+    // changes model/provider, but the job fails before the item is ever committed.
+    final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var supersededConfigItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config-superseded")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
+    supersededConfigItem.setModel("gpt-4o-mini").setProvider("azure-openai");
+    supersededConfigItem.setChangedAttributes(List.of("model", "provider"));
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(job1.key())
+            .withJobLease(job1.leaseToken())
+            .withHistory(List.of(supersededConfigItem))
+            .update();
+    final long supersededItemKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withLeaseToken(job1.leaseToken())
+        .withRetries(1)
+        .fail();
+
+    // Activation 2 (winning): re-activate and complete the job, without queuing any further item.
+    final var job2 = activateJobForProcessInstanceWithLease(processInstanceKey);
+
+    // when — the job completes under the winning lease
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withLeaseToken(job2.leaseToken())
+        .complete();
+
+    // then — the superseded CONFIGURATION item is discarded, never committed
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(supersededItemKey)
+            .getFirst();
+    assertThat(discarded.getKey())
+        .as("the superseded activation's CONFIGURATION item should be discarded")
+        .isEqualTo(supersededItemKey);
+
+    // and — applyConfigurationChanges only runs for COMMITTED items, so the discarded item's
+    // model/provider change must never reach the live agent instance, even after its job
+    // completed and the discard was applied. The position check proves this is not a snapshot
+    // taken before the discard: without it, COMPLETED could simply have been written first.
+    final var agentInstanceCompleted =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+            .withAgentInstanceKey(agentInstanceKey)
+            .getFirst();
+    assertThat(discarded.getPosition())
+        .as("the discard must already be applied when the agent instance completes")
+        .isLessThan(agentInstanceCompleted.getPosition());
+    assertThat(agentInstanceCompleted.getValue().getDefinition().getModel())
+        .as("the discarded item's model change must never be applied to the live agent instance")
+        .isEqualTo("gpt-4o");
+    assertThat(agentInstanceCompleted.getValue().getDefinition().getProvider())
+        .as(
+            "the discarded item's provider change must never be applied to the live agent"
+                + " instance")
+        .isEqualTo("openai");
+  }
+
   // --- helpers ---
 
   private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -11,17 +11,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -417,6 +422,141 @@ public class AgentHistoryCommitTest {
                 .map(Record::getKey))
         .as("the superseded activation's history item should be discarded")
         .containsExactly(supersededItemKey);
+  }
+
+  @Test
+  public void shouldKeepBothLeasesMetricsAfterDiscardingSupersededItemOnJobCompletion() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+
+    // Activation 1 (superseded): an AGENT_INSTANCE:UPDATE accumulates its item's metrics onto the
+    // agent instance immediately, before the job later fails and is re-activated.
+    final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var supersededItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-superseded")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("first attempt"));
+    supersededItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
+    final var firstUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(job1.key())
+            .withJobLease(job1.leaseToken())
+            .withHistory(List.of(supersededItem))
+            .update();
+    final long supersededItemKey = firstUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withLeaseToken(job1.leaseToken())
+        .withRetries(1)
+        .fail();
+
+    // Activation 2 (winning): a second item's metrics are accumulated on top of the first's,
+    // then the job completes.
+    final var job2 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final var winningItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-winning")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("second attempt"));
+    winningItem.getMetrics().setInputTokens(50L).setOutputTokens(20L);
+    final var secondUpdate =
+        ENGINE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKey(job2.key())
+            .withJobLease(job2.leaseToken())
+            .withHistory(List.of(winningItem))
+            .update();
+    final long winningItemKey = secondUpdate.getValue().getHistory().get(0).getAgentHistoryKey();
+
+    // both items' deltas are already summed on the agent instance, before either item is
+    // committed or discarded: metrics apply at accept time, not at commit time.
+    assertThat(secondUpdate.getValue().getMetrics().getInputTokens())
+        .as("both activations' input tokens are summed on the agent instance")
+        .isEqualTo(100L + 50L);
+    assertThat(secondUpdate.getValue().getMetrics().getOutputTokens())
+        .as("both activations' output tokens are summed on the agent instance")
+        .isEqualTo(40L + 20L);
+    assertThat(secondUpdate.getValue().getMetrics().getModelCalls())
+        .as("both activations' model calls are counted on the agent instance")
+        .isEqualTo(2);
+
+    // when — the job completes under the winning lease
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withLeaseToken(job2.leaseToken())
+        .complete();
+
+    // JobCompleteProcessor emits AGENT_HISTORY:COMMIT; scope subsequent assertions to it.
+    final var firstCommitted =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withJobKey(job2.key())
+            .getFirst();
+    final long commitPosition = firstCommitted.getSourceRecordPosition();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.COMMITTED)
+                .filter(r -> r.getSourceRecordPosition() == commitPosition)
+                .map(Record::getKey))
+        .as("only the winning activation's history item should be committed")
+        .containsExactly(winningItemKey);
+    final var discarded =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .withIntent(AgentHistoryIntent.DISCARDED)
+            .filter(r -> r.getSourceRecordPosition() == commitPosition)
+            .getFirst();
+    assertThat(discarded.getKey())
+        .as("the superseded activation's history item should be discarded")
+        .isEqualTo(supersededItemKey);
+
+    // and — the agent instance completes right after (its only service task's job just
+    // completed), carrying the metrics it held at that point. The discard is confirmed to have
+    // already applied by then, so this is not a snapshot taken before the discard: if discarding
+    // the superseded item had subtracted the metrics it already contributed at accept time, this
+    // total would be missing them.
+    final var agentInstanceCompleted =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.COMPLETED)
+            .withAgentInstanceKey(agentInstanceKey)
+            .getFirst();
+    assertThat(discarded.getPosition())
+        .as("the discard must already be applied when the agent instance completes")
+        .isLessThan(agentInstanceCompleted.getPosition());
+    assertThat(agentInstanceCompleted.getValue().getMetrics().getInputTokens())
+        .as("the discarded item's input tokens are still included after the job completed")
+        .isEqualTo(100L + 50L);
+    assertThat(agentInstanceCompleted.getValue().getMetrics().getOutputTokens())
+        .as("the discarded item's output tokens are still included after the job completed")
+        .isEqualTo(40L + 20L);
+    assertThat(agentInstanceCompleted.getValue().getMetrics().getModelCalls())
+        .as("the discarded item's model call is still counted after the job completed")
+        .isEqualTo(2);
   }
 
   // --- helpers ---

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -536,7 +536,7 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
-  public void shouldRejectWhenJobLeaseMismatch() {
+  public void shouldAcceptUpdateWithSupersededJobLeaseAndAccumulateItsMetrics() {
     // given
     ENGINE
         .deployment()
@@ -564,42 +564,95 @@ public class AgentInstanceHistoryBatchProcessingTest {
             .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
             .create()
             .getKey();
+
+    final var batch1 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .withType(helper.getJobType())
             .getFirst()
             .getKey();
-    ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
+    final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
 
-    // when — carries no lease even though the job has one
-    final var rejection =
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(lease1)
+        .withRetries(1)
+        .fail();
+
+    final var batch2 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex2 = batch2.getValue().getJobKeys().indexOf(jobKey);
+    final var lease2 = batch2.getValue().getJobs().get(jobIndex2).getLeaseToken();
+    assertThat(lease2).as("re-activation must advance the lease token").isNotEqualTo(lease1);
+
+    final var assistantItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-stale-lease")
+            .setRole(AgentHistoryRole.ASSISTANT)
+            .setLoopIteration(1)
+            .addContent(
+                new AgentHistoryMessageContent()
+                    .setContentType(AgentHistoryContentType.TEXT)
+                    .setText("hi"));
+    assistantItem.getMetrics().setInputTokens(100L).setOutputTokens(40L);
+    assistantItem.addToolCall(
+        new AgentHistoryEmbeddedToolCall().setToolCallId("call-1").setToolName("lookup"));
+
+    final var configItem =
+        new AgentHistoryRecord()
+            .setHistoryItemId("item-config-stale-lease")
+            .setRole(AgentHistoryRole.CONFIGURATION)
+            .setLoopIteration(1);
+    configItem.setModel("gpt-4o-mini").setProvider("azure-openai");
+    configItem.setChangedAttributes(List.of("model", "provider"));
+
+    // when — the update is sent under lease1, which the job no longer holds
+    final var updated =
         ENGINE
             .agentInstances()
             .withAgentInstanceKey(agentInstanceKey)
             .withElementInstanceKey(elementInstanceKey)
             .withJobKey(jobKey)
-            .withHistory(
-                List.of(
-                    new AgentHistoryRecord()
-                        .setHistoryItemId("item-1")
-                        .setRole(AgentHistoryRole.USER)
-                        .setLoopIteration(1)
-                        .addContent(
-                            new AgentHistoryMessageContent()
-                                .setContentType(AgentHistoryContentType.TEXT)
-                                .setText("hi"))))
-            .expectRejection()
+            .withJobLease(lease1)
+            .withHistory(List.of(assistantItem, configItem))
             .update();
 
     // then
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
-    assertThat(rejection.getRejectionReason())
-        .isEqualTo(
-            "Expected to update agent instance related to job with key '"
-                + jobKey
-                + "', but job did not hold the supplied lease. The job may have been "
-                + "re-activated.");
+    assertThat(updated.getIntent()).isEqualTo(AgentInstanceIntent.UPDATED);
+    assertThat(updated.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+
+    // and — its metrics are accumulated immediately onto the live agent instance, regardless of
+    // which lease the item arrived under.
+    assertThat(updated.getValue().getMetrics().getInputTokens()).isEqualTo(100L);
+    assertThat(updated.getValue().getMetrics().getOutputTokens()).isEqualTo(40L);
+    assertThat(updated.getValue().getMetrics().getModelCalls()).isEqualTo(1);
+    assertThat(updated.getValue().getMetrics().getToolCalls()).isEqualTo(1);
+
+    // and — the CONFIGURATION item is queued, not applied.
+    assertThat(updated.getValue().getDefinition().getModel()).isEqualTo("gpt-4o");
+    assertThat(updated.getValue().getDefinition().getProvider()).isEqualTo("openai");
+    assertThat(updated.getValue().getChangedAttributes()).doesNotContain("model", "provider");
+
+    // and — the history item itself is only recorded PENDING under its own (stale) lease: it is
+    // not committed as part of this update, since committing is reserved for the job's current
+    // (winning) lease.
+    final var clockResetKey = ENGINE.clock().reset().getKey();
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.COMMITTED)
+                .filter(
+                    r ->
+                        ((AgentHistoryRecordValue) r.getValue())
+                            .getHistoryItemId()
+                            .equals("item-stale-lease"))
+                .exists())
+        .as("an item pending under a stale lease is never committed by that same update")
+        .isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceHistoryBatchProcessingTest.java
@@ -104,6 +104,85 @@ public class AgentInstanceHistoryBatchProcessingTest {
   }
 
   @Test
+  public void shouldRejectCreateWhenJobLeaseMismatch() {
+    // given — unlike UPDATE, CREATE applies a CONFIGURATION item's changes and commits history
+    // right away, with no later commit/discard step to catch a stale lease. So CREATE keeps
+    // rejecting a stale lease outright instead of accepting it as PENDING (see
+    // shouldAcceptUpdateWithSupersededJobLeaseAndAccumulateItsMetrics for the UPDATE behavior).
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    SERVICE_TASK_ID,
+                    t -> t.zeebeJobType(helper.getJobType()).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst()
+            .getKey();
+
+    final var batch1 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(helper.getJobType())
+            .getFirst()
+            .getKey();
+    final var jobIndex1 = batch1.getValue().getJobKeys().indexOf(jobKey);
+    final var lease1 = batch1.getValue().getJobs().get(jobIndex1).getLeaseToken();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(helper.getJobType())
+        .withLeaseToken(lease1)
+        .withRetries(1)
+        .fail();
+
+    final var batch2 = ENGINE.jobs().withType(helper.getJobType()).withLease().activate();
+    final var jobIndex2 = batch2.getValue().getJobKeys().indexOf(jobKey);
+    final var lease2 = batch2.getValue().getJobs().get(jobIndex2).getLeaseToken();
+    assertThat(lease2).as("re-activation must advance the lease token").isNotEqualTo(lease1);
+
+    // when — the create is sent under lease1, which the job no longer holds
+    final var rejection =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .withJobKey(jobKey)
+            .withJobLease(lease1)
+            .withHistory(
+                List.of(
+                    new AgentHistoryRecord()
+                        .setHistoryItemId("item-1")
+                        .setRole(AgentHistoryRole.USER)
+                        .setLoopIteration(1)
+                        .addContent(
+                            new AgentHistoryMessageContent()
+                                .setContentType(AgentHistoryContentType.TEXT)
+                                .setText("hi"))))
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to update agent instance related to job with key '%d', but job did not "
+                    .formatted(jobKey)
+                + "hold the supplied lease. The job may have been re-activated.");
+  }
+
+  @Test
   public void shouldRejectWholeBatchWhenAnItemIsMissingHistoryItemId() {
     // given
     ENGINE

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -420,7 +420,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentInstanceDefinitionResult'
         metrics:
-          description: Aggregated metrics across all loopIterations of this agent instance.
+          description: |
+            Aggregated metrics across all loopIterations of this agent instance. Includes
+            history items later discarded: metrics are counted when an item is accepted,
+            not when it's committed.
           allOf:
             - $ref: '#/components/schemas/AgentInstanceMetrics'
         limits:
@@ -997,7 +1000,12 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentHistoryItemKey'
         historyItemId:
-          description: The historyItemId of this history item.
+          description: |
+            The client-supplied identifier this item was created with. Empty for items that don't
+            carry one. Not unique: a job can be re-activated under a superseded lease any number
+            of times before it completes, so one historyItemId can have zero or more DISCARDED
+            records and at most one COMMITTED record, since only historyItemKey is guaranteed
+            unique. Filter by commitStatus rather than assuming one record per historyItemId.
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/HistoryItemId'
         agentInstanceKey:


### PR DESCRIPTION
## Description

An agent's history and metrics no longer disappear when its job fails and gets re-activated (moving to a new lease) while a history batch for the old activation is still in flight. Previously, `AGENT_INSTANCE:UPDATE` rejected that whole update outright, so the metrics it carried were never counted.

The lease mismatch alone is no longer a rejection reason: the update is accepted, its metrics are accumulated immediately onto the live agent instance, and its history item is stored `PENDING` under its own (stale) lease exactly as it already was before this PR. The existing commit/discard logic in `AgentHistoryCommitProcessor` resolves it later, the same way it already resolves a normal race between two activations. A `CONFIGURATION` item in the same update still only applies on commit, unchanged.

Only `AGENT_INSTANCE:UPDATE` changes. `AGENT_INSTANCE:CREATE` keeps rejecting on a lease mismatch, since it has no later commit step to resolve a stale lease against.

Stacked on #61765, which must land first, or a discarded item's metrics could be double-counted on resend.

Docs (`agent-instances.yaml`) are updated for two consequences of this: metrics now count at accept time regardless of whether the item is later committed or discarded, and the same `historyItemId` can now appear twice downstream for one logical item (`DISCARDED` once, `COMMITTED` once) — readers should filter on `commitStatus` rather than assume one record per id.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #60715
