### PR TITLE
fix: RDBMS instance stays active on suspend/resume

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -329,8 +329,11 @@ public class DefaultExecutionQueue implements ExecutionQueue {
    * group is still preserved.<br>
    * <br>
    * In the second step the items inside the groups are sorted by the {@link WriteStatementType}
-   * (natural order) and {@link QueueItem#statementId()}. For some entities this step will lead to
-   * errors. Therefore, this second step can be deactivated in the {@link ContextType}.
+   * (natural order), then {@link QueueItem#order()} (default {@code 0}), then {@link
+   * QueueItem#statementId()}. The {@code order} field lets an individual item be placed before or
+   * after the others it would otherwise tie with, without changing how any other item in the group
+   * is sorted. For some entities this step will lead to errors. Therefore, this second step can be
+   * deactivated in the {@link ContextType}.
    *
    * @param items queue of items
    * @return optimized queue of items
@@ -347,7 +350,9 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       } else {
         final var contextItems = new ArrayList<>(entry.getValue());
         contextItems.sort(
-            Comparator.comparing(QueueItem::statementType).thenComparing(QueueItem::statementId));
+            Comparator.comparing(QueueItem::statementType)
+                .thenComparing(QueueItem::order)
+                .thenComparing(QueueItem::statementId));
         resultList.addAll(contextItems);
       }
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/QueueItem.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/QueueItem.java
@@ -14,7 +14,25 @@ public record QueueItem(
     WriteStatementType statementType,
     Object id,
     String statementId,
-    Object parameter) {
+    Object parameter,
+    int order) {
+
+  private static final int DEFAULT_ORDER = 0;
+
+  /**
+   * Default-order convenience constructor, used by the vast majority of call sites that don't need
+   * a specific position among same-{@link WriteStatementType} items for the same {@link
+   * ContextType} - those keep sorting by {@code statementId} as before, see {@link
+   * DefaultExecutionQueue#optimizeQueueOrder}.
+   */
+  public QueueItem(
+      final ContextType contextType,
+      final WriteStatementType statementType,
+      final Object id,
+      final String statementId,
+      final Object parameter) {
+    this(contextType, statementType, id, statementId, parameter, DEFAULT_ORDER);
+  }
 
   public QueueItem copy(final Function<QueueItemBuilder, QueueItemBuilder> builderFunction) {
     return builderFunction
@@ -25,7 +43,8 @@ public record QueueItem(
                 .statementType(statementType)
                 .id(id)
                 .statementId(statementId)
-                .parameter(parameter))
+                .parameter(parameter)
+                .order(order))
         .build();
   }
 
@@ -37,6 +56,7 @@ public record QueueItem(
     private Object id;
     private String statementId;
     private Object parameter;
+    private int order = DEFAULT_ORDER;
 
     public QueueItemBuilder contextType(final ContextType contextType) {
       this.contextType = contextType;
@@ -63,8 +83,13 @@ public record QueueItem(
       return this;
     }
 
+    public QueueItemBuilder order(final int order) {
+      this.order = order;
+      return this;
+    }
+
     public QueueItem build() {
-      return new QueueItem(contextType, statementType, id, statementId, parameter);
+      return new QueueItem(contextType, statementType, id, statementId, parameter, order);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
@@ -79,7 +79,8 @@ public class ProcessInstanceWriter implements RdbmsWriter {
               WriteStatementType.UPDATE,
               key,
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
-              dto));
+              dto,
+              Integer.MAX_VALUE));
     }
   }
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -579,6 +579,60 @@ class DefaultExecutionQueueTest {
     inOrder.verify(session).update(eq("ms.createIfNotExists"), any());
   }
 
+  @Test
+  public void shouldOrderByExplicitOrderBeforeFallingBackToStatementId() {
+    // given - a low-order UPDATE queued before a high-order UPDATE for the same row
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.UPDATE,
+            1L,
+            "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateSuspendedState",
+            "resumed"));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.UPDATE,
+            1L,
+            "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
+            "finished",
+            Integer.MAX_VALUE));
+
+    // when
+    executionQueue.flush();
+
+    // then - explicit order wins over the alphabetical statementId tiebreak: under the default
+    // sort, "updateStateAndEndDate" would run before "updateSuspendedState" and the resume update
+    // would overwrite the terminal state back to ACTIVE.
+    final var inOrder = Mockito.inOrder(session);
+    inOrder
+        .verify(session)
+        .update(eq("io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateSuspendedState"), any());
+    inOrder
+        .verify(session)
+        .update(eq("io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate"), any());
+  }
+
+  @Test
+  public void shouldFallBackToStatementIdWhenOrderIsEqual() {
+    // given - two items with the default order (0); relative order must still come from
+    // statementId alphabetically, unchanged from before the order field existed
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE, WriteStatementType.UPDATE, 1L, "zzz.statement", "z"));
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE, WriteStatementType.UPDATE, 1L, "aaa.statement", "a"));
+
+    // when
+    executionQueue.flush();
+
+    // then
+    final var inOrder = Mockito.inOrder(session);
+    inOrder.verify(session).update(eq("aaa.statement"), any());
+    inOrder.verify(session).update(eq("zzz.statement"), any());
+  }
+
   @ParameterizedTest
   @CsvSource({
     // statementId, expectedResult

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriterTest.java
@@ -65,7 +65,8 @@ class ProcessInstanceWriterTest {
                     WriteStatementType.UPDATE,
                     1L,
                     "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
-                    new EndProcessInstanceDto(1L, ProcessInstanceState.COMPLETED, NOW))));
+                    new EndProcessInstanceDto(1L, ProcessInstanceState.COMPLETED, NOW),
+                    Integer.MAX_VALUE)));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -137,6 +137,36 @@ public class ProcessInstanceIT {
   }
 
   @TestTemplate
+  public void shouldNotRevertToActiveWhenResumeAndFinishLandInSameFlush(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
+
+    // given
+    final ProcessInstanceDbModel instance =
+        ProcessInstanceFixtures.createRandomized(
+            b -> b.state(ProcessInstanceState.ACTIVE).suspendedDate(null));
+    createAndSaveProcessInstance(rdbmsWriters, instance);
+
+    // when
+    rdbmsWriters.getProcessInstanceWriter().suspend(instance.processInstanceKey(), NOW);
+    rdbmsWriters.getProcessInstanceWriter().resume(instance.processInstanceKey());
+    rdbmsWriters
+        .getProcessInstanceWriter()
+        .finish(instance.processInstanceKey(), ProcessInstanceState.COMPLETED, NOW);
+    rdbmsWriters.flush();
+
+    // then
+    final var readInstance =
+        processInstanceReader.findOne(instance.processInstanceKey()).orElse(null);
+
+    assertThat(readInstance).isNotNull();
+    assertThat(readInstance.state()).isEqualTo(ProcessInstanceState.COMPLETED);
+    assertThat(readInstance.endDate()).isNotNull();
+  }
+
+  @TestTemplate
   public void shouldFindProcessInstanceByBpmnProcessId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();


### PR DESCRIPTION
## Description

RDBMS related
[PROCESS_INSTANCE(preserveOrder: false)](https://github.com/camunda/camunda/blob/786a5dc74ee3e90dfb0955724f942dab957c9a46/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java#L40) leads to [DefaultExecutionQueue#optimizeQueueOrder](https://github.com/camunda/camunda/blob/42c8a9a600e12f1f7be70688d932a8b6284626e1/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java#L338) to sort statements and batch execute
Make sure `updateSuspendedState` is executed before `updateStateAndEndDates`

More info in parent issue and in slack discussion ([ref](https://camunda.slack.com/archives/C0AJXAUUY65/p1788428224359029?thread_ts=1788281194.115719&cid=C0AJXAUUY65))

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #61645

