### PR TITLE
refactor: migrate Admin operations log to new design system

### DIFF
--- a/identity/client/src/components/formV2/Select.tsx
+++ b/identity/client/src/components/formV2/Select.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { Dropdown as CarbonDropdown } from "@carbon/react";
+import { DropdownProps } from "@carbon/react/lib/components/Dropdown/Dropdown";
+import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize.ts";
+import useTranslate from "src/utility/localization";
+
+const ALL_OPTION = "all" as const;
+
+type Props<T extends string> = Omit<
+  DropdownProps<T | typeof ALL_OPTION>,
+  "label" | "items" | "selectedItem" | "onChange" | "itemToString"
+> & {
+  items: readonly T[];
+  selectedItem?: T;
+  onChange?: (data: { selectedItem?: T }) => void;
+};
+
+const Select = <T extends string>({
+  onChange,
+  items,
+  selectedItem,
+  ...rest
+}: Props<T>) => {
+  const { t } = useTranslate("components");
+  const options: (T | typeof ALL_OPTION)[] = [ALL_OPTION, ...items];
+
+  const controlledSelectedItem = selectedItem ?? ALL_OPTION;
+
+  function onDropdownChange({
+    selectedItem,
+  }: {
+    selectedItem: T | typeof ALL_OPTION | null;
+  }) {
+    if (!selectedItem || selectedItem === ALL_OPTION) {
+      onChange?.({ selectedItem: undefined });
+      return;
+    }
+
+    onChange?.({ selectedItem });
+  }
+
+  return (
+    <CarbonDropdown<T | typeof ALL_OPTION>
+      {...rest}
+      label={t("selectLabel")}
+      aria-label={t("selectLabel")}
+      size="sm"
+      items={options}
+      selectedItem={controlledSelectedItem}
+      itemToString={(item) =>
+        item === ALL_OPTION
+          ? t("selectAll")
+          : item
+            ? spaceAndCapitalize(item)
+            : ""
+      }
+      onChange={onDropdownChange}
+    />
+  );
+};
+
+export { Select };

--- a/identity/client/src/components/formV2/Select.tsx
+++ b/identity/client/src/components/formV2/Select.tsx
@@ -6,63 +6,82 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { Dropdown as CarbonDropdown } from "@carbon/react";
-import { DropdownProps } from "@carbon/react/lib/components/Dropdown/Dropdown";
+import { ReactNode, useId } from "react";
+import {
+  Label,
+  Select as DSSelect,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  cn,
+} from "@camunda/design-system";
 import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize.ts";
 import useTranslate from "src/utility/localization";
 
 const ALL_OPTION = "all" as const;
 
-type Props<T extends string> = Omit<
-  DropdownProps<T | typeof ALL_OPTION>,
-  "label" | "items" | "selectedItem" | "onChange" | "itemToString"
-> & {
+type Props<T extends string> = {
+  id?: string;
+  className?: string;
+  disabled?: boolean;
+  titleText?: ReactNode;
   items: readonly T[];
   selectedItem?: T;
   onChange?: (data: { selectedItem?: T }) => void;
 };
 
 const Select = <T extends string>({
-  onChange,
+  id,
+  className,
+  disabled,
+  titleText,
   items,
   selectedItem,
-  ...rest
+  onChange,
 }: Props<T>) => {
   const { t } = useTranslate("components");
-  const options: (T | typeof ALL_OPTION)[] = [ALL_OPTION, ...items];
+  const generatedId = useId();
+  const selectId = id ?? generatedId;
 
   const controlledSelectedItem = selectedItem ?? ALL_OPTION;
 
-  function onDropdownChange({
-    selectedItem,
-  }: {
-    selectedItem: T | typeof ALL_OPTION | null;
-  }) {
-    if (!selectedItem || selectedItem === ALL_OPTION) {
+  function handleValueChange(value: string) {
+    if (value === ALL_OPTION) {
       onChange?.({ selectedItem: undefined });
       return;
     }
 
-    onChange?.({ selectedItem });
+    onChange?.({ selectedItem: value as T });
   }
 
   return (
-    <CarbonDropdown<T | typeof ALL_OPTION>
-      {...rest}
-      label={t("selectLabel")}
-      aria-label={t("selectLabel")}
-      size="sm"
-      items={options}
-      selectedItem={controlledSelectedItem}
-      itemToString={(item) =>
-        item === ALL_OPTION
-          ? t("selectAll")
-          : item
-            ? spaceAndCapitalize(item)
-            : ""
-      }
-      onChange={onDropdownChange}
-    />
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      {titleText !== undefined ? (
+        <Label htmlFor={selectId}>{titleText}</Label>
+      ) : null}
+      <DSSelect
+        value={controlledSelectedItem}
+        onValueChange={handleValueChange}
+        disabled={disabled}
+      >
+        <SelectTrigger
+          id={selectId}
+          className="w-full"
+          aria-label={titleText === undefined ? t("selectLabel") : undefined}
+        >
+          <SelectValue placeholder={t("selectLabel")} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_OPTION}>{t("selectAll")}</SelectItem>
+          {items.map((item) => (
+            <SelectItem key={item} value={item}>
+              {spaceAndCapitalize(item)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </DSSelect>
+    </div>
   );
 };
 

--- a/identity/client/src/pages/operations-log/CellPropertyV2.tsx
+++ b/identity/client/src/pages/operations-log/CellPropertyV2.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.10";
+// TODO: Replace with Tailwind during design-system migration.
+import { OwnerInfo, PropertyText } from "./components/styled";
+import { CodeSnippet } from "@carbon/react";
+import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize";
+import { AuditLogOperationType } from "@camunda/camunda-api-zod-schemas/8.10";
+import useTranslate from "src/utility/localization";
+
+type Props = {
+  item: AuditLog;
+};
+
+const assignOperations: AuditLogOperationType[] = ["ASSIGN", "UNASSIGN"];
+
+const CellProperty: React.FC<Props> = ({ item }) => {
+  const { t } = useTranslate("operationsLog");
+
+  const showProperty =
+    (item.entityType === "AUTHORIZATION" && item.operationType === "CREATE") ||
+    assignOperations.includes(item.operationType);
+
+  if (item.result === "FAIL") {
+    return (
+      <div>
+        <PropertyText>{t("errorCode")}</PropertyText>
+        {item.entityDescription}
+      </div>
+    );
+  } else if (showProperty) {
+    return (
+      <div>
+        <PropertyText>
+          {item.entityType === "AUTHORIZATION" ? t("owner") : t("assignee")}
+        </PropertyText>
+        <OwnerInfo>
+          {item.relatedEntityType
+            ? spaceAndCapitalize(item.relatedEntityType)
+            : "-"}{" "}
+          <CodeSnippet type="inline">{item.relatedEntityKey}</CodeSnippet>
+        </OwnerInfo>
+      </div>
+    );
+  } else {
+    return "-";
+  }
+};
+
+export { CellProperty };

--- a/identity/client/src/pages/operations-log/CellPropertyV2.tsx
+++ b/identity/client/src/pages/operations-log/CellPropertyV2.tsx
@@ -7,9 +7,7 @@
  */
 
 import type { AuditLog } from "@camunda/camunda-api-zod-schemas/8.10";
-// TODO: Replace with Tailwind during design-system migration.
-import { OwnerInfo, PropertyText } from "./components/styled";
-import { CodeSnippet } from "@carbon/react";
+import { Text } from "@camunda/design-system";
 import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize";
 import { AuditLogOperationType } from "@camunda/camunda-api-zod-schemas/8.10";
 import useTranslate from "src/utility/localization";
@@ -30,22 +28,34 @@ const CellProperty: React.FC<Props> = ({ item }) => {
   if (item.result === "FAIL") {
     return (
       <div>
-        <PropertyText>{t("errorCode")}</PropertyText>
+        <Text
+          as="div"
+          variant="label-sm"
+          className="text-neutral-foreground-subtle"
+        >
+          {t("errorCode")}
+        </Text>
         {item.entityDescription}
       </div>
     );
   } else if (showProperty) {
     return (
       <div>
-        <PropertyText>
+        <Text
+          as="div"
+          variant="label-sm"
+          className="text-neutral-foreground-subtle"
+        >
           {item.entityType === "AUTHORIZATION" ? t("owner") : t("assignee")}
-        </PropertyText>
-        <OwnerInfo>
+        </Text>
+        <div className="whitespace-nowrap">
           {item.relatedEntityType
             ? spaceAndCapitalize(item.relatedEntityType)
             : "-"}{" "}
-          <CodeSnippet type="inline">{item.relatedEntityKey}</CodeSnippet>
-        </OwnerInfo>
+          <Text as="code" variant="code-sm">
+            {item.relatedEntityKey}
+          </Text>
+        </div>
       </div>
     );
   } else {

--- a/identity/client/src/pages/operations-log/ListV2.tsx
+++ b/identity/client/src/pages/operations-log/ListV2.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import useTranslate from "src/utility/localization";
 import Page, { PageHeader } from "src/components/layoutV2/Page";
 import EntityList from "src/components/entityListV2";
@@ -15,29 +15,20 @@ import { usePagination, SortConfig } from "src/utility/api";
 import { useQuery } from "@tanstack/react-query";
 import { auditLogQueries } from "src/utility/api/audit-logs/queries";
 import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize";
-// TODO: Replace with Tailwind during design-system migration.
-import {
-  OperationLogName,
-  SuccessIcon,
-  ErrorIcon,
-  Grid,
-  ColumnRightPadding,
-  CenteredRow,
-  StickySection,
-  EntityListStickyWrapper,
-} from "./components/styled";
 import {
   Button,
-  CodeSnippet,
-  Column,
-  Heading,
-  Stack,
-  TextInput,
-} from "@carbon/react";
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  PageContentLayout,
+  Text,
+} from "@camunda/design-system";
+import TextField from "src/components/formV2/TextField";
 import useDebounce from "react-debounced";
 import { useForm, FieldPath, FieldPathValue } from "react-hook-form";
 import { CellProperty } from "src/pages/operations-log/CellPropertyV2";
-import { Api, User } from "@carbon/react/icons";
+import { CircleCheck, Plug, User, XCircle } from "lucide-react";
 import AiAgentIcon from "src/assets/images/ai-agent.svg";
 // TODO: Replace with `DateRangePicker` from design system
 import { DateRangeField } from "src/components/form/DateRangeField";
@@ -165,11 +156,15 @@ const List: FC = () => {
         linkText={t("operationsLog").toLowerCase()}
         docsLinkPath="/components/admin/audit-operations/"
       />
-      <Grid condensed fullWidth>
-        <ColumnRightPadding sm={4} md={3} lg={4} xlg={3}>
-          <StickySection level={4}>
-            <Stack gap={5}>
-              <Heading>{t("filter")}</Heading>
+      <PageContentLayout
+        sidebarPosition="left"
+        sidebarWidth={240}
+        sidebar={
+          <Card className="sticky top-0">
+            <CardHeader>
+              <CardTitle>{t("filter")}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
               <Select
                 id="operationType"
                 items={[...ALLOWED_OPERATION_TYPES]}
@@ -205,17 +200,15 @@ const List: FC = () => {
                       onSelectValueChange("relatedEntityType", selectedItem);
                     }}
                   />
-                  <TextInput
-                    id="relatedEntityKey"
-                    labelText={t("ownerKey")}
+                  <TextField
+                    label={t("ownerKey")}
                     placeholder={t("ownerKeyPlaceholder")}
                     value={filters.relatedEntityKey}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      const value = e.target.value.trim();
+                    onChange={(newValue) => {
+                      const value = newValue.trim();
                       setValue("relatedEntityKey", value);
                       debounce(() => setDebouncedRelatedEntityKey(value ?? ""));
                     }}
-                    size="sm"
                   />
                 </>
               )}
@@ -228,17 +221,15 @@ const List: FC = () => {
                 items={[...ALLOWED_RESULT_TYPES]}
                 selectedItem={filters.result}
               />
-              <TextInput
-                id="actorId"
-                labelText={t("actor")}
+              <TextField
+                label={t("actor")}
                 placeholder={t("actorPlaceholder")}
                 value={filters.actor}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.trim();
+                onChange={(newValue) => {
+                  const value = newValue.trim();
                   setValue("actor", value);
                   debounce(() => setDebouncedActor(value ?? ""));
                 }}
-                size="sm"
               />
               <DateRangeField
                 isModalOpen={isDateRangeModalOpen}
@@ -255,107 +246,107 @@ const List: FC = () => {
                 popoverTitle="Filter by timestamp date range"
                 label={t("date")}
               />
-              <CenteredRow>
-                <Button
-                  kind="ghost"
-                  size="sm"
-                  disabled={
-                    !filters.operationType &&
-                    !filters.entityType &&
-                    !filters.result &&
-                    !filters.actor &&
-                    !filters.timestampFrom &&
-                    !filters.timestampTo
-                  }
-                  type="reset"
-                  onClick={() => {
-                    reset({
-                      operationType: undefined,
-                      entityType: undefined,
-                      relatedEntityType: undefined,
-                      relatedEntityKey: "",
-                      result: undefined,
-                      actor: "",
-                      timestampFrom: "",
-                      timestampTo: "",
-                    });
-                    setDebouncedActor("");
-                    setDebouncedRelatedEntityKey("");
-                  }}
-                >
-                  {t("reset")}
-                </Button>
-              </CenteredRow>
-            </Stack>
-          </StickySection>
-        </ColumnRightPadding>
-        <Column sm={4} md={5} lg={12} xlg={13}>
-          <EntityListStickyWrapper>
-            <EntityList
-              data={
-                auditLogs?.items.map((log) => ({
-                  id: log.auditLogKey,
-                  result:
-                    log.result === "SUCCESS" ? (
-                      <SuccessIcon size={20} />
-                    ) : (
-                      <ErrorIcon size={20} />
-                    ),
-                  operationType: (
-                    <OperationLogName>
-                      {spaceAndCapitalize(log.operationType)}
-                    </OperationLogName>
-                  ),
-                  entityType: spaceAndCapitalize(log.entityType),
-                  reference: (
-                    <CodeSnippet type="inline">
-                      {log.entityDescription?.trim() || log.entityKey}
-                    </CodeSnippet>
-                  ),
-                  property: <CellProperty item={log} />,
-                  actorId: log.actorId ? (
-                    <OperationLogName>
-                      {log.actorType === "CLIENT" ? (
-                        <Api aria-label="Client" />
-                      ) : (
-                        <User aria-label="User" />
-                      )}
-                      {log.agentElementId && <AiAgentIcon aria-label="Agent" />}
-                      {log.actorId}
-                    </OperationLogName>
+              <Button
+                className="mx-auto w-fit"
+                variant="ghost"
+                size="sm"
+                disabled={
+                  !filters.operationType &&
+                  !filters.entityType &&
+                  !filters.result &&
+                  !filters.actor &&
+                  !filters.timestampFrom &&
+                  !filters.timestampTo
+                }
+                type="reset"
+                onClick={() => {
+                  reset({
+                    operationType: undefined,
+                    entityType: undefined,
+                    relatedEntityType: undefined,
+                    relatedEntityKey: "",
+                    result: undefined,
+                    actor: "",
+                    timestampFrom: "",
+                    timestampTo: "",
+                  });
+                  setDebouncedActor("");
+                  setDebouncedRelatedEntityKey("");
+                }}
+              >
+                {t("reset")}
+              </Button>
+            </CardContent>
+          </Card>
+        }
+      >
+        <EntityList
+          data={
+            auditLogs?.items.map((log) => ({
+              id: log.auditLogKey,
+              result:
+                log.result === "SUCCESS" ? (
+                  <CircleCheck
+                    role="img"
+                    className="h-5 w-5 text-success-action-default"
+                    aria-label={spaceAndCapitalize(log.result)}
+                  />
+                ) : (
+                  <XCircle
+                    role="img"
+                    className="h-5 w-5 text-danger-action-default"
+                    aria-label={spaceAndCapitalize(log.result)}
+                  />
+                ),
+              operationType: spaceAndCapitalize(log.operationType),
+              entityType: spaceAndCapitalize(log.entityType),
+              reference: (
+                <Text as="code" variant="code-sm">
+                  {log.entityDescription?.trim() || log.entityKey}
+                </Text>
+              ),
+              property: <CellProperty item={log} />,
+              actorId: log.actorId ? (
+                <div className="flex items-center gap-1">
+                  {log.actorType === "CLIENT" ? (
+                    <Plug role="img" className="h-4 w-4" aria-label="Client" />
                   ) : (
-                    "-"
-                  ),
-                  timestamp: new Date(log.timestamp).toLocaleString(),
-                })) || []
-              }
-              headers={[
-                { header: "", key: "result" },
-                {
-                  header: t("operationType"),
-                  key: "operationType",
-                  isSortable: true,
-                },
-                {
-                  header: t("entityType"),
-                  key: "entityType",
-                  isSortable: true,
-                },
-                { header: t("reference"), key: "reference" },
-                { header: t("property"), key: "property" },
-                { header: t("actor"), key: "actorId", isSortable: true },
-                { header: t("date"), key: "timestamp", isSortable: true },
-              ]}
-              loading={loading}
-              setSort={handleSort}
-              page={{ ...page, ...auditLogs?.page }}
-              pageSizes={[50, 100, 200]}
-              setPageNumber={setPageNumber}
-              setPageSize={setPageSize}
-            />
-          </EntityListStickyWrapper>
-        </Column>
-      </Grid>
+                    <User role="img" className="h-4 w-4" aria-label="User" />
+                  )}
+                  {log.agentElementId && <AiAgentIcon aria-label="Agent" />}
+                  {log.actorId}
+                </div>
+              ) : (
+                "-"
+              ),
+              timestamp: new Date(log.timestamp).toLocaleString(),
+            })) || []
+          }
+          headers={[
+            { header: "", key: "result" },
+            {
+              header: t("operationType"),
+              key: "operationType",
+              isSortable: true,
+            },
+            {
+              header: t("entityType"),
+              key: "entityType",
+              isSortable: true,
+            },
+            { header: t("reference"), key: "reference" },
+            { header: t("property"), key: "property" },
+            { header: t("actor"), key: "actorId", isSortable: true },
+            { header: t("date"), key: "timestamp", isSortable: true },
+          ]}
+          loading={loading}
+          setSort={handleSort}
+          page={{ ...page, ...auditLogs?.page }}
+          pageSizes={[50, 100, 200]}
+          setPageNumber={setPageNumber}
+          setPageSize={setPageSize}
+        />
+      </PageContentLayout>
       {!loading && !success && (
         <TranslatedErrorInlineNotification
           title={t("operationsLogCouldNotLoad")}

--- a/identity/client/src/pages/operations-log/ListV2.tsx
+++ b/identity/client/src/pages/operations-log/ListV2.tsx
@@ -1,0 +1,374 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
+import useTranslate from "src/utility/localization";
+import Page, { PageHeader } from "src/components/layoutV2/Page";
+import EntityList from "src/components/entityListV2";
+import { TranslatedErrorInlineNotification } from "src/components/notificationsV2/InlineNotification";
+import { usePagination, SortConfig } from "src/utility/api";
+import { useQuery } from "@tanstack/react-query";
+import { auditLogQueries } from "src/utility/api/audit-logs/queries";
+import { spaceAndCapitalize } from "src/utility/format/spaceAndCapitalize";
+// TODO: Replace with Tailwind during design-system migration.
+import {
+  OperationLogName,
+  SuccessIcon,
+  ErrorIcon,
+  Grid,
+  ColumnRightPadding,
+  CenteredRow,
+  StickySection,
+  EntityListStickyWrapper,
+} from "./components/styled";
+import {
+  Button,
+  CodeSnippet,
+  Column,
+  Heading,
+  Stack,
+  TextInput,
+} from "@carbon/react";
+import useDebounce from "react-debounced";
+import { useForm, FieldPath, FieldPathValue } from "react-hook-form";
+import { CellProperty } from "src/pages/operations-log/CellPropertyV2";
+import { Api, User } from "@carbon/react/icons";
+import AiAgentIcon from "src/assets/images/ai-agent.svg";
+// TODO: Replace with `DateRangePicker` from design system
+import { DateRangeField } from "src/components/form/DateRangeField";
+import {
+  ALLOWED_ENTITY_TYPES,
+  ALLOWED_OPERATION_TYPES,
+  ALLOWED_RESULT_TYPES,
+  AuditLogFilters,
+  auditLogSearchParamsSync,
+} from "src/pages/operations-log/filters";
+import { useSearchParamsFilters } from "src/utility/filters/useSearchParamsFilters";
+import { Select } from "src/components/formV2/Select";
+
+type AuditLogSort = { field: string; order: "asc" | "desc" };
+
+const DEFAULT_SORT: AuditLogSort[] = [{ field: "timestamp", order: "desc" }];
+
+const ORDER_MAP: Record<SortConfig["order"], AuditLogSort["order"]> = {
+  ASC: "asc",
+  DESC: "desc",
+};
+
+const List: FC = () => {
+  const { t } = useTranslate("operationsLog");
+  const { t: tComponents } = useTranslate();
+  const { searchParamsFilters, setSearchParamsFilters } =
+    useSearchParamsFilters(auditLogSearchParamsSync);
+
+  const { watch, setValue, reset, subscribe } = useForm<AuditLogFilters>({
+    values: searchParamsFilters,
+  });
+  const filters = watch();
+
+  useEffect(
+    () =>
+      subscribe({
+        formState: { values: true },
+        callback: ({ values }) => setSearchParamsFilters(values),
+      }),
+    [subscribe, setSearchParamsFilters],
+  );
+
+  const debounce = useDebounce(500);
+  const [debouncedActor, setDebouncedActor] = useState<string>(filters.actor);
+  const [debouncedRelatedEntityKey, setDebouncedRelatedEntityKey] =
+    useState<string>(filters.relatedEntityKey);
+
+  const [isDateRangeModalOpen, setIsDateRangeModalOpen] =
+    useState<boolean>(false);
+
+  const {
+    pageParams,
+    page,
+    setPageNumber,
+    setPageSize,
+    setSort: setPaginationSort,
+  } = usePagination({
+    pageNumber: 1,
+    pageSize: 50,
+  });
+
+  const transformedSort = useMemo((): AuditLogSort[] => {
+    if (!pageParams.sort || pageParams.sort.length === 0) {
+      return DEFAULT_SORT;
+    }
+    return pageParams.sort.map(({ field, order }) => ({
+      field,
+      order: ORDER_MAP[order],
+    }));
+  }, [pageParams.sort]);
+
+  const {
+    data: auditLogs,
+    isLoading: loading,
+    isSuccess: success,
+    refetch: reload,
+  } = useQuery(
+    auditLogQueries.search({
+      sort: transformedSort,
+      filter: {
+        category: {
+          $eq: "ADMIN",
+        },
+        result: filters.result,
+        operationType: filters.operationType,
+        entityType: filters.entityType,
+        relatedEntityType: filters.relatedEntityType,
+        relatedEntityKey: debouncedRelatedEntityKey
+          ? debouncedRelatedEntityKey
+          : undefined,
+        actorId: debouncedActor ? debouncedActor : undefined,
+        timestamp:
+          filters.timestampFrom && filters.timestampTo
+            ? {
+                $gte: filters.timestampFrom,
+                $lte: filters.timestampTo,
+              }
+            : undefined,
+      },
+      page: {
+        from: pageParams.page.from,
+        limit: pageParams.page.limit,
+      },
+    }),
+  );
+
+  const handleSort = useCallback(
+    (sortConfig: SortConfig[] | undefined) => {
+      setPaginationSort(sortConfig);
+    },
+    [setPaginationSort],
+  );
+
+  const onSelectValueChange = <K extends FieldPath<AuditLogFilters>>(
+    field: K,
+    value: FieldPathValue<AuditLogFilters, K> | undefined,
+  ) => {
+    setValue(field, value as FieldPathValue<AuditLogFilters, K>);
+  };
+
+  return (
+    <Page>
+      <PageHeader
+        title={t("operationsLog")}
+        linkText={t("operationsLog").toLowerCase()}
+        docsLinkPath="/components/admin/audit-operations/"
+      />
+      <Grid condensed fullWidth>
+        <ColumnRightPadding sm={4} md={3} lg={4} xlg={3}>
+          <StickySection level={4}>
+            <Stack gap={5}>
+              <Heading>{t("filter")}</Heading>
+              <Select
+                id="operationType"
+                items={[...ALLOWED_OPERATION_TYPES]}
+                titleText={t("operationType")}
+                selectedItem={filters.operationType}
+                onChange={({ selectedItem }) => {
+                  onSelectValueChange("operationType", selectedItem);
+                }}
+              />
+              <Select
+                id="entityType"
+                items={[...ALLOWED_ENTITY_TYPES]}
+                titleText={t("entityType")}
+                selectedItem={filters.entityType}
+                onChange={({ selectedItem }) => {
+                  onSelectValueChange("entityType", selectedItem);
+
+                  if (selectedItem !== "AUTHORIZATION") {
+                    setValue("relatedEntityType", undefined);
+                    setValue("relatedEntityKey", "");
+                    setDebouncedRelatedEntityKey("");
+                  }
+                }}
+              />
+              {filters.entityType === "AUTHORIZATION" && (
+                <>
+                  <Select
+                    id="relatedEntityType"
+                    items={[...ALLOWED_ENTITY_TYPES]}
+                    titleText={t("ownerType")}
+                    selectedItem={filters.relatedEntityType}
+                    onChange={({ selectedItem }) => {
+                      onSelectValueChange("relatedEntityType", selectedItem);
+                    }}
+                  />
+                  <TextInput
+                    id="relatedEntityKey"
+                    labelText={t("ownerKey")}
+                    placeholder={t("ownerKeyPlaceholder")}
+                    value={filters.relatedEntityKey}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      const value = e.target.value.trim();
+                      setValue("relatedEntityKey", value);
+                      debounce(() => setDebouncedRelatedEntityKey(value ?? ""));
+                    }}
+                    size="sm"
+                  />
+                </>
+              )}
+              <Select
+                titleText={t("status")}
+                id="result-field"
+                onChange={({ selectedItem }) => {
+                  onSelectValueChange("result", selectedItem);
+                }}
+                items={[...ALLOWED_RESULT_TYPES]}
+                selectedItem={filters.result}
+              />
+              <TextInput
+                id="actorId"
+                labelText={t("actor")}
+                placeholder={t("actorPlaceholder")}
+                value={filters.actor}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  const value = e.target.value.trim();
+                  setValue("actor", value);
+                  debounce(() => setDebouncedActor(value ?? ""));
+                }}
+                size="sm"
+              />
+              <DateRangeField
+                isModalOpen={isDateRangeModalOpen}
+                onModalClose={() => setIsDateRangeModalOpen(false)}
+                onClick={() => setIsDateRangeModalOpen(true)}
+                value={{
+                  from: filters.timestampFrom ?? "",
+                  to: filters.timestampTo ?? "",
+                }}
+                onChange={([from, to]) => {
+                  setValue("timestampFrom", from ? from.toISOString() : "");
+                  setValue("timestampTo", to ? to.toISOString() : "");
+                }}
+                popoverTitle="Filter by timestamp date range"
+                label={t("date")}
+              />
+              <CenteredRow>
+                <Button
+                  kind="ghost"
+                  size="sm"
+                  disabled={
+                    !filters.operationType &&
+                    !filters.entityType &&
+                    !filters.result &&
+                    !filters.actor &&
+                    !filters.timestampFrom &&
+                    !filters.timestampTo
+                  }
+                  type="reset"
+                  onClick={() => {
+                    reset({
+                      operationType: undefined,
+                      entityType: undefined,
+                      relatedEntityType: undefined,
+                      relatedEntityKey: "",
+                      result: undefined,
+                      actor: "",
+                      timestampFrom: "",
+                      timestampTo: "",
+                    });
+                    setDebouncedActor("");
+                    setDebouncedRelatedEntityKey("");
+                  }}
+                >
+                  {t("reset")}
+                </Button>
+              </CenteredRow>
+            </Stack>
+          </StickySection>
+        </ColumnRightPadding>
+        <Column sm={4} md={5} lg={12} xlg={13}>
+          <EntityListStickyWrapper>
+            <EntityList
+              data={
+                auditLogs?.items.map((log) => ({
+                  id: log.auditLogKey,
+                  result:
+                    log.result === "SUCCESS" ? (
+                      <SuccessIcon size={20} />
+                    ) : (
+                      <ErrorIcon size={20} />
+                    ),
+                  operationType: (
+                    <OperationLogName>
+                      {spaceAndCapitalize(log.operationType)}
+                    </OperationLogName>
+                  ),
+                  entityType: spaceAndCapitalize(log.entityType),
+                  reference: (
+                    <CodeSnippet type="inline">
+                      {log.entityDescription?.trim() || log.entityKey}
+                    </CodeSnippet>
+                  ),
+                  property: <CellProperty item={log} />,
+                  actorId: log.actorId ? (
+                    <OperationLogName>
+                      {log.actorType === "CLIENT" ? (
+                        <Api aria-label="Client" />
+                      ) : (
+                        <User aria-label="User" />
+                      )}
+                      {log.agentElementId && <AiAgentIcon aria-label="Agent" />}
+                      {log.actorId}
+                    </OperationLogName>
+                  ) : (
+                    "-"
+                  ),
+                  timestamp: new Date(log.timestamp).toLocaleString(),
+                })) || []
+              }
+              headers={[
+                { header: "", key: "result" },
+                {
+                  header: t("operationType"),
+                  key: "operationType",
+                  isSortable: true,
+                },
+                {
+                  header: t("entityType"),
+                  key: "entityType",
+                  isSortable: true,
+                },
+                { header: t("reference"), key: "reference" },
+                { header: t("property"), key: "property" },
+                { header: t("actor"), key: "actorId", isSortable: true },
+                { header: t("date"), key: "timestamp", isSortable: true },
+              ]}
+              loading={loading}
+              setSort={handleSort}
+              page={{ ...page, ...auditLogs?.page }}
+              pageSizes={[50, 100, 200]}
+              setPageNumber={setPageNumber}
+              setPageSize={setPageSize}
+            />
+          </EntityListStickyWrapper>
+        </Column>
+      </Grid>
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("operationsLogCouldNotLoad")}
+          actionButton={{
+            label: tComponents("retry"),
+            onClick: () => {
+              void reload();
+            },
+          }}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/operations-log/index.tsx
+++ b/identity/client/src/pages/operations-log/index.tsx
@@ -8,14 +8,26 @@
 
 import { FC, lazy, Suspense } from "react";
 import { ListPageFallback } from "src/components/fallbacks";
+import { ListPageFallback as ListPageFallbackV2 } from "src/components/fallbacksV2";
 import PageRoutes from "src/components/router/PageRoutes";
+import { IS_NEW_DESIGN_SYSTEM_ENABLED } from "src/feature-flags";
 
-const List = lazy(() => import("./List"));
+const List = lazy(() =>
+  IS_NEW_DESIGN_SYSTEM_ENABLED ? import("./ListV2") : import("./List"),
+);
 
 const OperationsLog: FC = () => (
   <PageRoutes
     indexElement={
-      <Suspense fallback={<ListPageFallback />}>
+      <Suspense
+        fallback={
+          IS_NEW_DESIGN_SYSTEM_ENABLED ? (
+            <ListPageFallbackV2 />
+          ) : (
+            <ListPageFallback />
+          )
+        }
+      >
         <List />
       </Suspense>
     }


### PR DESCRIPTION
## Description

This PR migrates Operations log page to the new design system. As usual, the first PR duplicates the code for feature-flagging. The second one is the actual migration. Important detail: **I have not migrated the date-time range modal yet.** I will address it in a followup PR. In the future, a component/pattern for it can hopefully be provided by the design system: https://github.com/camunda/design-system/issues/581

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

relates #60632 

