### PR TITLE
docs: point secret cache size and eviction meters at the properties that tune them

### DIFF
--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetricsDoc.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/SecretCacheMetricsDoc.java
@@ -81,13 +81,14 @@ public enum SecretCacheMetricsDoc implements MeterDocumentation {
     public String getDescription() {
       return "Number of entries removed from a secret cache, per store and per cause. SIZE and "
           + "EXPIRED are what say the bound no longer fits the workload: sustained SIZE evictions "
-          + "mean the per-store maximum of "
+          + "mean the per-store maximum set by camunda.secrets.cache.max-size (default "
           + CaffeineSecretCache.DEFAULT_MAX_SIZE
-          + " entries is smaller than the working set, while a high EXPIRED rate together with a "
-          + "low hit rate means the "
+          + " entries) is smaller than the working set, while a high EXPIRED rate together with a "
+          + "low hit rate means the TTL set by camunda.secrets.cache.ttl (default "
           + CaffeineSecretCache.DEFAULT_TTL.toMinutes()
-          + "-minute TTL is shorter than the interval callers resolve at. Neither is configurable "
-          + "today, so both are worth reporting rather than tuning against. A forward jump of the "
+          + "m) is shorter than the interval callers resolve at. Both bounds are configurable and "
+          + "overridable per physical tenant, so a rate that stays high on either is a bound to "
+          + "raise rather than only a number to report. A forward jump of the "
           + "cluster clock is the one EXPIRED spike that means nothing: expiry follows that clock, "
           + "so time travel through /actuator/clock expires the whole cache at once. EXPLICIT "
           + "counts the invalidation the caching store performs when a store answers a secret "
@@ -117,15 +118,16 @@ public enum SecretCacheMetricsDoc implements MeterDocumentation {
   CACHE_SIZE {
     @Override
     public String getDescription() {
-      return "Estimated number of entries a secret cache currently holds, per store, out of a "
-          + "per-store maximum of "
+      return "Estimated number of entries a secret cache currently holds, per store, out of the "
+          + "per-store maximum set by camunda.secrets.cache.max-size (default "
           + CaffeineSecretCache.DEFAULT_MAX_SIZE
-          + " entries. Estimated because eviction is asynchronous, so the value can briefly sit "
-          + "above that maximum and can lag a removal: read it as a level to compare against it, "
-          + "not as an exact count. The maximum is fixed rather than configured, and is stated here "
-          + "because it is published on no meter of its own. Sitting at the maximum with a healthy "
-          + "hit rate is fine; sitting there while camunda.secret.cache.evictions with cause=SIZE "
-          + "keeps rising is the signal that the cache is too small.";
+          + " entries, overridable per physical tenant). Estimated because eviction is "
+          + "asynchronous, so the value can briefly sit above that maximum and can lag a removal: "
+          + "read it as a level to compare against it, not as an exact count. The default is "
+          + "stated here because the maximum is published on no meter of its own. Sitting at the "
+          + "maximum with a healthy hit rate is fine; sitting there while "
+          + "camunda.secret.cache.evictions with cause=SIZE keeps rising is the signal that the "
+          + "cache is too small.";
     }
 
     @Override

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMetricsDocTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/SecretCacheMetricsDocTest.java
@@ -99,15 +99,20 @@ final class SecretCacheMetricsDocTest {
   }
 
   @Test
-  void shouldStateTheBoundsTheCacheActuallyRunsWith() {
-    // given/when/then — neither bound is configurable, and neither is published on a meter of
-    // its own, so these descriptions are the only place an operator can read them. Asserting
-    // the live constants rather than literals keeps a changed default from making them lie
+  void shouldStateTheBoundsAndNameThePropertiesThatTuneThem() {
+    // given/when/then — neither bound is published on a meter of its own, so these descriptions
+    // are the only place an operator reads them, and both are configurable: without the property
+    // path, a reader watching a sustained SIZE or EXPIRED rate has nothing to act on. Asserting
+    // the live constants rather than literals keeps a changed default from making the stated
+    // values lie
     assertThat(SecretCacheMetricsDoc.CACHE_SIZE.getDescription())
-        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_MAX_SIZE));
+        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_MAX_SIZE))
+        .contains("camunda.secrets.cache.max-size");
     assertThat(SecretCacheMetricsDoc.CACHE_EVICTIONS.getDescription())
         .contains(String.valueOf(CaffeineSecretCache.DEFAULT_MAX_SIZE))
-        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_TTL.toMinutes()));
+        .contains(String.valueOf(CaffeineSecretCache.DEFAULT_TTL.toMinutes()))
+        .contains("camunda.secrets.cache.max-size")
+        .contains("camunda.secrets.cache.ttl");
   }
 
   @Test


### PR DESCRIPTION

## Description

Update stale javadoc in SecretCacheMetrics

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #61694

- [ ] This PR does not need a linked issue

