### PR TITLE
test: skip Process Instance Modification pending bug 61848

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -424,7 +424,8 @@ test.describe('Process Instance Modifications', () => {
       await expect(operateProcessInstancePage.addVariableButton).toBeHidden();
     });
 
-    test.describe('after adding a token to CollectMoney', () => {
+    // Skipped due to bug 61848: https://github.com/camunda/camunda/issues/61848
+    test.describe.skip('after adding a token to CollectMoney', () => {
       test.beforeEach(
         async ({
           page,


### PR DESCRIPTION
## Description

This PR skips Process Instance Modifications › Variables functionality in modification mode › after adding a token to CollectMoney test due to bug https://github.com/camunda/camunda/issues/61848

The whole `test.describe` is skipped as tests depend on each other.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

