### PR TITLE
ci: authenticate wretry's action clone to survive anonymous download limits

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -82,6 +82,25 @@ runs:
           docker context create zeebe-context
         fi
 
+    - name: Prepare wretry action-clone credential
+      # wretry does not reuse the runner's authenticated action download -- it fetches the wrapped
+      # action with its own `git clone`. For a public repo GitHub answers git's first probe with 200,
+      # so git is never challenged and credentials embedded in the clone URL are never sent: the
+      # clone is anonymous whatever `github_token` is passed, which is how GitHub's anonymous
+      # download limiting took out 33 CI jobs on 2026-09-03. An `http.<url>.extraheader` is sent
+      # unconditionally on the first request, so it is the only way to authenticate that clone.
+      # Handed to the wretry step through GIT_CONFIG_* rather than `git config --global` so it is
+      # scoped to that one step: nothing to clean up, and no global config to clobber.
+      id: wretry-clone-credential
+      shell: bash
+      env:
+        ACTION_CLONE_TOKEN: ${{ github.token }}
+      run: |
+        credential="$(printf 'x-access-token:%s' "$ACTION_CLONE_TOKEN" | base64 | tr -d '\n')"
+        # base64 of the token is a usable credential and does not match the raw secret, so Actions
+        # will not mask it on its own.
+        echo "::add-mask::$credential"
+        echo "header=AUTHORIZATION: basic $credential" >> "$GITHUB_OUTPUT"
     - name: Set up Docker Buildx
       # Wrapped in Wandalen/wretry.action: booting the builder pulls moby/buildkit from Docker Hub,
       # which answers 502 often enough to be the most frequent way an image build fails on healthy
@@ -94,6 +113,10 @@ runs:
       # docker/setup-buildx-action's action.yml has no `${{ }}` expressions of its own; re-check this
       # if that's still true when its pin next bumps.
       uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
+      env:
+        GIT_CONFIG_COUNT: '1'
+        GIT_CONFIG_KEY_0: http.https://github.com/.extraheader
+        GIT_CONFIG_VALUE_0: ${{ steps.wretry-clone-credential.outputs.header }}
       with:
         action: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         # wretry cannot inspect the wrapped action's error -- `retry_condition` only sees contexts
@@ -206,6 +229,9 @@ runs:
       env:
         DOCKER_BUILD_SUMMARY: false
         DOCKER_BUILD_RECORD_UPLOAD: false
+        GIT_CONFIG_COUNT: '1'
+        GIT_CONFIG_KEY_0: http.https://github.com/.extraheader
+        GIT_CONFIG_VALUE_0: ${{ steps.wretry-clone-credential.outputs.header }}
       with:
         action: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         # As above, wretry cannot classify the failure, so a broken Dockerfile or a 4xx from the

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -154,11 +154,34 @@ runs:
         secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token;
         secret/data/products/camunda/ci/harbor username | harbor-username;
         secret/data/products/camunda/ci/harbor password | harbor-password
+  - name: Prepare wretry action-clone credential
+    # wretry does not reuse the runner's authenticated action download -- it fetches the wrapped
+    # action with its own `git clone`. For a public repo GitHub answers git's first probe with 200,
+    # so git is never challenged and credentials embedded in the clone URL are never sent: the
+    # clone is anonymous whatever `github_token` is passed, which is how GitHub's anonymous
+    # download limiting took out 33 CI jobs on 2026-09-03. An `http.<url>.extraheader` is sent
+    # unconditionally on the first request, so it is the only way to authenticate that clone.
+    # Handed to the wretry step through GIT_CONFIG_* rather than `git config --global` so it is
+    # scoped to that one step: nothing to clean up, and no global config to clobber.
+    id: wretry-clone-credential
+    shell: bash
+    env:
+      ACTION_CLONE_TOKEN: ${{ github.token }}
+    run: |
+      credential="$(printf 'x-access-token:%s' "$ACTION_CLONE_TOKEN" | base64 | tr -d '\n')"
+      # base64 of the token is a usable credential and does not match the raw secret, so Actions
+      # will not mask it on its own.
+      echo "::add-mask::$credential"
+      echo "header=AUTHORIZATION: basic $credential" >> "$GITHUB_OUTPUT"
   - name: Setup Java
     # wretry retries setup-java through transient network/setup failures (INC-7417). Same pattern
     # as build-platform-docker; `_js_action` pin lets the *_context inputs be overridden.
     # `token` is passed explicitly since github_context is blanked (setup-java defaults it from it).
     uses: Wandalen/wretry.action@71a909ebf09f3ffdc6f42a17bd54ecb43481da49 # v3.8.0_js_action
+    env:
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: http.https://github.com/.extraheader
+      GIT_CONFIG_VALUE_0: ${{ steps.wretry-clone-credential.outputs.header }}
     with:
       action: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       attempt_limit: 3


### PR DESCRIPTION
## Description

A ~30 minute window of GitHub anonymous-download limiting on 2026-09-03 opened **33 CI incidents**
across `stable/8.7`, `8.8` and `8.10` (umbrella: INC-7723). All 120 failure lines came from one
place — the `git clone` that `Wandalen/wretry.action` runs to fetch the action it wraps:

```
fatal: remote error: GitHub is temporarily limiting some unauthenticated downloads
```

The non-obvious part: a `github_token` was **already** passed at all three call sites, and it never
mattered. For a public repo GitHub answers git's first unauthenticated `info/refs` probe with `200`,
so git is never challenged and credentials in the clone URL are never sent — a deliberately invalid
token still clones a public repo, and a curl trace shows no `Authorization` header at all. The clone
is anonymous whatever token you supply. It was also unretryable: wretry clones before `attempt_limit`
is read, so 63 of 65 jobs made exactly one attempt and died in ~1.2s despite `attempt_delay: 10000`.

**Fix:** give each wretry step an `http.https://github.com/.extraheader` via `GIT_CONFIG_*` in its
own `env:`. An extraheader *is* sent on the first request, so the clone is authenticated. Verified
against a private-repo oracle: clone succeeds with the env, fails without it, and no global git
config is written — so there is nothing to clean up and nothing to clobber. Basic is required;
Bearer is rejected.

Full root-cause trail, alternatives considered (removing the wrappers, other tokens, vendoring), and
why this is step-scoped rather than `git config --global` + cleanup are in the commit message.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

> Backport labels deliberately not added yet — needs a decision, because the two files differ in
> reach. `build-platform-docker`'s wrapper exists on **all** `stable/*` branches and buildx clones
> failed on 8.7/8.8/8.10, so that half is worth backporting everywhere. `setup-build`'s wrapper
> exists only on **8.10 and main**, so that hunk will conflict on 8.7/8.8/8.9. Per the
> [CI backport policy](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes) a
> reliability change *should* go to all `stable/*`.

## Related issues

- [x] This PR does not need a linked issue
