### PR TITLE
test: cover zone-layout partition placement for every physical tenant

### DIFF
--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -327,15 +327,41 @@ public class ExtendedConfigurationBuilder {
 
   /**
    * Same as {@link #flatPropertiesFor(Camunda)} but emits the keys under an arbitrary {@code
-   * prefix} instead of the top-level {@code camunda} header — e.g. {@code
-   * camunda.physical-tenants.<id>} so a physical-tenant {@link Camunda} can be flattened into the
-   * very keys the broker binds it from (see {@code
-   * io.camunda.configuration.physicaltenants.PhysicalTenantResolver}).
+   * prefix} instead of the top-level {@code camunda} header.
+   *
+   * <p>Still diffs against a pristine {@code Camunda}, so this is only correct for a {@code config}
+   * whose absent keys fall back to pristine defaults. To flatten a physical tenant under {@code
+   * camunda.physical-tenants.<id>}, use {@link #flatPropertiesFor(Camunda, String, Camunda)} with
+   * the root configuration as the baseline — an absent tenant key resolves to the root's value, not
+   * to the pristine default.
    */
   public static Map<String, Object> flatPropertiesFor(final Camunda config, final String prefix) {
-    final Map<String, Object> defaultMap = flatten(new Camunda());
+    return flatPropertiesFor(config, prefix, new Camunda());
+  }
+
+  /**
+   * Same as {@link #flatPropertiesFor(Camunda, String)} but diffs against an explicit {@code
+   * baseline} instead of a pristine {@code new Camunda()}.
+   *
+   * <p>The baseline decides which fields are <em>omitted</em>, so it must be whatever the consumer
+   * of these properties falls back to for a key that is absent. For the top-level {@code camunda.*}
+   * properties that is a pristine {@code Camunda}, which is what the other overloads pass. For a
+   * physical tenant it is the <em>root</em> configuration: {@code PhysicalTenantResolver} builds
+   * each tenant by binding {@code camunda.*} into a fresh instance and only then overlaying {@code
+   * camunda.physical-tenants.<id>.*}, so an omitted tenant key resolves to the root's value, not to
+   * the pristine default. Diffing a tenant against a pristine baseline instead would silently drop
+   * any tenant value that happens to equal a pristine default while the root differs — the tenant
+   * would then inherit the root's value rather than the declared one.
+   *
+   * <p>{@code config} must be expressed relative to the same {@code baseline} (i.e. built by
+   * copying it and applying the overrides), otherwise every field the baseline itself moved away
+   * from the pristine default reads as a deliberate override.
+   */
+  public static Map<String, Object> flatPropertiesFor(
+      final Camunda config, final String prefix, final Camunda baseline) {
+    final Map<String, Object> baselineMap = flatten(baseline);
     final Map<String, Object> configuredMap = flatten(config);
-    final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
+    final Map<String, Object> diff = diffMaps(baselineMap, configuredMap);
     putLegacyNodeIdPropertyIfNeeded(diff);
     final Map<String, Object> flat = new LinkedHashMap<>();
     flattenInto(diff, prefix, flat);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/MultiPhysicalTenantZoneAwarePartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/MultiPhysicalTenantZoneAwarePartitionDistributionIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.zoneaware;
+
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.ZONE_A;
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.ZONE_B;
+
+import io.camunda.configuration.Zone;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies that a zone-aware cluster honours its zone layout for <em>every</em> physical tenant,
+ * not only the default one.
+ *
+ * <p>A zone layout is cluster-wide: {@code cluster.partitioning} and {@code cluster.zone} are both
+ * on the physical-tenant override deny-list ({@code PhysicalTenantOverridePolicyValidation}), and
+ * {@code StaticConfigurationGenerator} builds a single {@code PartitionDistributor} from the root
+ * broker configuration. What <em>is</em> per-tenant is the partition group that distributor is
+ * applied to, so the property under test is that each tenant's own partition group is laid out
+ * across the zones the cluster declares.
+ *
+ * <p>The tenants deliberately have different partition counts. {@code
+ * StaticConfigurationGenerator#getSortedPartitionIds} flattens every tenant's partitions into one
+ * list ordered by {@code (physicalTenantId, partitionNumber)}, and {@code
+ * ZoneAwarePartitionDistributor} offsets each partition's placement by its index in that flat list,
+ * so each tenant is placed at a different offset within it. The assertions below are layout
+ * invariants rather than exact member sets, so they hold at any offset; the differing counts
+ * exercise them at several offsets instead of at the single symmetric one equal counts would
+ * produce. The offsets themselves are deliberately not pinned — they are the distributor's internal
+ * round-robin, not the zone layout under test.
+ *
+ * <p>Cluster shape: {@value #BROKERS_COUNT} brokers over two zones, RF {@value
+ * #REPLICATION_FACTOR}. Zone A has 2 brokers and takes 1 replica at priority 1000; zone B has 1
+ * broker and takes 1 replica at priority 500. Since a zone holds fewer replicas than it has
+ * brokers, which broker inside zone A holds a given partition is a real choice rather than a
+ * consequence of RF covering the whole cluster.
+ */
+@ZeebeIntegration
+final class MultiPhysicalTenantZoneAwarePartitionDistributionIT {
+
+  private static final int BROKERS_COUNT = 3;
+  private static final int REPLICATION_FACTOR = 2;
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final int DEFAULT_TENANT_PARTITIONS = 2;
+  private static final int TENANT_A_PARTITIONS = 3;
+  private static final int TENANT_B_PARTITIONS = 1;
+
+  private static final List<Zone> ZONE_CONFIGS =
+      List.of(new Zone(ZONE_A, 2, 1, 1000), new Zone(ZONE_B, 1, 1, 500));
+
+  // the default tenant's partition count stays the cluster's own, so the extension's readiness
+  // wait - which only sees the gateway's unscoped topology - still matches
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none(), TENANT_A_PARTITIONS)
+          .withTenant(TENANT_B, Storage.none(), TENANT_B_PARTITIONS)
+          .build();
+
+  @TestZeebe(purgeAfterEach = false)
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .withName("multi-pt-zone-aware-distribution")
+          .withBrokersCount(BROKERS_COUNT)
+          .withEmbeddedGateway(true)
+          .withPartitionsCount(DEFAULT_TENANT_PARTITIONS)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .multiZone(ZONE_CONFIGS)
+          // replaces the builder's default broker config, which is where unauthenticated access
+          // would otherwise be enabled
+          .withBrokerConfig(broker -> TENANTS.configure(broker.withUnauthenticatedAccess()))
+          .build();
+
+  @ParameterizedTest(name = "physical tenant ''{0}''")
+  @MethodSource("physicalTenants")
+  void shouldAssignPartitionsPerZoneLayout(
+      final String physicalTenantId, final int partitionCount) {
+    ZoneHelpers.assertPartitionsAssignedPerZoneLayout(
+        ClusterActuator.of(CLUSTER.availableGateway()),
+        physicalTenantId,
+        ZONE_CONFIGS,
+        partitionCount,
+        REPLICATION_FACTOR);
+  }
+
+  @ParameterizedTest(name = "physical tenant ''{0}''")
+  @MethodSource("physicalTenants")
+  void shouldElectLeadersInHighestPriorityZone(
+      final String physicalTenantId, final int partitionCount) {
+    // zoneA(priority 1000) > zoneB(priority 500)
+    ZoneHelpers.assertLeadersInZone(CLUSTER, physicalTenantId, ZONE_A, partitionCount);
+  }
+
+  static Stream<Arguments> physicalTenants() {
+    return Stream.of(
+        Arguments.of(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, DEFAULT_TENANT_PARTITIONS),
+        Arguments.of(TENANT_A, TENANT_A_PARTITIONS),
+        Arguments.of(TENANT_B, TENANT_B_PARTITIONS));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -16,13 +16,30 @@ import io.camunda.configuration.ZoneAware;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.PartitionState;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 
 public class ZoneHelpers {
+
+  /**
+   * Generous upper bound for the per-physical-tenant assertions below. A non-default tenant's Raft
+   * groups are not covered by the {@code @TestZeebe} extension's readiness wait, which only looks
+   * at the gateway's unscoped topology, so they may still be electing when a test body starts.
+   */
+  private static final Duration ASSERTION_TIMEOUT = Duration.ofSeconds(60);
 
   public static TestCluster createCluster(
       final String name,
@@ -86,6 +103,208 @@ public class ZoneHelpers {
                   .extracting(PartitionState::getId)
                   .containsExactlyInAnyOrder(1, 2);
             });
+  }
+
+  /**
+   * Asserts that every partition of {@code physicalTenantId} is assigned according to {@code
+   * zones}: each zone holds exactly its configured {@link Zone#numberOfReplicas()} replicas of
+   * every partition, the preferred leader sits in the highest-priority zone, and within a zone the
+   * tenant's partitions are spread over that zone's brokers.
+   *
+   * <p>The preferred leader is the replica holding Raft priority {@code replicationFactor}, which
+   * is the highest priority {@link
+   * io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor} hands out and which it
+   * always gives to a broker in the highest-priority zone.
+   *
+   * <p>Reads the assignment from the physical-tenant-scoped cluster topology, so it describes what
+   * the cluster configuration decided. Use {@link #assertLeadersInZone} for what the brokers
+   * actually run.
+   *
+   * <p>The spread check is a balance property (no broker in a zone holds more than one replica more
+   * than another), so it only discriminates where a zone has more than one broker and the tenant
+   * has enough partitions to distribute over them; for a single-broker zone, or a tenant with a
+   * single partition, it is satisfied trivially.
+   */
+  public static void assertPartitionsAssignedPerZoneLayout(
+      final ClusterActuator actuator,
+      final String physicalTenantId,
+      final List<Zone> zones,
+      final int partitionCount,
+      final int replicationFactor) {
+    final var highestPriorityZone =
+        zones.stream().max(Comparator.comparingInt(Zone::priority)).orElseThrow().name();
+
+    Awaitility.await("physical tenant '%s' is assigned per zone layout".formatted(physicalTenantId))
+        .atMost(ASSERTION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var replicas = replicasByPartition(actuator, physicalTenantId);
+              assertThat(replicas.keySet())
+                  .as("physical tenant '%s' has all its partitions assigned", physicalTenantId)
+                  .containsExactlyInAnyOrderElementsOf(partitionIds(partitionCount));
+
+              replicas.forEach(
+                  (partitionId, members) -> {
+                    zones.forEach(
+                        zone ->
+                            assertThat(membersInZone(members.keySet(), zone.name()))
+                                .as(
+                                    "partition %d of physical tenant '%s' has %d replica(s) in"
+                                        + " zone '%s'",
+                                    partitionId,
+                                    physicalTenantId,
+                                    zone.numberOfReplicas(),
+                                    zone.name())
+                                .hasSize(zone.numberOfReplicas()));
+
+                    assertThat(preferredLeaders(members, replicationFactor))
+                        .as(
+                            "partition %d of physical tenant '%s' prefers a leader in the"
+                                + " highest-priority zone '%s'",
+                            partitionId, physicalTenantId, highestPriorityZone)
+                        .singleElement()
+                        .matches(member -> member.isInZone(highestPriorityZone));
+                  });
+
+              zones.forEach(
+                  zone -> {
+                    final var replicasPerBroker = replicasPerBrokerInZone(replicas, zone);
+                    final var counts = replicasPerBroker.values();
+                    assertThat(max(counts) - min(counts))
+                        .as(
+                            "physical tenant '%s' spreads its partitions over the brokers of zone"
+                                + " '%s', but they are assigned as %s",
+                            physicalTenantId, zone.name(), replicasPerBroker)
+                        .isLessThanOrEqualTo(1);
+                  });
+            });
+  }
+
+  /**
+   * Asserts that every partition of {@code physicalTenantId} has exactly one leader and that the
+   * leader runs on a broker in {@code zone}.
+   *
+   * <p>The runtime counterpart to {@link #assertPartitionsAssignedPerZoneLayout}: it queries each
+   * broker's own view of the partitions it runs for that physical tenant, so it fails if the
+   * assignment never materialised into elected Raft leaders.
+   */
+  public static void assertLeadersInZone(
+      final TestCluster cluster,
+      final String physicalTenantId,
+      final String zone,
+      final int partitionCount) {
+    Awaitility.await(
+            "physical tenant '%s' elected every leader in zone '%s'"
+                .formatted(physicalTenantId, zone))
+        .atMost(ASSERTION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var leaders = leadersByPartition(cluster, physicalTenantId);
+              assertThat(leaders)
+                  .as("every partition of physical tenant '%s' has a leader", physicalTenantId)
+                  .containsOnlyKeys(partitionIds(partitionCount));
+              leaders.forEach(
+                  (partitionId, members) ->
+                      assertThat(members)
+                          .as(
+                              "partition %d of physical tenant '%s' has exactly one leader, in"
+                                  + " zone '%s'",
+                              partitionId, physicalTenantId, zone)
+                          .singleElement()
+                          .matches(member -> member.isInZone(zone)));
+            });
+  }
+
+  /** The members holding each of {@code physicalTenantId}'s partitions, keyed by partition id. */
+  private static Map<Integer, Map<MemberId, PartitionState>> replicasByPartition(
+      final ClusterActuator actuator, final String physicalTenantId) {
+    final Map<Integer, Map<MemberId, PartitionState>> replicas = new HashMap<>();
+    // a physical-tenant-scoped topology already reports only that tenant's partition group, so
+    // every partition below belongs to it
+    for (final var broker : actuator.getTopology(physicalTenantId).getBrokers()) {
+      final var member = memberIdOf(broker.getId());
+      broker
+          .getPartitions()
+          .forEach(
+              partition ->
+                  replicas
+                      .computeIfAbsent(partition.getId(), id -> new HashMap<>())
+                      .put(member, partition));
+    }
+    return replicas;
+  }
+
+  /**
+   * A reported broker id as a {@link MemberId}. Zone-aware clusters report the string form ({@code
+   * zone-a_0}), non-zone-aware ones a bare integer; both are handled so a mismatch cannot surface
+   * as a {@link ClassCastException} swallowed by an {@code ignoreExceptions} await.
+   */
+  private static MemberId memberIdOf(final BrokerId brokerId) {
+    return switch (brokerId) {
+      case final BrokerId.String s -> MemberId.from(s.value());
+      case final BrokerId.Integer i -> MemberId.from(String.valueOf(i.value()));
+      default ->
+          throw new IllegalStateException("unexpected broker id type: " + brokerId.getClass());
+    };
+  }
+
+  /** The members currently leading each of {@code physicalTenantId}'s partitions. */
+  private static Map<Integer, List<MemberId>> leadersByPartition(
+      final TestCluster cluster, final String physicalTenantId) {
+    final Map<Integer, List<MemberId>> leaders = new HashMap<>();
+    cluster
+        .brokers()
+        .forEach(
+            (member, broker) ->
+                PartitionsActuator.of(broker)
+                    .query(physicalTenantId)
+                    .forEach(
+                        (partitionId, status) -> {
+                          if ("Leader".equalsIgnoreCase(status.role())) {
+                            leaders
+                                .computeIfAbsent(partitionId, id -> new ArrayList<>())
+                                .add(member);
+                          }
+                        }));
+    return leaders;
+  }
+
+  /** How many of the tenant's partitions each broker of {@code zone} holds a replica of. */
+  private static Map<MemberId, Long> replicasPerBrokerInZone(
+      final Map<Integer, Map<MemberId, PartitionState>> replicas, final Zone zone) {
+    final Map<MemberId, Long> replicasPerBroker = new HashMap<>();
+    for (int localNodeIdx = 0; localNodeIdx < zone.numberOfBrokers(); localNodeIdx++) {
+      final var member = MemberId.from(zone.name(), localNodeIdx);
+      replicasPerBroker.put(
+          member, replicas.values().stream().filter(m -> m.containsKey(member)).count());
+    }
+    return replicasPerBroker;
+  }
+
+  private static List<MemberId> preferredLeaders(
+      final Map<MemberId, PartitionState> members, final int replicationFactor) {
+    return members.entrySet().stream()
+        .filter(entry -> Objects.equals(entry.getValue().getPriority(), replicationFactor))
+        .map(Map.Entry::getKey)
+        .toList();
+  }
+
+  private static List<MemberId> membersInZone(final Set<MemberId> members, final String zone) {
+    return members.stream().filter(member -> member.isInZone(zone)).toList();
+  }
+
+  private static List<Integer> partitionIds(final int partitionCount) {
+    return IntStream.rangeClosed(1, partitionCount).boxed().toList();
+  }
+
+  private static long max(final Collection<Long> counts) {
+    return counts.stream().mapToLong(Long::longValue).max().orElse(0);
+  }
+
+  private static long min(final Collection<Long> counts) {
+    return counts.stream().mapToLong(Long::longValue).min().orElse(0);
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -39,8 +40,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.http.client.ReactorResourceFactory;
 
@@ -48,6 +52,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     implements TestApplication<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestSpringApplication.class);
+  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
 
   protected ConfigurableApplicationContext springContext;
   protected final Camunda unifiedConfig;
@@ -59,7 +64,14 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private final Collection<ApplicationContextInitializer> additionalInitializers;
   private final ReactorResourceFactory reactorResourceFactory = new ReactorResourceFactory();
   private final Set<String> refreshableKeys = new HashSet<>();
-  private final Map<String, Camunda> ptConfigs = new LinkedHashMap<>();
+
+  /**
+   * Physical-tenant overrides, kept as the modifiers themselves rather than as materialised {@link
+   * Camunda} instances: each tenant's configuration is only built at {@link #createSpringBuilder()}
+   * time, by copying the root configuration <em>as it stands then</em> and replaying these onto it
+   * (see {@link #physicalTenantProperties}).
+   */
+  private final Map<String, List<Consumer<Camunda>>> ptConfigModifiers = new LinkedHashMap<>();
 
   public TestSpringApplication(final Class<?>... springApplications) {
     this(new Camunda(), springApplications);
@@ -243,19 +255,34 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   /**
-   * Mutates the unified configuration for a single physical tenant. The per-tenant {@link Camunda}
-   * is flattened into {@code camunda.physical-tenants.<tenantId>.*} properties at {@link
-   * #createSpringBuilder()} time, mirroring how {@code
-   * io.camunda.configuration.physicaltenants.PhysicalTenantResolver} binds a physical tenant from
-   * those same keys. Use {@link #withUnifiedConfig(Consumer)} for the root ({@code default})
-   * tenant.
+   * Mutates the unified configuration for a single physical tenant. Use {@link
+   * #withUnifiedConfig(Consumer)} for the root ({@code default}) tenant.
+   *
+   * <p>{@code modifier} is <em>not</em> applied here. It is recorded and replayed at {@link
+   * #createSpringBuilder()} time onto a copy of the root configuration, which is then flattened
+   * into {@code camunda.physical-tenants.<tenantId>.*} properties. This mirrors how {@code
+   * io.camunda.configuration.physicaltenants.PhysicalTenantResolver} resolves a tenant — bind
+   * {@code camunda.*} into a fresh instance, then overlay the tenant's own keys — so only the
+   * fields a modifier actually changes relative to the root are emitted, and everything else is
+   * inherited at runtime.
+   *
+   * <p>Two consequences worth knowing:
+   *
+   * <ul>
+   *   <li>A modifier sees the <em>root's</em> values, not pristine defaults. A read-modify-write
+   *       modifier (e.g. appending to a list) therefore extends the root's value, which is what the
+   *       tenant would have inherited anyway.
+   *   <li>Because the root is copied at {@link #createSpringBuilder()} time, root configuration
+   *       applied after this call is still picked up. Ordering between {@link #withUnifiedConfig}
+   *       and this method does not matter.
+   * </ul>
    *
    * @param tenantId the physical tenant id
    * @param modifier a configuration function that accepts the tenant's Camunda configuration object
    * @return itself for chaining
    */
   public T withPtConfig(final String tenantId, final Consumer<Camunda> modifier) {
-    modifier.accept(ptConfigs.computeIfAbsent(tenantId, id -> new Camunda()));
+    ptConfigModifiers.computeIfAbsent(tenantId, id -> new ArrayList<>()).add(modifier);
     return self();
   }
 
@@ -276,8 +303,8 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
    * @return itself for chaining
    */
   public T removePtConfig(final String tenantId) {
-    ptConfigs.remove(tenantId);
-    final String prefix = "camunda.physical-tenants." + tenantId + ".";
+    ptConfigModifiers.remove(tenantId);
+    final String prefix = PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".";
     propertyOverrides.keySet().removeIf(key -> key.startsWith(prefix));
     return self();
   }
@@ -378,16 +405,25 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     // Flatten the in-memory unified config into camunda.* properties at the latest possible point,
     // so every with*Config / withUnifiedConfig call made up to now is captured. Refreshable so that
     // fields cleared between stop/start (e.g. an exporter removed) don't remain.
-    final Map<String, Object> flatProperties =
-        new LinkedHashMap<>(ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig));
+    final Map<String, Object> rootProperties =
+        ExtendedConfigurationBuilder.flatPropertiesFor(unifiedConfig);
+    final Map<String, Object> flatProperties = new LinkedHashMap<>(rootProperties);
     // withRefreshableProperties replaces (not accumulates) the refreshable set, so the root config
     // and every physical tenant must be merged into a single map before registering them.
-    ptConfigs.forEach(
-        (tenantId, ptConfig) ->
-            flatProperties.putAll(
-                ExtendedConfigurationBuilder.flatPropertiesFor(
-                    ptConfig, "camunda.physical-tenants." + tenantId)));
+    if (!ptConfigModifiers.isEmpty()) {
+      final Map<String, Object> rootEnvironment = rootEnvironmentProperties(rootProperties);
+      final Camunda rootBaseline = rootSeededConfig(rootEnvironment);
+      ptConfigModifiers.forEach(
+          (tenantId, modifiers) ->
+              flatProperties.putAll(
+                  physicalTenantProperties(
+                      rootEnvironment,
+                      rootBaseline,
+                      modifiers,
+                      PHYSICAL_TENANTS_PREFIX + "." + tenantId)));
+    }
     withRefreshableProperties(flatProperties);
+    requireEveryPhysicalTenantDeclared();
     return MainSupport.createDefaultApplicationBuilder()
         .bannerMode(Mode.OFF)
         .registerShutdownHook(false)
@@ -399,6 +435,116 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   @Override
   public String toString() {
     return getClass().getSimpleName() + "{nodeId = " + nodeId() + "}";
+  }
+
+  /**
+   * The properties for one physical tenant, expressed under {@code prefix}.
+   *
+   * <p>A key is emitted when the modifiers moved it away from the root — the value the tenant would
+   * otherwise inherit — <em>or</em> when they moved it away from a pristine {@link Camunda}, which
+   * is as close as a value diff gets to "the modifiers set it at all". Neither rule alone is
+   * enough. Diffing only against the root drops a value the modifiers deliberately copied from it,
+   * and some subtrees must be <em>declared</em> rather than inherited: {@code
+   * PhysicalTenantRequiredOverrideValidation} rejects a tenant without its own {@code
+   * security.initialization.*}, which {@code CamundaMultiDBExtension} satisfies by copying the
+   * root's block verbatim. Diffing only against a pristine instance is the older, weaker rule that
+   * dropped any value equal to a pristine default. The union keeps both guarantees.
+   *
+   * <p>Values always come from the root-seeded build. The two builds can only disagree for a
+   * modifier that reads before it writes, and every key such a modifier touches differs from the
+   * root, so the root-seeded diff wins wherever it has an opinion.
+   *
+   * <p>The modifiers therefore run twice, once per build, and must not have side effects outside
+   * the {@link Camunda} they are handed.
+   */
+  private Map<String, Object> physicalTenantProperties(
+      final Map<String, Object> rootEnvironment,
+      final Camunda rootBaseline,
+      final List<Consumer<Camunda>> modifiers,
+      final String prefix) {
+    final Map<String, Object> setByModifiers =
+        ExtendedConfigurationBuilder.flatPropertiesFor(
+            applyModifiers(new Camunda(), modifiers), prefix);
+    final Map<String, Object> differsFromRoot =
+        ExtendedConfigurationBuilder.flatPropertiesFor(
+            applyModifiers(rootSeededConfig(rootEnvironment), modifiers), prefix, rootBaseline);
+    final Map<String, Object> properties = new LinkedHashMap<>(setByModifiers);
+    properties.putAll(differsFromRoot);
+    return properties;
+  }
+
+  /**
+   * A copy of the root configuration, reconstructed by binding its own flat properties into a fresh
+   * {@link Camunda} rather than by deep-copying the live instance — {@code rootEnvironment} is
+   * exactly "pristine plus everything the root changed", so binding it onto a pristine instance
+   * reproduces the root faithfully, through the same Spring binding the application itself performs
+   * on these properties. A copy is essential: the modifiers must not touch the root configuration
+   * object.
+   */
+  private Camunda rootSeededConfig(final Map<String, Object> rootEnvironment) {
+    // see withUnifiedConfig: unified-config getters validate against legacy properties read from a
+    // statically pinned Environment, which a previously booted test application may still own.
+    // Bindable.ofInstance reads current values through those getters, so re-pin before binding.
+    new UnifiedConfigurationHelper(new StandardEnvironment());
+    final var environment = new StandardEnvironment();
+    environment.getPropertySources().addFirst(new MapPropertySource("rootConfig", rootEnvironment));
+    final var config = new Camunda();
+    Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(config));
+    return config;
+  }
+
+  private Camunda applyModifiers(final Camunda config, final List<Consumer<Camunda>> modifiers) {
+    // as above: the modifiers read through the same validating getters
+    new UnifiedConfigurationHelper(new StandardEnvironment());
+    modifiers.forEach(modifier -> modifier.accept(config));
+    return config;
+  }
+
+  /**
+   * The properties a physical tenant inherits from: the flattened root configuration, plus any
+   * {@code camunda.*} key set directly through {@link #withProperty} — which has no {@link Camunda}
+   * field behind it and so cannot appear in the flattened form, yet still reaches the broker and is
+   * still what an omitted tenant key resolves to. Keys left over from a previous start are skipped;
+   * {@link #withRefreshableProperties} is about to replace them.
+   */
+  private Map<String, Object> rootEnvironmentProperties(final Map<String, Object> rootProperties) {
+    final Map<String, Object> rootEnvironment = new LinkedHashMap<>();
+    propertyOverrides.forEach(
+        (key, value) -> {
+          if (key.startsWith(Camunda.PREFIX + ".")
+              && !key.startsWith(PHYSICAL_TENANTS_PREFIX + ".")
+              && !refreshableKeys.contains(key)) {
+            rootEnvironment.put(key, value);
+          }
+        });
+    rootEnvironment.putAll(rootProperties);
+    return rootEnvironment;
+  }
+
+  /**
+   * Fails when a physical tenant declared through {@link #withPtConfig} ended up with no {@code
+   * camunda.physical-tenants.<id>.*} property at all.
+   *
+   * <p>{@code PhysicalTenantResolver} discovers tenants from exactly those keys, so a tenant that
+   * emits none does not exist and the broker simply boots without it — surfacing much later as a
+   * topology that never completes rather than as a configuration error. Since only values that
+   * differ from the root are emitted, this is what happens when every one of a tenant's overrides
+   * resolves to the root's own value. Declaring such a tenant is not expressible in production
+   * either, for the same reason, so the fix is to give it at least one differing value rather than
+   * to work around it here.
+   */
+  private void requireEveryPhysicalTenantDeclared() {
+    for (final String tenantId : ptConfigModifiers.keySet()) {
+      final String prefix = PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".";
+      if (propertyOverrides.keySet().stream().noneMatch(key -> key.startsWith(prefix))) {
+        throw new IllegalStateException(
+            ("physical tenant '%s' declares no configuration that differs from the root, so it "
+                    + "would not be discovered by PhysicalTenantResolver and the broker would "
+                    + "start without it. Give it at least one value that differs from the root "
+                    + "configuration.")
+                .formatted(tenantId));
+      }
+    }
   }
 
   private void overridePropertyIfAbsent(final String key, final Object value) {

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantConfigFlatteningTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantConfigFlatteningTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A physical tenant declared via {@link TestSpringApplication#withPtConfig} is emitted as {@code
+ * camunda.physical-tenants.<id>.*} properties, and the broker resolves it by binding {@code
+ * camunda.*} into a fresh instance and only then overlaying those keys ({@code
+ * PhysicalTenantResolver}). An omitted tenant key therefore resolves to the <em>root's</em> value,
+ * which is what these tests pin: a tenant emits exactly the fields it changes relative to the root,
+ * no more and no less.
+ */
+@SuppressWarnings("resource")
+final class PhysicalTenantConfigFlatteningTest {
+
+  private static final String TENANT = "tenanta";
+  private static final String ABSENT = "<absent>";
+
+  @Test
+  void shouldEmitTenantValueThatEqualsThePristineDefaultButNotTheRoot() {
+    // given - a root with 2 partitions, and a tenant that wants exactly 1. 1 is also the pristine
+    // Camunda default, so a tenant flattened against a pristine baseline would emit nothing here
+    // and silently inherit the root's 2
+    final var broker =
+        new TestStandaloneBroker()
+            .withClusterConfig(cluster -> cluster.setPartitionCount(2))
+            .withPtConfig(TENANT, camunda -> camunda.getCluster().setPartitionCount(1));
+
+    // when
+    broker.createSpringBuilder();
+
+    // then
+    assertThat(tenantProperty(broker, "cluster.partition-count"))
+        .as("the declared partition count reaches the broker rather than being inherited")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldStillDeclareAValueTheModifierCopiedFromTheRoot() {
+    // given - a tenant that sets a value identical to the root's. CamundaMultiDBExtension does
+    // exactly this with security.initialization, because a tenant must own that block and may not
+    // inherit it (PhysicalTenantRequiredOverrideValidation) - so the declaration must survive even
+    // though it changes nothing
+    final var broker =
+        new TestStandaloneBroker()
+            .withClusterConfig(cluster -> cluster.setPartitionCount(3))
+            .withPtConfig(TENANT, camunda -> camunda.getCluster().setPartitionCount(3));
+
+    // when
+    broker.createSpringBuilder();
+
+    // then
+    assertThat(tenantProperty(broker, "cluster.partition-count"))
+        .as("a value the modifier set is declared even when it equals the root's")
+        .isEqualTo(3);
+  }
+
+  @Test
+  void shouldRejectATenantThatEmitsNoProperty() {
+    // given - a tenant that overrides nothing at all, so nothing is emitted under
+    // camunda.physical-tenants.<id> and PhysicalTenantResolver, which discovers tenants from
+    // exactly those keys, would never see it
+    final var broker = new TestStandaloneBroker().withPtConfig(TENANT, camunda -> {});
+
+    // when / then - fail here rather than silently start a broker without the tenant
+    assertThatThrownBy(broker::createSpringBuilder)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(TENANT)
+        .hasMessageContaining("differs from the root");
+  }
+
+  @Test
+  void shouldNotEmitRootValuesTheTenantNeverOverrode() {
+    // given - a root that moves several cluster-wide fields away from their pristine defaults,
+    // and a tenant that overrides only the partition count. Those fields are non-overridable per
+    // tenant (PhysicalTenantOverridePolicyValidation), so emitting them would fail resolution
+    // outright rather than merely being redundant
+    final var broker =
+        new TestStandaloneBroker()
+            .withClusterConfig(
+                cluster -> {
+                  cluster.setPartitionCount(2);
+                  cluster.setReplicationFactor(3);
+                  cluster.setSize(3);
+                  cluster.setName("some-cluster");
+                })
+            .withPtConfig(TENANT, camunda -> camunda.getCluster().setPartitionCount(1));
+
+    // when
+    broker.createSpringBuilder();
+
+    // then
+    assertThat(tenantProperty(broker, "cluster.size")).isEqualTo(ABSENT);
+    assertThat(tenantProperty(broker, "cluster.name")).isEqualTo(ABSENT);
+    assertThat(tenantProperty(broker, "cluster.replication-factor")).isEqualTo(ABSENT);
+    assertThat(tenantProperty(broker, "cluster.partition-count"))
+        .as("the one field the tenant did override is still emitted")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldPickUpRootConfigurationAppliedAfterTheTenantWasDeclared() {
+    // given - the tenant is declared before the root partition count is set, so a modifier applied
+    // eagerly against the root-of-the-moment would see the wrong baseline
+    final var broker =
+        new TestStandaloneBroker()
+            .withPtConfig(TENANT, camunda -> camunda.getCluster().setPartitionCount(1))
+            .withClusterConfig(cluster -> cluster.setPartitionCount(2));
+
+    // when
+    broker.createSpringBuilder();
+
+    // then
+    assertThat(tenantProperty(broker, "cluster.partition-count"))
+        .as("declaration order between root and tenant configuration does not matter")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldLetTenantModifierBuildOnTheRootValueItWouldInherit() {
+    // given - a root snapshot period, and a tenant modifier that derives its value from whatever
+    // the tenant would otherwise inherit. The pristine default is 5m, so a modifier reading a
+    // pristine instance would land on 6m instead
+    final var broker =
+        new TestStandaloneBroker()
+            .withDataConfig(data -> data.setSnapshotPeriod(Duration.ofMinutes(10)))
+            .withPtConfig(
+                TENANT,
+                camunda ->
+                    camunda
+                        .getData()
+                        .setSnapshotPeriod(camunda.getData().getSnapshotPeriod().plusMinutes(1)));
+
+    // when
+    broker.createSpringBuilder();
+
+    // then
+    assertThat(tenantProperty(broker, "data.snapshot-period"))
+        .as("a tenant modifier observes the root's values, not pristine defaults")
+        .hasToString(Duration.ofMinutes(11).toString());
+  }
+
+  @Test
+  void shouldDeclareAnInitializationBlockCopiedFromTheRoot() {
+    // given - the shape CamundaMultiDBExtension uses: the root seeds an initialization user, and
+    // the tenant copies that block verbatim because PhysicalTenantRequiredOverrideValidation
+    // rejects a tenant that has none of its own. Copying it changes nothing relative to the root,
+    // so a root-only diff would drop it and the broker would fail to resolve the tenant at all
+    final var rootUser = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
+    final var broker =
+        new TestStandaloneBroker()
+            .withSecurityConfig(
+                security -> security.getInitialization().setUsers(List.of(rootUser)))
+            .withPtConfig(
+                TENANT,
+                camunda -> camunda.getSecurity().getInitialization().setUsers(List.of(rootUser)));
+
+    // when
+    broker.createSpringBuilder();
+
+    // then
+    assertThat(tenantProperty(broker, "security.initialization.users[0].username"))
+        .as("the tenant declares its own initialization block even when copied from the root")
+        .isEqualTo("demo");
+  }
+
+  private static Object tenantProperty(final TestStandaloneBroker broker, final String relative) {
+    return broker.property(
+        "camunda.physical-tenants." + TENANT + "." + relative, Object.class, ABSENT);
+  }
+}


### PR DESCRIPTION
Adds `MultiPhysicalTenantZoneAwarePartitionDistributionIT` — one multi-zone cluster with three physical tenants at different partition counts, - asserting per tenant that each zone holds exactly its configured replicas of every partition, that the preferred leader sits in the highest-priority zone, that partitions are spread over the brokers within a zone, and that every partition has exactly one *elected* leader there..

### First commit: a test-infra fix this depends on

A physical tenant declared via `withPtConfig` silently lost any value equal to a pristine `Camunda` default — declaring 1 partition for tenantA on a cluster with root count 2 gave that tenantA 2 partitions instead of 1. The tenant config was flattened by diffing against a *pristine* baseline, but an absent tenant key falls back to the *root* at runtime (`PhysicalTenantResolver` binds `camunda.*`, then overlays the tenant's keys).

The test infra now resolves a tenant the same way: modifiers are recorded and replayed onto a copy of the root, then diffed against it, so only genuine differences are emitted. Note one behavioural change — a modifier now observes the root's values rather than pristine defaults.

## Related issues

closes #61838
