### PR TITLE
fix: align authorization filter with operations log

### DIFF
--- a/identity/client/src/pages/authorizations/ListV2.tsx
+++ b/identity/client/src/pages/authorizations/ListV2.tsx
@@ -56,7 +56,7 @@ const List: FC<ListProps> = ({
   const availableResourceTypes = isTenantsApiEnabled
     ? ALL_RESOURCE_TYPES
     : RESOURCE_TYPES_WITHOUT_TENANT;
-  const authorizationTypeOptions = useMemo(
+  const resourceTypeOptions = useMemo(
     () =>
       availableResourceTypes.map((resourceType) => ({
         label: t(resourceType),
@@ -146,14 +146,14 @@ const List: FC<ListProps> = ({
         sidebar={
           <Card>
             <CardHeader>
-              <CardTitle>{t("filters")}</CardTitle>
+              <CardTitle>{t("filter")}</CardTitle>
             </CardHeader>
             <CardContent className="flex flex-col gap-1.5">
-              <Label htmlFor={comboboxId}>{t("authorizationType")}</Label>
+              <Label htmlFor={comboboxId}>{t("resourceType")}</Label>
               <Combobox
                 id={comboboxId}
                 className="w-full"
-                options={authorizationTypeOptions}
+                options={resourceTypeOptions}
                 value={selectedResourceType}
                 onValueChange={(value) => {
                   if (!value) {

--- a/identity/client/src/utility/localization/en/authorizations.json
+++ b/identity/client/src/utility/localization/en/authorizations.json
@@ -11,7 +11,7 @@
   "authorizationDescription": "Authorizations define access permissions for different resources. Create an authorization by selecting an owner, resource, and at least one permission.",
   "resourceType": "Resource type",
   "authorizationType": "Authorization type",
-  "filters": "Filters",
+  "filter": "Filter",
   "authorizationLoadError": "The list of authorizations could not be loaded.",
   "authorizationCreated": "Authorization created",
   "authorizationCreatedSuccess": "You have successfully created the {{resourceType}} authorization",


### PR DESCRIPTION
## Description

@zsofiakm [noticed](https://camunda.slack.com/archives/C09BZKV8TG8/p1788429187185589?thread_ts=1788341305.607039&cid=C09BZKV8TG8) that the filter in the Authorization page has the wrong label. During the migration an incorrect aria-label form the tabs list was picked.

This PR fixes the label (and variable name), and aligns filter area heading with the Operations log page.


## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

relates #60636

