### PR TITLE
fix: commit a recovered joint configuration before leaving joint consensus

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -98,7 +98,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             this,
             this::isPausedForTransfer,
             this::initializing,
-            () -> configuring() || jointConsensus());
+            this::reconfigurationInProgress);
     pauseGuard =
         new LeadershipTransferPauseGuard(
             context,
@@ -106,7 +106,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             leadershipTransferRunner,
             this::isRunning,
             this::initializing,
-            () -> configuring() || jointConsensus());
+            this::reconfigurationInProgress);
   }
 
   @Override
@@ -125,20 +125,27 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     lastZbEntry = findLastZeebeEntry();
 
     if (jointConsensus() || forcedConfiguration()) {
-      // Come out of joint consensus or forced configuration
-      raft.getThreadContext()
-          .execute(
-              () -> {
-                if (!isRunning()) {
-                  // The role was stopped between scheduling and running this task, e.g. because
-                  // the server stepped down or shut down. Do not append as an ex-leader; the next
-                  // elected leader resumes the exit from joint consensus.
-                  return;
-                }
-                final var currentMembers = raft.getCluster().getConfiguration().newMembers();
-                ongoingReconfigurationRequestFuture = new CompletableFuture<>();
-                leaveJointConsensus(currentMembers, raft.getCluster().getConfiguration());
-              });
+      // Come out of joint consensus or forced configuration - but only once the no-op entry has
+      // committed, which commits the recovered configuration entry below it under that
+      // configuration's own quorum. That mirrors the normal path, where leaveJointConsensus runs
+      // from the commit of the joint entry it appended. Appending the final configuration any
+      // earlier would let it, and the joint entry with it, commit under the new members' quorum
+      // alone, dropping the old members' majority that joint consensus exists to keep. The same
+      // rule keeps onReconfigure from accepting changes while initializing().
+      commitInitialEntriesFuture.whenCompleteAsync(
+          (ignored, error) -> {
+            if (error != null || !isRunning()) {
+              // The no-op entry did not commit, or the role was stopped before it did, e.g.
+              // because the server stepped down or shut down. Do not append as an ex-leader; the
+              // next elected leader resumes the exit from joint consensus. commitInitialEntries
+              // steps down on its own when the commit fails, so there is nothing more to do here.
+              return;
+            }
+            final var currentMembers = raft.getCluster().getConfiguration().newMembers();
+            ongoingReconfigurationRequestFuture = new CompletableFuture<>();
+            leaveJointConsensus(currentMembers, raft.getCluster().getConfiguration());
+          },
+          raft.getThreadContext());
     }
 
     return super.start().thenRun(this::startTimers).thenApply(v -> this);
@@ -191,8 +198,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                   .build()));
     }
 
-    // If another configuration change is already under way, reject the configuration.
-    if (configuring() || jointConsensus()) {
+    // If another configuration change is already under way, reject the configuration. A forced
+    // configuration counts: its exit is queued behind the no-op commit, the same moment
+    // initializing() stops rejecting requests, so without this gate a request could race the
+    // queued exit for the single in-flight change.
+    if (reconfigurationInProgress()) {
       /*
        If the request is a duplicate, return the current future. This is essential for completing
        the join of a second member into a single-member cluster. During a join retry, if the
@@ -202,8 +212,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
        There is no future to return when the configuration change was not requested from this
        leader role: a leader that recovered a joint configuration resumes its exit from a task
-       queued in start(), and until that task runs there is nothing to hook onto. Reject the
-       request as retriable instead of returning null.
+       that start() runs once the no-op entry has committed, and until then there is nothing to
+       hook onto. Reject the request as retriable instead of returning null.
       */
       if (isDuplicateReconfigureRequest(request) && ongoingReconfigurationRequestFuture != null) {
         return ongoingReconfigurationRequestFuture;
@@ -707,6 +717,15 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   private boolean jointConsensus() {
     return raft.getCluster().inJointConsensus();
+  }
+
+  /**
+   * True while a configuration entry is appended but not yet committed, or while the current
+   * configuration still has to be followed by another one: the final configuration after a joint
+   * one, or the first regular configuration after a forced one.
+   */
+  private boolean reconfigurationInProgress() {
+    return configuring() || jointConsensus() || forcedConfiguration();
   }
 
   private boolean forcedConfiguration() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -121,6 +121,32 @@ final class ReconfigurationTest {
     return result;
   }
 
+  /**
+   * Drops entry-carrying append requests from {@code sender} to {@code receiver} while {@code
+   * enabled}. Heartbeats still pass, so the receiver keeps its leader and only the entries stay
+   * unacknowledged; the drop completes asynchronously so a failing append does not refuel the next
+   * one on the single raft thread.
+   */
+  private static void dropEntryAppendsTo(
+      final RaftServer sender, final MemberId receiver, final AtomicBoolean enabled) {
+    final var protocol = (TestRaftServerProtocol) sender.getContext().getProtocol();
+    protocol.interceptDelivery(
+        VersionedAppendRequest.class,
+        (target, request) -> {
+          final var result = new CompletableFuture<Void>();
+          CompletableFuture.runAsync(
+              () -> {
+                if (enabled.get() && target.equals(receiver) && !request.entries().isEmpty()) {
+                  result.completeExceptionally(new ConnectException("append dropped"));
+                } else {
+                  result.complete(null);
+                }
+              },
+              CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
+          return result;
+        });
+  }
+
   private RaftServer createServer(
       final Path dir, final ClusterMembershipService membershipService) {
     return createServer(dir, membershipService, config -> {});
@@ -518,6 +544,68 @@ final class ReconfigurationTest {
 
   @Nested
   final class Leaving {
+
+    /**
+     * Reproduces <a href="https://github.com/camunda/camunda/issues/60086">#60086</a>: a leader
+     * that recovers an uncommitted joint configuration must commit it before it appends the final
+     * configuration, as the normal reconfiguration path does. Appending the final configuration
+     * right away lets it, and the joint entry below it, commit under the new members' quorum alone.
+     * For a two-member cluster scaling down to one, that quorum is the leader by itself, so the
+     * leaving member's removal would commit without the leaving member having acknowledged
+     * anything.
+     */
+    @Test
+    void recoveredJointConfigurationCommitsBeforeTheFinalOne(@TempDir final Path tmp) {
+      // given - a two-member cluster in which m2 leaves, but appends to m2 are dropped so the joint
+      // configuration {1,2} -> {1} cannot commit. m2 still answers polls and votes, so m1 can be
+      // elected under the joint configuration.
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      CompletableFuture.allOf(m1.bootstrap(id1, id2), m2.bootstrap(id1, id2)).join();
+      awaitLeaderIsIn(servers, m1);
+
+      final var dropAppendsToM2 = new AtomicBoolean(true);
+      dropEntryAppendsTo(m1, id2, dropAppendsToM2);
+      m2.leave();
+      Awaitility.await("m1 appended the joint configuration")
+          .untilAsserted(
+              () ->
+                  assertThat(m1.getContext().getCluster().getConfiguration())
+                      .returns(true, Configuration::requiresJointConsensus));
+
+      // when - m1 restarts, recovers the joint configuration from its log and is elected again
+      m1.shutdown().join();
+      final var restartedM1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      dropEntryAppendsTo(restartedM1, id2, dropAppendsToM2);
+      final var m1Started = restartedM1.bootstrap(id1, id2);
+      awaitLeader(restartedM1);
+
+      // then - the final configuration is not appended while the joint one cannot commit
+      Awaitility.await("m1 stays in joint consensus while m2 cannot acknowledge the joint entry")
+          .during(Duration.ofSeconds(3))
+          .untilAsserted(
+              () ->
+                  assertThat(restartedM1.getContext().getCluster().getConfiguration())
+                      .returns(true, Configuration::requiresJointConsensus));
+
+      // and the leave completes once m2 acknowledges the joint configuration
+      dropAppendsToM2.set(false);
+      Awaitility.await("m1 left joint consensus with m2 removed")
+          .untilAsserted(
+              () -> {
+                final var configuration = restartedM1.getContext().getCluster().getConfiguration();
+                assertThat(configuration.requiresJointConsensus()).isFalse();
+                assertThat(configuration.newMembers())
+                    .extracting(RaftMember::memberId)
+                    .containsExactly(id1);
+                assertThat(restartedM1.getContext().getCommitIndex())
+                    .isGreaterThanOrEqualTo(configuration.index());
+              });
+      assertThat(m1Started).succeedsWithin(Duration.ofSeconds(10));
+    }
+
     @Test
     void followerCanLeaveCluster(@TempDir final Path tmp) {
       // given - a cluster with 3 members
@@ -1923,6 +2011,50 @@ final class ReconfigurationTest {
                     .describedAs("Member 1 has come out of force configuration")
                     .isFalse();
               });
+    }
+
+    /**
+     * The force-configure counterpart of {@code
+     * recoveredJointConfigurationCommitsBeforeTheFinalOne}: the leader elected under a forced
+     * configuration appends the first regular configuration only once its no-op entry has
+     * committed, like every other configuration change.
+     */
+    @Test
+    void leaderLeavesForcedConfigurationOnlyAfterItsNoOpEntryCommits() {
+      // given - the cluster is forced down to {1,2} with 3 and 4 gone, while entry-carrying
+      // appends between 1 and 2 are dropped. Either may become leader; heartbeats and votes pass.
+      m3.shutdown().join();
+      m4.shutdown().join();
+      final var dropEntryAppends = new AtomicBoolean(true);
+      dropEntryAppendsTo(m1, id2, dropEntryAppends);
+      dropEntryAppendsTo(m2, id1, dropEntryAppends);
+      m2.forceConfigure(newMembers()).join();
+
+      // when - a leader is elected under the forced configuration
+      final var leader = awaitLeader(m1, m2);
+      final var leaderServer = getLeaderServer(List.of(m1, m2)).orElseThrow();
+
+      // then - it stays in the forced configuration while the other member cannot acknowledge the
+      // no-op entry ...
+      Awaitility.await("the leader keeps the forced configuration while its no-op cannot commit")
+          .during(Duration.ofSeconds(2))
+          .untilAsserted(
+              () ->
+                  assertThat(leaderServer.getContext().getCluster().getConfiguration())
+                      .returns(true, Configuration::force));
+
+      // ... and leaves it once the no-op entry commits
+      dropEntryAppends.set(false);
+      Awaitility.await("the leader appends a regular configuration once the no-op committed")
+          .untilAsserted(
+              () -> {
+                final var configuration = leaderServer.getContext().getCluster().getConfiguration();
+                assertThat(configuration.force()).isFalse();
+                assertThat(configuration.allMembers())
+                    .extracting(RaftMember::memberId)
+                    .containsExactlyInAnyOrder(id1, id2);
+              });
+      assertThat(appendEntry(leader).commit()).succeedsWithin(Duration.ofSeconds(10));
     }
 
     private Map<MemberId, Type> newMembers() {


### PR DESCRIPTION
## Description

A leader that starts under a joint configuration - recovered from its log after a restart, or re-elected while one is pending - left joint consensus immediately: `LeaderRole.start()` appended the final configuration without waiting for anything. Configuration takes effect on append, so the leader's quorum became the new members' majority alone and the joint entry committed with it. For a two-member cluster scaling down to one, that quorum is the leader by itself, so the leaving member's removal committed without the leaving member having acknowledged anything.

The recovery path now waits for the leader's own no-op entry to commit before it leaves joint consensus. A leader cannot count replicas of an entry from an earlier term, and `LeaderAppender` only advances the commit index once it reaches the current term's no-op entry, so committing the no-op commits the recovered configuration entry under that configuration's own quorum. This mirrors the normal path, where `leaveJointConsensus` runs from the commit of the joint entry, and it is the rule `onReconfigure` already enforces with `initializing()`.

The alternative from the issue, rejecting multi-member reconfigurations so that old and new majorities always intersect, was not taken: it would make the shortcut safe by arithmetic instead of removing it. The commit message has the full reasoning.

## Testing

`ReconfigurationTest.Leaving#recoveredJointConfigurationCommitsBeforeTheFinalOne` drops append requests to the leaving member of a two-member cluster while it still answers polls and votes, restarts the leader under the resulting joint configuration, and asserts the leader stays in joint consensus until the leaving member acknowledges the joint entry. It fails on `main` and passes with the fix. `ReconfigurationTest`, the randomized Raft join, scale-down, and force-configure properties, and the full `zeebe/atomix/cluster` suite pass locally.

## Related issues

closes #60086
