### PR TITLE
fix: bound usage-metric reads to the managed async-read executor [stable/8.8]

### DIFF
--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -60,12 +60,14 @@ public final class UsageMetricsServices
 
     final CompletableFuture<UsageMetricStatisticsEntity> statsFuture =
         CompletableFuture.supplyAsync(
-            () -> authUsageMetricsSearchClient.usageMetricStatistics(query));
+            () -> authUsageMetricsSearchClient.usageMetricStatistics(query),
+            executorProvider.getExecutor());
     final CompletableFuture<UsageMetricTUStatisticsEntity> tuStatsFuture =
         CompletableFuture.supplyAsync(
             () ->
                 authUsageMetricsSearchClient.usageMetricTUStatistics(
-                    mapToUsageMetricsTUQuery(query)));
+                    mapToUsageMetricsTUQuery(query)),
+            executorProvider.getExecutor());
 
     return SearchQueryResult.of(Tuple.of(statsFuture.join(), tuStatsFuture.join()));
   }

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -58,16 +58,16 @@ public final class UsageMetricsServices
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.system().readUsageMetric())));
 
+    final var executor = executorProvider.getExecutor();
     final CompletableFuture<UsageMetricStatisticsEntity> statsFuture =
         CompletableFuture.supplyAsync(
-            () -> authUsageMetricsSearchClient.usageMetricStatistics(query),
-            executorProvider.getExecutor());
+            () -> authUsageMetricsSearchClient.usageMetricStatistics(query), executor);
     final CompletableFuture<UsageMetricTUStatisticsEntity> tuStatsFuture =
         CompletableFuture.supplyAsync(
             () ->
                 authUsageMetricsSearchClient.usageMetricTUStatistics(
                     mapToUsageMetricsTUQuery(query)),
-            executorProvider.getExecutor());
+            executor);
 
     return SearchQueryResult.of(Tuple.of(statsFuture.join(), tuStatsFuture.join()));
   }

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -22,11 +22,19 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class UsageMetricsServiceTest {
 
+  private static final String READ_THREAD_NAME = "test-api-services-read";
+
+  private ExecutorService executor;
   private UsageMetricsServices services;
   private UsageMetricsSearchClient client;
 
@@ -34,14 +42,22 @@ public final class UsageMetricsServiceTest {
   public void before() {
     client = mock(UsageMetricsSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    executor = Executors.newFixedThreadPool(2, r -> new Thread(r, READ_THREAD_NAME));
+    final var executorProvider = mock(ApiServicesExecutorProvider.class);
+    when(executorProvider.getExecutor()).thenReturn(executor);
     services =
         new UsageMetricsServices(
             mock(BrokerClient.class),
             mock(SecurityContextProvider.class),
             client,
             null,
-            mock(ApiServicesExecutorProvider.class),
+            executorProvider,
             null);
+  }
+
+  @AfterEach
+  public void after() {
+    executor.shutdownNow();
   }
 
   @Test
@@ -52,13 +68,7 @@ public final class UsageMetricsServiceTest {
     when(client.usageMetricTUStatistics(any()))
         .thenReturn(new UsageMetricTUStatisticsEntity(16, null));
 
-    final var startTime =
-        OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
-    final var endTime = OffsetDateTime.of(2023, 1, 2, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
-    final UsageMetricsQuery searchQuery =
-        SearchQueryBuilders.usageMetricsSearchQuery()
-            .filter(new UsageMetricsFilter.Builder().startTime(startTime).endTime(endTime).build())
-            .build();
+    final UsageMetricsQuery searchQuery = usageMetricsQuery();
 
     // when
     final var searchQueryResult = services.search(searchQuery);
@@ -69,5 +79,38 @@ public final class UsageMetricsServiceTest {
             Tuple.of(
                 new UsageMetricStatisticsEntity(16, 14, 2, null),
                 new UsageMetricTUStatisticsEntity(16, null)));
+  }
+
+  @Test
+  public void shouldRunReadsOnTheManagedExecutor() {
+    // given
+    final Set<String> readThreadNames = ConcurrentHashMap.newKeySet();
+    when(client.usageMetricStatistics(any()))
+        .thenAnswer(
+            invocation -> {
+              readThreadNames.add(Thread.currentThread().getName());
+              return new UsageMetricStatisticsEntity(16, 14, 2, null);
+            });
+    when(client.usageMetricTUStatistics(any()))
+        .thenAnswer(
+            invocation -> {
+              readThreadNames.add(Thread.currentThread().getName());
+              return new UsageMetricTUStatisticsEntity(16, null);
+            });
+
+    // when
+    services.search(usageMetricsQuery());
+
+    // then
+    assertThat(readThreadNames).containsExactly(READ_THREAD_NAME);
+  }
+
+  private static UsageMetricsQuery usageMetricsQuery() {
+    final var startTime =
+        OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
+    final var endTime = OffsetDateTime.of(2023, 1, 2, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
+    return SearchQueryBuilders.usageMetricsSearchQuery()
+        .filter(new UsageMetricsFilter.Builder().startTime(startTime).endTime(endTime).build())
+        .build();
   }
 }

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -22,10 +22,9 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.time.OffsetDateTime;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,9 @@ public final class UsageMetricsServiceTest {
   public void before() {
     client = mock(UsageMetricsSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
-    executor = Executors.newFixedThreadPool(2, r -> new Thread(r, READ_THREAD_NAME));
+    executor =
+        Executors.newFixedThreadPool(
+            2, Thread.ofPlatform().name(READ_THREAD_NAME).daemon(true).factory());
     final var executorProvider = mock(ApiServicesExecutorProvider.class);
     when(executorProvider.getExecutor()).thenReturn(executor);
     services =
@@ -84,17 +85,18 @@ public final class UsageMetricsServiceTest {
   @Test
   public void shouldRunReadsOnTheManagedExecutor() {
     // given
-    final Set<String> readThreadNames = ConcurrentHashMap.newKeySet();
+    final var statsReadThread = new AtomicReference<String>();
+    final var tuStatsReadThread = new AtomicReference<String>();
     when(client.usageMetricStatistics(any()))
         .thenAnswer(
             invocation -> {
-              readThreadNames.add(Thread.currentThread().getName());
+              statsReadThread.set(Thread.currentThread().getName());
               return new UsageMetricStatisticsEntity(16, 14, 2, null);
             });
     when(client.usageMetricTUStatistics(any()))
         .thenAnswer(
             invocation -> {
-              readThreadNames.add(Thread.currentThread().getName());
+              tuStatsReadThread.set(Thread.currentThread().getName());
               return new UsageMetricTUStatisticsEntity(16, null);
             });
 
@@ -102,7 +104,8 @@ public final class UsageMetricsServiceTest {
     services.search(usageMetricsQuery());
 
     // then
-    assertThat(readThreadNames).containsExactly(READ_THREAD_NAME);
+    assertThat(statsReadThread).hasValue(READ_THREAD_NAME);
+    assertThat(tuStatsReadThread).hasValue(READ_THREAD_NAME);
   }
 
   private static UsageMetricsQuery usageMetricsQuery() {


### PR DESCRIPTION
## Problem

`UsageMetricsServices.search()` offloads its two reads (usage-metric statistics and TU statistics) with the single-argument `CompletableFuture.supplyAsync(Supplier)` overload, so both run on the JVM common `ForkJoinPool`. The injected `ApiServicesExecutorProvider` — the bounded pool used by every other `ApiServices` async read — was unused here.

The results are correct, so there is no functional impact. What is missing is the bounding and isolation the async-read pool provides: under load these reads compete with all other common-pool work in the JVM, and the pool's configured limit does not apply to them. The path runs on every usage-metrics query.

## Change

Both offloads now pass `executorProvider.getExecutor()`.

`UsageMetricsServiceTest` used a bare `ApiServicesExecutorProvider` mock whose `getExecutor()` returned `null`, so it now provides a named pool and exercises the real submit path. A new test asserts that both reads run on a thread from that pool, which is the property this fix is about.

## Related issues

relates to #55699
