### PR TITLE
fix: distinguish deleted process definitions in Operate

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.test.tsx
@@ -6,13 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen} from 'modules/testing-library';
+import {render, screen, within} from 'modules/testing-library';
 import {DiagramHeader} from '.';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {MemoryRouter} from 'react-router-dom';
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {searchResult} from 'modules/testUtils';
 import type {ProcessDefinitionSelection} from 'modules/hooks/processDefinitions';
+import {mockSearchProcessDefinitions} from 'modules/mocks/api/v2/processDefinitions/searchProcessDefinitions';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
@@ -46,6 +47,7 @@ const noMatchSelection: ProcessDefinitionSelection = {
 describe('DiagramHeader', () => {
   beforeEach(() => {
     mockSearchProcessInstances().withSuccess(searchResult([]));
+    mockSearchProcessDefinitions().withSuccess(searchResult([]));
   });
 
   it('should render header with full data', async () => {
@@ -94,6 +96,44 @@ describe('DiagramHeader', () => {
 
     expect(
       await screen.findByRole('button', {name: /delete process definition/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should identify a deleted definition and explain that deletion purges its history', async () => {
+    const {user} = render(
+      <DiagramHeader
+        processDefinitionSelection={{
+          ...singleVersionSelection,
+          definition: {
+            ...singleVersionSelection.definition,
+            state: 'DELETED',
+          },
+        }}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(await screen.findByTestId('deleted-tag')).toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /delete process definition/i,
+      }),
+    );
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Delete Process Definition',
+    });
+
+    expect(
+      within(dialog).getByText(
+        'This process definition is already deleted. Continuing will permanently remove its remaining history:',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(
+        'Yes, I confirm I want to permanently delete this process definition history.',
+      ),
     ).toBeInTheDocument();
   });
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/DiagramHeader/index.tsx
@@ -118,6 +118,7 @@ const ProcessOperationsContent: React.FC<
       processDefinitionKey={definitionKey}
       processName={name}
       processVersion={version}
+      processDefinitionState={definition.state}
     />
   );
 };

--- a/operate/client/src/App/Processes/ListView/Filters/ProcessField.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/ProcessField.tsx
@@ -64,8 +64,7 @@ const ProcessField: React.FC = observer(() => {
 
             return {
               id: definition.identifier,
-              label:
-                definition.state === 'DELETED' ? `${label} (Deleted)` : label,
+              label,
             };
           })}
           value={input.value}

--- a/operate/client/src/App/Processes/ListView/Filters/ProcessField.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/ProcessField.tsx
@@ -57,12 +57,15 @@ const ProcessField: React.FC = observer(() => {
             }
           }}
           items={definitions.map((definition) => {
+            const label =
+              isMultiTenancyEnabled && !specificTenantId
+                ? `${definition.label} - ${tenantsById[definition.tenantId]}`
+                : definition.label;
+
             return {
               id: definition.identifier,
               label:
-                isMultiTenancyEnabled && !specificTenantId
-                  ? `${definition.label} - ${tenantsById[definition.tenantId]}`
-                  : definition.label,
+                definition.state === 'DELETED' ? `${label} (Deleted)` : label,
             };
           })}
           value={input.value}

--- a/operate/client/src/App/Processes/ListView/Filters/ProcessVersionField.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/ProcessVersionField.tsx
@@ -34,6 +34,15 @@ const ProcessVersionField: React.FC = observer(() => {
   return (
     <Field name="processDefinitionVersion">
       {({input}) => {
+        const inputValue = input.value === 'all' ? 'all' : Number(input.value);
+        const selectedItem =
+          versions.find(({value}) => value === inputValue) ??
+          (input.value === ''
+            ? null
+            : {
+                value: inputValue,
+              });
+
         return (
           <Dropdown
             label="Select a Process Version"
@@ -41,15 +50,23 @@ const ProcessVersionField: React.FC = observer(() => {
             titleText="Version"
             id="processVersion"
             onChange={({selectedItem}) => {
-              input.onChange(selectedItem);
+              input.onChange(selectedItem?.value);
               form.change('elementId', undefined);
             }}
             disabled={isDisabled}
             items={versions}
-            itemToString={(item) =>
-              item === 'all' || item === null ? 'All versions' : item.toString()
-            }
-            selectedItem={input.value === 'all' ? 'all' : Number(input.value)}
+            itemToString={(item) => {
+              if (item === null) {
+                return '';
+              }
+              if (item.value === 'all') {
+                return 'All versions';
+              }
+              return item.state === 'DELETED'
+                ? `${item.value} (Deleted)`
+                : item.value.toString();
+            }}
+            selectedItem={selectedItem}
             size="sm"
           />
         );

--- a/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
@@ -73,6 +73,38 @@ describe('Filters', () => {
     );
   });
 
+  it('should mark deleted process definitions in the name filter', async () => {
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition(),
+        createProcessDefinition({
+          processDefinitionId: 'deletedProcess',
+          processDefinitionKey: 'deletedProcess1',
+          name: 'Deleted process',
+          state: 'DELETED',
+        }),
+      ]),
+    );
+
+    const {user} = render(<Filters />, {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('combobox', {
+          name: 'Name',
+        }),
+      ).toBeEnabled(),
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Name'}));
+
+    expect(
+      screen.getByRole('option', {name: 'Deleted process (Deleted)'}),
+    ).toBeInTheDocument();
+  });
+
   it.todo('should load values from the URL', async () => {
     const MOCK_PARAMS = {
       processDefinitionId: 'bigVarProcess',

--- a/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
@@ -73,14 +73,32 @@ describe('Filters', () => {
     );
   });
 
-  it('should mark deleted process definitions in the name filter', async () => {
+  it('should mark deleted process definitions in the version filter', async () => {
     mockSearchProcessDefinitions().withSuccess(
       searchResult([
-        createProcessDefinition(),
+        createProcessDefinition({
+          processDefinitionId: 'deletedProcess',
+          processDefinitionKey: 'deletedProcess2',
+          name: 'Deleted process',
+          version: 2,
+          state: 'DELETED',
+        }),
         createProcessDefinition({
           processDefinitionId: 'deletedProcess',
           processDefinitionKey: 'deletedProcess1',
           name: 'Deleted process',
+          version: 1,
+          state: 'ACTIVE',
+        }),
+      ]),
+    );
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({
+          processDefinitionId: 'deletedProcess',
+          processDefinitionKey: 'deletedProcess2',
+          name: 'Deleted process',
+          version: 2,
           state: 'DELETED',
         }),
       ]),
@@ -101,8 +119,23 @@ describe('Filters', () => {
     await user.click(screen.getByRole('combobox', {name: 'Name'}));
 
     expect(
-      screen.getByRole('option', {name: 'Deleted process (Deleted)'}),
+      screen.getByRole('option', {name: 'Deleted process'}),
     ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', {name: 'Deleted process'}));
+
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText('Version', {selector: 'button'}),
+      ).toHaveTextContent('2 (Deleted)'),
+    );
+
+    await user.click(screen.getByLabelText('Version', {selector: 'button'}));
+
+    expect(
+      screen.getByRole('option', {name: '2 (Deleted)'}),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: '1'})).toBeInTheDocument();
   });
 
   it.todo('should load values from the URL', async () => {

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.test.tsx
@@ -71,6 +71,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -138,6 +139,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -182,6 +184,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -226,6 +229,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -271,6 +275,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -313,6 +318,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -365,6 +371,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -411,6 +418,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -441,6 +449,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -476,6 +485,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -497,6 +507,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );
@@ -529,6 +540,7 @@ describe('<ProcessOperations />', () => {
         processDefinitionKey="2251799813687094"
         processName="myProcess"
         processVersion={2}
+        processDefinitionState="ACTIVE"
       />,
       {wrapper: Wrapper},
     );

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/index.tsx
@@ -9,7 +9,7 @@
 import {useState} from 'react';
 import {DangerButton} from 'modules/components/OperationItem/DangerButton';
 import {OperationItems} from 'modules/components/OperationItems';
-import {DeleteButtonContainer} from 'modules/components/DeleteDefinition/styled';
+import {DeleteButtonContainer} from './styled';
 import {InlineLoading, Link, ListItem, Stack} from '@carbon/react';
 import {DrainingTag} from 'modules/components/DrainingTag';
 import {DeleteDefinitionModal} from 'modules/components/DeleteDefinitionModal';
@@ -23,15 +23,23 @@ import {useRunningInstancesCount} from 'modules/queries/processInstance/useRunni
 import {useDeleteResource} from 'modules/mutations/resource/useDeleteResource';
 import {useDrainingProcessDefinitions} from 'modules/queries/processDefinitions/useDrainingProcessDefinitions';
 import {DRAINING_MESSAGES} from 'modules/utils/draining';
+import {DeletedTag} from 'modules/components/DeletedTag';
+import type {ProcessDefinition} from '@camunda/camunda-api-zod-schemas/8.10';
 
 type Props = {
   processDefinitionKey: string;
   processName: string;
   processVersion: number;
+  processDefinitionState: ProcessDefinition['state'];
 };
 
 const ProcessOperations: React.FC<Props> = observer(
-  ({processDefinitionKey, processName, processVersion}) => {
+  ({
+    processDefinitionKey,
+    processName,
+    processVersion,
+    processDefinitionState,
+  }) => {
     const [isDeleteModalVisible, setIsDeleteModalVisible] =
       useState<boolean>(false);
 
@@ -58,6 +66,7 @@ const ProcessOperations: React.FC<Props> = observer(
 
     const {data: draining} = useDrainingProcessDefinitions();
     const isDraining = !!draining?.byKey.has(processDefinitionKey);
+    const isDeleted = processDefinitionState === 'DELETED';
 
     const isOperationRunning = deleteResourceMutation.isPending;
 
@@ -73,37 +82,53 @@ const ProcessOperations: React.FC<Props> = observer(
               align="left-top"
             />
           ) : (
-            <OperationItems>
-              <DangerButton
-                title={
-                  (runningInstancesCount ?? 0) > 0
-                    ? 'Only process definitions without running instances can be deleted.'
-                    : `Delete Process Definition "${processName} - Version ${processVersion}"`
-                }
-                type="DELETE"
-                disabled={
-                  isOperationRunning || (runningInstancesCount ?? 0) !== 0
-                }
-                onClick={() => {
-                  tracking.track({
-                    eventName: 'definition-deletion-button',
-                    resource: 'process',
-                    version: processVersion.toString(),
-                  });
+            <>
+              {isDeleted && <DeletedTag align="left-top" />}
+              <OperationItems>
+                <DangerButton
+                  title={
+                    (runningInstancesCount ?? 0) > 0
+                      ? 'Only process definitions without running instances can be deleted.'
+                      : isDeleted
+                        ? `Delete Process Definition History "${processName} - Version ${processVersion}"`
+                        : `Delete Process Definition "${processName} - Version ${processVersion}"`
+                  }
+                  type="DELETE"
+                  disabled={
+                    isOperationRunning || (runningInstancesCount ?? 0) !== 0
+                  }
+                  onClick={() => {
+                    tracking.track({
+                      eventName: 'definition-deletion-button',
+                      resource: 'process',
+                      version: processVersion.toString(),
+                    });
 
-                  setIsDeleteModalVisible(true);
-                }}
-              />
-            </OperationItems>
+                    setIsDeleteModalVisible(true);
+                  }}
+                />
+              </OperationItems>
+            </>
           )}
         </DeleteButtonContainer>
         <DeleteDefinitionModal
           title="Delete Process Definition"
-          description="You are about to delete the following process definition:"
-          confirmationText="Yes, I confirm I want to delete this process definition."
+          description={
+            isDeleted
+              ? 'This process definition is already deleted. Continuing will permanently remove its remaining history:'
+              : 'You are about to delete the following process definition:'
+          }
+          confirmationText={
+            isDeleted
+              ? 'Yes, I confirm I want to permanently delete this process definition history.'
+              : 'Yes, I confirm I want to delete this process definition.'
+          }
           isVisible={isDeleteModalVisible}
-          warningTitle="Deleting a process definition will permanently remove it and will
-        impact the following:"
+          warningTitle={
+            isDeleted
+              ? 'Deleting the remaining process definition history is permanent and will impact the following:'
+              : 'Deleting a process definition will permanently remove it and will impact the following:'
+          }
           warningContent={
             <Stack gap={6}>
               <UnorderedList nested>

--- a/operate/client/src/App/Processes/ListView/ProcessOperations/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/ProcessOperations/styled.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {DeleteButtonContainer as BaseDeleteButtonContainer} from 'modules/components/DeleteDefinition/styled';
+import styled from 'styled-components';
+
+const DeleteButtonContainer = styled(BaseDeleteButtonContainer)`
+  gap: var(--cds-spacing-03);
+`;
+
+export {DeleteButtonContainer};

--- a/operate/client/src/modules/components/DeletedTag/index.test.tsx
+++ b/operate/client/src/modules/components/DeletedTag/index.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {DeletedTag} from './index';
+
+describe('<DeletedTag />', () => {
+  it('should render the deleted tag', () => {
+    render(<DeletedTag />);
+
+    expect(screen.getByTestId('deleted-tag')).toBeInTheDocument();
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+  });
+
+  it('should explain the deleted state on keyboard focus', async () => {
+    const {user} = render(<DeletedTag />);
+
+    await user.tab();
+
+    expect(screen.getByTestId('deleted-tag')).toHaveFocus();
+    expect(
+      await screen.findByText(
+        'This process definition has been deleted. Its record remains available until its history is permanently deleted.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/modules/components/DeletedTag/index.tsx
+++ b/operate/client/src/modules/components/DeletedTag/index.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Tag, Tooltip} from '@carbon/react';
+
+type Props = {
+  align?: React.ComponentProps<typeof Tooltip>['align'];
+};
+
+const DeletedTag: React.FC<Props> = ({align = 'top'}) => (
+  <Tooltip
+    label="This process definition has been deleted. Its record remains available until its history is permanently deleted."
+    align={align}
+    autoAlign
+  >
+    <Tag size="md" type="red" data-testid="deleted-tag" tabIndex={0}>
+      Deleted
+    </Tag>
+  </Tooltip>
+);
+
+export {DeletedTag};

--- a/operate/client/src/modules/hooks/processDefinitions.test.tsx
+++ b/operate/client/src/modules/hooks/processDefinitions.test.tsx
@@ -136,7 +136,12 @@ describe('useProcessDefinitionVersions', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual(['all', 3, 2, 1]);
+    expect(result.current.data).toEqual([
+      {value: 'all'},
+      {value: 3, state: 'ACTIVE'},
+      {value: 2, state: 'ACTIVE'},
+      {value: 1, state: 'ACTIVE'},
+    ]);
   });
 
   it('should return versions without "all" when only a single version exists', async () => {
@@ -149,7 +154,27 @@ describe('useProcessDefinitionVersions', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([1]);
+    expect(result.current.data).toEqual([{value: 1, state: 'ACTIVE'}]);
+  });
+
+  it('should preserve the state of each version', async () => {
+    mockSearchProcessDefinitions().withSuccess(
+      searchResult([
+        createProcessDefinition({version: 2, state: 'DELETED'}),
+        createProcessDefinition({version: 1, state: 'ACTIVE'}),
+      ]),
+    );
+
+    const {result} = renderHook(() => useProcessDefinitionVersions('someId'), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([
+      {value: 'all'},
+      {value: 2, state: 'DELETED'},
+      {value: 1, state: 'ACTIVE'},
+    ]);
   });
 
   it('should disable the query when no processDefinitionId is provided', () => {

--- a/operate/client/src/modules/hooks/processDefinitions.ts
+++ b/operate/client/src/modules/hooks/processDefinitions.ts
@@ -20,6 +20,11 @@ interface ProcessDefinitionWithIdentifier extends ProcessDefinition {
   label: string;
 }
 
+interface ProcessDefinitionVersionOption {
+  value: number | 'all';
+  state?: ProcessDefinition['state'];
+}
+
 type ProcessDefinitionSelection =
   | {kind: 'no-match'}
   | {kind: 'single-version'; definition: ProcessDefinition}
@@ -83,8 +88,15 @@ function useProcessDefinitionVersions(
       sort: [{field: 'version', order: 'desc'}],
     },
     select: (definitions) => {
-      const versions = definitions.map((definition) => definition.version);
-      return versions.length > 1 ? ['all', ...versions] : versions;
+      const versions: ProcessDefinitionVersionOption[] = definitions.map(
+        ({version, state}) => ({
+          value: version,
+          state,
+        }),
+      );
+      return versions.length > 1
+        ? [{value: 'all' as const}, ...versions]
+        : versions;
     },
   });
 }


### PR DESCRIPTION
## Description

Operate rendered process definitions retained for history cleanup like active
definitions because the Processes filter discarded their API state and the
selected-definition header did not receive it.

This change:

- marks deleted definitions in the Name filter
- shows a keyboard-accessible `Deleted` status tag in the process header
- keeps history cleanup available while clarifying the button and modal copy

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #61729

- [ ] This PR does not need a linked issue
