### PR TITLE
refactor: Update engine mappings docs

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -21,24 +21,8 @@ public class EngineMappings {
   private InputMode inputMode = InputMode.COMBINED;
   private OutputMode outputMode = OutputMode.COMBINED;
 
-  /**
-   * When set, evaluates input mappings with both the primary resolver ({@code inputMode}) and this
-   * comparison resolver, then logs a warning if their results differ. Intended for diagnostic use
-   * only: each activation evaluates mappings with both resolvers and compares the result documents,
-   * which adds overhead for large mapping sets.
-   *
-   * <p>Has no effect when null (default) or when set to the same value as {@code inputMode}.
-   */
   @Nullable private InputMode inputComparisonMode = null;
 
-  /**
-   * When set, evaluates output mappings with both the primary resolver ({@code outputMode}) and
-   * this comparison resolver, then logs a warning if their results differ. Intended for diagnostic
-   * use only: each completion evaluates mappings with both resolvers and compares the result
-   * documents, which adds overhead for large mapping sets.
-   *
-   * <p>Has no effect when null (default) or when set to the same value as {@code outputMode}.
-   */
   @Nullable private OutputMode outputComparisonMode = null;
 
   /**
@@ -63,9 +47,8 @@ public class EngineMappings {
 
   /**
    * Controls the input-mapping resolver used during process instance execution. When set to {@code
-   * COMBINED}, the engine uses {@code CombinedInputMappingResolver} which merges all input mappings
-   * into a single combined result. When set to {@code ORDERED}, the engine uses {@code
-   * OrderedMappingResolver} which applies mappings in modeling order.
+   * COMBINED}, all input mappings are merged into a single combined result. When set to {@code
+   * ORDERED}, mappings are applied in modeling order.
    *
    * <p><strong>Experimental:</strong> This setting and all input modes are experimental and may
    * change in a future release.
@@ -84,10 +67,21 @@ public class EngineMappings {
   }
 
   /**
-   * Returns the optional comparison resolver used alongside {@code inputMode} for diagnostics.
+   * Controls the optional comparison mode for input mappings. When set, input mappings are evaluated
+   * with both the primary mode ({@code inputMode}) and this comparison mode, and a warning is
+   * logged if the results differ.
    *
    * <p><strong>Experimental:</strong> This setting and all input modes are experimental and may
    * change in a future release.
+   *
+   * <p>Intended for diagnostic use only: each activation evaluates mappings with both modes and
+   * compares the result documents, which adds overhead for large mapping sets.
+   *
+   * <p>This configuration can be accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.mappings.input-comparison-mode}.
+   *
+   * <p>Defaults to {@code null}. Has no effect when null or when set to the same value as
+   * {@code input-mode}.
    */
   public @Nullable InputMode getInputComparisonMode() {
     return inputComparisonMode;
@@ -98,10 +92,17 @@ public class EngineMappings {
   }
 
   /**
-   * Controls the output-mapping resolver used during process instance execution.
+   * Controls the output-mapping resolver used during process instance execution. When set to {@code
+   * COMBINED}, all output mappings are merged into a single combined result. When set to {@code
+   * ORDERED}, mappings are applied in modeling order.
    *
    * <p><strong>Experimental:</strong> This setting and all output modes are experimental and may
    * change in a future release.
+   *
+   * <p>This configuration can be accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.mappings.output-mode}.
+   *
+   * <p>Defaults to {@code COMBINED}.
    */
   public OutputMode getOutputMode() {
     return outputMode;
@@ -112,10 +113,21 @@ public class EngineMappings {
   }
 
   /**
-   * Returns the optional comparison resolver used alongside {@code outputMode} for diagnostics.
+   * Controls the optional comparison mode for output mappings. When set, output mappings are
+   * evaluated with both the primary mode ({@code outputMode}) and this comparison mode, and a
+   * warning is logged if the results differ.
    *
    * <p><strong>Experimental:</strong> This setting and all output modes are experimental and may
    * change in a future release.
+   *
+   * <p>Intended for diagnostic use only: each completion evaluates mappings with both modes and
+   * compares the result documents, which adds overhead for large mapping sets.
+   *
+   * <p>This configuration can be accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.mappings.output-comparison-mode}.
+   *
+   * <p>Defaults to {@code null}. Has no effect when null or when set to the same value as
+   * {@code output-mode}.
    */
   public @Nullable OutputMode getOutputComparisonMode() {
     return outputComparisonMode;

--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -12,6 +12,9 @@ import org.jspecify.annotations.Nullable;
 /**
  * Defines configuration for the engine's mapping resolution strategy. The prefix for this class is
  * camunda.processing.engine.mappings.
+ *
+ * <p><strong>Experimental:</strong> This configuration and all input/output mapping modes are
+ * experimental and may change in a future release.
  */
 public class EngineMappings {
 
@@ -38,11 +41,21 @@ public class EngineMappings {
    */
   @Nullable private OutputMode outputComparisonMode = null;
 
+  /**
+   * Experimental input-mapping resolution modes.
+   *
+   * <p><strong>Experimental:</strong> These modes may change in a future release.
+   */
   public enum InputMode {
     ORDERED,
     COMBINED
   }
 
+  /**
+   * Experimental output-mapping resolution modes.
+   *
+   * <p><strong>Experimental:</strong> These modes may change in a future release.
+   */
   public enum OutputMode {
     ORDERED,
     COMBINED
@@ -53,6 +66,9 @@ public class EngineMappings {
    * COMBINED}, the engine uses {@code CombinedInputMappingResolver} which merges all input mappings
    * into a single combined result. When set to {@code ORDERED}, the engine uses {@code
    * OrderedMappingResolver} which applies mappings in modeling order.
+   *
+   * <p><strong>Experimental:</strong> This setting and all input modes are experimental and may
+   * change in a future release.
    *
    * <p>This configuration can be accessed via the environment variable: <br>
    * {@code camunda.processing.engine.mappings.input-mode}.
@@ -67,6 +83,12 @@ public class EngineMappings {
     this.inputMode = inputMode;
   }
 
+  /**
+   * Returns the optional comparison resolver used alongside {@code inputMode} for diagnostics.
+   *
+   * <p><strong>Experimental:</strong> This setting and all input modes are experimental and may
+   * change in a future release.
+   */
   public @Nullable InputMode getInputComparisonMode() {
     return inputComparisonMode;
   }
@@ -75,6 +97,12 @@ public class EngineMappings {
     this.inputComparisonMode = inputComparisonMode;
   }
 
+  /**
+   * Controls the output-mapping resolver used during process instance execution.
+   *
+   * <p><strong>Experimental:</strong> This setting and all output modes are experimental and may
+   * change in a future release.
+   */
   public OutputMode getOutputMode() {
     return outputMode;
   }
@@ -83,6 +111,12 @@ public class EngineMappings {
     this.outputMode = outputMode;
   }
 
+  /**
+   * Returns the optional comparison resolver used alongside {@code outputMode} for diagnostics.
+   *
+   * <p><strong>Experimental:</strong> This setting and all output modes are experimental and may
+   * change in a future release.
+   */
   public @Nullable OutputMode getOutputComparisonMode() {
     return outputComparisonMode;
   }

--- a/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMappings.java
@@ -67,9 +67,9 @@ public class EngineMappings {
   }
 
   /**
-   * Controls the optional comparison mode for input mappings. When set, input mappings are evaluated
-   * with both the primary mode ({@code inputMode}) and this comparison mode, and a warning is
-   * logged if the results differ.
+   * Controls the optional comparison mode for input mappings. When set, input mappings are
+   * evaluated with both the primary mode ({@code inputMode}) and this comparison mode, and a
+   * warning is logged if the results differ.
    *
    * <p><strong>Experimental:</strong> This setting and all input modes are experimental and may
    * change in a future release.
@@ -80,8 +80,8 @@ public class EngineMappings {
    * <p>This configuration can be accessed via the environment variable: <br>
    * {@code camunda.processing.engine.mappings.input-comparison-mode}.
    *
-   * <p>Defaults to {@code null}. Has no effect when null or when set to the same value as
-   * {@code input-mode}.
+   * <p>Defaults to {@code null}. Has no effect when null or when set to the same value as {@code
+   * input-mode}.
    */
   public @Nullable InputMode getInputComparisonMode() {
     return inputComparisonMode;
@@ -126,8 +126,8 @@ public class EngineMappings {
    * <p>This configuration can be accessed via the environment variable: <br>
    * {@code camunda.processing.engine.mappings.output-comparison-mode}.
    *
-   * <p>Defaults to {@code null}. Has no effect when null or when set to the same value as
-   * {@code output-mode}.
+   * <p>Defaults to {@code null}. Has no effect when null or when set to the same value as {@code
+   * output-mode}.
    */
   public @Nullable OutputMode getOutputComparisonMode() {
     return outputComparisonMode;

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1334,23 +1334,29 @@ camunda: # Type: io.camunda.configuration.Camunda
         fixed-storage-ordinal-key: -1 # Type: Integer, Env: CAMUNDA_PROCESSING_ENGINE_STORAGEORDINALS_FIXEDSTORAGEORDINALKEY
 
       mappings: # Type: io.camunda.configuration.EngineMappings
-        # Controls which input-mapping evaluation strategy to use: ORDERED (per-mapping
-        # declaration order) or COMBINED (default, legacy combined-FEEL-context behavior restoring
-        # the pre-baddd911435 single-expression evaluation).
+        # Experimental: controls the input-mapping resolver used during process
+        # instance execution:
+        # COMBINED (default) merges all input mappings into a single combined result,
+        # while ORDERED applies mappings in modeling order.
         input-mode: COMBINED # Type: InputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_INPUTMODE
-        # When set, also evaluates input mappings with this second resolver and logs a warning
+        # Experimental: when set, also evaluates input mappings with this second
+        # resolver and logs a warning
         # if the results differ from the primary resolver. Intended for migration diagnostics
         # only: each activation evaluates mappings with both resolvers and compares the
-        # result documents, which adds overhead for large mapping sets.
+        # result documents, which adds overhead for large mapping sets. Has no effect
+        # when null (default) or when set to the same value as input-mode.
         input-comparison-mode: ~ # Type: InputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_INPUTCOMPARISONMODE
-        # Controls which output-mapping evaluation strategy to use: ORDERED (default, per-mapping
-        # declaration order) or COMBINED (legacy combined-FEEL-context behavior restoring the
-        # pre-#59087 single-expression evaluation).
+        # Experimental: controls the output-mapping resolver used during process
+        # instance execution:
+        # COMBINED (default) merges all output mappings into a single combined result,
+        # while ORDERED applies mappings in modeling order.
         output-mode: COMBINED # Type: OutputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_OUTPUTMODE
-        # When set, also evaluates output mappings with this second resolver and logs a warning
+        # Experimental: when set, also evaluates output mappings with this second
+        # resolver and logs a warning
         # if the results differ from the primary resolver. Intended for migration diagnostics
         # only: each completion evaluates mappings with both resolvers and compares the
-        # result documents, which adds overhead for large mapping sets.
+        # result documents, which adds overhead for large mapping sets. Has no effect
+        # when null (default) or when set to the same value as output-mode.
         output-comparison-mode: ~ # Type: OutputMappingMode, Env: CAMUNDA_PROCESSING_ENGINE_MAPPINGS_OUTPUTCOMPARISONMODE
 
     flow-control: # Type: io.camunda.configuration.FlowControl


### PR DESCRIPTION
## Description

Minor documentation changes to add an experimental marker for the engine variable mappings and to update the `default.yaml` descriptions. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->
 
related to https://github.com/camunda/camunda/issues/61879

