### PR TITLE
refactor: remove unnecessary legacy mapping from dynamic config

### DIFF
--- a/service/src/main/java/io/camunda/service/RecoveryServices.java
+++ b/service/src/main/java/io/camunda/service/RecoveryServices.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.TenantRestoreArguments;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.util.Either;
@@ -102,15 +101,10 @@ public final class RecoveryServices extends PhysicalTenantScopedApiServices<Reco
         dryRun);
   }
 
-  public CompletableFuture<Either<ErrorResponse, ClusterConfiguration>> restoreStatus(
+  public CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> restoreStatus(
       final CamundaAuthentication authentication) {
     return withAnyPermission(
-        RESTORE_AUTHORIZATIONS,
-        authentication,
-        () ->
-            clusterConfigurationRequestSender
-                .getTopology()
-                .thenApply(result -> result.map(CurrentClusterConfiguration::toLegacyDefault)));
+        RESTORE_AUTHORIZATIONS, authentication, clusterConfigurationRequestSender::getTopology);
   }
 
   private <T> CompletableFuture<T> withAnyPermission(

--- a/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RecoveryServicesTest.java
@@ -333,7 +333,7 @@ public class RecoveryServicesTest {
 
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
-    assertThat(future.join().get()).isEqualTo(configuration.toLegacyDefault());
+    assertThat(future.join().get()).isEqualTo(configuration);
     verify(clusterConfigurationRequestSender).getTopology();
   }
 
@@ -348,7 +348,7 @@ public class RecoveryServicesTest {
 
     // then
     assertThat(future).succeedsWithin(ofSeconds(1));
-    assertThat(future.join().get()).isEqualTo(configuration.toLegacyDefault());
+    assertThat(future.join().get()).isEqualTo(configuration);
     verify(clusterConfigurationRequestSender).getTopology();
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -13,14 +13,12 @@ import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.Member;
 import io.camunda.cluster.PartitionId;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.PartitionRoleValues;
 import io.camunda.zeebe.broker.client.api.BrokerClientTopologyMetrics;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientTopologyImpl.ConfiguredClusterState;
-import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
@@ -300,9 +298,7 @@ public final class BrokerTopologyManagerImpl extends Actor
       final BrokerClientTopologyImpl oldTopology) {
     final var newClusterSize = clusterTopology.clusterSize();
     final PartitionGroupConfiguration partitionGroupConfiguration =
-        ClusterConfigurationManagerService.USE_NEW_CONFIG
-            ? clusterTopology.partitionGroup(groupId)
-            : clusterTopology.partitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+        clusterTopology.partitionGroup(groupId);
     if (partitionGroupConfiguration == null) {
       LOG.warn("No partition group configuration found for group {}, skipping update", groupId);
       return oldTopology;

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -98,6 +98,12 @@ final class TestTopologyManager implements BrokerTopologyManager {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public void onClusterConfigurationUpdated(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException();
+  }
+
   @NullMarked
   private static final class TestBrokerClusterState implements BrokerClusterState {
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -269,30 +269,17 @@ public class DynamicClusterConfigurationService
    */
   private InconsistentConfigurationListener inconsistentConfigurationListener(
       final BrokerStartupContext brokerStartupContext) {
-    final var memberId =
-        brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
     final var springBrokerBridge = brokerStartupContext.getSpringBrokerBridge();
 
-    return new InconsistentConfigurationListener() {
-      @Override
-      public void onInconsistentConfiguration(
-          final ClusterConfiguration newTopology, final ClusterConfiguration oldTopology) {
-        shutdownOnInconsistentTopology(memberId, springBrokerBridge, newTopology, oldTopology);
-      }
-
-      @Override
-      public void onInconsistentConfiguration(
-          final CurrentClusterConfiguration newConfiguration,
-          final CurrentClusterConfiguration oldConfiguration) {
-        LOGGER.warn(
-            "Received a newer cluster configuration which differs for this broker across partition groups. Shutting down broker. oldVersion={}, newVersion={}",
-            oldConfiguration.version(),
-            newConfiguration.version());
-        springBrokerBridge.initiateShutdown(
-            ERROR_CODE_ON_INCONSISTENT_TOPOLOGY,
-            "Inconsistent cluster topology detected - topology was changed while broker was"
-                + " unreachable or broker encountered data loss");
-      }
+    return (newConfiguration, oldConfiguration) -> {
+      LOGGER.warn(
+          "Received a newer cluster configuration which differs for this broker across partition groups. Shutting down broker. oldVersion={}, newVersion={}",
+          oldConfiguration.version(),
+          newConfiguration.version());
+      springBrokerBridge.initiateShutdown(
+          ERROR_CODE_ON_INCONSISTENT_TOPOLOGY,
+          "Inconsistent cluster topology detected - topology was changed while broker was"
+              + " unreachable or broker encountered data loss");
     };
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
@@ -60,24 +60,6 @@ public interface ClusterConfigurationManager {
      * @param oldConfiguration the local configuration before receiving the new one
      */
     void onInconsistentConfiguration(
-        ClusterConfiguration newConfiguration, ClusterConfiguration oldConfiguration);
-
-    /**
-     * New-model counterpart of {@link #onInconsistentConfiguration(ClusterConfiguration,
-     * ClusterConfiguration)}, invoked when the local member's state differs, in any partition
-     * group, between the old and newly-merged {@link CurrentClusterConfiguration}. Defaults to
-     * projecting both configurations to their legacy default-group view so that listeners written
-     * against the legacy model keep working unchanged; override this directly to react to
-     * inconsistencies in a specific, non-default partition group.
-     *
-     * @param newConfiguration new configuration after merging
-     * @param oldConfiguration the local configuration before merging
-     */
-    default void onInconsistentConfiguration(
-        final CurrentClusterConfiguration newConfiguration,
-        final CurrentClusterConfiguration oldConfiguration) {
-      onInconsistentConfiguration(
-          newConfiguration.toLegacyDefault(), oldConfiguration.toLegacyDefault());
-    }
+        CurrentClusterConfiguration newConfiguration, CurrentClusterConfiguration oldConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
@@ -14,8 +14,6 @@ import java.util.function.UnaryOperator;
 
 public interface ClusterConfigurationManager {
 
-  ActorFuture<ClusterConfiguration> getClusterConfiguration();
-
   ActorFuture<ClusterConfiguration> updateClusterConfiguration(
       UnaryOperator<ClusterConfiguration> updatedConfiguration);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -181,15 +181,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
             () -> this.persistedCurrentConfiguration.getConfiguration());
   }
 
-  /** Legacy single-group projection of the multi-partition-group configuration. */
-  @Override
-  public ActorFuture<ClusterConfiguration> getClusterConfiguration() {
-    final var future = executor.<ClusterConfiguration>createFuture();
-    executor.run(
-        () -> future.complete(persistedCurrentConfiguration.getConfiguration().toLegacyDefault()));
-    return future;
-  }
-
   /**
    * Not supported on the multi-partition-group model — the legacy single-group configuration cannot
    * be mutated in isolation. Use {@link #updateMultiConfiguration} instead.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -37,7 +37,6 @@ import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
@@ -302,10 +301,6 @@ public final class ClusterConfigurationManagerService
                   .onComplete(result);
             });
     return result;
-  }
-
-  public ActorFuture<ClusterConfiguration> getClusterTopology() {
-    return clusterConfigurationManager.getClusterConfiguration();
   }
 
   public ActorFuture<CurrentClusterConfiguration> getClusterConfiguration() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -65,15 +65,6 @@ public final class ClusterConfigurationManagerService
     implements ClusterConfigurationUpdateNotifier, AsyncClosable {
   public static final String TOPOLOGY_FILE_NAME = ".topology.meta";
 
-  /**
-   * Static feature flag indicating that the manager operates on the multi-partition-group model.
-   * Kept as a named constant for callers outside this class that still branch on it explicitly
-   * (e.g. {@code BrokerTopologyManagerImpl}, {@code GatewayClusterConfigurationService}); within
-   * this class and {@link ClusterConfigurationManagerImpl}, the legacy single-group code path has
-   * been removed and the new model always runs.
-   */
-  public static final boolean USE_NEW_CONFIG = true;
-
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
   private final PersistedCurrentClusterConfiguration persistedCurrentClusterConfiguration;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationUpdateNotifier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationUpdateNotifier.java
@@ -27,14 +27,9 @@ public interface ClusterConfigurationUpdateNotifier {
    */
   void removeUpdateListener(ClusterConfigurationUpdateListener listener);
 
-  @FunctionalInterface
   interface ClusterConfigurationUpdateListener {
     void onClusterConfigurationUpdated(ClusterConfiguration clusterConfiguration);
 
-    default void onClusterConfigurationUpdated(
-        final CurrentClusterConfiguration clusterConfiguration) {
-      // Temporary workaround until fully switched to the new data model.
-      onClusterConfigurationUpdated(clusterConfiguration.toLegacyDefault());
-    }
+    void onClusterConfigurationUpdated(final CurrentClusterConfiguration clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
@@ -30,13 +30,13 @@ import org.slf4j.LoggerFactory;
  * configuration. So the service does not run ClusterConfigurationManager, but only contains the
  * ClusterConfigurationGossiper.
  *
- * <p>When {@link ClusterConfigurationManagerService#USE_NEW_CONFIG} is enabled, this service tracks
- * and gossips the multi-partition-group {@link CurrentClusterConfiguration} instead of the legacy
- * single-group {@link ClusterConfiguration}, mirroring what {@link ClusterConfigurationManagerImpl}
- * does for brokers. This matters beyond the gateway's own view: before this, the gateway only ever
- * gossiped the legacy field, so any real broker that fell back to {@code
- * CurrentClusterConfiguration#fromLegacy} for a message relayed by the gateway could construct a
- * lossy reconstruction of an in-progress plan that conflicted with its own, natively-tracked one.
+ * <p>This service tracks and gossips the multi-partition-group {@link CurrentClusterConfiguration}
+ * instead of the legacy single-group {@link ClusterConfiguration}, mirroring what {@link
+ * ClusterConfigurationManagerImpl} does for brokers. This matters beyond the gateway's own view:
+ * before this, the gateway only ever gossiped the legacy field, so any real broker that fell back
+ * to {@code CurrentClusterConfiguration#fromLegacy} for a message relayed by the gateway could
+ * construct a lossy reconstruction of an in-progress plan that conflicted with its own,
+ * natively-tracked one.
  */
 public class GatewayClusterConfigurationService extends Actor
     implements ClusterConfigurationUpdateNotifier {
@@ -57,18 +57,11 @@ public class GatewayClusterConfigurationService extends Actor
       final ClusterMembershipService memberShipService,
       final ClusterConfigurationGossiperConfig config,
       final MeterRegistry meterRegistry) {
-    this(
-        communicationService,
-        memberShipService,
-        config,
-        meterRegistry,
-        ClusterConfigurationManagerService.USE_NEW_CONFIG);
+    this(communicationService, memberShipService, config, meterRegistry, true);
   }
 
   /**
-   * @param useNewConfig overrides {@link ClusterConfigurationManagerService#USE_NEW_CONFIG} for
-   *     testing; production code always goes through the constructor above, which uses the
-   *     compile-time flag.
+   * @param useNewConfig allows overriding for testing; production code always enables this.
    */
   @VisibleForTesting
   GatewayClusterConfigurationService(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
@@ -13,13 +13,11 @@ import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiper;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * ClusterConfigurationGossiper.
  *
  * <p>This service tracks and gossips the multi-partition-group {@link CurrentClusterConfiguration}
- * instead of the legacy single-group {@link ClusterConfiguration}, mirroring what {@link
+ * instead of the legacy single-group {@code ClusterConfiguration}, mirroring what {@link
  * ClusterConfigurationManagerImpl} does for brokers. This matters beyond the gateway's own view:
  * before this, the gateway only ever gossiped the legacy field, so any real broker that fell back
  * to {@code CurrentClusterConfiguration#fromLegacy} for a message relayed by the gateway could
@@ -44,9 +42,7 @@ public class GatewayClusterConfigurationService extends Actor
       LoggerFactory.getLogger(GatewayClusterConfigurationService.class);
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
 
-  // Keep an in memory copy of the configuration. No need to persist it. Exactly one of the two
-  // fields below is actively updated, matching useNewConfig.
-  private ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
+  // Keep an in memory copy of the configuration. No need to persist it.
   private CurrentClusterConfiguration currentClusterConfiguration =
       CurrentClusterConfiguration.uninitialized();
   private final TopologyMetrics topologyMetrics;
@@ -57,19 +53,6 @@ public class GatewayClusterConfigurationService extends Actor
       final ClusterMembershipService memberShipService,
       final ClusterConfigurationGossiperConfig config,
       final MeterRegistry meterRegistry) {
-    this(communicationService, memberShipService, config, meterRegistry, true);
-  }
-
-  /**
-   * @param useNewConfig allows overriding for testing; production code always enables this.
-   */
-  @VisibleForTesting
-  GatewayClusterConfigurationService(
-      final ClusterCommunicationService communicationService,
-      final ClusterMembershipService memberShipService,
-      final ClusterConfigurationGossiperConfig config,
-      final MeterRegistry meterRegistry,
-      final boolean useNewConfig) {
     topologyMetrics = new TopologyMetrics(meterRegistry);
     clusterConfigurationGossiper =
         new ClusterConfigurationGossiper(
@@ -78,8 +61,8 @@ public class GatewayClusterConfigurationService extends Actor
             memberShipService,
             new ProtoBufSerializer(),
             config,
-            useNewConfig ? ignored -> {} : this::updateClusterTopology,
-            useNewConfig ? this::updateCurrentClusterTopology : null,
+            ignored -> {},
+            this::updateCurrentClusterTopology,
             topologyMetrics);
   }
 
@@ -105,34 +88,6 @@ public class GatewayClusterConfigurationService extends Actor
   @Override
   protected void onActorClosing() {
     clusterConfigurationGossiper.close();
-  }
-
-  private void updateClusterTopology(final ClusterConfiguration clusterConfiguration) {
-
-    actor.run(
-        () -> {
-          if (clusterConfiguration == null || clusterConfiguration.isUninitialized()) {
-            return;
-          }
-
-          try {
-            final var mergedTopology = this.clusterConfiguration.merge(clusterConfiguration);
-            if (mergedTopology.equals(this.clusterConfiguration)) {
-              return;
-            }
-            LOG.debug(
-                "Received new configuration {}. Updating local configuration to {}",
-                clusterConfiguration,
-                mergedTopology);
-            this.clusterConfiguration = mergedTopology;
-            clusterConfigurationGossiper.updateClusterConfiguration(this.clusterConfiguration);
-          } catch (final Exception updateFailed) {
-            LOG.warn(
-                "Failed to process received configuration update {}",
-                clusterConfiguration,
-                updateFailed);
-          }
-        });
   }
 
   private void updateCurrentClusterTopology(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
@@ -78,11 +77,6 @@ public interface ClusterConfigurationCoordinatorSupplier {
   static ClusterConfigurationCoordinatorSupplier from(
       final Supplier<CurrentClusterConfiguration> clusterTopologySupplier) {
     return ofMembers(() -> getActiveMembers(clusterTopologySupplier.get()));
-  }
-
-  static ClusterConfigurationCoordinatorSupplier of(
-      final Supplier<ClusterConfiguration> clusterTopologySupplier) {
-    return ofMembers(() -> clusterTopologySupplier.get().members().keySet());
   }
 
   private static Set<MemberId> getActiveMembers(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreStatus.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreStatus.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionPreRestoreOperation;
@@ -45,7 +45,7 @@ public record RestoreStatus(ChangePlan plan, List<BrokerRestoreStatus> brokers) 
     this(plan, mapBrokers(plan));
   }
 
-  public static Optional<RestoreStatus> of(final ClusterConfiguration configuration) {
+  public static Optional<RestoreStatus> of(final PartitionGroupConfiguration configuration) {
     return configuration
         .pendingChanges()
         .filter(RestoreStatus::isRestoreInProgress)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -202,7 +202,8 @@ public final class ClusterConfigurationGossiper
     LOGGER.trace("Updated local gossipState to {}", updatedConfiguration);
     gossip();
     notifyListeners(updatedConfiguration);
-    topologyMetrics.updateFromTopology(updatedConfiguration);
+    topologyMetrics.updateFromTopology(
+        CurrentClusterConfiguration.fromLegacy(updatedConfiguration));
   }
 
   private void onCurrentConfigurationUpdated(
@@ -214,7 +215,7 @@ public final class ClusterConfigurationGossiper
     LOGGER.trace("Updated local gossipState to {}", updatedConfiguration);
     gossip();
     notifyListeners(updatedConfiguration);
-    topologyMetrics.updateFromTopology(legacyView);
+    topologyMetrics.updateFromTopology(updatedConfiguration);
   }
 
   private void notifyListeners(final CurrentClusterConfiguration updatedConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
@@ -12,8 +12,9 @@ import static io.camunda.zeebe.dynamic.config.metrics.TopologyMetricsDoc.*;
 import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.util.micrometer.EnumMeter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -53,19 +54,52 @@ public final class TopologyMetrics {
     return value;
   }
 
-  public void updateFromTopology(final ClusterConfiguration topology) {
-    topologyVersion.set(topology.version());
-    changeStatus.state(
+  /**
+   * Reports the same values the legacy single-group projection carried: the topology version and
+   * the state of the change plan currently active in the global configuration or, failing that, the
+   * default partition group — a cluster applies at most one plan that touches either at a time, so
+   * that one plan is the cluster's change.
+   */
+  public void updateFromTopology(final CurrentClusterConfiguration topology) {
+    final var globalConfiguration = topology.globalConfiguration();
+    final var defaultGroup =
         topology
+            .partitionGroups()
+            .getOrDefault(
+                CurrentClusterConfiguration.DEFAULT_GROUP,
+                PartitionGroupConfiguration.empty(topology.version()));
+    topologyVersion.set(Math.max(globalConfiguration.version(), defaultGroup.version()));
+
+    final var pendingChanges =
+        globalConfiguration
             .pendingChanges()
+            .<ChangePlan>map(plan -> plan)
+            .filter(ChangePlan::hasPendingChanges)
+            .or(
+                () ->
+                    defaultGroup
+                        .pendingChanges()
+                        .<ChangePlan>map(plan -> plan)
+                        .filter(ChangePlan::hasPendingChanges));
+    changeStatus.state(
+        pendingChanges
             .map(ChangePlan::status)
-            .or(() -> topology.lastChange().map(CompletedChange::status))
+            .or(() -> topology.phasedChangeState().lastChange().map(TopologyMetrics::legacyStatus))
             .orElse(Status.COMPLETED));
-    changeId.set(topology.pendingChanges().map(ChangePlan::id).orElse(0L));
-    changeVersion.set(topology.pendingChanges().map(ChangePlan::version).orElse(0));
+    changeId.set(pendingChanges.map(ChangePlan::id).orElse(0L));
+    changeVersion.set(pendingChanges.map(ChangePlan::version).orElse(0));
     pendingOperations.set(
-        topology.pendingChanges().map(ChangePlan::pendingOperations).map(List::size).orElse(0));
+        pendingChanges.map(ChangePlan::pendingOperations).map(List::size).orElse(0));
     completedOperations.set(
-        topology.pendingChanges().map(ChangePlan::completedOperations).map(List::size).orElse(0));
+        pendingChanges.map(ChangePlan::completedOperations).map(List::size).orElse(0));
+  }
+
+  /** The terminal status as the gauge's {@link ClusterChangePlan.Status} labels it. */
+  private static Status legacyStatus(final CompletedPhasedChange change) {
+    return switch (change.status()) {
+      case COMPLETED -> Status.COMPLETED;
+      case FAILED -> Status.FAILED;
+      case CANCELLED -> Status.CANCELLED;
+    };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -116,7 +116,7 @@ public record CurrentClusterConfiguration(
    * mid-migration between the two modes rather than unzoned.
    *
    * <p>Both are global state, so this reads the same fields {@link
-   * ClusterConfiguration#isUnzoned()} does — the projection through {@link #toLegacyDefault()} that
+   * ClusterConfiguration#isUnzoned()} does — the projection through {@link #toLegacy(String)} that
    * method needs is not.
    */
   public boolean isUnzoned() {
@@ -134,7 +134,7 @@ public record CurrentClusterConfiguration(
    *
    * <p>Both are global state, so this reads the same fields {@link
    * ClusterConfiguration#isFullyZoneAware()} does — the projection through {@link
-   * #toLegacyDefault()} that method needs is not.
+   * #toLegacy(String)})} that method needs is not.
    */
   public boolean isFullyZoneAware() {
     return globalConfiguration.members().keySet().stream().allMatch(member -> member.zone() != null)
@@ -150,7 +150,7 @@ public record CurrentClusterConfiguration(
    *
    * <p>Both are global state, so this reads the same fields {@link
    * ClusterConfiguration#isPartiallyZoneAware()} does — the projection through {@link
-   * #toLegacyDefault()} that method needs is not.
+   * #toLegacy(String)})} that method needs is not.
    */
   public boolean isPartiallyZoneAware() {
     final var members = globalConfiguration.members().keySet();
@@ -305,9 +305,7 @@ public record CurrentClusterConfiguration(
   /**
    * Projects this multi-group configuration back to a legacy single-group {@link
    * ClusterConfiguration} representing the named partition group. This is the inverse of {@link
-   * #fromLegacy(ClusterConfiguration)} and backs the {@code getClusterConfiguration()} compat
-   * accessor used by read consumers (e.g. the REST topology API) that have not yet migrated to the
-   * multi-group model.
+   * #fromLegacy(ClusterConfiguration)}.
    *
    * <p>Each member combines its cluster-wide lifecycle state (from {@link #globalConfiguration})
    * with its partition assignment in {@code groupId} (from {@code partitionGroups[groupId]}); a

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -468,6 +468,16 @@ public record CurrentClusterConfiguration(
     return new CurrentClusterConfiguration(version, updated, partitionGroups, phasedChangeState);
   }
 
+  public CurrentClusterConfiguration initPartitionGroup(final String groupId) {
+    if (hasPartitionGroup(groupId)) {
+      throw new IllegalStateException("Partition group %s already exists".formatted(groupId));
+    }
+    final var updatedPartitionGroups = new HashMap<>(partitionGroups);
+    updatedPartitionGroups.put(groupId, PartitionGroupConfiguration.empty(0));
+    return new CurrentClusterConfiguration(
+        version, globalConfiguration, updatedPartitionGroups, phasedChangeState);
+  }
+
   /**
    * Applies {@code updater} to the named partition group. Returns {@code this} if the group is
    * unchanged.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -133,7 +134,8 @@ public record GlobalConfiguration(
    * @throws IllegalStateException if the broker is not part of the cluster
    */
   public GlobalConfiguration updateMember(
-      final MemberId memberId, final UnaryOperator<BrokerState> memberStateUpdater) {
+      final MemberId memberId,
+      final Function<BrokerState, @Nullable BrokerState> memberStateUpdater) {
     final BrokerState current = members.get(memberId);
     if (current == null) {
       throw new IllegalStateException(
@@ -141,11 +143,15 @@ public record GlobalConfiguration(
               "Expected to update member %s, but it is not part of the cluster", memberId.id()));
     }
     final var updated = memberStateUpdater.apply(current);
-    if (updated.equals(current)) {
+    if (current.equals(updated)) {
       return this;
     }
     final var updatedMembers = new HashMap<>(members);
-    updatedMembers.put(memberId, updated);
+    if (updated != null) {
+      updatedMembers.put(memberId, updated);
+    } else {
+      updatedMembers.remove(memberId);
+    }
     return withMembers(updatedMembers);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -227,7 +228,8 @@ public record PartitionGroupConfiguration(
    * @throws IllegalStateException if the broker is not part of the group
    */
   public PartitionGroupConfiguration updateMember(
-      final MemberId memberId, final UnaryOperator<BrokerPartitionState> memberStateUpdater) {
+      final MemberId memberId,
+      final Function<BrokerPartitionState, @Nullable BrokerPartitionState> memberStateUpdater) {
     final BrokerPartitionState current = members.get(memberId);
     if (current == null) {
       throw new IllegalStateException(
@@ -235,11 +237,15 @@ public record PartitionGroupConfiguration(
               "Expected to update member %s, but it is not part of the group", memberId.id()));
     }
     final var updated = memberStateUpdater.apply(current);
-    if (updated.equals(current)) {
+    if (current.equals(updated)) {
       return this;
     }
     final var updatedMembers = new HashMap<>(members);
-    updatedMembers.put(memberId, updated);
+    if (updated != null) {
+      updatedMembers.put(memberId, updated);
+    } else {
+      updatedMembers.remove(memberId);
+    }
     return withMembers(updatedMembers);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -149,7 +149,7 @@ public final class ConfigurationUtil {
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(
-      final ClusterConfiguration clusterConfiguration, final String groupName) {
+      final CurrentClusterConfiguration clusterConfiguration, final String groupName) {
     if (clusterConfiguration.isUninitialized()) {
       throw new IllegalStateException(
           "Cannot generated partition distribution from uninitialized configuration");
@@ -157,6 +157,7 @@ public final class ConfigurationUtil {
 
     final var memberPriorityByPartition = new HashMap<Integer, Map<MemberId, Integer>>();
     clusterConfiguration
+        .partitionGroup(groupName)
         .members()
         .forEach(
             (memberId, member) -> {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -55,8 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Exercises {@link ClusterConfigurationManagerService} end-to-end against the new
- * multi-partition-group model ({@code USE_NEW_CONFIG = true}). Assertions read the {@link
+ * Exercises {@link ClusterConfigurationManagerService} end-to-end. Assertions read the {@link
  * CurrentClusterConfiguration} directly (via {@link
  * ClusterConfigurationManagerService#getClusterConfiguration()}) rather than the legacy compat
  * projection ({@code toLegacyDefault()}), since that projection cannot distinguish "uninitialized"

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -59,8 +59,8 @@ import org.junit.jupiter.api.io.TempDir;
  * multi-partition-group model ({@code USE_NEW_CONFIG = true}). Assertions read the {@link
  * CurrentClusterConfiguration} directly (via {@link
  * ClusterConfigurationManagerService#getClusterConfiguration()}) rather than the legacy compat
- * projection ({@code getClusterTopology()}/{@code toLegacyDefault()}), since that projection cannot
- * distinguish "uninitialized" from "initialized but empty" for the new model.
+ * projection ({@code toLegacyDefault()}), since that projection cannot distinguish "uninitialized"
+ * from "initialized but empty" for the new model.
  */
 class ClusterConfigurationManagementIntegrationTest {
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -19,7 +19,6 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
-import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
@@ -36,7 +35,6 @@ import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -897,22 +895,9 @@ final class ClusterConfigurationManagerImplTest {
     final var newConfigSeen = new AtomicReference<CurrentClusterConfiguration>();
     final var oldConfigSeen = new AtomicReference<CurrentClusterConfiguration>();
     manager.registerTopologyChangedListener(
-        new InconsistentConfigurationListener() {
-          @Override
-          public void onInconsistentConfiguration(
-              final ClusterConfiguration newConfiguration,
-              final ClusterConfiguration oldConfiguration) {
-            org.assertj.core.api.Assertions.fail(
-                "Expected CurrentClusterConfiguration overload to be used for inconsistency detection");
-          }
-
-          @Override
-          public void onInconsistentConfiguration(
-              final CurrentClusterConfiguration newConfiguration,
-              final CurrentClusterConfiguration oldConfiguration) {
-            newConfigSeen.set(newConfiguration);
-            oldConfigSeen.set(oldConfiguration);
-          }
+        (newConfiguration, oldConfiguration) -> {
+          newConfigSeen.set(newConfiguration);
+          oldConfigSeen.set(oldConfiguration);
         });
 
     // when — a force-scale-down is received via gossip: member 0 is stripped out of the "tenanta"

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplTest.java
@@ -1848,8 +1848,7 @@ final class ClusterConfigurationManagerImplTest {
 
   /**
    * A fresh cluster with no configured cluster id must still come up with one, and it must be
-   * visible through the legacy projection: consumers such as the Hub ping read {@code
-   * BrokerTopologyManager#getClusterConfiguration().clusterId()} and block until it is present.
+   * visible through the legacy projection.
    */
   @Test
   void shouldStartFromStaticInitializerWithGeneratedClusterId() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationServiceTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationServiceTest.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.CloseHelper;
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -82,12 +81,12 @@ final class GatewayClusterConfigurationServiceTest {
   }
 
   @Test
-  void shouldReceiveNewModelConfigurationWhenUseNewConfigIsEnabled() {
+  void shouldReceiveNewModelConfiguration() {
     // given — a broker gossiping the new-model configuration, and a gateway wired for the new
     // model
     broker1 = new TestBroker(createClusterNode(clusterNodes.get(0), clusterNodes), true);
     broker1.start();
-    startGateway(clusterNodes.get(1), true);
+    startGateway(clusterNodes.get(1));
 
     final var brokerConfiguration =
         CurrentClusterConfiguration.fromLegacy(
@@ -130,7 +129,7 @@ final class GatewayClusterConfigurationServiceTest {
     broker3 = new TestBroker(createClusterNode(clusterNodes.get(2), clusterNodes), true);
     broker1.start();
     broker3.start();
-    startGateway(clusterNodes.get(1), true);
+    startGateway(clusterNodes.get(1));
 
     final var tenantGroup =
         new PartitionGroupConfiguration(
@@ -167,7 +166,7 @@ final class GatewayClusterConfigurationServiceTest {
     broker3 = new TestBroker(createClusterNode(clusterNodes.get(2), clusterNodes), true);
     broker1.start();
     broker3.start();
-    startGateway(clusterNodes.get(1), true);
+    startGateway(clusterNodes.get(1));
 
     final var brokerTopology =
         ClusterConfiguration.init()
@@ -194,43 +193,7 @@ final class GatewayClusterConfigurationServiceTest {
             () -> assertThat(broker3.currentClusterConfiguration).isEqualTo(reconstructed));
   }
 
-  @Test
-  void shouldStillReceiveLegacyConfigurationWhenUseNewConfigIsDisabled() {
-    // given — a broker gossiping only the legacy configuration, and a gateway wired for the
-    // legacy model only (useNewConfig=false), matching pre-fix behavior
-    broker1 = new TestBroker(createClusterNode(clusterNodes.get(0), clusterNodes), false);
-    broker1.start();
-    startGateway(clusterNodes.get(1), false);
-
-    final var brokerTopology =
-        ClusterConfiguration.init()
-            .addMember(broker1.id(), MemberState.initializeAsActive(Map.of()));
-
-    final var received = new AtomicReference<ClusterConfiguration>();
-    gateway.addUpdateListener(
-        new ClusterConfigurationUpdateListener() {
-          @Override
-          public void onClusterConfigurationUpdated(
-              final ClusterConfiguration clusterConfiguration) {
-            received.set(clusterConfiguration);
-          }
-
-          @Override
-          public void onClusterConfigurationUpdated(
-              final CurrentClusterConfiguration clusterConfiguration) {
-            Assertions.fail("Did not expect update of new configuration model");
-          }
-        });
-
-    // when
-    broker1.setTopology(brokerTopology);
-
-    // then
-    Awaitility.await("The gateway has received the legacy configuration via gossip")
-        .untilAsserted(() -> assertThat(received.get()).isEqualTo(brokerTopology));
-  }
-
-  private void startGateway(final Node node, final boolean useNewConfig) {
+  private void startGateway(final Node node) {
     gatewayCluster = createClusterNode(node, clusterNodes);
     gatewayCluster.start().join();
     gateway =
@@ -238,8 +201,7 @@ final class GatewayClusterConfigurationServiceTest {
             gatewayCluster.getCommunicationService(),
             gatewayCluster.getMembershipService(),
             config,
-            meterRegistry,
-            useNewConfig);
+            meterRegistry);
     gateway.start(actorScheduler).join();
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationServiceTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationServiceTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.CloseHelper;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -212,6 +213,12 @@ final class GatewayClusterConfigurationServiceTest {
           public void onClusterConfigurationUpdated(
               final ClusterConfiguration clusterConfiguration) {
             received.set(clusterConfiguration);
+          }
+
+          @Override
+          public void onClusterConfigurationUpdated(
+              final CurrentClusterConfiguration clusterConfiguration) {
+            Assertions.fail("Did not expect update of new configuration model");
           }
         });
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
@@ -12,18 +12,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.util.MemberIdArbitraries;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
@@ -32,9 +30,12 @@ import org.junit.jupiter.api.Test;
 
 class AddMembersTransformerTest {
 
-  final ClusterConfiguration currentTopology =
-      ClusterConfiguration.init()
-          .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()));
+  final CurrentClusterConfiguration currentTopology =
+      CurrentClusterConfiguration.init()
+          .updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration.addMember(
+                      MemberId.from("1"), BrokerState.initializeAsActive()));
 
   @Test
   void shouldGenerateMemberJoinOperation() {
@@ -103,11 +104,13 @@ class AddMembersTransformerTest {
     final MemberId existingMember = MemberId.from("1");
     final var addRequest = new AddMembersTransformer(Set.of(existingMember));
     final var zonedConfiguration =
-        ClusterConfiguration.builder()
-            .members(Map.of(MemberId.from("zone-a", 0), MemberState.uninitialized()))
-            .partitionDistributorConfig(
-                Optional.of(new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1)))))
-            .build();
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(MemberId.from("zone-a", 0), BrokerState.initializeAsActive())
+                        .setPartitionDistributorConfig(
+                            new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1)))));
 
     // when
     final var result = plannedOperations(addRequest, zonedConfiguration);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddZoneTransformerTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
@@ -33,6 +32,7 @@ import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Nested;
@@ -40,25 +40,24 @@ import org.junit.jupiter.api.Test;
 
 final class AddZoneTransformerTest {
 
+  public static final String GROUP_NAME = "temp";
   private static final DynamicPartitionConfig PARTITION_CONFIG = DynamicPartitionConfig.init();
-
   // single-zone cluster left over after zone-b failed over: 2 partitions, zone-a only (RF=1)
   private static final ZoneAwareConfig SINGLE_ZONE_CONFIG =
       new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000)));
-
   private static final Set<MemberId> SINGLE_ZONE_MEMBERS = Set.of(ZONE_A_0);
-
   private static final List<PartitionId> PARTITION_IDS =
-      IntStream.rangeClosed(1, 2).mapToObj(i -> new PartitionId("temp", i)).toList();
+      IntStream.rangeClosed(1, 2).mapToObj(i -> new PartitionId(GROUP_NAME, i)).toList();
 
-  private static ClusterConfiguration buildTopology(
+  private static CurrentClusterConfiguration buildTopology(
       final ZoneAwareConfig config, final Set<MemberId> members) {
     final var distribution =
         new ZoneAwarePartitionDistributor(config.zones())
             .distributePartitions(members, PARTITION_IDS, config.replicationFactor());
-    final var topology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
-    return topology.setPartitionDistributorConfig(config);
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members, distribution, Map.of(GROUP_NAME, PARTITION_CONFIG), "c")
+        .updateGlobalConfiguration(
+            globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
   }
 
   @Test
@@ -69,13 +68,13 @@ final class AddZoneTransformerTest {
         new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
 
     // when
-    final var result =
-        plannedOperations(
-            new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0)), currentTopology);
+    final var phasesResult =
+        new AddZoneTransformer(ZONE_B, 1, 500, Set.of(ZONE_B_0)).phases(currentTopology);
 
     // then
-    EitherAssert.assertThat(result).isRight();
-    final var operations = result.get();
+    EitherAssert.assertThat(phasesResult).isRight();
+    final var phases = phasesResult.get();
+    final var operations = TestChangePlan.flatten(phases);
     assertThat(operations)
         .containsExactly(
             new MemberJoinOperation(ZONE_B_0),
@@ -87,9 +86,11 @@ final class AddZoneTransformerTest {
             new PartitionPromoteOperation(ZONE_B_0, 2),
             new PartitionReconfigurePriorityOperation(ZONE_A_0, 2, 2));
 
-    final var newTopology = TestTopologyChangeSimulator.apply(currentTopology, operations);
-    assertThat(newTopology.partitionDistributorConfig()).hasValue(expectedConfig);
-    assertThat(newTopology.members().keySet()).containsExactlyInAnyOrder(ZONE_A_0, ZONE_B_0);
+    final var newTopology = TestTopologyChangeSimulator.apply(currentTopology, phases);
+    assertThat(newTopology.globalConfiguration().partitionDistributorConfig())
+        .hasValue(expectedConfig);
+    assertThat(newTopology.globalConfiguration().members().keySet())
+        .containsExactlyInAnyOrder(ZONE_A_0, ZONE_B_0);
   }
 
   @Test
@@ -118,12 +119,16 @@ final class AddZoneTransformerTest {
     final var distribution =
         new RoundRobinPartitionDistributor().distributePartitions(plainMembers, PARTITION_IDS, 2);
     final var roundRobinTopology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c")
-            .setPartitionDistributorConfig(new RoundRobinConfig());
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+                plainMembers, distribution, Map.of(GROUP_NAME, PARTITION_CONFIG), "c")
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.setPartitionDistributorConfig(new RoundRobinConfig()));
     // and: the same topology without any persisted partition distributor config
     final var noConfigTopology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
-    assertThat(noConfigTopology.partitionDistributorConfig()).isEmpty();
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            plainMembers, distribution, Map.of(GROUP_NAME, PARTITION_CONFIG), "c");
+    assertThat(noConfigTopology.globalConfiguration().partitionDistributorConfig()).isEmpty();
 
     // when / then: config present but not ZoneAware
     final var roundRobinResult =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -14,18 +14,15 @@ import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.RoutingStateInitializer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
@@ -38,6 +35,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.util.Either;
@@ -77,7 +75,7 @@ final class ClusterPatchRequestTransformerTest {
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
                 patchRequest.newReplicationFactor()),
-            ClusterConfiguration.init());
+            CurrentClusterConfiguration.init());
 
     // then
     assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
@@ -86,16 +84,10 @@ final class ClusterPatchRequestTransformerTest {
   @Test
   void shouldRejectWhenScalingDownPartitions() {
     // given
-    final var currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-
-    // when
     final var patchRequest =
         new ClusterPatchRequest(Set.of(), Set.of(), Optional.of(1), Optional.empty(), false);
+
+    // when
     final var result =
         plannedOperations(
             new ClusterPatchRequestTransformer(
@@ -103,7 +95,19 @@ final class ClusterPatchRequestTransformerTest {
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
                 patchRequest.newReplicationFactor()),
-            ClusterConfiguration.init());
+            CurrentClusterConfiguration.init()
+                .initPartitionGroup(DEFAULT_GROUP)
+                .updatePartitionGroupConfig(
+                    DEFAULT_GROUP,
+                    partitionGroupConfiguration ->
+                        partitionGroupConfiguration.addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1,
+                                    PartitionState.active(1, partitionConfig),
+                                    2,
+                                    PartitionState.active(1, partitionConfig))))));
 
     // then
     assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
@@ -113,13 +117,30 @@ final class ClusterPatchRequestTransformerTest {
   void shouldScaleUpBrokersWhenPartitionUnchanged() {
     // given
     final var currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)));
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(id0, BrokerState.initializeAsActive())
+                        .addMember(id1, BrokerState.initializeAsActive()))
+            .initPartitionGroup(DEFAULT_GROUP)
+            .updatePartitionGroupConfig(
+                DEFAULT_GROUP,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1, PartitionState.active(1, partitionConfig),
+                                    2, PartitionState.active(2, partitionConfig))))
+                        .addMember(
+                            id1,
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1, PartitionState.active(1, partitionConfig),
+                                    2, PartitionState.active(1, partitionConfig))))
+                        .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
     // when
     final var patchRequest =
@@ -137,11 +158,24 @@ final class ClusterPatchRequestTransformerTest {
   void shouldScaleDownBrokersWhenPartitionUnchanged() {
     // given
     final var currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(id0, BrokerState.initializeAsActive())
+                        .addMember(id1, BrokerState.initializeAsActive()))
+            .initPartitionGroup(DEFAULT_GROUP)
+            .updatePartitionGroupConfig(
+                DEFAULT_GROUP,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1, PartitionState.active(1, partitionConfig),
+                                    2, PartitionState.active(1, partitionConfig))))
+                        .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
     // when
     final var patchRequest =
@@ -160,11 +194,24 @@ final class ClusterPatchRequestTransformerTest {
   void shouldAddAndRemoveBrokersWhenPartitionsUnchanged() {
     // given
     final var currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(id0, BrokerState.initializeAsActive())
+                        .addMember(id1, BrokerState.initializeAsActive()))
+            .initPartitionGroup(DEFAULT_GROUP)
+            .updatePartitionGroupConfig(
+                DEFAULT_GROUP,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1, PartitionState.active(1, partitionConfig),
+                                    2, PartitionState.active(1, partitionConfig))))
+                        .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
     // when
     final var patchRequest =
@@ -183,13 +230,25 @@ final class ClusterPatchRequestTransformerTest {
   @Test
   void shouldAddAndRemoveBrokersAndAddPartitions() {
     // given
-    var currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer().modify(currentTopology).join();
+    final var currentTopology =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(id0, BrokerState.initializeAsActive())
+                        .addMember(id1, BrokerState.initializeAsActive()))
+            .initPartitionGroup(DEFAULT_GROUP)
+            .updatePartitionGroupConfig(
+                DEFAULT_GROUP,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1, PartitionState.active(1, partitionConfig),
+                                    2, PartitionState.active(1, partitionConfig))))
+                        .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
     // when
     final int newPartitionCount = 4;
@@ -214,13 +273,27 @@ final class ClusterPatchRequestTransformerTest {
   @Test
   void shouldAddAndRemoveBrokersAndAddPartitionsAndChangeReplicationFactor() {
     // given
-    var currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer().modify(currentTopology).join();
+    final var currentTopology =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(id0, BrokerState.initializeAsActive())
+                        .addMember(id1, BrokerState.initializeAsActive()))
+            .initPartitionGroup(DEFAULT_GROUP)
+            .updatePartitionGroupConfig(
+                DEFAULT_GROUP,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(1, PartitionState.active(1, partitionConfig))))
+                        .addMember(
+                            id1,
+                            BrokerPartitionState.initialize(
+                                Map.of(2, PartitionState.active(1, partitionConfig))))
+                        .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
     // when
     final int newPartitionCount = 4;
@@ -247,35 +320,36 @@ final class ClusterPatchRequestTransformerTest {
       final int partitionCount,
       final Set<MemberId> expectedMembers,
       final ClusterPatchRequest patchRequest,
-      final ClusterConfiguration oldClusterTopology,
+      final CurrentClusterConfiguration oldClusterTopology,
       final Set<PartitionMetadata> expectedNewDistribution) {
 
     // when
-    final var result =
-        plannedOperations(
-            new ClusterPatchRequestTransformer(
+    final var phasesResult =
+        new ClusterPatchRequestTransformer(
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
-                patchRequest.newReplicationFactor()),
-            oldClusterTopology);
-    assertThat(result).isRight();
-    final var operations = result.get();
+                patchRequest.newReplicationFactor())
+            .phases(oldClusterTopology);
+    assertThat(phasesResult).isRight();
+    final var phases = phasesResult.get();
+    final var operations = TestChangePlan.flatten(phases);
 
-    // apply operations to generate new topology
-    final ClusterConfiguration newTopology =
-        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+    // apply phases to generate new topology
+    final var newTopology = TestTopologyChangeSimulator.apply(oldClusterTopology, phases);
 
     // then
-    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    final var newDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(newTopology, DEFAULT_GROUP);
     Assertions.assertThat(newDistribution)
         .usingRecursiveComparison()
         .ignoringCollectionOrder()
         .isEqualTo(expectedNewDistribution);
-    Assertions.assertThat(newTopology.members().keySet())
+    Assertions.assertThat(newTopology.getMembers())
         .describedAs("Expected cluster members")
         .containsExactlyInAnyOrderElementsOf(expectedMembers);
-    Assertions.assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+    Assertions.assertThat(newTopology.partitionGroup(DEFAULT_GROUP).partitionCount())
+        .isEqualTo(partitionCount);
     if (oldPartitionCount == partitionCount) {
       Assertions.assertThat(operations)
           .allSatisfy(
@@ -300,7 +374,7 @@ final class ClusterPatchRequestTransformerTest {
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> new PartitionId("temp", id))
+        .mapToObj(id -> new PartitionId(DEFAULT_GROUP, id))
         .collect(Collectors.toList());
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterRestoreRequestTransformerTest.java
@@ -19,11 +19,9 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
@@ -228,12 +226,6 @@ final class ClusterRestoreRequestTransformerTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty());
-  }
-
-  private static ClusterConfiguration recoveringConfiguration() {
-    final var partitions = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
-    return ClusterConfiguration.init()
-        .addMember(MEMBER, MemberState.initializeAsActive(partitions).toRecovering());
   }
 
   /** Resolves every request to the backups it asked for, on the single partition of the member. */

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -15,17 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
@@ -242,15 +241,24 @@ final class ClusterScaleRequestTransformerTest {
                 zone.isPresent()
                     ? ((ZoneAwareConfig) effectiveConfig).replicationFactor()
                     : replicationFactor);
-    ClusterConfiguration oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
+    CurrentClusterConfiguration oldClusterTopology =
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            oldMembers,
+            oldDistribution,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionConfig),
+            "clusterId");
     if (zone.isPresent()) {
-      oldClusterTopology = oldClusterTopology.setPartitionDistributorConfig(effectiveConfig);
+      oldClusterTopology =
+          oldClusterTopology.updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration.setPartitionDistributorConfig(effectiveConfig));
     }
     for (final MemberId member : oldMembers) {
-      if (!oldClusterTopology.hasMember(member)) {
+      if (!oldClusterTopology.globalConfiguration().hasMember(member)) {
         oldClusterTopology =
-            oldClusterTopology.addMember(member, MemberState.initializeAsActive(Map.of()));
+            oldClusterTopology.updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.addMember(member, BrokerState.initializeAsActive()));
       }
     }
     // when
@@ -271,41 +279,46 @@ final class ClusterScaleRequestTransformerTest {
       final int partitionCount,
       final Set<MemberId> expectedMembers,
       final ClusterScaleRequest patchRequest,
-      final ClusterConfiguration oldClusterTopology,
+      final CurrentClusterConfiguration oldClusterTopology,
       final Set<PartitionMetadata> expectedNewDistribution,
       final Optional<String> zone) {
 
     // when
-    final var result =
-        plannedOperations(
-            new ClusterScaleRequestTransformer(
+    final var phasesResult =
+        new ClusterScaleRequestTransformer(
                 patchRequest.brokerCount(),
                 patchRequest.newPartitionCount(),
                 patchRequest.newReplicationFactor(),
-                zone),
-            oldClusterTopology);
-    assertThat(result).isRight();
-    final var operations = result.get();
+                zone)
+            .phases(oldClusterTopology);
+    assertThat(phasesResult).isRight();
+    final var phases = phasesResult.get();
+    final var operations = TestChangePlan.flatten(phases);
 
-    // apply operations to generate new topology
-    final ClusterConfiguration newTopology =
-        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+    // apply phases to generate new topology
+    final var newTopology = TestTopologyChangeSimulator.apply(oldClusterTopology, phases);
 
     // then
-    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    final var newDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(
+            newTopology, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     assertThat(newDistribution)
         .usingRecursiveComparison()
         .ignoringCollectionOrder()
         .isEqualTo(expectedNewDistribution);
-    assertThat(newTopology.members().keySet())
+    assertThat(newTopology.getMembers())
         .describedAs("Expected cluster members")
         .containsExactlyInAnyOrderElementsOf(expectedMembers);
-    assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+    assertThat(
+            newTopology
+                .partitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .partitionCount())
+        .isEqualTo(partitionCount);
   }
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> new PartitionId("temp", id))
+        .mapToObj(id -> new PartitionId(DEFAULT_GROUP, id))
         .collect(Collectors.toList());
   }
 
@@ -357,13 +370,14 @@ final class ClusterScaleRequestTransformerTest {
   @Test
   void shouldRejectNonZoneAwareCluster() {
     // given
+    final var members = membersInZone(Optional.of(ZONE_A), 3);
     final var distribution =
         new RoundRobinConfig()
             .toDistributor()
-            .distributePartitions(
-                membersInZone(Optional.of(ZONE_A), 3), getSortedPartitionIds(3), 1);
+            .distributePartitions(members, getSortedPartitionIds(3), 1);
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members, distribution, Map.of(DEFAULT_GROUP, partitionConfig), "clusterId");
 
     // when
     final var result =
@@ -379,7 +393,7 @@ final class ClusterScaleRequestTransformerTest {
         .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class);
   }
 
-  private ClusterConfiguration zoneAwareTopology(
+  private CurrentClusterConfiguration zoneAwareTopology(
       final int zoneABrokers, final int zoneAReplicas, final int partitionCount) {
     final var config = zoneAwareConfig(zoneAReplicas);
     final var members = scaledMembers(zoneABrokers);
@@ -388,15 +402,10 @@ final class ClusterScaleRequestTransformerTest {
             .toDistributor()
             .distributePartitions(
                 members, getSortedPartitionIds(partitionCount), config.replicationFactor());
-    var topology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "temp")
-            .setPartitionDistributorConfig(config);
-    for (final MemberId member : members) {
-      if (!topology.hasMember(member)) {
-        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
-      }
-    }
-    return topology;
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members, distribution, Map.of(DEFAULT_GROUP, partitionConfig), "clusterId")
+        .updateGlobalConfiguration(
+            globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
   }
 
   private ZoneAwareConfig zoneAwareConfig(final int zoneAReplicas) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersTransformerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
-import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
 import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.TENANT_A;
 import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.partitionGroupPhase;
 import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
@@ -16,12 +15,13 @@ import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 final class ForceRemoveBrokersTransformerTest {
 
+  private static final String GROUP_NAME = "temp";
   private final MemberId id0 = MemberId.from("0");
   private final MemberId id1 = MemberId.from("1");
   private final MemberId id2 = MemberId.from("2");
@@ -40,25 +41,54 @@ final class ForceRemoveBrokersTransformerTest {
   @Test
   void shouldForceRemoveBrokers() {
     // given
-    final ClusterConfiguration currentTopology =
-        ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .addMember(id2, MemberState.initializeAsActive(Map.of()))
-            .addMember(id3, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-            .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
-            .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+    final var currentTopology =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(id0, BrokerState.initializeAsActive())
+                        .addMember(id1, BrokerState.initializeAsActive())
+                        .addMember(id2, BrokerState.initializeAsActive())
+                        .addMember(id3, BrokerState.initializeAsActive()))
+            .initPartitionGroup(GROUP_NAME)
+            .updatePartitionGroupConfig(
+                GROUP_NAME,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            id0,
+                            BrokerPartitionState.initialize(
+                                Map.of(1, PartitionState.active(1, partitionConfig))))
+                        .addMember(
+                            id1,
+                            BrokerPartitionState.initialize(
+                                Map.of(1, PartitionState.active(2, partitionConfig))))
+                        .addMember(
+                            id2,
+                            BrokerPartitionState.initialize(
+                                Map.of(2, PartitionState.active(1, partitionConfig))))
+                        .addMember(
+                            id3,
+                            BrokerPartitionState.initialize(
+                                Map.of(2, PartitionState.active(2, partitionConfig))))
+                        .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
     // when
     final var patchRequest = new ForceRemoveBrokersRequest(Set.of(id1, id3), false);
 
     // remove members 1 and 3
     final var expectedTopology =
-        currentTopology.updateMember(id1, ignore -> null).updateMember(id3, ignore -> null);
+        currentTopology
+            .updateGlobalConfiguration(
+                globalConfiguration -> globalConfiguration.updateMember(id1, ignored -> null))
+            .updatePartitionGroupConfig(
+                GROUP_NAME,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .updateMember(id1, ignored -> null)
+                        .updateMember(id3, ignored -> null));
     final var expectedDistribution =
-        ConfigurationUtil.getPartitionDistributionFrom(expectedTopology, "temp");
+        ConfigurationUtil.getPartitionDistributionFrom(expectedTopology, GROUP_NAME);
 
     // then
     applyRequestAndVerifyResultingTopology(
@@ -74,13 +104,25 @@ final class ForceRemoveBrokersTransformerTest {
     // given
     final var configuration =
         withMirroredTenant(
-            ClusterConfiguration.init()
-                .addMember(id0, MemberState.initializeAsActive(Map.of()))
-                .addMember(id1, MemberState.initializeAsActive(Map.of()))
-                .updateMember(
-                    id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-                .updateMember(
-                    id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig))));
+            CurrentClusterConfiguration.init()
+                .updateGlobalConfiguration(
+                    globalConfiguration ->
+                        globalConfiguration
+                            .addMember(id0, BrokerState.initializeAsActive())
+                            .addMember(id1, BrokerState.initializeAsActive()))
+                .initPartitionGroup(GROUP_NAME)
+                .updatePartitionGroupConfig(
+                    GROUP_NAME,
+                    partitionGroupConfiguration ->
+                        partitionGroupConfiguration
+                            .addMember(
+                                id0,
+                                BrokerPartitionState.initialize(
+                                    Map.of(1, PartitionState.active(1, partitionConfig))))
+                            .addMember(
+                                id1,
+                                BrokerPartitionState.initialize(
+                                    Map.of(1, PartitionState.active(2, partitionConfig))))));
 
     // when — broker 1 is gone
     final var phases =
@@ -101,30 +143,31 @@ final class ForceRemoveBrokersTransformerTest {
       final int partitionCount,
       final Set<MemberId> expectedMembers,
       final ForceRemoveBrokersRequest patchRequest,
-      final ClusterConfiguration oldClusterTopology,
+      final CurrentClusterConfiguration oldClusterTopology,
       final Set<PartitionMetadata> expectedNewDistribution) {
 
     // when
-    final var result =
-        plannedOperations(
-            new ForceRemoveBrokersRequestTransformer(patchRequest.membersToRemove(), id0),
-            oldClusterTopology);
-    assertThat(result).isRight();
-    final var operations = result.get();
+    final var phasesResult =
+        new ForceRemoveBrokersRequestTransformer(patchRequest.membersToRemove(), id0)
+            .phases(oldClusterTopology);
+    assertThat(phasesResult).isRight();
+    final var phases = phasesResult.get();
+    final var operations = TestChangePlan.flatten(phases);
 
-    // apply operations to generate new topology
-    final ClusterConfiguration newTopology =
-        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+    // apply phases to generate new topology
+    final var newTopology = TestTopologyChangeSimulator.apply(oldClusterTopology, phases);
 
     // then
-    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    final var newDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(newTopology, GROUP_NAME);
     Assertions.assertThat(newDistribution)
         .usingRecursiveComparison()
         .ignoringCollectionOrder()
         .isEqualTo(expectedNewDistribution);
-    Assertions.assertThat(newTopology.members().keySet())
+    Assertions.assertThat(newTopology.getMembers())
         .describedAs("Expected cluster members")
         .containsExactlyInAnyOrderElementsOf(expectedMembers);
-    Assertions.assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+    Assertions.assertThat(newTopology.partitionGroup(GROUP_NAME).partitionCount())
+        .isEqualTo(partitionCount);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveZoneTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveZoneTransformerTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
@@ -31,6 +31,7 @@ import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Nested;
@@ -48,16 +49,23 @@ final class ForceRemoveZoneTransformerTest {
   private static final Set<MemberId> DUAL_ZONE_MEMBERS = Set.of(ZONE_A_0, ZONE_B_0);
 
   private static final List<PartitionId> PARTITION_IDS =
-      IntStream.rangeClosed(1, 2).mapToObj(i -> new PartitionId("temp", i)).toList();
+      IntStream.rangeClosed(1, 2)
+          .mapToObj(i -> new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, i))
+          .toList();
 
-  private static ClusterConfiguration buildTopology(
+  private static CurrentClusterConfiguration buildTopology(
       final ZoneAwareConfig config, final Set<MemberId> members) {
     final var distribution =
         new ZoneAwarePartitionDistributor(config.zones())
             .distributePartitions(members, PARTITION_IDS, config.replicationFactor());
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
-    return topology.setPartitionDistributorConfig(config);
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members,
+            distribution,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_CONFIG),
+            "c");
+    return topology.updateGlobalConfiguration(
+        globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
   }
 
   @Test
@@ -91,8 +99,14 @@ final class ForceRemoveZoneTransformerTest {
     final var distribution =
         new RoundRobinPartitionDistributor().distributePartitions(plainMembers, PARTITION_IDS, 2);
     final var roundRobinTopology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c")
-            .setPartitionDistributorConfig(new RoundRobinConfig());
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+                plainMembers,
+                distribution,
+                Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_CONFIG),
+                "c")
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.setPartitionDistributorConfig(new RoundRobinConfig()));
 
     // when
     final var result =
@@ -128,7 +142,9 @@ final class ForceRemoveZoneTransformerTest {
         new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_B, 1, 500), new ZoneSpec(ZONE_A, 1, 1000)));
     final var currentTopology =
         buildTopology(singleZoneConfig, Set.of(ZONE_B_0))
-            .setPartitionDistributorConfig(ghostZoneConfig);
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.setPartitionDistributorConfig(ghostZoneConfig));
 
     // when
     final var result = plannedOperations(new ForceRemoveZoneTransformer(ZONE_B), currentTopology);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
@@ -14,15 +14,18 @@ import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMi
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
 import java.util.Set;
@@ -37,16 +40,37 @@ class ForceScaleDownRequestTransformerTest {
 
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
-  private final ClusterConfiguration currentTopology =
-      ClusterConfiguration.init()
-          .addMember(id0, MemberState.initializeAsActive(Map.of()))
-          .addMember(id1, MemberState.initializeAsActive(Map.of()))
-          .addMember(id2, MemberState.initializeAsActive(Map.of()))
-          .addMember(id3, MemberState.initializeAsActive(Map.of()))
-          .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-          .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-          .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
-          .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+  private final CurrentClusterConfiguration currentTopology =
+      CurrentClusterConfiguration.init()
+          .updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration
+                      .addMember(id0, BrokerState.initializeAsActive())
+                      .addMember(id1, BrokerState.initializeAsActive())
+                      .addMember(id2, BrokerState.initializeAsActive())
+                      .addMember(id3, BrokerState.initializeAsActive()))
+          .initPartitionGroup(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+          .updatePartitionGroupConfig(
+              PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+              partitionGroupConfiguration ->
+                  partitionGroupConfiguration
+                      .addMember(
+                          id0,
+                          BrokerPartitionState.initialize(
+                              Map.of(1, PartitionState.active(1, partitionConfig))))
+                      .addMember(
+                          id1,
+                          BrokerPartitionState.initialize(
+                              Map.of(1, PartitionState.active(2, partitionConfig))))
+                      .addMember(
+                          id2,
+                          BrokerPartitionState.initialize(
+                              Map.of(2, PartitionState.active(1, partitionConfig))))
+                      .addMember(
+                          id3,
+                          BrokerPartitionState.initialize(
+                              Map.of(2, PartitionState.active(2, partitionConfig))))
+                      .setRoutingState(RoutingState.initializeWithPartitionCount(2)));
 
   @Test
   void shouldGenerateForceConfigureOperations() {
@@ -178,18 +202,17 @@ class ForceScaleDownRequestTransformerTest {
                       .hasMessageContaining("{%s=[1]}".formatted(TENANT_A)));
     }
 
-    /** A cluster of the four members, where only the given brokers replicate partition 1. */
-    private ClusterConfiguration partitionOne(final MemberId... replicas) {
-      var topology = ClusterConfiguration.init();
-      for (final var member : Set.of(id0, id1, id2, id3)) {
-        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
-      }
+    /**
+     * A partition group of the four members, where only the given brokers replicate partition 1.
+     */
+    private PartitionGroupConfiguration partitionOne(final MemberId... replicas) {
+      var group = PartitionGroupConfiguration.empty(PartitionGroupConfiguration.INITIAL_VERSION);
       var priority = 1;
       for (final var replica : replicas) {
         final var partition = PartitionState.active(priority++, partitionConfig);
-        topology = topology.updateMember(replica, member -> member.addPartition(1, partition));
+        group = group.addMember(replica, BrokerPartitionState.initialize(Map.of(1, partition)));
       }
-      return topology;
+      return group.setRoutingState(RoutingState.initializeWithPartitionCount(1));
     }
 
     /**
@@ -198,18 +221,21 @@ class ForceScaleDownRequestTransformerTest {
      * tenant is judged on its own replicas.
      */
     private CurrentClusterConfiguration twoTenants(
-        final ClusterConfiguration defaultTenant, final ClusterConfiguration otherTenant) {
-      final var defaultGroup = CurrentClusterConfiguration.DEFAULT_GROUP;
-      final var base = CurrentClusterConfiguration.fromLegacy(defaultTenant);
-      return new CurrentClusterConfiguration(
-          base.version(),
-          base.globalConfiguration(),
-          Map.of(
-              defaultGroup,
-              base.partitionGroup(defaultGroup),
-              TENANT_A,
-              CurrentClusterConfiguration.fromLegacy(otherTenant).partitionGroup(defaultGroup)),
-          base.phasedChangeState());
+        final PartitionGroupConfiguration defaultTenant,
+        final PartitionGroupConfiguration otherTenant) {
+      return CurrentClusterConfiguration.init()
+          .updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration
+                      .addMember(id0, BrokerState.initializeAsActive())
+                      .addMember(id1, BrokerState.initializeAsActive())
+                      .addMember(id2, BrokerState.initializeAsActive())
+                      .addMember(id3, BrokerState.initializeAsActive()))
+          .initPartitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+          .updatePartitionGroupConfig(
+              CurrentClusterConfiguration.DEFAULT_GROUP, ignored -> defaultTenant)
+          .initPartitionGroup(TENANT_A)
+          .updatePartitionGroupConfig(TENANT_A, ignored -> otherTenant);
     }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformerTest.java
@@ -11,14 +11,13 @@ import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperatio
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.util.MemberIdArbitraries;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.Set;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
@@ -27,10 +26,13 @@ import org.junit.jupiter.api.Test;
 
 class RemoveMembersTransformerTest {
 
-  final ClusterConfiguration currentTopology =
-      ClusterConfiguration.init()
-          .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
-          .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()));
+  final CurrentClusterConfiguration currentTopology =
+      CurrentClusterConfiguration.init()
+          .updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration
+                      .addMember(MemberId.from("1"), BrokerState.initializeAsActive())
+                      .addMember(MemberId.from("2"), BrokerState.initializeAsActive()));
 
   @Test
   void shouldGenerateMemberJoinOperation() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformerTest.java
@@ -23,13 +23,11 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.OperationGraph;
 import io.camunda.zeebe.dynamic.config.state.OperationId;
@@ -76,13 +74,33 @@ final class RestoreRequestTransformerTest {
         false);
   }
 
-  private static ClusterConfiguration recoveringTopology() {
-    return ClusterConfiguration.init()
-        .addMember(
+  private static CurrentClusterConfiguration recoveringTopology() {
+    return singleTenantCluster(
+        Map.of(
             MEMBER,
-            MemberState.initializeAsActive(
+            BrokerPartitionState.initialize(
                     Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))
-                .toRecovering());
+                .setMode(Mode.RECOVERING)));
+  }
+
+  /** The given members as a cluster with a single partition group on the default tenant. */
+  private static CurrentClusterConfiguration singleTenantCluster(
+      final Map<MemberId, BrokerPartitionState> members) {
+    var configuration = CurrentClusterConfiguration.init();
+    for (final var member : members.keySet()) {
+      configuration =
+          configuration.updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration.addMember(member, BrokerState.initializeAsActive()));
+    }
+    configuration = configuration.initPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID);
+    for (final var member : members.entrySet()) {
+      configuration =
+          configuration.updatePartitionGroupConfig(
+              DEFAULT_PHYSICAL_TENANT_ID,
+              group -> group.addMember(member.getKey(), member.getValue()));
+    }
+    return configuration;
   }
 
   private static RestoreResolvedRequest resolvedRequest() {
@@ -121,7 +139,10 @@ final class RestoreRequestTransformerTest {
             registryWithValidator(validatorReturning(Either.right(resolvedRequest()))));
 
     // when
-    final var result = plannedOperations(transformer, ClusterConfiguration.init());
+    final var result =
+        plannedOperations(
+            transformer,
+            CurrentClusterConfiguration.init().initPartitionGroup(DEFAULT_PHYSICAL_TENANT_ID));
 
     // then
     EitherAssert.assertThat(result)
@@ -137,9 +158,12 @@ final class RestoreRequestTransformerTest {
     final var memberTwo = MemberId.from("1");
     final var partitionState = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
     final var topology =
-        ClusterConfiguration.init()
-            .addMember(memberOne, MemberState.initializeAsActive(partitionState))
-            .addMember(memberTwo, MemberState.initializeAsActive(partitionState).toRecovering());
+        singleTenantCluster(
+            Map.of(
+                memberOne,
+                BrokerPartitionState.initialize(partitionState),
+                memberTwo,
+                BrokerPartitionState.initialize(partitionState).setMode(Mode.RECOVERING)));
     final var transformer =
         new RestoreRequestTransformer(
             restoreRequest(),
@@ -279,9 +303,12 @@ final class RestoreRequestTransformerTest {
     final var memberTwo = MemberId.from("1");
     final var partitionState = Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()));
     final var topology =
-        ClusterConfiguration.init()
-            .addMember(memberOne, MemberState.initializeAsActive(partitionState).toRecovering())
-            .addMember(memberTwo, MemberState.initializeAsActive(partitionState).toRecovering());
+        singleTenantCluster(
+            Map.of(
+                memberOne,
+                BrokerPartitionState.initialize(partitionState).setMode(Mode.RECOVERING),
+                memberTwo,
+                BrokerPartitionState.initialize(partitionState).setMode(Mode.RECOVERING)));
     final var resolved = new RestoreResolvedRequest(Map.of(1, new long[] {1L, 2L}), false);
     final var transformer =
         new RestoreRequestTransformer(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreStatusTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreStatusTest.java
@@ -73,7 +73,8 @@ final class RestoreStatusTest {
     final var configuration =
         PartitionGroupConfiguration.empty(0)
             .startGraphConfigurationChange(
-                OperationGraph.sequential(List.of(new PartitionJoinOperation(BROKER_1, 1, 1, true))));
+                OperationGraph.sequential(
+                    List.of(new PartitionJoinOperation(BROKER_1, 1, 1, true))));
 
     // when / then
     assertThat(RestoreStatus.of(configuration)).isEmpty();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreStatusTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreStatusTest.java
@@ -11,14 +11,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.PartitionRestoreState;
-import io.camunda.zeebe.dynamic.config.state.ChangePlan;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
@@ -29,7 +28,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Test;
 
 final class RestoreStatusTest {
@@ -43,7 +44,7 @@ final class RestoreStatusTest {
   @Test
   void shouldReturnEmptyWhenNoChange() {
     // given
-    final var configuration = ClusterConfiguration.init();
+    final var configuration = PartitionGroupConfiguration.empty(1);
 
     // when / then
     assertThat(RestoreStatus.of(configuration)).isEmpty();
@@ -57,7 +58,9 @@ final class RestoreStatusTest {
     final var lastChange =
         new CompletedChange(
             RESTORE_CHANGE_ID, Status.COMPLETED, STARTED_AT, STARTED_AT.plusSeconds(60));
-    final var configuration = configurationWith(Optional.of(lastChange), Optional.empty());
+    final var configuration =
+        new PartitionGroupConfiguration(
+            0, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.of(lastChange));
 
     // when / then
     assertThat(RestoreStatus.of(configuration)).isEmpty();
@@ -67,16 +70,10 @@ final class RestoreStatusTest {
   void shouldReturnEmptyForUnrelatedPendingChange() {
     // given
     // an ordinary partition join, not part of a restore, must not be misdetected.
-    final var plan =
-        new ClusterChangePlan(
-            42L,
-            1,
-            Status.IN_PROGRESS,
-            STARTED_AT,
-            List.of(),
-            List.<ClusterConfigurationChangeOperation>of(
-                new PartitionJoinOperation(BROKER_1, 1, 1, true)));
-    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+    final var configuration =
+        PartitionGroupConfiguration.empty(0)
+            .startGraphConfigurationChange(
+                OperationGraph.sequential(List.of(new PartitionJoinOperation(BROKER_1, 1, 1, true))));
 
     // when / then
     assertThat(RestoreStatus.of(configuration)).isEmpty();
@@ -86,16 +83,11 @@ final class RestoreStatusTest {
   void shouldReturnEmptyForPendingModeTransitionWithoutRestoreOps() {
     // given
     // a plain mode transition to PROCESSING that never involved a restore operation.
-    final var plan =
-        new ClusterChangePlan(
-            42L,
-            1,
-            Status.IN_PROGRESS,
-            STARTED_AT,
-            List.of(),
-            List.<ClusterConfigurationChangeOperation>of(
-                new ModeChangeOperation(BROKER_1, Mode.PROCESSING)));
-    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+    final var configuration =
+        PartitionGroupConfiguration.empty(0)
+            .startGraphConfigurationChange(
+                OperationGraph.sequential(
+                    List.of(new ModeChangeOperation(BROKER_1, Mode.PROCESSING))));
 
     // when / then
     assertThat(RestoreStatus.of(configuration)).isEmpty();
@@ -105,24 +97,33 @@ final class RestoreStatusTest {
   void shouldMapInProgressRestoreWithPerPartitionDetail() {
     // given
     // broker 1: partition 1 fully restored, partition 2 pre-restored but restore still pending
-    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
-    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L, 11L));
-    final var pre2 = new PartitionPreRestoreOperation(BROKER_1, 2);
-    final var restore2 = new PartitionRestoreOperation(BROKER_1, 2, backups(20L));
-    final var modeChange = new ModeChangeOperation(BROKER_1, Mode.PROCESSING);
-
-    final var plan =
-        new ClusterChangePlan(
-            RESTORE_CHANGE_ID,
-            5,
-            Status.IN_PROGRESS,
-            STARTED_AT,
-            List.of(
-                new CompletedOperation(pre1, STARTED_AT.plusSeconds(1)),
-                new CompletedOperation(restore1, STARTED_AT.plusSeconds(2)),
-                new CompletedOperation(pre2, STARTED_AT.plusSeconds(3))),
-            List.<ClusterConfigurationChangeOperation>of(restore2, modeChange));
-    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+    final var configuration =
+        new PartitionGroupConfiguration(
+            0,
+            PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+            Map.of(),
+            Optional.empty(),
+            Optional.of(
+                new DependencyChangePlan(
+                    RESTORE_CHANGE_ID,
+                    Status.IN_PROGRESS,
+                    STARTED_AT,
+                    OperationGraph.sequential(
+                        List.of(
+                            new PartitionPreRestoreOperation(BROKER_1, 1),
+                            new PartitionRestoreOperation(BROKER_1, 1, backups(10L, 11L)),
+                            new PartitionPreRestoreOperation(BROKER_1, 2),
+                            new PartitionRestoreOperation(BROKER_1, 2, backups(20L)),
+                            new ModeChangeOperation(BROKER_1, Mode.PROCESSING))),
+                    new TreeMap<>(
+                        Map.of(
+                            new OperationId(0),
+                            STARTED_AT.plusSeconds(1),
+                            new OperationId(1),
+                            STARTED_AT.plusSeconds(2),
+                            new OperationId(2),
+                            STARTED_AT.plusSeconds(3))))),
+            Optional.empty());
 
     // when
     final var status = RestoreStatus.of(configuration).orElseThrow();
@@ -157,15 +158,9 @@ final class RestoreStatusTest {
     // given
     final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
     final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L));
-    final var plan =
-        new ClusterChangePlan(
-            RESTORE_CHANGE_ID,
-            1,
-            Status.IN_PROGRESS,
-            STARTED_AT,
-            List.of(),
-            List.<ClusterConfigurationChangeOperation>of(pre1, restore1));
-    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+    final var configuration =
+        PartitionGroupConfiguration.empty(0)
+            .startGraphConfigurationChange(OperationGraph.sequential(List.of(pre1, restore1)));
 
     // when
     final var status = RestoreStatus.of(configuration).orElseThrow();
@@ -182,21 +177,17 @@ final class RestoreStatusTest {
     // given
     // all restore operations completed; only the trailing mode-transition-to-PROCESSING remains
     // pending. This must still be reported as an in-progress restore.
-    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
-    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L));
-    final var plan =
-        new ClusterChangePlan(
-            RESTORE_CHANGE_ID,
-            3,
-            Status.IN_PROGRESS,
-            STARTED_AT,
-            List.of(
-                new CompletedOperation(pre1, STARTED_AT.plusSeconds(1)),
-                new CompletedOperation(restore1, STARTED_AT.plusSeconds(2))),
-            List.<ClusterConfigurationChangeOperation>of(
-                new ModeChangeOperation(BROKER_1, Mode.PROCESSING),
-                new AwaitModeChangeOperation(BROKER_1, Mode.PROCESSING)));
-    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+    final var configuration =
+        PartitionGroupConfiguration.empty(0)
+            .startGraphConfigurationChange(
+                OperationGraph.sequential(
+                    List.of(
+                        new PartitionPreRestoreOperation(BROKER_1, 1),
+                        new PartitionRestoreOperation(BROKER_1, 1, backups(10L)),
+                        new ModeChangeOperation(BROKER_1, Mode.PROCESSING),
+                        new AwaitModeChangeOperation(BROKER_1, Mode.PROCESSING))))
+            .completeOperation(new OperationId(0), UnaryOperator.identity())
+            .completeOperation(new OperationId(1), UnaryOperator.identity());
 
     // when
     final var status = RestoreStatus.of(configuration).orElseThrow();
@@ -213,24 +204,21 @@ final class RestoreStatusTest {
     // all restore and mode-transition operations completed; only the trailing
     // UpdateIncarnationNumberOperation remains pending. This must still be reported as an
     // in-progress restore.
-    final var pre1 = new PartitionPreRestoreOperation(BROKER_1, 1);
-    final var restore1 = new PartitionRestoreOperation(BROKER_1, 1, backups(10L));
-    final var modeChange = new ModeChangeOperation(BROKER_1, Mode.PROCESSING);
-    final var awaitModeChange = new AwaitModeChangeOperation(BROKER_1, Mode.PROCESSING);
-    final var plan =
-        new ClusterChangePlan(
-            RESTORE_CHANGE_ID,
-            5,
-            Status.IN_PROGRESS,
-            STARTED_AT,
-            List.of(
-                new CompletedOperation(pre1, STARTED_AT.plusSeconds(1)),
-                new CompletedOperation(restore1, STARTED_AT.plusSeconds(2)),
-                new CompletedOperation(modeChange, STARTED_AT.plusSeconds(3)),
-                new CompletedOperation(awaitModeChange, STARTED_AT.plusSeconds(4))),
-            List.<ClusterConfigurationChangeOperation>of(
-                new UpdateIncarnationNumberOperation(BROKER_1)));
-    final var configuration = configurationWith(Optional.empty(), Optional.of(plan));
+    final var configuration =
+        new PartitionGroupConfiguration(
+                0, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty())
+            .startGraphConfigurationChange(
+                OperationGraph.sequential(
+                    List.of(
+                        new PartitionPreRestoreOperation(BROKER_1, 1),
+                        new PartitionRestoreOperation(BROKER_1, 1, backups(10L)),
+                        new ModeChangeOperation(BROKER_1, Mode.PROCESSING),
+                        new AwaitModeChangeOperation(BROKER_1, Mode.PROCESSING),
+                        new UpdateIncarnationNumberOperation(BROKER_1))))
+            .completeOperation(new OperationId(0), UnaryOperator.identity())
+            .completeOperation(new OperationId(1), UnaryOperator.identity())
+            .completeOperation(new OperationId(2), UnaryOperator.identity())
+            .completeOperation(new OperationId(3), UnaryOperator.identity());
 
     // when
     final var status = RestoreStatus.of(configuration).orElseThrow();
@@ -243,18 +231,5 @@ final class RestoreStatusTest {
 
   private static TreeSet<Long> backups(final Long... ids) {
     return new TreeSet<>(List.of(ids));
-  }
-
-  private static ClusterConfiguration configurationWith(
-      final Optional<CompletedChange> lastChange, final Optional<ChangePlan> pendingChanges) {
-    return new ClusterConfiguration(
-        2,
-        Map.of(),
-        lastChange,
-        pendingChanges,
-        Optional.empty(),
-        Optional.empty(),
-        0,
-        Optional.empty());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -8,14 +8,15 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import static io.camunda.zeebe.dynamic.config.api.TestChangePlan.plannedOperations;
+import static io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures.withMirroredTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -183,9 +184,15 @@ class ScaleRequestTransformerTest {
         distributor.distributePartitions(
             oldMembers, getSortedPartitionIds(partitionCount), replicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            oldMembers,
+            oldDistribution,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, partitionConfig),
+            "clusterId");
     if (config != null) {
-      oldClusterTopology = oldClusterTopology.setPartitionDistributorConfig(config);
+      oldClusterTopology =
+          oldClusterTopology.updateGlobalConfiguration(
+              globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
     }
 
     // when
@@ -229,23 +236,29 @@ class ScaleRequestTransformerTest {
         distributor.distributePartitions(
             oldMembers, getSortedPartitionIds(partitionCount), replicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            oldMembers,
+            oldDistribution,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionConfig),
+            "clusterId");
     if (config != null) {
-      oldClusterTopology = oldClusterTopology.setPartitionDistributorConfig(config);
+      oldClusterTopology =
+          oldClusterTopology.updateGlobalConfiguration(
+              globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
     }
 
     // when
-    final var operations =
-        plannedOperations(new ScaleRequestTransformer(newMembers), oldClusterTopology).get();
+    final var phases = new ScaleRequestTransformer(newMembers).phases(oldClusterTopology).get();
 
-    // apply operations to generate new topology
-    final ClusterConfiguration newTopology =
-        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+    // apply phases to generate new topology
+    final var newTopology = TestTopologyChangeSimulator.apply(oldClusterTopology, phases);
 
     // then
-    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    final var newDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(
+            newTopology, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     assertThat(newDistribution).isEqualTo(expectedNewDistribution);
-    assertThat(newTopology.members().keySet()).containsExactlyInAnyOrderElementsOf(newMembers);
+    assertThat(newTopology.getMembers()).containsExactlyInAnyOrderElementsOf(newMembers);
   }
 
   @Test
@@ -298,7 +311,7 @@ class ScaleRequestTransformerTest {
 
   private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> new PartitionId("temp", id))
+        .mapToObj(id -> new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, id))
         .collect(Collectors.toList());
   }
 
@@ -315,18 +328,24 @@ class ScaleRequestTransformerTest {
       final Consumer<List<ClusterConfigurationChangeOperation>> whenRight) {
     final var clusterSize = 3;
     final var replicationFactor = 3;
+    final var members =
+        IntStream.range(1, clusterSize)
+            .mapToObj(id -> MemberId.from(Integer.toString(id)))
+            .collect(Collectors.toSet());
     final var distribution =
         new RoundRobinPartitionDistributor()
             .distributePartitions(
-                IntStream.range(1, clusterSize)
-                    .mapToObj(id -> MemberId.from(Integer.toString(id)))
-                    .collect(Collectors.toSet()),
+                members,
                 partitionsInRange(1, 1 + currentPartitionCount).stream()
-                    .map(i -> new PartitionId("temp", i))
+                    .map(i -> new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, i))
                     .toList(),
                 replicationFactor);
     final var config =
-        ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "clusterId");
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members,
+            distribution,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, partitionConfig),
+            "clusterId");
     final var transformer =
         new ScaleRequestTransformer(
             getClusterMembers(clusterSize), Optional.of(3), Optional.of(desiredPartitionCount));
@@ -359,22 +378,13 @@ class ScaleRequestTransformerTest {
     }
 
     private CurrentClusterConfiguration twoTenantCluster(final Set<MemberId> members) {
-      final var legacy =
-          ConfigurationUtil.getClusterConfigFrom(
+      return withMirroredTenant(
+          ConfigurationUtil.getCurrentClusterConfigurationFrom(
+              members,
               new RoundRobinPartitionDistributor()
                   .distributePartitions(members, sortedPartitionIds(3), 1),
-              DynamicPartitionConfig.init(),
-              "clusterId");
-      final var single = CurrentClusterConfiguration.fromLegacy(legacy);
-      return new CurrentClusterConfiguration(
-          single.version(),
-          single.globalConfiguration(),
-          Map.of(
-              CurrentClusterConfiguration.DEFAULT_GROUP,
-              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
-              TENANT_A,
-              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
-          single.phasedChangeState());
+              Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, DynamicPartitionConfig.init()),
+              "clusterId"));
     }
 
     @Test
@@ -621,16 +631,19 @@ class ScaleRequestTransformerTest {
       final Set<MemberId> newMembers = new HashSet<>(UNSCALED_MEMBERS);
       newMembers.add(MemberId.from("zone-b", 1));
       final var oldTopology =
-          ConfigurationUtil.getClusterConfigFrom(
+          ConfigurationUtil.getCurrentClusterConfigurationFrom(
+                  UNSCALED_MEMBERS,
                   ZONE_AWARE_CONFIG
                       .toDistributor()
                       .distributePartitions(
                           UNSCALED_MEMBERS,
                           getSortedPartitionIds(3),
                           ZONE_AWARE_CONFIG.replicationFactor()),
-                  partitionConfig,
+                  Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, partitionConfig),
                   "clusterId")
-              .setPartitionDistributorConfig(ZONE_AWARE_CONFIG);
+              .updateGlobalConfiguration(
+                  globalConfiguration ->
+                      globalConfiguration.setPartitionDistributorConfig(ZONE_AWARE_CONFIG));
 
       // when
       final var operations =
@@ -703,25 +716,18 @@ class ScaleRequestTransformerTest {
     }
 
     private CurrentClusterConfiguration twoTenantZoneAwareCluster(final Set<MemberId> members) {
-      final var legacy =
-          ConfigurationUtil.getClusterConfigFrom(
+      return withMirroredTenant(
+          ConfigurationUtil.getCurrentClusterConfigurationFrom(
+                  members,
                   ZONE_AWARE_CONFIG
                       .toDistributor()
                       .distributePartitions(
                           members, sortedPartitionIds(3), ZONE_AWARE_CONFIG.replicationFactor()),
-                  DynamicPartitionConfig.init(),
+                  Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, DynamicPartitionConfig.init()),
                   "clusterId")
-              .setPartitionDistributorConfig(ZONE_AWARE_CONFIG);
-      final var single = CurrentClusterConfiguration.fromLegacy(legacy);
-      return new CurrentClusterConfiguration(
-          single.version(),
-          single.globalConfiguration(),
-          Map.of(
-              CurrentClusterConfiguration.DEFAULT_GROUP,
-              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
-              TENANT_A,
-              single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
-          single.phasedChangeState());
+              .updateGlobalConfiguration(
+                  globalConfiguration ->
+                      globalConfiguration.setPartitionDistributorConfig(ZONE_AWARE_CONFIG)));
     }
 
     @Test
@@ -731,16 +737,19 @@ class ScaleRequestTransformerTest {
       final Set<MemberId> newMembers = new HashSet<>(UNSCALED_MEMBERS);
       newMembers.add(MemberId.from("zone-c", 0));
       final var oldTopology =
-          ConfigurationUtil.getClusterConfigFrom(
+          ConfigurationUtil.getCurrentClusterConfigurationFrom(
+                  UNSCALED_MEMBERS,
                   ZONE_AWARE_CONFIG
                       .toDistributor()
                       .distributePartitions(
                           UNSCALED_MEMBERS,
                           getSortedPartitionIds(3),
                           ZONE_AWARE_CONFIG.replicationFactor()),
-                  partitionConfig,
+                  Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, partitionConfig),
                   "clusterId")
-              .setPartitionDistributorConfig(ZONE_AWARE_CONFIG);
+              .updateGlobalConfiguration(
+                  globalConfiguration ->
+                      globalConfiguration.setPartitionDistributorConfig(ZONE_AWARE_CONFIG));
 
       // when
       final var operations =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestChangePlan.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestChangePlan.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
@@ -36,16 +35,11 @@ final class TestChangePlan {
   private TestChangePlan() {}
 
   static Either<Exception, List<ClusterConfigurationChangeOperation>> plannedOperations(
-      final ConfigurationChangeRequest request, final ClusterConfiguration topology) {
-    return plannedOperations(request, CurrentClusterConfiguration.fromLegacy(topology));
-  }
-
-  static Either<Exception, List<ClusterConfigurationChangeOperation>> plannedOperations(
       final ConfigurationChangeRequest request, final CurrentClusterConfiguration configuration) {
     return request.phases(configuration).map(TestChangePlan::flatten);
   }
 
-  private static List<ClusterConfigurationChangeOperation> flatten(final List<Phase> phases) {
+  static List<ClusterConfigurationChangeOperation> flatten(final List<Phase> phases) {
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
     for (final var phase : phases) {
       switch (phase) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
@@ -19,14 +19,13 @@ import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChange
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.OperationId;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import java.util.List;
 import java.util.TreeMap;
@@ -34,17 +33,12 @@ import java.util.TreeMap;
 /**
  * Drains a change plan against the same appliers the broker uses, so a transformer test can assert
  * on the configuration its request actually produces rather than on the operation list alone.
- *
- * <p>Takes and returns the legacy single-group {@link ClusterConfiguration} because that is what
- * the transformer tests build their fixtures and expectations in. On a single-tenant cluster the
- * conversion is lossless in both directions, so the plan is simulated on the real model in between.
  */
 final class TestTopologyChangeSimulator {
 
-  static ClusterConfiguration apply(
-      final ClusterConfiguration currentTopology,
-      final List<ClusterConfigurationChangeOperation> operations) {
-    if (operations.isEmpty()) {
+  static CurrentClusterConfiguration apply(
+      final CurrentClusterConfiguration currentTopology, final List<Phase> phases) {
+    if (phases.isEmpty()) {
       return currentTopology;
     }
 
@@ -58,12 +52,10 @@ final class TestTopologyChangeSimulator {
             new NoopModeChangeExecutor(),
             new RestoreChangeExecutor.NoopRestoreChangeExecutor());
 
-    final var started =
-        CurrentClusterConfiguration.fromLegacy(currentTopology)
-            .initPlan(CurrentClusterConfiguration.toPhases(operations));
+    final var started = currentTopology.initPlan(phases);
     final var planId = started.phasedChangeState().pending().keySet().iterator().next();
 
-    return drainPlan(started, planId, globalAppliers, groupAppliers).toLegacyDefault();
+    return drainPlan(started, planId, globalAppliers, groupAppliers);
   }
 
   private static CurrentClusterConfiguration drainPlan(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
@@ -35,6 +35,7 @@ import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Nested;
@@ -55,17 +56,23 @@ class UpdatePartitionDistributionTransformerTest {
   private static final Set<MemberId> MEMBERS = Set.of(ZONE_A_0, ZONE_A_1, ZONE_B_0);
 
   private static final List<PartitionId> PARTITION_IDS =
-      IntStream.rangeClosed(1, 3).mapToObj(i -> new PartitionId("temp", i)).toList();
+      IntStream.rangeClosed(1, 3)
+          .mapToObj(i -> new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, i))
+          .toList();
 
   /** Builds a topology whose partitions are placed by ZoneAwarePartitionDistributor. */
-  private static ClusterConfiguration buildTopology(
+  private static CurrentClusterConfiguration buildTopology(
       final ZoneAwareConfig config, final Set<MemberId> members) {
     final var distribution =
         new ZoneAwarePartitionDistributor(config.zones())
             .distributePartitions(members, PARTITION_IDS, config.replicationFactor());
-    final var topology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
-    return topology.setPartitionDistributorConfig(config);
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members,
+            distribution,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_CONFIG),
+            "c")
+        .updateGlobalConfiguration(
+            globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
   }
 
   @Test
@@ -165,7 +172,11 @@ class UpdatePartitionDistributionTransformerTest {
     final var distribution =
         new RoundRobinPartitionDistributor().distributePartitions(plainMembers, PARTITION_IDS, 2);
     final var roundRobinTopology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            plainMembers,
+            distribution,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_CONFIG),
+            "c");
     final var newConfig =
         new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
     final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
@@ -188,8 +199,14 @@ class UpdatePartitionDistributionTransformerTest {
         new RoundRobinPartitionDistributor(List.of(ZONE_A, ZONE_B))
             .distributePartitions(mixedMembers, PARTITION_IDS, 2);
     final var mixedTopology =
-        ConfigurationUtil.getClusterConfigFrom(mixedDistribution, PARTITION_CONFIG, "c")
-            .setPartitionDistributorConfig(INITIAL_CONFIG);
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+                mixedMembers,
+                mixedDistribution,
+                Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_CONFIG),
+                "c")
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.setPartitionDistributorConfig(INITIAL_CONFIG));
     final var newConfig =
         new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 500), new ZoneSpec(ZONE_B, 1, 1000)));
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateRoutingStateTransformerTest.java
@@ -16,11 +16,9 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.NotFound;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -43,11 +41,14 @@ class UpdateRoutingStateTransformerTest {
   private final MemberId id1 = MemberId.from("1");
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
-  private final ClusterConfiguration currentTopology =
-      ClusterConfiguration.init()
-          .addMember(id1, MemberState.initializeAsActive(Map.of()))
-          .updateMember(
-              id1, member -> member.addPartition(1, PartitionState.active(1, partitionConfig)));
+  private final CurrentClusterConfiguration currentTopology =
+      CurrentClusterConfiguration.init()
+          .updateGlobalConfiguration(
+              globalConfiguration ->
+                  globalConfiguration.addMember(id1, BrokerState.initializeAsActive()))
+          .initPartitionGroup(DEFAULT_GROUP)
+          .updatePartitionGroupConfig(
+              DEFAULT_GROUP, group -> group.addMember(id1, hostingAPartition()));
 
   @Test
   void shouldGenerateUpdateRoutingStateOperationWhenEnabled() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
@@ -28,6 +27,7 @@ import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Nested;
@@ -35,15 +35,15 @@ import org.junit.jupiter.api.Test;
 
 final class UpdateZonePrioritiesTransformerTest {
 
+  public static final String GROUP_NAME = "temp";
   private static final DynamicPartitionConfig PARTITION_CONFIG = DynamicPartitionConfig.init();
-
   private static final List<PartitionId> PARTITION_IDS =
-      IntStream.rangeClosed(1, 2).mapToObj(i -> new PartitionId("temp", i)).toList();
+      IntStream.rangeClosed(1, 2).mapToObj(i -> new PartitionId(GROUP_NAME, i)).toList();
 
-  // Builds a fully zone-aware ClusterConfiguration with one member per zone. Modeled on
+  // Builds a fully zone-aware cluster topology with one member per zone. Modeled on
   // ForceRemoveZoneTransformerTest#buildTopology /
   // UpdatePartitionDistributionTransformerTest#buildTopology.
-  private ClusterConfiguration zoneAwareCluster(final ZoneSpec... zones) {
+  private CurrentClusterConfiguration zoneAwareCluster(final ZoneSpec... zones) {
     final var config = new ZoneAwareConfig(List.of(zones));
     final var members =
         config.zones().stream()
@@ -53,8 +53,10 @@ final class UpdateZonePrioritiesTransformerTest {
         new ZoneAwarePartitionDistributor(config.zones())
             .distributePartitions(Set.copyOf(members), PARTITION_IDS, config.replicationFactor());
     final var topology =
-        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
-    return topology.setPartitionDistributorConfig(config);
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            members, distribution, Map.of(GROUP_NAME, PARTITION_CONFIG), "c");
+    return topology.updateGlobalConfiguration(
+        globalConfiguration -> globalConfiguration.setPartitionDistributorConfig(config));
   }
 
   @Test
@@ -128,7 +130,7 @@ final class UpdateZonePrioritiesTransformerTest {
   @Test
   void shouldRejectWhenNotZoneAware() {
     // given a non-zone-aware cluster (no PartitionDistributorConfig persisted)
-    final var config = ClusterConfiguration.init();
+    final var config = CurrentClusterConfiguration.init();
     final var result =
         plannedOperations(new UpdateZonePrioritiesTransformer(List.of(ZONE_A)), config);
     EitherAssert.assertThat(result).isLeft();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -16,14 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.cluster.ZoneLayout;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
@@ -35,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.PhysicalTenantFixtures;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,10 +57,12 @@ final class ZoneMigrationRequestTransformerTest {
     final var configUpdatedTopology = setZoneAwareConfig(initialTopology, zones);
 
     // when
-    final var result =
-        plannedOperations(new ZoneMigrationRequestTransformer(ZONE_A), configUpdatedTopology);
-    assertThat(result).isRight();
-    assertThat(result.get())
+    final var phasesResult =
+        new ZoneMigrationRequestTransformer(ZONE_A).phases(configUpdatedTopology);
+    assertThat(phasesResult).isRight();
+    final var phases = phasesResult.get();
+    final var operations = TestChangePlan.flatten(phases);
+    assertThat(operations)
         // check is unordered because member ordering between runs is not stable
         .containsExactly(
             new MemberJoinOperation(ZONE_A_0),
@@ -106,12 +107,13 @@ final class ZoneMigrationRequestTransformerTest {
             new MemberLeaveOperation(BARE_0),
             new MemberLeaveOperation(BARE_1),
             new MemberLeaveOperation(BARE_2));
-    final var newTopology = TestTopologyChangeSimulator.apply(configUpdatedTopology, result.get());
+    final var newTopology = TestTopologyChangeSimulator.apply(configUpdatedTopology, phases);
 
     // then
     assertThat(newTopology.isFullyZoneAware()).isTrue();
-    assertThat(newTopology.partitionDistributorConfig()).hasValue(new ZoneAwareConfig(zones));
-    assertThat(newTopology.members().keySet())
+    assertThat(newTopology.globalConfiguration().partitionDistributorConfig())
+        .hasValue(new ZoneAwareConfig(zones));
+    assertThat(newTopology.globalConfiguration().members().keySet())
         .containsExactlyInAnyOrder(ZONE_A_0, ZONE_A_1, ZONE_A_2);
     assertSamePartitionDistribution(
         initialTopology, newTopology, nodeMapping(IntStream.range(0, 3), ZONE_A));
@@ -167,16 +169,17 @@ final class ZoneMigrationRequestTransformerTest {
 
     // then
     assertThat(afterSecondaryMigration.isPartiallyZoneAware()).isTrue();
-    assertThat(afterSecondaryMigration.partitionDistributorConfig())
+    assertThat(afterSecondaryMigration.globalConfiguration().partitionDistributorConfig())
         .hasValue(new ZoneAwareConfig(zones));
-    assertThat(afterSecondaryMigration.members().keySet())
+    assertThat(afterSecondaryMigration.globalConfiguration().members().keySet())
         .containsExactlyInAnyOrder(BARE_0, BARE_2, ZONE_B_0, ZONE_B_1);
     assertSamePartitionDistribution(
         initialTopology, afterSecondaryMigration, mixedDualRegionNodeMapping());
 
     assertThat(finalTopology.isFullyZoneAware()).isTrue();
-    assertThat(finalTopology.partitionDistributorConfig()).hasValue(new ZoneAwareConfig(zones));
-    assertThat(finalTopology.members().keySet())
+    assertThat(finalTopology.globalConfiguration().partitionDistributorConfig())
+        .hasValue(new ZoneAwareConfig(zones));
+    assertThat(finalTopology.globalConfiguration().members().keySet())
         .containsExactlyInAnyOrder(ZONE_A_0, ZONE_A_1, ZONE_B_0, ZONE_B_1);
     assertSamePartitionDistribution(
         initialTopology, finalTopology, dualRegionNodeMapping(4, List.of(ZONE_A, ZONE_B)));
@@ -245,7 +248,10 @@ final class ZoneMigrationRequestTransformerTest {
   void shouldRejectInvalidPartitionDistribution() {
     // given
     final var oldTopology =
-        unzonedTopology(3, 3, 3).setPartitionDistributorConfig(new RoundRobinConfig());
+        unzonedTopology(3, 3, 3)
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.setPartitionDistributorConfig(new RoundRobinConfig()));
 
     // when
     final var result = plannedOperations(new ZoneMigrationRequestTransformer(ZONE_A), oldTopology);
@@ -326,12 +332,11 @@ final class ZoneMigrationRequestTransformerTest {
                         "Zone migration request targets unknown zone 'unknown-zone'"));
   }
 
-  private ClusterConfiguration migrate(
-      final ClusterConfiguration oldTopology, final String zoneName) {
-    final var result =
-        plannedOperations(new ZoneMigrationRequestTransformer(zoneName), oldTopology);
-    assertThat(result).isRight();
-    return TestTopologyChangeSimulator.apply(oldTopology, result.get());
+  private CurrentClusterConfiguration migrate(
+      final CurrentClusterConfiguration oldTopology, final String zoneName) {
+    final var phasesResult = new ZoneMigrationRequestTransformer(zoneName).phases(oldTopology);
+    assertThat(phasesResult).isRight();
+    return TestTopologyChangeSimulator.apply(oldTopology, phasesResult.get());
   }
 
   /**
@@ -339,31 +344,21 @@ final class ZoneMigrationRequestTransformerTest {
    * every broker holds partitions of both tenants. Enough to tell a plan that saw every tenant's
    * partition group from one that only ever saw the default group.
    */
-  private CurrentClusterConfiguration twoTenantCluster(final ClusterConfiguration topology) {
-    final var single = CurrentClusterConfiguration.fromLegacy(topology);
-    return new CurrentClusterConfiguration(
-        single.version(),
-        single.globalConfiguration(),
-        Map.of(
-            CurrentClusterConfiguration.DEFAULT_GROUP,
-            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
-            TENANT_A,
-            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
-        single.phasedChangeState());
+  private CurrentClusterConfiguration twoTenantCluster(final CurrentClusterConfiguration topology) {
+    return PhysicalTenantFixtures.withMirroredTenant(topology);
   }
 
-  private ClusterConfiguration setZoneAwareConfig(
-      final ClusterConfiguration topology, final List<ZoneSpec> zones) {
-    final var result =
-        plannedOperations(
-            new UpdatePartitionDistributionTransformer(new ZoneAwareConfig(zones)), topology);
-    assertThat(result).isRight();
-    return TestTopologyChangeSimulator.apply(topology, result.get());
+  private CurrentClusterConfiguration setZoneAwareConfig(
+      final CurrentClusterConfiguration topology, final List<ZoneSpec> zones) {
+    final var phasesResult =
+        new UpdatePartitionDistributionTransformer(new ZoneAwareConfig(zones)).phases(topology);
+    assertThat(phasesResult).isRight();
+    return TestTopologyChangeSimulator.apply(topology, phasesResult.get());
   }
 
   private void assertSamePartitionDistribution(
-      final ClusterConfiguration oldTopology,
-      final ClusterConfiguration newTopology,
+      final CurrentClusterConfiguration oldTopology,
+      final CurrentClusterConfiguration newTopology,
       final Map<MemberId, MemberId> nodeMapping) {
     final Map<Integer, Set<MemberId>> expected =
         partitionToMembers(oldTopology).entrySet().stream()
@@ -377,22 +372,15 @@ final class ZoneMigrationRequestTransformerTest {
         .isEqualTo(expected);
   }
 
-  private int indexOf(
-      final List<ClusterConfigurationChangeOperation> operations,
-      final ClusterConfigurationChangeOperation expectedOperation) {
-    final var index = operations.indexOf(expectedOperation);
-    assertThat(index)
-        .describedAs("expected operation %s to be part of the migration plan", expectedOperation)
-        .isNotNegative();
-    return index;
-  }
-
-  private Map<Integer, Set<MemberId>> partitionToMembers(final ClusterConfiguration topology) {
-    return ConfigurationUtil.getPartitionDistributionFrom(topology, "temp").stream()
+  private Map<Integer, Set<MemberId>> partitionToMembers(
+      final CurrentClusterConfiguration topology) {
+    return ConfigurationUtil.getPartitionDistributionFrom(
+            topology, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .stream()
         .collect(Collectors.toMap(p -> p.id().number(), p -> Set.copyOf(p.members())));
   }
 
-  private ClusterConfiguration unzonedTopology(
+  private CurrentClusterConfiguration unzonedTopology(
       final int clusterSize, final int partitionCount, final int replicationFactor) {
     final Set<MemberId> members =
         IntStream.range(0, clusterSize).mapToObj(MemberId::from).collect(Collectors.toSet());
@@ -400,18 +388,16 @@ final class ZoneMigrationRequestTransformerTest {
         new RoundRobinConfig()
             .toDistributor()
             .distributePartitions(members, sortedPartitionIds(partitionCount), replicationFactor);
-    var topology = ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "cid");
-    for (final MemberId member : members) {
-      if (!topology.hasMember(member)) {
-        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
-      }
-    }
-    return topology;
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        members,
+        distribution,
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionConfig),
+        "cid");
   }
 
   private List<PartitionId> sortedPartitionIds(final int partitionCount) {
     return IntStream.rangeClosed(1, partitionCount)
-        .mapToObj(id -> new PartitionId("temp", id))
+        .mapToObj(id -> new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, id))
         .collect(Collectors.toList());
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -14,14 +14,14 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.PartitionStateAssert;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.Map;
@@ -140,40 +140,53 @@ class ConfigurationUtilTest {
 
     final var expected = Set.of(partitionTwo, partitionOne);
 
-    final ClusterConfiguration topology =
-        ClusterConfiguration.init()
-            .addMember(
-                member(0),
-                MemberState.initializeAsActive(
-                    Map.of(
-                        1,
-                        PartitionState.active(1, partitionConfig),
-                        2,
-                        PartitionState.active(3, partitionConfig),
-                        // A joining member should not be included in the partition distribution
-                        3,
-                        PartitionState.joining(4, partitionConfig))))
-            .addMember(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(
-                        1,
-                        PartitionState.active(2, partitionConfig),
-                        // A leaving member should be included in the partition distribution
-                        2,
-                        PartitionState.active(2, partitionConfig).toLeaving())))
-            .addMember(
-                member(2),
-                MemberState.initializeAsActive(
-                    Map.of(
-                        1,
-                        PartitionState.active(3, partitionConfig),
-                        2,
-                        PartitionState.active(1, partitionConfig))));
+    final var configuration =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(member(0), BrokerState.initializeAsActive())
+                        .addMember(member(1), BrokerState.initializeAsActive())
+                        .addMember(member(2), BrokerState.initializeAsActive()))
+            .initPartitionGroup(GROUP_NAME)
+            .updatePartitionGroupConfig(
+                GROUP_NAME,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            member(0),
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1,
+                                    PartitionState.active(1, partitionConfig),
+                                    2,
+                                    PartitionState.active(3, partitionConfig),
+                                    // A joining member should not be included in the partition
+                                    // distribution
+                                    3,
+                                    PartitionState.joining(4, partitionConfig))))
+                        .addMember(
+                            member(1),
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1,
+                                    PartitionState.active(2, partitionConfig),
+                                    // A leaving member should be included in the partition
+                                    // distribution
+                                    2,
+                                    PartitionState.active(2, partitionConfig).toLeaving())))
+                        .addMember(
+                            member(2),
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1,
+                                    PartitionState.active(3, partitionConfig),
+                                    2,
+                                    PartitionState.active(1, partitionConfig)))));
 
     // when
     final var partitionDistribution =
-        ConfigurationUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+        ConfigurationUtil.getPartitionDistributionFrom(configuration, GROUP_NAME);
 
     // then
     assertThat(partitionDistribution).containsExactlyInAnyOrderElementsOf(expected);
@@ -199,30 +212,37 @@ class ConfigurationUtilTest {
             member(0));
 
     final var expected = Set.of(partitionTwo, partitionOne);
-
-    final ClusterConfiguration topology =
-        ClusterConfiguration.init()
-            .addMember(
-                member(0),
-                MemberState.initializeAsActive(
-                    Map.of(
-                        1,
-                        PartitionState.active(1, partitionConfig),
-                        2,
-                        PartitionState.active(3, partitionConfig))))
-            .addMember(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(
-                        1,
-                        PartitionState.active(2, partitionConfig),
-                        2,
-                        PartitionState.active(2, partitionConfig))))
-            .addMember(member(2), MemberState.initializeAsActive(Map.of()).toLeaving());
-
+    final var configuration =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(member(0), BrokerState.initializeAsActive())
+                        .addMember(member(1), BrokerState.initializeAsActive()))
+            .initPartitionGroup(GROUP_NAME)
+            .updatePartitionGroupConfig(
+                GROUP_NAME,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            member(0),
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1,
+                                    PartitionState.active(1, partitionConfig),
+                                    2,
+                                    PartitionState.active(3, partitionConfig))))
+                        .addMember(
+                            member(1),
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1,
+                                    PartitionState.active(2, partitionConfig),
+                                    2,
+                                    PartitionState.active(2, partitionConfig)))));
     // when
     final var partitionDistribution =
-        ConfigurationUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+        ConfigurationUtil.getPartitionDistributionFrom(configuration, GROUP_NAME);
 
     // then
     assertThat(partitionDistribution).containsExactlyInAnyOrderElementsOf(expected);
@@ -268,12 +288,19 @@ class ConfigurationUtilTest {
         new PartitionMetadata(
             new PartitionId(GROUP_NAME, 1), Set.of(member(0)), Map.of(member(0), 1), 1, member(0));
 
-    final ClusterConfiguration topology =
-        ClusterConfiguration.init()
-            .addMember(
-                member(0),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1, partitionConfig).toRecovering())));
+    final var topology =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration.addMember(member(0), BrokerState.initializeAsActive()))
+            .initPartitionGroup(GROUP_NAME)
+            .updatePartitionGroupConfig(
+                GROUP_NAME,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration.addMember(
+                        member(0),
+                        BrokerPartitionState.initialize(
+                            Map.of(1, PartitionState.active(1, partitionConfig).toRecovering()))));
 
     // when
     final var partitionDistribution =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -16,12 +16,13 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.PartitionStateAssert;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState;
-import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.Map;
@@ -322,16 +323,27 @@ class ConfigurationUtilTest {
             2,
             member(0));
 
-    final ClusterConfiguration topology =
-        ClusterConfiguration.init()
-            .addMember(
-                member(0),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(2, partitionConfig))))
-            .addMember(
-                member(1),
-                MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.joining(1, partitionConfig).toLearner())));
+    final CurrentClusterConfiguration topology =
+        CurrentClusterConfiguration.init()
+            .updateGlobalConfiguration(
+                globalConfiguration ->
+                    globalConfiguration
+                        .addMember(member(0), BrokerState.initializeAsActive())
+                        .addMember(member(1), BrokerState.initializeAsActive()))
+            .initPartitionGroup(GROUP_NAME)
+            .updatePartitionGroupConfig(
+                GROUP_NAME,
+                partitionGroupConfiguration ->
+                    partitionGroupConfiguration
+                        .addMember(
+                            member(0),
+                            BrokerPartitionState.initialize(
+                                Map.of(1, PartitionState.active(2, partitionConfig))))
+                        .addMember(
+                            member(1),
+                            BrokerPartitionState.initialize(
+                                Map.of(
+                                    1, PartitionState.joining(1, partitionConfig).toLearner()))));
 
     // when
     final var partitionDistribution =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/PhysicalTenantFixtures.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
@@ -23,7 +22,9 @@ public final class PhysicalTenantFixtures {
   /**
    * The given single-group topology as a multi-group configuration whose two partition groups are
    * mirror images: the default tenant and {@link #TENANT_A} run the same partitions over the same
-   * brokers.
+   * brokers. The input's single group is renamed to the default group in the process — a group's
+   * name is irrelevant to the operations these fixtures plan, and the mirrored shape is what the
+   * tests assert on.
    *
    * <p>Mirroring rather than varying the two is what makes a plan easy to read: whatever a request
    * does to the default tenant it must do to the other one as well, so a plan that only ever saw
@@ -31,17 +32,18 @@ public final class PhysicalTenantFixtures {
    * that has to be derived.
    */
   public static CurrentClusterConfiguration withMirroredTenant(
-      final ClusterConfiguration topology) {
-    final var single = CurrentClusterConfiguration.fromLegacy(topology);
+      final CurrentClusterConfiguration topology) {
+    if (topology.partitionGroups().size() != 1) {
+      throw new IllegalArgumentException(
+          "Expected a topology with exactly one partition group, but got "
+              + topology.partitionGroups().keySet());
+    }
+    final var singleGroup = topology.partitionGroups().values().iterator().next();
     return new CurrentClusterConfiguration(
-        single.version(),
-        single.globalConfiguration(),
-        Map.of(
-            CurrentClusterConfiguration.DEFAULT_GROUP,
-            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP),
-            TENANT_A,
-            single.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)),
-        single.phasedChangeState());
+        topology.version(),
+        topology.globalConfiguration(),
+        Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, singleGroup, TENANT_A, singleGroup),
+        topology.phasedChangeState());
   }
 
   /**

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -18,8 +18,9 @@ import io.camunda.zeebe.dynamic.config.api.RestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.BrokerRestoreStatus;
 import io.camunda.zeebe.dynamic.config.api.RestoreStatus.PartitionRestoreStatus;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
@@ -101,12 +102,23 @@ public final class RecoveryController {
                 .recoveryServices(physicalTenantId)
                 .restoreStatus(authentication)
                 .thenApply(ClusterModeChangeMapper::unwrapOrThrow)
+                .thenApply(config -> partitionGroupConfigurationOrThrow(config, physicalTenantId))
                 .thenApply(RecoveryController::restoreStatus),
         RecoveryController::mapRestoreStatus,
         HttpStatus.OK);
   }
 
-  private static RestoreStatus restoreStatus(final ClusterConfiguration configuration) {
+  private static PartitionGroupConfiguration partitionGroupConfigurationOrThrow(
+      final CurrentClusterConfiguration configuration, final String physicalTenantId) {
+    if (!configuration.hasPartitionGroup(physicalTenantId)) {
+      throw new ServiceException(
+          "No configuration found for physical tenant '%s'".formatted(physicalTenantId),
+          Status.NOT_FOUND);
+    }
+    return configuration.partitionGroup(physicalTenantId);
+  }
+
+  private static RestoreStatus restoreStatus(final PartitionGroupConfiguration configuration) {
     return RestoreStatus.of(configuration)
         .orElseThrow(
             () -> new ServiceException("No restore is currently in progress", Status.NOT_FOUND));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.gateway.protocol.model.RestoreBrokerStatus;
 import io.camunda.gateway.protocol.model.RestorePartitionStatus;
 import io.camunda.gateway.protocol.model.RestoreStatusResponse;
@@ -25,16 +26,16 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreParameters;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
-import io.camunda.zeebe.dynamic.config.state.ChangePlan;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.OperationGraph;
+import io.camunda.zeebe.dynamic.config.state.OperationId;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
@@ -42,13 +43,16 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionRestoreOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -364,13 +368,46 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldReturnNotFoundWhenPhysicalTenantNotFound() {
+    // given
+    final var partitionGroups = Map.<String, PartitionGroupConfiguration>of();
+
+    // when
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new CurrentClusterConfiguration(
+                        1,
+                        GlobalConfiguration.init(),
+                        partitionGroups,
+                        PhasedChangeState.empty()))));
+
+    // then
+    expectRestoreStatusProblem(
+        HttpStatus.NOT_FOUND, "NOT_FOUND", "No configuration found for physical tenant 'default'");
+  }
+
+  @Test
   void shouldReturnNotFoundWhenNoRestore() {
     // given
-    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
-        .thenReturn(CompletableFuture.completedFuture(Either.right(ClusterConfiguration.init())));
+    final var partitionGroups =
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PartitionGroupConfiguration.empty(1));
 
-    // when / then
-    expectNoRestoreInProgress();
+    // when
+    Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new CurrentClusterConfiguration(
+                        1,
+                        GlobalConfiguration.init(),
+                        partitionGroups,
+                        PhasedChangeState.empty()))));
+
+    // then
+    expectRestoreStatusProblem(
+        HttpStatus.NOT_FOUND, "NOT_FOUND", "No restore is currently in progress");
   }
 
   @Test
@@ -379,19 +416,21 @@ public class RecoveryControllerTest extends RestControllerTest {
     final var broker = MemberId.from("1");
     final var startedAt = Instant.parse("2024-01-01T10:00:00Z");
     final var plan =
-        new ClusterChangePlan(
+        new DependencyChangePlan(
             -2L,
-            3,
             Status.IN_PROGRESS,
             startedAt,
-            List.of(
-                new CompletedOperation(
-                    new PartitionPreRestoreOperation(broker, 1), startedAt.plusSeconds(1)),
-                new CompletedOperation(
+            OperationGraph.sequential(
+                List.<ClusterConfigurationChangeOperation>of(
+                    new PartitionPreRestoreOperation(broker, 1),
                     new PartitionRestoreOperation(broker, 1, new TreeSet<>(List.of(10L, 11L))),
-                    startedAt.plusSeconds(2))),
-            List.<ClusterConfigurationChangeOperation>of(
-                new ModeChangeOperation(broker, Mode.PROCESSING)));
+                    new ModeChangeOperation(broker, Mode.PROCESSING))),
+            new TreeMap<>(
+                Map.of(
+                    new OperationId(0),
+                    startedAt.plusSeconds(1),
+                    new OperationId(1),
+                    startedAt.plusSeconds(2))));
     stubTopology(Optional.empty(), Optional.of(plan));
 
     // when
@@ -449,14 +488,14 @@ public class RecoveryControllerTest extends RestControllerTest {
     // given
     final var broker = MemberId.from("1");
     final var plan =
-        new ClusterChangePlan(
+        new DependencyChangePlan(
             42L,
-            1,
             Status.IN_PROGRESS,
             Instant.parse("2024-01-01T10:00:00Z"),
-            List.of(),
-            List.<ClusterConfigurationChangeOperation>of(
-                new ModeChangeOperation(broker, Mode.PROCESSING)));
+            OperationGraph.sequential(
+                List.<ClusterConfigurationChangeOperation>of(
+                    new ModeChangeOperation(broker, Mode.PROCESSING))),
+            Collections.emptySortedMap());
     stubTopology(Optional.empty(), Optional.of(plan));
 
     // when / then
@@ -521,17 +560,23 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   private void stubTopology(
-      final Optional<CompletedChange> lastChange, final Optional<ChangePlan> pendingChanges) {
+      final Optional<CompletedChange> lastChange,
+      final Optional<DependencyChangePlan> pendingChanges) {
     final var configuration =
-        new ClusterConfiguration(
+        new CurrentClusterConfiguration(
             2,
-            Map.of(),
-            lastChange,
-            pendingChanges,
-            Optional.empty(),
-            Optional.empty(),
-            0,
-            Optional.empty());
+            new GlobalConfiguration(
+                6,
+                Optional.empty(),
+                Map.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                new PartitionGroupConfiguration(
+                    1, 1, Map.of(), Optional.empty(), pendingChanges, lastChange)),
+            new PhasedChangeState(1, Map.of(), List.of()));
     Mockito.when(recoveryServices.restoreStatus(Mockito.any()))
         .thenReturn(CompletableFuture.completedFuture(Either.right(configuration)));
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -66,6 +66,12 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
     throw new UnsupportedOperationException("Not yet implemented");
   }
 
+  @Override
+  public void onClusterConfigurationUpdated(
+      final CurrentClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
   public void setPartitionHealthStatus(
       final BrokerMemberId nodeId,
       final int partitionId,

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/HashBasedDispatchStrategyTest.java
@@ -213,5 +213,11 @@ final class HashBasedDispatchStrategyTest {
     public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void onClusterConfigurationUpdated(
+        final CurrentClusterConfiguration clusterConfiguration) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -115,5 +115,11 @@ final class PublishMessageDispatchStrategyTest {
     public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void onClusterConfigurationUpdated(
+        final CurrentClusterConfiguration clusterConfiguration) {
+      throw new UnsupportedOperationException();
+    }
   }
 }


### PR DESCRIPTION
## What this change does

Completes the switch of `zeebe/dynamic-config` to the multi-partition-group
`CurrentClusterConfiguration`: every request transformer, applier, the change
coordinator, the gateway configuration service and the topology metrics now
plan, validate and apply changes natively on the new model, without routing
through the legacy single-group `ClusterConfiguration`.

The legacy model itself is kept — it remains the backwards-compatibility
surface, not the working model:

- **Gossip**: dual-write continues (field 2 carries the new model, field 1 the
  legacy projection for not-yet-upgraded brokers); incoming legacy-only gossip
  is still migrated via `fromLegacy`.
- **Wire**: `ProtoBufSerializer` keeps encoding the legacy response part;
  `ClusterConfigurationChangeResponse.legacyResponse` stays mandatory so peers
  that only read field 1 keep working.
- **Persistence**: `PersistedCurrentClusterConfiguration` keeps reading legacy
  persisted files and migrating them on load.
- **Coordinator result**: `ConfigurationChangeResult` keeps its legacy
  projections — they are what the management API answers with, and removing
  them was not worth the risk.
- **restore-standalone**: `RestoreManager` still bootstraps through the legacy
  `StaticConfiguration#generateTopology` path, so the legacy bootstrap
  (`ConfigurationUtil#getClusterConfigFrom`, the legacy initializer variants)
  stays.

## What's in it

- Remove the legacy mapping from the conflict handler, the update-handler
  default implementation, the compile-time flag and the fallback for requests
  that don't support phased change plans; fix restore-status determination for
  any physical tenant.
- Migrate the whole transformer test suite (16 classes) to build fixtures on
  `CurrentClusterConfiguration`. `TestTopologyChangeSimulator` now drains the
  request's own phases instead of reconstructing phases from the flattened
  operation list — the reconstruction always targeted the default group and
  silently dropped per-tenant targeting. `TestChangePlan` loses its legacy
  overload.
  - One deliberate expectation change: the scale tests asserted the *partition
    group* contains every member after scaling, which was legacy flat-map
    semantics. Group membership means "holds a partition of this tenant", and
    with replication factor 1 a joined broker legitimately holds none — the
    assertions now check cluster-level membership, which is what the legacy
    `members()` call checked before.
- Remove dead legacy members: `ClusterConfigurationCoordinatorSupplier.of(…)`
  (no callers) and the gateway service's second, legacy configuration field
  with its `useNewConfig` flag (production always ran the new model). The
  gateway still relays gossip from old peers — covered by the remaining relay
  test.
- `TopologyMetrics` reads from `CurrentClusterConfiguration` directly, with the
  same values the legacy projection carried (version, active change id/status,
  pending/completed operation counts); gauge labels are unchanged.

## Why

Requests planned on the legacy projection cannot see physical tenants other
than the default one, which blocks tenant-aware features and keeps two
diverging representations of the same cluster state alive. This PR makes the
new model the only working representation inside the module while preserving
every compatibility path a mixed-version cluster or an old backup needs.

## Related issues

Related to #61586 