### PR TITLE
feat: add --no-browser flag to skip opening a browser on startup

### DIFF
--- a/c8run/README.md
+++ b/c8run/README.md
@@ -100,4 +100,4 @@ If you want to run your own connectors runtime, start C8Run with `./c8run start 
 
 ### Headless startup
 
-To start C8Run without opening a browser window (for example, in a headless dev environment or an autostart script), use `./c8run start --no-browser`.
+To start C8Run without opening a browser window (for example, in a headless dev environment or an autostart script), use `./c8run start --no-browser`. A headless start also leaves the quickstart marker untouched, so the next regular (non-headless) start still shows the quickstart URL instead of jumping straight to Operate.

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -97,3 +97,7 @@ The workflow produces platform-specific artifacts for Linux, macOS (ARM and Inte
 C8Run automatically starts the connectors runtime through Spring Boot's `PropertiesLauncher` for connector bundles versioned 8.9.0 or newer (including snapshots). Older bundles continue to run via the legacy `JarLauncher`, so you can switch versions in `.env` without extra configuration.
 
 If you want to run your own connectors runtime, start C8Run with `./c8run start --disable-connectors` to skip launching the bundled connectors jar.
+
+### Headless startup
+
+To start C8Run without opening a browser window (for example, in a headless dev environment or an autostart script), use `./c8run start --no-browser`.

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -75,12 +75,14 @@ Options:
   --extra-driver <path>     Copy a JDBC driver into the Camunda lib directory before startup (repeat per jar)
   --keystore <path>         Enable HTTPS with a TLS certificate (JKS format)
   --keystorePassword <pw>  Password for the provided keystore
+  --no-browser              Start Camunda 8 Run without opening a browser window
   --port <number>           Set the main Camunda port (default: 8080)
   --log-level <level>       Set log level (e.g., info, debug)
 
 Examples:
   %[1]s start
   %[1]s start --disable-connectors
+  %[1]s start --no-browser
   %[1]s start --config ./my-config.yaml
   %[1]s stop
 
@@ -173,6 +175,7 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
 	startFlagSet.StringVar(&settings.Config, "config", "", "Applies the specified configuration file.")
 	startFlagSet.BoolVar(&settings.DisableConnectors, "disable-connectors", false, "Skips starting the bundled connectors runtime.")
+	startFlagSet.BoolVar(&settings.NoBrowser, "no-browser", false, "Skips opening a browser window after startup.")
 	startFlagSet.Var((*stringSliceFlag)(&settings.ExtraDrivers), "extra-driver", "Path to a JDBC driver jar to copy into the Camunda lib directory (repeatable).")
 	startFlagSet.BoolVar(&settings.Detached, "detached", false, "Starts Camunda Run as a detached process")
 	startFlagSet.IntVar(&settings.Port, "port", 8080, "Port to run Camunda on")

--- a/c8run/cmd/c8run/main_test.go
+++ b/c8run/cmd/c8run/main_test.go
@@ -225,3 +225,19 @@ func TestShouldParseDisableConnectorsFlagOnStart(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, settings.DisableConnectors)
 }
+
+func TestShouldParseNoBrowserFlagOnStart(t *testing.T) {
+	// given
+	oldArgs := os.Args
+	os.Args = []string{"c8run", "start", "--no-browser"}
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+
+	// when
+	settings, _, err := getBaseCommandSettings("start")
+
+	// then
+	require.NoError(t, err)
+	assert.True(t, settings.NoBrowser)
+}

--- a/c8run/docs/runtime-rules.md
+++ b/c8run/docs/runtime-rules.md
@@ -49,6 +49,8 @@ The marker path is resolved in this order:
 
 To force the quickstart URL to appear again, delete the marker file from whichever location was resolved.
 
+Pass `--no-browser` to skip opening a browser window entirely (for example, in a headless dev environment or an autostart script). Status output and the quickstart marker are still written as usual — only the browser launch is skipped.
+
 ## Connectors Startup
 
 C8Run starts Connectors from the connector bundle plus `custom_connectors/*`. Connectors runs alongside the main Camunda process and shares the same shutdown lifecycle.
@@ -86,6 +88,7 @@ Common start flags:
 ./c8run start --log-level debug
 ./c8run start --username demo --password demo
 ./c8run start --startup-url http://localhost:8080/operate
+./c8run start --no-browser
 ```
 
 Use `./c8run help` to print all supported commands and flags. When running in the foreground, `Ctrl+C` initiates graceful shutdown.

--- a/c8run/docs/runtime-rules.md
+++ b/c8run/docs/runtime-rules.md
@@ -49,7 +49,7 @@ The marker path is resolved in this order:
 
 To force the quickstart URL to appear again, delete the marker file from whichever location was resolved.
 
-Pass `--no-browser` to skip opening a browser window entirely (for example, in a headless dev environment or an autostart script). Status output and the quickstart marker are still written as usual — only the browser launch is skipped.
+Pass `--no-browser` to skip opening a browser window entirely (for example, in a headless dev environment or an autostart script). Status output is still printed as usual, but the quickstart marker is left untouched — a headless first start never shows the quickstart, so the next normal start still shows it instead of jumping straight to Operate.
 
 ## Connectors Startup
 

--- a/c8run/docs/versions.md
+++ b/c8run/docs/versions.md
@@ -82,6 +82,7 @@ variant is published separately.
 - `--docker` flag removed.
 - RDBMS support and H2 defaults retained from 8.9.
 - Go minimum is 1.25.
+- `--no-browser` flag added to skip opening a browser window after startup.
 
 ---
 

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -65,13 +65,13 @@ func QueryCamunda(ctx context.Context, c8 opener, name string, settings types.C8
 			if err := c8.OpenBrowser(ctx, settings.StartupUrl); err != nil {
 				log.Err(err).Msg("Failed to open browser")
 			}
+			if err := markSeenStartup(settings.StartupMarkerPath); err != nil {
+				log.Warn().Err(err).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
+			}
 		}
 		if err := printStatusFunc(settings); err != nil {
 			log.Err(err).Msg("Failed to print status")
 			return err
-		}
-		if err := markSeenStartup(settings.StartupMarkerPath); err != nil {
-			log.Warn().Err(err).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
 		}
 		return nil
 	}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -65,13 +65,15 @@ func QueryCamunda(ctx context.Context, c8 opener, name string, settings types.C8
 			if err := c8.OpenBrowser(ctx, settings.StartupUrl); err != nil {
 				log.Err(err).Msg("Failed to open browser")
 			}
-			if err := markSeenStartup(settings.StartupMarkerPath); err != nil {
-				log.Warn().Err(err).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
-			}
 		}
 		if err := printStatusFunc(settings); err != nil {
 			log.Err(err).Msg("Failed to print status")
 			return err
+		}
+		if !settings.NoBrowser {
+			if err := markSeenStartup(settings.StartupMarkerPath); err != nil {
+				log.Warn().Err(err).Str("path", settings.StartupMarkerPath).Msg("Failed to persist quickstart marker")
+			}
 		}
 		return nil
 	}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -61,8 +61,10 @@ var (
 func QueryCamunda(ctx context.Context, c8 opener, name string, settings types.C8RunSettings, retries int) error {
 	healthEndpoint := fmt.Sprintf("%s://localhost:9600/actuator/health", settings.GetProtocol())
 	if isRunningFunc(ctx, name, healthEndpoint, retries, 14*time.Second) {
-		if err := c8.OpenBrowser(ctx, settings.StartupUrl); err != nil {
-			log.Err(err).Msg("Failed to open browser")
+		if !settings.NoBrowser {
+			if err := c8.OpenBrowser(ctx, settings.StartupUrl); err != nil {
+				log.Err(err).Msg("Failed to open browser")
+			}
 		}
 		if err := printStatusFunc(settings); err != nil {
 			log.Err(err).Msg("Failed to print status")

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -174,8 +174,12 @@ func TestShouldSkipOpeningBrowserWhenNoBrowserIsSet(t *testing.T) {
 	if !printStatusCalled {
 		t.Fatal("expected printStatusFunc to still be called")
 	}
-	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
-		t.Fatalf("expected quickstart marker not to be consumed on a headless start, but it was created")
+	_, err = os.Stat(markerPath)
+	if err == nil {
+		t.Fatal("expected quickstart marker not to be consumed on a headless start, but it was created")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking marker path: %v", err)
 	}
 }
 

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -174,8 +174,8 @@ func TestShouldSkipOpeningBrowserWhenNoBrowserIsSet(t *testing.T) {
 	if !printStatusCalled {
 		t.Fatal("expected printStatusFunc to still be called")
 	}
-	if _, err := os.Stat(markerPath); err != nil {
-		t.Fatalf("expected marker file to still be created: %v", err)
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("expected quickstart marker not to be consumed on a headless start, but it was created")
 	}
 }
 

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -135,6 +135,50 @@ func TestShouldMarkQuickstartAsSeenAfterSuccessfulStartup(t *testing.T) {
 	}
 }
 
+func TestShouldSkipOpeningBrowserWhenNoBrowserIsSet(t *testing.T) {
+	// given
+	markerPath := filepath.Join(t.TempDir(), ".c8run-quickstart-seen")
+	settings := types.C8RunSettings{
+		StartupUrl:        "http://localhost:8080/operate",
+		StartupMarkerPath: markerPath,
+		NoBrowser:         true,
+	}
+	opener := &stubOpener{}
+
+	originalIsRunningFunc := isRunningFunc
+	originalPrintStatusFunc := printStatusFunc
+	printStatusCalled := false
+	t.Cleanup(func() {
+		isRunningFunc = originalIsRunningFunc
+		printStatusFunc = originalPrintStatusFunc
+	})
+
+	isRunningFunc = func(_ context.Context, _ string, _ string, _ int, _ time.Duration) bool {
+		return true
+	}
+	printStatusFunc = func(types.C8RunSettings) error {
+		printStatusCalled = true
+		return nil
+	}
+
+	// when
+	err := QueryCamunda(context.Background(), opener, "Camunda", settings, 0)
+	if err != nil {
+		t.Fatalf("QueryCamunda failed: %v", err)
+	}
+
+	// then
+	if opener.url != "" {
+		t.Fatalf("expected browser not to be opened, but it was opened with %s", opener.url)
+	}
+	if !printStatusCalled {
+		t.Fatal("expected printStatusFunc to still be called")
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected marker file to still be created: %v", err)
+	}
+}
+
 func TestShouldShowConnectorsAsDisabledInStatusOutput(t *testing.T) {
 	// given
 	cwd, err := os.Getwd()

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -18,6 +18,7 @@ type C8RunSettings struct {
 	ResolvedConfigPath   string
 	Detached             bool
 	DisableConnectors    bool
+	NoBrowser            bool
 	Port                 int
 	Keystore             string
 	KeystorePassword     string


### PR DESCRIPTION
## Description
Adds a `--no-browser` flag to `c8run start` that suppresses the automatic browser launch after startup, for headless/autostart use (e.g. Linux dev boxes). Status output still runs unconditionally. The quickstart marker is intentionally left untouched on a headless start — since the browser never showed the quickstart, the next regular (non-headless) start still shows it instead of jumping straight to Operate.

## Checklist
- [ ] Enable backports when necessary
- [ ] N/A: does not touch the C8 Orchestration Cluster E2E Test Suite

## Related issues
closes #38090

## Test plan
- [x] `go test ./...` passes in `c8run/`
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build -o c8run ./cmd/c8run` succeeds; `./c8run help` shows `--no-browser`
- [x] Unit tests added: flag parsing (`cmd/c8run/main_test.go`), browser-skip behavior, and marker-not-consumed behavior (`internal/health/camunda_test.go`)