### PR TITLE
test: cover a partition join whose joiner is too slow to catch up

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -11,6 +11,8 @@ package io.camunda.configuration;
 import static io.camunda.zeebe.broker.system.configuration.ClusterCfg.DEFAULT_ELECTION_TIMEOUT;
 import static io.camunda.zeebe.broker.system.configuration.ExperimentalCfg.DEFAULT_MAX_APPENDS_PER_FOLLOWER;
 import static io.camunda.zeebe.broker.system.configuration.ExperimentalCfg.DEFAULT_MAX_APPEND_BATCH_SIZE;
+import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_JOIN_CATCH_UP_TIMEOUT;
+import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_PROMOTION_LAG_THRESHOLD;
 import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_SNAPSHOT_CHUNK_SIZE;
 import static io.camunda.zeebe.broker.system.configuration.ExperimentalRaftCfg.DEFAULT_SNAPSHOT_REQUEST_TIMEOUT;
 
@@ -130,6 +132,22 @@ public class Raft {
    * requestTimeout is recommended.
    */
   private Duration configurationChangeTimeout = Duration.ofSeconds(10);
+
+  /**
+   * Sets how long a member joining a partition is given to catch up to the entry that admitted it.
+   * A join is only complete once the joiner has replicated that entry; until then it is a
+   * non-voting learner. If the joiner does not get there in time, the attempt fails and is retried
+   * from scratch, so a value below the time a joiner needs to replicate the backlog makes joins
+   * fail repeatedly. On slow networks or with large logs, raise it.
+   */
+  private Duration joinCatchUpTimeout = DEFAULT_JOIN_CATCH_UP_TIMEOUT;
+
+  /**
+   * Sets the maximum replication lag, in bytes, a learner may have for the leader to promote it to
+   * a voting member. Promoting a learner that still lags would shrink the effective quorum, so the
+   * leader waits until the learner is within this threshold.
+   */
+  private DataSize promotionLagThreshold = DEFAULT_PROMOTION_LAG_THRESHOLD;
 
   /**
    * If the leader is not able to reach the quorum, the leader may step down. This is triggered if
@@ -332,6 +350,22 @@ public class Raft {
 
   public void setConfigurationChangeTimeout(final Duration configurationChangeTimeout) {
     this.configurationChangeTimeout = configurationChangeTimeout;
+  }
+
+  public Duration getJoinCatchUpTimeout() {
+    return joinCatchUpTimeout;
+  }
+
+  public void setJoinCatchUpTimeout(final Duration joinCatchUpTimeout) {
+    this.joinCatchUpTimeout = joinCatchUpTimeout;
+  }
+
+  public DataSize getPromotionLagThreshold() {
+    return promotionLagThreshold;
+  }
+
+  public void setPromotionLagThreshold(final DataSize promotionLagThreshold) {
+    this.promotionLagThreshold = promotionLagThreshold;
   }
 
   public Duration getMaxQuorumResponseTimeout() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -650,6 +650,8 @@ public class BrokerBasedPropertiesOverride {
         .getExperimental()
         .getRaft()
         .setConfigurationChangeTimeout(raft.getConfigurationChangeTimeout());
+    override.getExperimental().getRaft().setJoinCatchUpTimeout(raft.getJoinCatchUpTimeout());
+    override.getExperimental().getRaft().setPromotionLagThreshold(raft.getPromotionLagThreshold());
     override
         .getExperimental()
         .getRaft()

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -44,6 +44,8 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.snapshot-request-timeout=5s",
         "camunda.cluster.raft.snapshot-chunk-size=2GB",
         "camunda.cluster.raft.configuration-change-timeout=20s",
+        "camunda.cluster.raft.join-catch-up-timeout=90s",
+        "camunda.cluster.raft.promotion-lag-threshold=32MB",
         "camunda.cluster.raft.max-quorum-response-timeout=10s",
         "camunda.cluster.raft.min-step-down-failure-count=5",
         "camunda.cluster.raft.prefer-snapshot-replication-threshold=110",
@@ -100,6 +102,8 @@ public class ClusterRaftTest {
           .returns(Duration.ofSeconds(5), ExperimentalRaftCfg::getSnapshotRequestTimeout)
           .returns(DataSize.ofGigabytes(2), ExperimentalRaftCfg::getSnapshotChunkSize)
           .returns(Duration.ofSeconds(20), ExperimentalRaftCfg::getConfigurationChangeTimeout)
+          .returns(Duration.ofSeconds(90), ExperimentalRaftCfg::getJoinCatchUpTimeout)
+          .returns(DataSize.ofMegabytes(32), ExperimentalRaftCfg::getPromotionLagThreshold)
           .returns(Duration.ofSeconds(10), ExperimentalRaftCfg::getMaxQuorumResponseTimeout)
           .returns(5, ExperimentalRaftCfg::getMinStepDownFailureCount)
           .returns(110, ExperimentalRaftCfg::getPreferSnapshotReplicationThreshold)

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -66,6 +66,7 @@ cluster.raft.election-timeout
 cluster.raft.flush-delay
 cluster.raft.flush-enabled
 cluster.raft.heartbeat-interval
+cluster.raft.join-catch-up-timeout
 cluster.raft.max-append-batch-size
 cluster.raft.max-appends-per-follower
 cluster.raft.max-quorum-response-timeout
@@ -73,6 +74,7 @@ cluster.raft.min-step-down-failure-count
 cluster.raft.preallocate-segment-files
 cluster.raft.prefer-snapshot-replication-threshold
 cluster.raft.priority-election-enabled
+cluster.raft.promotion-lag-threshold
 cluster.raft.rebalance.leader-wait-timeout
 cluster.raft.rebalance.max-transfer-attempts
 cluster.raft.rebalance.replication-lag-threshold

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -301,9 +301,9 @@ public final class ReconfigurationHelper {
               raftContext.removeCommitListener(listener);
               result.completeExceptionally(
                   new TimeoutException(
-                      "Join request was accepted at index %d, but that configuration entry did"
-                          + " not commit locally within the join catch-up timeout of %s"
-                              .formatted(index, raftContext.getJoinCatchUpTimeout())));
+                      ("Join request was accepted at index %d, but that configuration entry did"
+                              + " not commit locally within the join catch-up timeout of %s")
+                          .formatted(index, raftContext.getJoinCatchUpTimeout())));
             });
     raftContext.addCommitListener(listener);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -17,10 +17,10 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public static final Duration DEFAULT_SNAPSHOT_REQUEST_TIMEOUT = Duration.ofMillis(2500);
   public static final DataSize DEFAULT_SNAPSHOT_CHUNK_SIZE = DataSize.ofMegabytes(8);
-  private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
   // Keep in sync with the defaults in RaftPartitionConfig, which these override on startup.
-  private static final Duration DEFAULT_JOIN_CATCH_UP_TIMEOUT = Duration.ofSeconds(60);
-  private static final DataSize DEFAULT_PROMOTION_LAG_THRESHOLD = DataSize.ofMegabytes(16);
+  public static final Duration DEFAULT_JOIN_CATCH_UP_TIMEOUT = Duration.ofSeconds(60);
+  public static final DataSize DEFAULT_PROMOTION_LAG_THRESHOLD = DataSize.ofMegabytes(16);
+  private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
   // Requests should time out faster than the election timeout to ensure that a single missed
   // heartbeat does not cause immediate re-election.
   private static final Duration DEFAULT_REQUEST_TIMEOUT = DEFAULT_ELECTION_TIMEOUT;

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -342,6 +342,12 @@
     </dependency>
 
     <dependency>
+      <groupId>eu.rekawek.toxiproxy</groupId>
+      <artifactId>toxiproxy-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.dasniko</groupId>
       <artifactId>testcontainers-keycloak</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/SlowJoinerPartitionJoinTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/SlowJoinerPartitionJoinTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.dynamic;
+
+import static io.camunda.zeebe.it.cluster.clustering.dynamic.Utils.assertChangeIsPlanned;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.GetTopologyResponse;
+import io.camunda.zeebe.management.cluster.PartitionStateCode;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.testcontainers.ProxyRegistry;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.io.IOException;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Covers the transport-level shape of the partition join deadlock (<a
+ * href="https://github.com/camunda/camunda/issues/60090">#60090</a>): a joining member whose
+ * messaging is slow rather than broken, for longer than a join attempt is allowed to take, across
+ * several attempts. Each failed attempt tears the joiner's partition down and unregisters its
+ * messaging handlers before the next attempt re-creates them; the deterministic Raft tests cannot
+ * exercise that, since they run on an in-memory protocol.
+ *
+ * <p>Since joins are two-phase, the leader admits the joiner as a non-voting learner and answers at
+ * once; the part of a join that depends on the joiner's own connectivity is catching up to the
+ * admitting entry, bounded by the join catch-up timeout. Every attempt starts with the leader
+ * configuring the re-created member and then replicating to it, so delaying each message towards
+ * the joiner by more than half the catch-up timeout makes every attempt time out. The change stays
+ * pending until the messages are fast again.
+ *
+ * <p>Toxiproxy proxies TCP only; the members' UDP gossip does not pass it, so a short sync interval
+ * propagates membership over TCP instead, as in {@code AdvertisedAddressTest}. The container is
+ * started per test rather than per class, so that a rerun of the test gets working proxies.
+ */
+final class SlowJoinerPartitionJoinTest {
+  private static final String TOXIPROXY_IMAGE = "shopify/toxiproxy:2.1.0";
+  private static final Duration JOIN_CATCH_UP_TIMEOUT = Duration.ofSeconds(2);
+  private static final Duration MESSAGE_DELAY = Duration.ofSeconds(3);
+  // The reconciler retries a failed operation with a backoff that starts at ten seconds, so this is
+  // room for three failed attempts.
+  private static final Duration SLOW_PERIOD = Duration.ofSeconds(40);
+  private static final Duration JOIN_TIMEOUT = Duration.ofMinutes(3);
+
+  private static final MemberId JOINER = MemberId.from("1");
+  private static final int PARTITION = 1;
+
+  @Test
+  void shouldCompleteJoinAfterJoinerWasTooSlowToCatchUpForSeveralAttempts() throws IOException {
+    try (final var toxiproxy =
+        ProxyRegistry.addExposedPorts(
+                new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE)))
+            .withAccessToHost(true)) {
+      toxiproxy.start();
+      final var proxies = new ProxyRegistry(toxiproxy);
+      try (final var cluster = buildCluster(toxiproxy, proxies)) {
+        // given - a cluster in which every message towards the joiner is delayed for longer than
+        // a join attempt may take to catch up
+        cluster.start().awaitCompleteTopology();
+        final var joinerProxy =
+            proxies.getOrCreateHostProxy(
+                cluster.brokers().get(JOINER).mappedPort(TestZeebePort.CLUSTER));
+        final var delay =
+            joinerProxy
+                .proxy()
+                .toxics()
+                .latency("slow-joiner", ToxicDirection.UPSTREAM, MESSAGE_DELAY.toMillis());
+
+        // when - the joiner is asked to join a partition it does not have
+        final var actuator = ClusterActuator.of(cluster.availableGateway());
+        final var response = actuator.joinPartition(Integer.parseInt(JOINER.id()), PARTITION, 1);
+        assertChangeIsPlanned(response);
+
+        // then - no attempt completes while the joiner is slow: the change stays pending and the
+        // partition stays in the joining state across several attempts ...
+        Awaitility.await("join does not complete while the joiner is slow")
+            .during(SLOW_PERIOD)
+            .atMost(SLOW_PERIOD.plusSeconds(10))
+            .untilAsserted(
+                () -> {
+                  final var topology = actuator.getTopology();
+                  assertThat(topology.getPendingChange()).isNotNull();
+                  assertThat(isCompleted(topology, response.getChangeId())).isFalse();
+                  ClusterActuatorAssert.assertThat(cluster)
+                      .brokerHasPartitionAtState(
+                          Integer.parseInt(JOINER.id()), PARTITION, PartitionStateCode.JOINING);
+                });
+
+        // ... and the join completes once messages reach the joiner in time again
+        delay.remove();
+        Awaitility.await("join completes once the joiner is fast again")
+            .timeout(JOIN_TIMEOUT)
+            .untilAsserted(
+                () -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(response));
+        ClusterActuatorAssert.assertThat(cluster)
+            .hasAppliedChanges(response)
+            .brokerHasPartition(Integer.parseInt(JOINER.id()), PARTITION);
+        cluster.awaitHealthyTopology();
+      }
+    }
+  }
+
+  private static boolean isCompleted(final GetTopologyResponse topology, final long changeId) {
+    final var lastChange = topology.getLastChange();
+    return lastChange != null && lastChange.getId() == changeId;
+  }
+
+  private static TestCluster buildCluster(
+      final ToxiproxyContainer toxiproxy, final ProxyRegistry proxies) {
+    final var cluster =
+        TestCluster.builder()
+            .withEmbeddedGateway(false)
+            .withGatewaysCount(1)
+            .withBrokersCount(2)
+            .withPartitionsCount(2)
+            .withReplicationFactor(1)
+            .withBrokerConfig(broker -> configureBroker(broker, toxiproxy, proxies))
+            .withGatewayConfig(gateway -> configureGateway(gateway, toxiproxy, proxies))
+            .build();
+    // The cluster is not aware of the proxies, so the initial contact points have to be rebuilt.
+    final var contactPoints =
+        cluster.brokers().values().stream()
+            .map(
+                broker ->
+                    proxiedAddress(broker.mappedPort(TestZeebePort.CLUSTER), toxiproxy, proxies))
+            .toList();
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            b ->
+                b.withUnifiedConfig(
+                    cfg -> cfg.getCluster().setInitialContactPoints(contactPoints)));
+    cluster
+        .gateways()
+        .values()
+        .forEach(
+            g ->
+                g.withUnifiedConfig(
+                    cfg -> cfg.getCluster().setInitialContactPoints(contactPoints)));
+    return cluster;
+  }
+
+  private static void configureBroker(
+      final TestStandaloneBroker broker,
+      final ToxiproxyContainer toxiproxy,
+      final ProxyRegistry proxies) {
+    final var internalApiProxy =
+        proxies.getOrCreateHostProxy(broker.mappedPort(TestZeebePort.CLUSTER));
+    broker
+        .withCreateSchema(false)
+        // Not part of the unified configuration yet; the legacy property still binds.
+        .withProperty(
+            "zeebe.broker.experimental.raft.joinCatchUpTimeout", JOIN_CATCH_UP_TIMEOUT.toString())
+        .withUnifiedConfig(
+            cfg -> {
+              final var internalApi = cfg.getCluster().getNetwork().getInternalApi();
+              internalApi.setAdvertisedHost(toxiproxy.getHost());
+              internalApi.setAdvertisedPort(
+                  toxiproxy.getMappedPort(internalApiProxy.internalPort()));
+              final var membership = cfg.getCluster().getMembership();
+              membership.setSyncInterval(Duration.ofMillis(100));
+              // Membership probes must outlive the injected delay, or the slow joiner is declared
+              // dead and messaging stops addressing it altogether. The test is about a member
+              // that is slow, not one that is gone.
+              membership.setProbeTimeout(MESSAGE_DELAY.multipliedBy(2));
+              membership.setFailureTimeout(Duration.ofMinutes(1));
+            });
+  }
+
+  private static void configureGateway(
+      final TestGateway<?> gateway,
+      final ToxiproxyContainer toxiproxy,
+      final ProxyRegistry proxies) {
+    final var internalApiProxy =
+        proxies.getOrCreateHostProxy(gateway.mappedPort(TestZeebePort.CLUSTER));
+    gateway.withUnifiedConfig(
+        cfg -> {
+          final var internalApi = cfg.getCluster().getNetwork().getInternalApi();
+          internalApi.setAdvertisedHost(toxiproxy.getHost());
+          internalApi.setAdvertisedPort(toxiproxy.getMappedPort(internalApiProxy.internalPort()));
+        });
+  }
+
+  private static String proxiedAddress(
+      final int hostPort, final ToxiproxyContainer toxiproxy, final ProxyRegistry proxies) {
+    final var proxy = proxies.getOrCreateHostProxy(hostPort);
+    return toxiproxy.getHost() + ":" + toxiproxy.getMappedPort(proxy.internalPort());
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/SlowJoinerPartitionJoinTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/SlowJoinerPartitionJoinTest.java
@@ -163,11 +163,9 @@ final class SlowJoinerPartitionJoinTest {
         proxies.getOrCreateHostProxy(broker.mappedPort(TestZeebePort.CLUSTER));
     broker
         .withCreateSchema(false)
-        // Not part of the unified configuration yet; the legacy property still binds.
-        .withProperty(
-            "zeebe.broker.experimental.raft.joinCatchUpTimeout", JOIN_CATCH_UP_TIMEOUT.toString())
         .withUnifiedConfig(
             cfg -> {
+              cfg.getCluster().getRaft().setJoinCatchUpTimeout(JOIN_CATCH_UP_TIMEOUT);
               final var internalApi = cfg.getCluster().getNetwork().getInternalApi();
               internalApi.setAdvertisedHost(toxiproxy.getHost());
               internalApi.setAdvertisedPort(


### PR DESCRIPTION
## Description

Adds `SlowJoinerPartitionJoinTest`, a qa integration test for the transport-level shape of the partition join deadlock: a joiner whose messaging is slow rather than broken, for longer than a join attempt may take, across several attempts. Each failed attempt tears the joiner's partition down and unregisters its messaging handlers before the next one re-creates them, which the deterministic Raft tests on the in-memory protocol cannot exercise.

With two-phase joins the leader admits the joiner as a learner and answers at once, so the part that depends on the joiner's connectivity is catching up to the admitting entry, bounded by `joinCatchUpTimeout`. The test sets that to 2s and delays every message towards the joiner by 3s through Toxiproxy (same wiring as `AdvertisedAddressTest`), holds the join for 40 seconds, room for three failed attempts under the reconciler's backoff, asserting the change is not completed and the partition stays `JOINING`, then removes the delay and asserts the change completes and the topology is healthy. Membership probe and failure timeouts are raised so the slow joiner is not declared dead; otherwise messaging would stop addressing it and the test would cover a gone member instead of a slow one.

## Testing

The test needs Docker for the Toxiproxy container. On my machine the existing `AdvertisedAddressTest` fails the same way this test did (membership probes through the host port forwarding never answer, the topology never completes), so I could not validate it locally. CI is the validation for this PR; draft until the qa job is green.

## Related issues

closes #60090

Also fixes the join catch-up timeout message, which formatted neither the index nor the timeout; the first CI run of this test surfaced it.
