### PR TITLE
test: prevent a leaked mock SecurityContext in test

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/OidcCamundaUserServiceTest.java
@@ -27,6 +27,7 @@ import io.camunda.service.TenantServices;
 import jakarta.json.Json;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -77,6 +78,15 @@ public class OidcCamundaUserServiceTest {
             tenantServices,
             authorizedClientRepository,
             null);
+  }
+
+  // SecurityContextHolder is a thread-local shared by every test in the surefire fork, and the
+  // contexts set here are Mockito mocks whose getAuthentication() is permanently stubbed. Leaving
+  // one behind makes a later test's SecurityContextHolder.getContext().setAuthentication(...) a
+  // silent no-op, so it authenticates as this class's token instead of its own.
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
   }
 
   @Test


### PR DESCRIPTION
`OidcCamundaUserServiceTest` left a Mockito mock SecurityContext in SecurityContextHolder's thread-local, so a later test's `getContext().setAuthentication(...)` was a silent no-op on that mock and the request kept this class's stubbed token. `SessionAuthenticationRefreshTest.shouldRefreshOnApiAfterInterval` then failed with 401 under the full module suite, 5/5, while passing in isolation.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #58300
