### PR TITLE
perf: halve the runner for analyze/optimize

### DIFF
--- a/.claude/skills/ci-runner-utilization/SKILL.md
+++ b/.claude/skills/ci-runner-utilization/SKILL.md
@@ -42,6 +42,7 @@ Downsizing follows the same family: `gcp-perf-core-16-default` → `gcp-perf-cor
   - Verify: `bq query --use_legacy_sql=false 'SELECT 1'`
 - Data is in `ci-30-162810.prod_ci_analytics.build_status_v2` (90-day retention)
 - CPU/memory metrics were added on 2026-05-18 — data availability starts from that date
+- Always match `ci_url` exactly. A `LIKE "%camunda/camunda%"` also matches camunda-optimize, camunda-docs, camunda-platform-helm and others, mixing other repos' jobs into the results
 
 ## How to analyze
 
@@ -61,7 +62,7 @@ SELECT
   ROUND(MAX(memory_usage_ratio_p95), 3) AS max_mem_p95
 FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
 WHERE cpu_usage_ratio_p95 IS NOT NULL
-  AND ci_url LIKE "%camunda/camunda%"
+  AND ci_url = "https://github.com/camunda/camunda"
   AND runner_type IS NOT NULL
   AND (runner_type LIKE "gcp-%" OR runner_type LIKE "aws-%")
 GROUP BY job_name, runner_type
@@ -86,7 +87,7 @@ SELECT
   ROUND(MAX(memory_usage_ratio_p95), 3) AS max_mem_p95
 FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
 WHERE cpu_usage_ratio_p95 IS NOT NULL
-  AND ci_url LIKE "%camunda/camunda%"
+  AND ci_url = "https://github.com/camunda/camunda"
   AND runner_type IS NOT NULL
   AND (runner_type LIKE "gcp-%" OR runner_type LIKE "aws-%")
 GROUP BY job_name, runner_type
@@ -106,7 +107,7 @@ SELECT
   COUNT(*) AS total_runs,
   ROUND(AVG(cpu_usage_ratio_p95), 3) AS overall_avg_cpu_p95
 FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
-WHERE ci_url LIKE "%camunda/camunda%"
+WHERE ci_url = "https://github.com/camunda/camunda"
   AND cpu_usage_ratio_p95 IS NOT NULL
   AND runner_type IS NOT NULL
 GROUP BY runner_type
@@ -128,7 +129,7 @@ SELECT
   ROUND(memory_usage_ratio_p95, 3) AS mem_p95,
   build_status
 FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
-WHERE ci_url LIKE "%camunda/camunda%"
+WHERE ci_url = "https://github.com/camunda/camunda"
   AND job_name = "REPLACE_WITH_JOB_NAME"
   AND cpu_usage_ratio_p95 IS NOT NULL
 ORDER BY report_time DESC

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -72,7 +72,7 @@ jobs:
           runner: gcp-core-4-longrunning
         - name: optimize
           path: ./optimize
-          runner: gcp-core-16-longrunning
+          runner: gcp-core-8-longrunning
           maven-config: |
             -DskipQaBuild=true
         - name: single-app


### PR DESCRIPTION
## Description

`analyze/optimize` (Check Licenses) runs on `gcp-core-16-longrunning` at avg CPU 0.102 and p99 0.182 — under 3 effective cores of 16. This moves it to `gcp-core-8-longrunning`, reclaiming **~13,600 core-hours per 90 days** (~55k/yr). 4 cores is viable on CPU but peak memory would reach 0.90 of the limit, so 8 is the safe step.

Measured on this PR's own CI against a trigger-matched, same-era baseline (n=6):

| Job | Runner | This PR | Baseline median | Baseline range |
|---|---|---|---|---|
| `analyze/optimize` | **8 cores (changed)** | 6.48 min | 6.23 | 4.40–6.85 |
| `analyze/single-app` | 16 cores (unchanged control) | 8.58 min | 8.60 | 7.30–10.52 |

The unchanged control landed at 8.58 against a median of 8.60, so this run's environment was typical and the changed job's +4% (~15s) can be read at face value — inside the baseline range on both raw duration and the paired `optimize/single-app` ratio (0.755 vs baseline 0.603–0.774).

Also fixes the `ci-runner-utilization` skill, whose queries filtered with `ci_url LIKE "%camunda/camunda%"` and so also matched camunda-optimize, camunda-docs, camunda-platform-helm and three other repos. That is what produced ~9,700 wasted core-hours of `big-ssd` / `es-compatibility` jobs the analysis first flagged as monorepo candidates — those jobs live in camunda-optimize. All four queries now match `ci_url` exactly, with the failure mode recorded in Prerequisites.

## Notes for reviewers

### Sizing methodology

Sizing uses **p95/p99 of `cpu_usage_ratio_p95`**, not `MAX`. Across 16k+ samples per job `MAX` is effectively p99.99: 40 of ~200 job/runner pairs report `MAX = 1.0` while sitting at p95 ≈ 0.25, so `MAX` alone rejects nearly every genuine candidate. The skill's decision table is written around `MAX` and is worth revisiting separately.

Other large wasters were checked and deliberately left alone — `physical-tenant-acceptance-tests/*` (p95 0.50), `*-integration-tests/qa/migration-tests` (p99 0.48–0.50), `async-replication-integration-tests` (p99 0.48), `analyze/c8run` (p99 0.51), and the scheduled `database-integration-tests/*` matrix (p95 ~0.5, memory 0.44). Each either demands real p99 headroom or has memory that would exceed 0.85 on a halved runner.

### Validation

- Full CI was green on the pre-rebase revision: 148 pass, 0 fail, 41 skipping. It is re-running after the rebase onto newer `main`.
- **actionlint clean.** A bare run flags every `gcp-*` label including pre-existing ones, since the repo's labels come from a config the pinned action merges from `infra-global-github-actions` base + `custom/camunda/camunda/actionlint.yaml`. I reproduced that merge, confirmed the new label is valid, and re-ran clean.
- **conftest: 57 tests, 0 failures.** The two `check-licenses.yml` warnings (65-min `analyze` timeout, missing `print-metadata` step) are pre-existing and unrelated to a runner label.
- No spotless run needed: `pom.xml` excludes `.claude/skills/**/*.md` from the markdown formatter.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) — not needed, cost optimization only relevant on `main`

## Related issues

- [x] This PR does not need a linked issue
