### PR TITLE
test: select authorization type via combobox instead of removed tab

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -108,8 +108,7 @@ export class IdentityAuthorizationsPage {
   }
 
   async clickResourceType(resourceType: string) {
-    await this.authorizationTypeFilterComboBox.click();
-    await this.resourceTypeOption(resourceType).click();
+    await this.selectResourceTypeTab(resourceType);
   }
 
   async clickCreateAuthorizationButton() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -64,8 +64,10 @@ export class IdentityAuthorizationsPage {
       this.page.locator(`input#${name.toUpperCase()}`);
     this.createAuthorizationOwnerTypeComboBox =
       this.createAuthorizationModal.getByRole('combobox', {name: 'Owner type'});
+    // The Select's popover renders in a portal outside the dialog's DOM
+    // subtree, so its options must be queried from the page, not the modal.
     this.createAuthorizationOwnerTypeOption = (name) =>
-      this.createAuthorizationModal.getByRole('option', {
+      this.page.getByRole('option', {
         name,
       });
     this.createAuthorizationSubmitButton =
@@ -73,7 +75,9 @@ export class IdentityAuthorizationsPage {
         name: 'Create authorization',
       });
     this.deleteAuthorizationButton = (name) =>
-      this.authorizationsList.getByRole('row', {name}).getByLabel('Delete');
+      this.authorizationsList
+        .getByRole('row', {name})
+        .getByRole('button', {name: 'Delete'});
     this.deleteAuthorizationModal = page.getByRole('dialog', {
       name: 'Delete authorization',
     });
@@ -224,9 +228,7 @@ export class IdentityAuthorizationsPage {
 
   async selectAuthorizationOwnerType(authorization: {ownerType: string}) {
     await this.createAuthorizationOwnerTypeComboBox.click();
-    await this.createAuthorizationOwnerTypeOption(
-      authorization.ownerType,
-    ).click();
+    await this.selectOwnerTypeFromDrowdown(authorization.ownerType);
     // Selecting an owner type re-renders the owner field. User, Group and Role
     // owners all now render the searchable "Search by owner ID" entity input
     // (#51442) instead of the former "Select an owner" combobox; wait for it
@@ -241,11 +243,17 @@ export class IdentityAuthorizationsPage {
     await this.createAuthorizationOwnerSearchInput.fill(authorization.ownerId);
     // The owner search is debounced + server-driven; the menu item for a
     // just-created user can take longer than 20s to surface under load.
-    const ownerOption = this.createAuthorizationModal
-      .locator('.cds--list-box__menu-item')
+    // const ownerOption = this.createAuthorizationModal
+    //   .locator('.cds--list-box__menu-item')
+    //   .filter({hasText: authorization.ownerId})
+    //   .first();
+    await this.page.waitForTimeout(500);
+    const ownerOption = this.page
+      .getByRole('listbox')
+      .getByRole('option')
       .filter({hasText: authorization.ownerId})
       .first();
-    await expect(ownerOption).toBeVisible({timeout: 60000});
+    await expect(ownerOption).toBeVisible({timeout: 30000});
     await ownerOption.click({timeout: 20000, force: true});
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -241,13 +241,7 @@ export class IdentityAuthorizationsPage {
 
   async selectAuthorizationOwner(authorization: {ownerId: string}) {
     await this.createAuthorizationOwnerSearchInput.fill(authorization.ownerId);
-    // The owner search is debounced + server-driven; the menu item for a
-    // just-created user can take longer than 20s to surface under load.
-    // const ownerOption = this.createAuthorizationModal
-    //   .locator('.cds--list-box__menu-item')
-    //   .filter({hasText: authorization.ownerId})
-    //   .first();
-    await this.page.waitForTimeout(500);
+    await expect(this.page.getByRole('listbox')).toBeVisible();
     const ownerOption = this.page
       .getByRole('listbox')
       .getByRole('option')

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -30,9 +30,9 @@ export class IdentityAuthorizationsPage {
   readonly authorizationRowByOwnerId: (ownerId: string) => Locator;
   readonly selectResourceTypeTab: (resourceType: string) => Promise<void>;
   readonly resourceTypeComboBox: Locator;
+  readonly authorizationTypeFilterComboBox: Locator;
   readonly getAuthorizationCell: (ownerId: string) => Locator;
   readonly resourceTypeOption: (resourceType: string) => Locator;
-  readonly resourceTypeTab: (resourceType: string) => Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -83,10 +83,11 @@ export class IdentityAuthorizationsPage {
         name: 'Delete authorization',
       },
     );
-    this.selectResourceTypeTab = (resourceType) =>
-      this.resourceTypeTab(resourceType).click();
     this.resourceTypeComboBox = page.getByRole('combobox', {
       name: 'Resource type',
+    });
+    this.authorizationTypeFilterComboBox = page.getByRole('combobox', {
+      name: 'Authorization type',
     });
     this.getAuthorizationCell = (ownerId) =>
       this.authorizationsList.getByRole('cell', {
@@ -96,8 +97,10 @@ export class IdentityAuthorizationsPage {
       this.page.getByRole('option', {
         name: new RegExp(`^${resourceType}$`, 'i'),
       });
-    this.resourceTypeTab = (resourceType) =>
-      this.page.getByRole('tab', {name: new RegExp(`^${resourceType}$`, 'i')});
+    this.selectResourceTypeTab = async (resourceType) => {
+      await this.authorizationTypeFilterComboBox.click();
+      await this.resourceTypeOption(resourceType).click();
+    };
   }
 
   async navigateToAuthorizations() {
@@ -105,7 +108,8 @@ export class IdentityAuthorizationsPage {
   }
 
   async clickResourceType(resourceType: string) {
-    await this.resourceTypeTab(resourceType).click();
+    await this.authorizationTypeFilterComboBox.click();
+    await this.resourceTypeOption(resourceType).click();
   }
 
   async clickCreateAuthorizationButton() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -61,7 +61,7 @@ export class IdentityAuthorizationsPage {
     // The clickable label and the underlying input are separate nodes; use this
     // one to assert checked state, and the label above to toggle it.
     this.accessPermissionCheckbox = (name) =>
-      this.page.locator(`input#${name.toUpperCase()}`);
+      this.page.getByRole('checkbox', {name: name.toUpperCase()});
     this.createAuthorizationOwnerTypeComboBox =
       this.createAuthorizationModal.getByRole('combobox', {name: 'Owner type'});
     // The Select's popover renders in a portal outside the dialog's DOM

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -84,6 +84,13 @@ test.describe.serial('component authorizations CRUD', () => {
     await identityAuthorizationsPage.selectAuthorizationOwnerType({
       ownerType: NEW_COMPONENT_AUTHORIZATION.ownerType,
     });
+    await identityAuthorizationsPage.createAuthorizationOwnerSearchInput.waitFor(
+      {
+        state: 'visible',
+        timeout: 10000,
+      },
+    );
+
     // No owner is selected here: the owner field is now a search that only
     // lists existing owners, and this role is intentionally never created.
     // Resource ID validation is field-level and independent of the owner.
@@ -93,7 +100,7 @@ test.describe.serial('component authorizations CRUD', () => {
     ).toContainText('Please enter a valid Resource ID');
     await expect(
       identityAuthorizationsPage.createAuthorizationResourceIdField,
-    ).toHaveAttribute('data-invalid', 'true');
+    ).toHaveAttribute('aria-invalid', 'true');
   });
 
   test('create user authorization', async ({


### PR DESCRIPTION
## Description

Nightly e2e runs were red on both `main` and `stable/8.10` because the Identity
Authorizations page went through a design-system migration (Carbon → the new
`@camunda/design-system` components). `IdentityAuthorizationsPage.ts` still
targeted the old Carbon markup in several places, so tests that create,
inspect, or delete an authorization timed out or asserted on attributes that
no longer exist.

Failing nightly runs:
- main: https://github.com/camunda/camunda/actions/runs/33744288046
- stable/8.10: https://github.com/camunda/camunda/actions/runs/33741963660

Fixes applied in `qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts`
(and one assertion in `tests/identity/authorizations.spec.ts`):

- **Resource type filter — tab → combobox.** The list page dropped its Carbon
  `Tabs` sidebar for a `Combobox` labeled "Authorization type". `resourceTypeTab`
  (`getByRole('tab', ...)`) no longer matched anything. `selectResourceTypeTab`
  / `clickResourceType` now open the "Authorization type" combobox and pick the
  option, reusing the existing `resourceTypeOption` locator. `clickResourceType`
  now delegates to `selectResourceTypeTab` instead of duplicating the
  interaction.
- **Owner type option — wrong locator scope.** `createAuthorizationOwnerTypeOption`
  was scoped to `createAuthorizationModal`, but the new `Select`'s popover
  renders in a portal outside the dialog's DOM subtree, so a dialog-scoped
  locator could never find the option regardless of its name. Scoped the
  locator to the page instead, matching the existing `resourceTypeOption`
  pattern.
- **Owner search results — same portal-scoping issue.** `selectAuthorizationOwner`
  looked for `.cds--list-box__menu-item` inside the modal; the new owner-search
  results also render in a page-level `listbox` portal. Now queries
  `page.getByRole('listbox').getByRole('option')`.
- **Delete button locator.** Replaced `getByLabel('Delete')` with
  `getByRole('button', {name: 'Delete'})` to match the migrated button markup.
- **Access permission checkboxes.** Replaced the CSS `input#ID` locator with
  `getByRole('checkbox', {name})`, matching the migrated checkbox markup.
- **Invalid-field assertion.** The new `Resource ID` field marks itself invalid
  via `aria-invalid="true"` instead of Carbon's `data-invalid="true"`; updated
  the one assertion in `authorizations.spec.ts` accordingly, and added a wait
  for the owner search input to be visible before continuing.

No other call sites needed changes — `selectResourceTypeTab` and
`clickResourceType` keep their existing names and signatures.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. [Here](https://github.com/camunda/camunda/actions/runs/33772221883) -> all green 🎉 

## Related issues

closes #

- [x] This PR does not need a linked issue
