### PR TITLE
fix: paginate primary backup listing requests

### DIFF
--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -36,7 +36,9 @@ import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
@@ -58,6 +60,8 @@ public final class ManifestManager {
    * The path format is constructed by partitionId/checkpointId/nodeId/manifest.json
    */
   private static final String MANIFEST_PATH_FORMAT = "manifests/%s/%s/%s/manifest.json";
+
+  private static final int LIST_PAGE_SIZE = 1000;
 
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
@@ -225,15 +229,23 @@ public final class ManifestManager {
 
   public Collection<Manifest> listManifests(final BackupIdentifierWildcard wildcard) {
     assureContainerCreated();
-    return blobContainerClient
-        .listBlobs(new ListBlobsOptions().setPrefix(wildcardPrefix(wildcard)), null)
-        .stream()
-        .map(BlobItem::getName)
-        .filter(path -> filterBlobsByWildcard(wildcard, path))
-        .map(this::getManifestWithPath)
-        .filter(Objects::nonNull)
-        .filter(m -> wildcard.matches(m.id()))
-        .toList();
+    final var manifests = new ArrayList<Manifest>();
+    final var options =
+        new ListBlobsOptions()
+            .setPrefix(wildcardPrefix(wildcard))
+            .setMaxResultsPerPage(LIST_PAGE_SIZE);
+    for (final var page :
+        blobContainerClient.listBlobs(options, null).iterableByPage(null, LIST_PAGE_SIZE)) {
+      manifests.addAll(
+          page.getValue().stream()
+              .map(BlobItem::getName)
+              .filter(path -> filterBlobsByWildcard(wildcard, path))
+              .map(this::getManifestWithPath)
+              .filter(Objects::nonNull)
+              .filter(manifest -> wildcard.matches(manifest.id()))
+              .toList());
+    }
+    return List.copyOf(manifests);
   }
 
   public static String manifestPath(final Manifest manifest) {

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/ManifestManagerTest.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/ManifestManagerTest.java
@@ -12,16 +12,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.Manifest.StatusCode;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -62,6 +66,29 @@ final class ManifestManagerTest {
             CheckpointType.MANUAL_BACKUP),
         new NamedFileSetImpl(Map.of()),
         new NamedFileSetImpl(Map.of()));
+  }
+
+  @Test
+  void shouldListManifestsAcrossPages() {
+    // given
+    final var identifiers =
+        IntStream.range(0, 1001)
+            .mapToObj(checkpointId -> new BackupIdentifierImpl(1337, 0, checkpointId))
+            .toList();
+    identifiers.forEach(
+        identifier -> manifestManager.createInitialManifest(createBackup(identifier)));
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(Optional.empty(), Optional.of(0), CheckpointPattern.any());
+
+    // when
+    final var manifests = manifestManager.listManifests(wildcard);
+
+    // then
+    assertThat(manifests)
+        .hasSize(1001)
+        .extracting(manifest -> manifest.id())
+        .containsExactlyInAnyOrderElementsOf(identifiers)
+        .doesNotHaveDuplicates();
   }
 
   @Nested

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/ManifestManager.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.common.BackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.common.Manifest;
 import io.camunda.zeebe.backup.common.Manifest.InProgressManifest;
+import io.camunda.zeebe.backup.common.SemaphoreLeasedScheduler;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
 import java.io.IOException;
@@ -37,8 +39,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -59,6 +63,8 @@ public final class ManifestManager {
           .setSerializationInclusion(Include.NON_ABSENT);
   public static final int PRECONDITION_FAILED = 412;
   private static final int LIST_MAX_RETRIES = 6;
+  private static final int LIST_PAGE_SIZE = 1000;
+  private static final int MANIFEST_READ_PARALLELISM = 16;
   private static final int MAX_CAUSE_DEPTH = 20;
   private static final Duration MIN_LIST_RETRY_DELAY = Duration.ofMillis(100);
   private static final Duration MAX_LIST_RETRY_DELAY = Duration.ofSeconds(2);
@@ -96,6 +102,7 @@ public final class ManifestManager {
   private final Storage client;
   private final String basePath;
   private final ExecutorService executor;
+  private final Semaphore manifestReadConcurrencyLimit = new Semaphore(MANIFEST_READ_PARALLELISM);
 
   ManifestManager(
       final Storage client,
@@ -207,37 +214,49 @@ public final class ManifestManager {
     final var blobFilter = filterBlobsByWildcard(wildcard);
     LOG.debug("Listing backup statuses for wildcard {}", wildcard);
     final var prefix = wildcardPrefix(wildcard);
-    final var listing = listManifestBlobsWithRetry(prefix);
-    final var statusFutures = new ArrayList<CompletableFuture<BackupStatus>>();
-    for (final var blob : listing) {
-      if (!blobFilter.test(blob)) {
-        continue;
+    final var statuses = new ArrayList<BackupStatus>();
+    var pageToken = Optional.<String>empty();
+
+    while (true) {
+      final var page = listManifestBlobPageWithRetry(prefix, pageToken);
+      final var statusFutures = new ArrayList<CompletableFuture<BackupStatus>>();
+      for (final var blob : page.getValues()) {
+        if (!blobFilter.test(blob)) {
+          continue;
+        }
+        final var fromMetadata =
+            ManifestMetadata.toBackupStatus(blob, basePath, MANIFEST_BLOB_NAME);
+        if (fromMetadata.isPresent()) {
+          statusFutures.add(CompletableFuture.completedFuture(fromMetadata.get()));
+        } else {
+          // Fallback: download the manifest for blobs without metadata
+          statusFutures.add(downloadManifestStatus(blob));
+        }
       }
-      final var fromMetadata = ManifestMetadata.toBackupStatus(blob, basePath, MANIFEST_BLOB_NAME);
-      if (fromMetadata.isPresent()) {
-        statusFutures.add(CompletableFuture.completedFuture(fromMetadata.get()));
-      } else {
-        // Fallback: download the manifest for blobs without metadata
-        statusFutures.add(downloadManifestStatus(blob));
+
+      CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new)).join();
+      statuses.addAll(
+          statusFutures.stream()
+              .map(CompletableFuture::join)
+              .filter(status -> wildcard.matches(status.id()))
+              .toList());
+
+      if (!page.hasNextPage()) {
+        LOG.debug("Found {} matching backup statuses for wildcard {}", statuses.size(), wildcard);
+        return List.copyOf(statuses);
       }
+      pageToken = Optional.of(page.getNextPageToken());
     }
-
-    CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new)).join();
-    LOG.debug("Found {} matching backup statuses for wildcard {}", statusFutures.size(), wildcard);
-
-    return statusFutures.stream()
-        .map(CompletableFuture::join)
-        .filter(status -> wildcard.matches(status.id()))
-        .toList();
   }
 
-  private List<Blob> listManifestBlobsWithRetry(final String prefix) {
+  private Page<Blob> listManifestBlobPageWithRetry(
+      final String prefix, final Optional<String> pageToken) {
     try {
       final var operationName =
           "list GCS backup manifests from bucket '%s' with prefix '%s'"
               .formatted(bucketInfo.getName(), prefix);
       return MANIFEST_LIST_RETRY.decorate(
-          operationName, () -> listManifestBlobs(prefix), ignored -> false);
+          operationName, () -> listManifestBlobPage(prefix, pageToken), ignored -> false);
     } catch (final RuntimeException e) {
       throw e;
     } catch (final Exception e) {
@@ -248,13 +267,12 @@ public final class ManifestManager {
     }
   }
 
-  private List<Blob> listManifestBlobs(final String prefix) {
-    final var blobs = new ArrayList<Blob>();
-    client
-        .list(bucketInfo.getName(), BlobListOption.prefix(prefix))
-        .iterateAll()
-        .forEach(blobs::add);
-    return blobs;
+  private Page<Blob> listManifestBlobPage(final String prefix, final Optional<String> pageToken) {
+    final var options = new ArrayList<BlobListOption>();
+    options.add(BlobListOption.prefix(prefix));
+    options.add(BlobListOption.pageSize(LIST_PAGE_SIZE));
+    pageToken.map(BlobListOption::pageToken).ifPresent(options::add);
+    return client.list(bucketInfo.getName(), options.toArray(BlobListOption[]::new));
   }
 
   private static boolean shouldRetryListOperation(final Throwable error) {
@@ -298,7 +316,7 @@ public final class ManifestManager {
   }
 
   private CompletableFuture<BackupStatus> downloadManifestStatus(final Blob blob) {
-    return CompletableFuture.supplyAsync(
+    return SemaphoreLeasedScheduler.schedule(
         () -> {
           try {
             final var manifest =
@@ -308,7 +326,8 @@ public final class ManifestManager {
             throw new UncheckedIOException(e);
           }
         },
-        executor);
+        executor,
+        manifestReadConcurrencyLimit);
   }
 
   public void deleteManifest(final Manifest manifest) {

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ManifestManagerTest.java
@@ -13,6 +13,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.StorageException;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
@@ -33,7 +34,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -252,8 +258,7 @@ final class ManifestManagerTest {
     Mockito.when(blob.getName()).thenReturn("basePathmanifests/2/3/1/manifest.json");
     Mockito.when(blob.getMetadata()).thenReturn(ManifestMetadata.fromManifest(manifest));
     final var page = mockBlobPage(blob);
-    Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
-    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
         .thenThrow(
             new StorageException(
                 new IOException("universe domain metadata request failed while listing manifests")))
@@ -273,7 +278,139 @@ final class ManifestManagerTest {
               Assertions.assertThat(status.id()).isEqualTo(backup.id());
               Assertions.assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
             });
-    Mockito.verify(client, Mockito.times(2)).list(Mockito.eq("bucket"), Mockito.any());
+    Mockito.verify(client, Mockito.times(2))
+        .list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class));
+  }
+
+  @Test
+  void shouldRetryOnlyFailedManifestPage() {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var manager =
+        new ManifestManager(
+            client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
+    final var firstBackup =
+        new BackupImpl(
+            new BackupIdentifierImpl(1, 2, 3),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new NamedFileSetImpl(Map.of()),
+            new NamedFileSetImpl(Map.of()));
+    final var secondBackup =
+        new BackupImpl(
+            new BackupIdentifierImpl(1, 2, 4),
+            new BackupDescriptorImpl(1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+            new NamedFileSetImpl(Map.of()),
+            new NamedFileSetImpl(Map.of()));
+    final var firstBlob = manifestBlob(firstBackup);
+    final var secondBlob = manifestBlob(secondBackup);
+    final var firstPage = mockBlobPage(List.of(firstBlob), "page-2");
+    final var secondPage = mockBlobPage(List.of(secondBlob), null);
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
+        .thenReturn(firstPage)
+        .thenThrow(
+            new StorageException(
+                new IOException("universe domain metadata request failed while listing manifests")))
+        .thenReturn(secondPage);
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+    // when
+    final var statuses = manager.listBackupStatuses(wildcard);
+
+    // then
+    Assertions.assertThat(statuses)
+        .extracting(status -> status.id())
+        .containsExactlyInAnyOrder(firstBackup.id(), secondBackup.id());
+    final ArgumentCaptor<BlobListOption[]> optionsCaptor =
+        ArgumentCaptor.forClass(BlobListOption[].class);
+    Mockito.verify(client, Mockito.times(3)).list(Mockito.eq("bucket"), optionsCaptor.capture());
+    final var requests = optionsCaptor.getAllValues();
+    Assertions.assertThat(requests.get(0))
+        .contains(BlobListOption.prefix("basePathmanifests/"), BlobListOption.pageSize(1000))
+        .doesNotContain(BlobListOption.pageToken("page-2"));
+    Assertions.assertThat(requests.get(1))
+        .contains(
+            BlobListOption.prefix("basePathmanifests/"),
+            BlobListOption.pageSize(1000),
+            BlobListOption.pageToken("page-2"));
+    Assertions.assertThat(requests.get(2)).containsExactlyInAnyOrder(requests.get(1));
+  }
+
+  @Test
+  void shouldLimitConcurrentLegacyManifestReads() throws Exception {
+    // given
+    final var client = Mockito.mock(Storage.class);
+    final var executor =
+        Executors.newThreadPerTaskExecutor(
+            Thread.ofVirtual().name("manifest-list-test-", 0).factory());
+    try {
+      final var manager =
+          new ManifestManager(client, BucketInfo.of("bucket"), "basePath", executor);
+      final var backup =
+          new BackupImpl(
+              new BackupIdentifierImpl(1, 2, 3),
+              new BackupDescriptorImpl(
+                  1, 1, "version", Instant.now(), CheckpointType.MANUAL_BACKUP),
+              new NamedFileSetImpl(Map.of()),
+              new NamedFileSetImpl(Map.of()));
+      final var manifestBytes =
+          ManifestManager.MAPPER.writeValueAsBytes(Manifest.createInProgress(backup).complete());
+      final var blobs =
+          IntStream.range(0, 17)
+              .mapToObj(
+                  checkpointId -> {
+                    final var blob = Mockito.mock(Blob.class);
+                    final var blobId =
+                        BlobId.of(
+                            "bucket",
+                            "basePathmanifests/2/%d/1/manifest.json".formatted(checkpointId));
+                    Mockito.when(blob.getName()).thenReturn(blobId.getName());
+                    Mockito.when(blob.getBlobId()).thenReturn(blobId);
+                    return blob;
+                  })
+              .toList();
+      final var page = mockBlobPage(blobs, null);
+      Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
+          .thenReturn(page);
+      final var concurrentReads = new AtomicInteger();
+      final var maximumConcurrentReads = new AtomicInteger();
+      final var releaseReads = new CountDownLatch(1);
+      final var readsStarted = new CountDownLatch(16);
+      Mockito.when(client.readAllBytes(Mockito.any(BlobId.class)))
+          .thenAnswer(
+              ignored -> {
+                maximumConcurrentReads.accumulateAndGet(
+                    concurrentReads.incrementAndGet(), Math::max);
+                readsStarted.countDown();
+                try {
+                  if (!releaseReads.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to release manifest reads");
+                  }
+                  return manifestBytes;
+                } finally {
+                  concurrentReads.decrementAndGet();
+                }
+              });
+      final var wildcard =
+          new BackupIdentifierWildcardImpl(
+              Optional.empty(), Optional.empty(), BackupIdentifierWildcard.CheckpointPattern.any());
+
+      // when
+      final var listing = CompletableFuture.supplyAsync(() -> manager.listBackupStatuses(wildcard));
+
+      // then
+      try {
+        Assertions.assertThat(readsStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        Assertions.assertThat(concurrentReads).hasValue(16);
+      } finally {
+        releaseReads.countDown();
+      }
+      Assertions.assertThat(listing.get(10, TimeUnit.SECONDS)).hasSize(17);
+      Assertions.assertThat(maximumConcurrentReads).hasValue(16);
+    } finally {
+      executor.close();
+    }
   }
 
   @Test
@@ -294,8 +431,7 @@ final class ManifestManagerTest {
     Mockito.when(blob.getName()).thenReturn("basePathmanifests/2/3/1/manifest.json");
     Mockito.when(blob.getMetadata()).thenReturn(ManifestMetadata.fromManifest(manifest));
     final var page = mockBlobPage(blob);
-    Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
-    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
         .thenThrow(
             new RuntimeException(
                 new StorageException(
@@ -317,7 +453,8 @@ final class ManifestManagerTest {
               Assertions.assertThat(status.id()).isEqualTo(backup.id());
               Assertions.assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
             });
-    Mockito.verify(client, Mockito.times(2)).list(Mockito.eq("bucket"), Mockito.any());
+    Mockito.verify(client, Mockito.times(2))
+        .list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class));
   }
 
   @Test
@@ -327,7 +464,7 @@ final class ManifestManagerTest {
     final var manager =
         new ManifestManager(
             client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
-    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
         .thenThrow(new StorageException(0, "not an I/O failure"));
     final var wildcard =
         new BackupIdentifierWildcardImpl(
@@ -337,7 +474,7 @@ final class ManifestManagerTest {
     Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("not an I/O failure");
-    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class));
   }
 
   @Test
@@ -347,7 +484,7 @@ final class ManifestManagerTest {
     final var manager =
         new ManifestManager(
             client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
-    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
         .thenThrow(new StorageException(0, "cyclic cause", new CyclicCauseException()));
     final var wildcard =
         new BackupIdentifierWildcardImpl(
@@ -360,7 +497,7 @@ final class ManifestManagerTest {
             Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
                 .isInstanceOf(StorageException.class)
                 .hasMessageContaining("cyclic cause"));
-    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class));
   }
 
   @Test
@@ -370,7 +507,7 @@ final class ManifestManagerTest {
     final var manager =
         new ManifestManager(
             client, BucketInfo.of("bucket"), "basePath", Executors.newSingleThreadExecutor());
-    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
         .thenThrow(new StorageException(400, "bad request"));
     final var wildcard =
         new BackupIdentifierWildcardImpl(
@@ -380,7 +517,7 @@ final class ManifestManagerTest {
     Assertions.assertThatThrownBy(() -> manager.listBackupStatuses(wildcard))
         .isInstanceOf(StorageException.class)
         .hasMessageContaining("bad request");
-    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class));
   }
 
   @Test
@@ -399,7 +536,7 @@ final class ManifestManagerTest {
     firstCause.initCause(secondCause);
     secondCause.initCause(firstCause);
 
-    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any()))
+    Mockito.when(client.list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class)))
         .thenThrow(new RuntimeException("cyclic failure", firstCause));
 
     // when / then
@@ -410,14 +547,34 @@ final class ManifestManagerTest {
               .isInstanceOf(RuntimeException.class)
               .hasMessageContaining("cyclic failure");
         });
-    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any());
+    Mockito.verify(client).list(Mockito.eq("bucket"), Mockito.any(BlobListOption[].class));
+  }
+
+  private static Page<Blob> mockBlobPage(final Blob blob) {
+    return mockBlobPage(List.of(blob), null);
   }
 
   @SuppressWarnings("unchecked")
-  private static Page<Blob> mockBlobPage(final Blob blob) {
+  private static Page<Blob> mockBlobPage(final List<Blob> blobs, final String nextPageToken) {
     final var page = Mockito.mock(Page.class);
-    Mockito.when(page.iterateAll()).thenReturn(List.of(blob));
+    Mockito.when(page.getValues()).thenReturn(blobs);
+    Mockito.when(page.hasNextPage()).thenReturn(nextPageToken != null);
+    Mockito.when(page.getNextPageToken()).thenReturn(nextPageToken);
     return page;
+  }
+
+  private static Blob manifestBlob(final BackupImpl backup) {
+    final var manifest = Manifest.createInProgress(backup).complete();
+    final var blob = Mockito.mock(Blob.class);
+    Mockito.when(blob.getName())
+        .thenReturn(
+            "basePathmanifests/%d/%d/%s/manifest.json"
+                .formatted(
+                    backup.id().partitionId(),
+                    backup.id().checkpointId(),
+                    backup.id().brokerId().id()));
+    Mockito.when(blob.getMetadata()).thenReturn(ManifestMetadata.fromManifest(manifest));
+    return blob;
   }
 
   private static final class CyclicCauseException extends RuntimeException {

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.util.SemanticVersion;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -96,6 +97,7 @@ public final class S3BackupStore implements BackupStore {
   static final String METADATA_OBJECT_NAME = "metadata.json";
   private static final Logger LOG = LoggerFactory.getLogger(S3BackupStore.class);
   private static final int SCAN_PARALLELISM = 16;
+  private static final int LIST_PAGE_SIZE = 1000;
   private static final int MAX_DELETE_BATCH_SIZE = 1000;
   private final Pattern backupIdentifierPattern;
   private final S3BackupConfig config;
@@ -464,44 +466,69 @@ public final class S3BackupStore implements BackupStore {
             });
   }
 
-  SdkPublisher<BackupIdentifier> findBackupIds(
+  CompletableFuture<Collection<Manifest>> readManifestObjects(
+      final BackupIdentifierWildcard wildcard) {
+    final var legacyManifests = readManifestObjects(wildcard, true);
+    final var manifests = readManifestObjects(wildcard, false);
+
+    return legacyManifests.thenCombine(
+        manifests,
+        (legacyResults, results) -> {
+          final var combined = new HashSet<>(legacyResults);
+          combined.addAll(results);
+          combined.removeIf(manifest -> !wildcard.matches(manifest.id()));
+          return combined;
+        });
+  }
+
+  private CompletableFuture<Collection<Manifest>> readManifestObjects(
       final BackupIdentifierWildcard wildcard, final boolean legacyStructure) {
     final var prefix = legacyStructure ? legacyWildcardPrefix(wildcard) : wildcardPrefix(wildcard);
     LOG.atTrace()
         .addKeyValue("pattern", wildcard)
         .setMessage("Searching for matching manifest files")
         .log();
-    return client
-        .listObjectsV2Paginator(cfg -> cfg.bucket(config.bucketName()).prefix(prefix))
-        .contents()
-        .filter(obj -> obj.key().endsWith(MANIFEST_OBJECT_KEY))
-        .map(S3Object::key)
-        .map(this::tryParseKeyAsId)
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .filter(wildcard::matches);
+    return readManifestObjectsPage(wildcard, prefix, Optional.empty(), new ArrayList<>());
   }
 
-  CompletableFuture<Collection<Manifest>> readManifestObjects(
-      final BackupIdentifierWildcard wildcard) {
+  private CompletableFuture<Collection<Manifest>> readManifestObjectsPage(
+      final BackupIdentifierWildcard wildcard,
+      final String prefix,
+      final Optional<String> continuationToken,
+      final Collection<Manifest> manifests) {
+    return client
+        .listObjectsV2(
+            request -> {
+              request.bucket(config.bucketName()).prefix(prefix).maxKeys(LIST_PAGE_SIZE);
+              continuationToken.ifPresent(request::continuationToken);
+            })
+        .thenCompose(
+            response -> {
+              final var backupIds =
+                  response.contents().stream()
+                      .filter(object -> object.key().endsWith(MANIFEST_OBJECT_KEY))
+                      .map(S3Object::key)
+                      .map(this::tryParseKeyAsId)
+                      .flatMap(Optional::stream)
+                      .filter(wildcard::matches)
+                      .toList();
+              final var aggregator = new AsyncAggregatingSubscriber<Manifest>(SCAN_PARALLELISM);
+              SdkPublisher.fromIterable(backupIds)
+                  .map(this::readManifestObject)
+                  .subscribe(aggregator);
 
-    final var legacyAggregator = new AsyncAggregatingSubscriber<Manifest>(SCAN_PARALLELISM);
-    final var legacyPublisher = findBackupIds(wildcard, true).map(this::readManifestObject);
-    legacyPublisher.subscribe(legacyAggregator);
-
-    final var aggregator = new AsyncAggregatingSubscriber<Manifest>(SCAN_PARALLELISM);
-    final var publisher = findBackupIds(wildcard, false).map(this::readManifestObject);
-    publisher.subscribe(aggregator);
-
-    return legacyAggregator
-        .result()
-        .thenCombine(
-            aggregator.result(),
-            (legacyManifests, manifests) -> {
-              final var combined = new HashSet<>(legacyManifests);
-              combined.addAll(manifests);
-              combined.removeIf(m -> !wildcard.matches(m.id()));
-              return combined;
+              return aggregator
+                  .result()
+                  .thenCompose(
+                      pageManifests -> {
+                        manifests.addAll(pageManifests);
+                        final var nextContinuationToken = response.nextContinuationToken();
+                        if (nextContinuationToken == null) {
+                          return CompletableFuture.completedFuture(manifests);
+                        }
+                        return readManifestObjectsPage(
+                            wildcard, prefix, Optional.of(nextContinuationToken), manifests);
+                      });
             });
   }
 

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreListTest.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreListTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.backup.s3.manifest.Manifest;
+import io.camunda.zeebe.backup.s3.manifest.NoBackupManifest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@ExtendWith(MockitoExtension.class)
+final class S3BackupStoreListTest {
+
+  private static final int PAGE_SIZE = 1000;
+  private static final int FIRST_PAGE_MANIFESTS = 17;
+
+  @Mock private S3AsyncClient client;
+
+  private final List<ListObjectsV2Request> requests = new ArrayList<>();
+  private final ConcurrentLinkedQueue<PendingManifest> pendingManifests =
+      new ConcurrentLinkedQueue<>();
+  private final AtomicInteger currentManifestReads = new AtomicInteger();
+  private final AtomicInteger maximumCurrentManifestReads = new AtomicInteger();
+  private S3BackupStore store;
+
+  @BeforeEach
+  void setUp() {
+    final var config = new S3BackupConfig.Builder().withBucketName("test-bucket").build();
+    store = spy(new S3BackupStore(config, client));
+
+    when(client.listObjectsV2(
+            org.mockito.ArgumentMatchers.<Consumer<ListObjectsV2Request.Builder>>any()))
+        .thenAnswer(
+            invocation -> {
+              final Consumer<ListObjectsV2Request.Builder> requestConfigurer =
+                  invocation.getArgument(0);
+              final var requestBuilder = ListObjectsV2Request.builder();
+              requestConfigurer.accept(requestBuilder);
+              final var request = requestBuilder.build();
+              requests.add(request);
+              return CompletableFuture.completedFuture(responseFor(request));
+            });
+
+    doAnswer(
+            invocation -> {
+              final BackupIdentifier id = invocation.getArgument(0);
+              final var manifest = new NoBackupManifest(BackupIdentifierImpl.from(id));
+              final var result = new CompletableFuture<Manifest>();
+              if (id.partitionId() == 1 && id.checkpointId() < FIRST_PAGE_MANIFESTS - 1) {
+                maximumCurrentManifestReads.accumulateAndGet(
+                    currentManifestReads.incrementAndGet(), Math::max);
+                result.whenComplete((ignored, error) -> currentManifestReads.decrementAndGet());
+              }
+              pendingManifests.add(new PendingManifest(manifest, result));
+              return result;
+            })
+        .when(store)
+        .readManifestObject(any());
+  }
+
+  @Test
+  void shouldListAllManifestPagesWithBoundedReads() {
+    // given
+    final var wildcard =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.empty(), CheckpointPattern.any());
+
+    // when
+    final var result = store.list(wildcard);
+
+    // then
+    assertThat(requests).hasSize(3);
+    assertThat(currentManifestReads).hasValue(16);
+    assertThat(maximumCurrentManifestReads).hasValue(16);
+
+    pendingManifests.stream()
+        .filter(
+            pending ->
+                pending.manifest().id().partitionId() == 1
+                    && pending.manifest().id().checkpointId() < FIRST_PAGE_MANIFESTS - 1)
+        .findFirst()
+        .orElseThrow()
+        .complete();
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(pendingManifests)
+                    .filteredOn(pending -> pending.manifest().id().partitionId() == 1)
+                    .hasSize(FIRST_PAGE_MANIFESTS + 1));
+
+    completePendingManifests();
+    Awaitility.await().untilAsserted(() -> assertThat(requests).hasSize(4));
+    completePendingManifests();
+
+    final var statuses = result.join();
+    assertThat(statuses).hasSize(19).extracting(BackupStatus::id).doesNotHaveDuplicates();
+    assertThat(maximumCurrentManifestReads).hasValue(16);
+    assertRequestsUseExpectedPagination();
+  }
+
+  private void assertRequestsUseExpectedPagination() {
+    assertThat(requests).allSatisfy(request -> assertThat(request.maxKeys()).isEqualTo(PAGE_SIZE));
+
+    final var legacyRequests =
+        requests.stream().filter(request -> request.prefix().isEmpty()).toList();
+    assertThat(legacyRequests).hasSize(2);
+    assertThat(legacyRequests.get(0).continuationToken()).isNull();
+    assertThat(legacyRequests.get(1).continuationToken()).isEqualTo("legacy-page-2");
+
+    final var currentRequests =
+        requests.stream().filter(request -> request.prefix().equals("manifests/")).toList();
+    assertThat(currentRequests).hasSize(2);
+    assertThat(currentRequests.get(0).continuationToken()).isNull();
+    assertThat(currentRequests.get(1).continuationToken()).isEqualTo("current-page-2");
+  }
+
+  private void completePendingManifests() {
+    pendingManifests.forEach(PendingManifest::complete);
+  }
+
+  private static ListObjectsV2Response responseFor(final ListObjectsV2Request request) {
+    if (request.prefix().isEmpty()) {
+      if (request.continuationToken() == null) {
+        return response(List.of(), "legacy-page-2");
+      }
+      return response(
+          List.of(manifestObject("2/200/1/manifest.json"), manifestObject("1/16/1/manifest.json")),
+          null);
+    }
+
+    if (request.continuationToken() == null) {
+      final var manifests =
+          IntStream.range(0, FIRST_PAGE_MANIFESTS)
+              .mapToObj(index -> manifestObject("manifests/1/%d/1/manifest.json".formatted(index)))
+              .toList();
+      return response(manifests, "current-page-2");
+    }
+    return response(List.of(manifestObject("manifests/1/999/1/manifest.json")), null);
+  }
+
+  private static ListObjectsV2Response response(
+      final List<S3Object> contents, final String continuationToken) {
+    return ListObjectsV2Response.builder()
+        .contents(contents)
+        .nextContinuationToken(continuationToken)
+        .build();
+  }
+
+  private static S3Object manifestObject(final String key) {
+    return S3Object.builder().key(key).build();
+  }
+
+  private record PendingManifest(Manifest manifest, CompletableFuture<Manifest> result) {
+    private void complete() {
+      result.complete(manifest);
+    }
+  }
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,6 +37,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public final class BackupRequestHandler implements BackupApi {
+  private static final Duration BACKUP_REQUEST_TIMEOUT = Duration.ofSeconds(60);
 
   final BrokerClient brokerClient;
   final BrokerTopologyManager topologyManager;
@@ -173,7 +175,9 @@ public final class BackupRequestHandler implements BackupApi {
                   topology.getPartitions().stream()
                       .map(requestCreator)
                       .map(request -> stampPhysicalTenant(request, physicalTenantId))
-                      .map(brokerClient::sendRequestWithRetry)
+                      .map(
+                          request ->
+                              brokerClient.sendRequestWithRetry(request, BACKUP_REQUEST_TIMEOUT))
                       .toList();
               return CompletableFuture.allOf(responses.toArray(CompletableFuture[]::new))
                   .thenApply(

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/client/api/BackupRequestHandlerTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/client/api/BackupRequestHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.client.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class BackupRequestHandlerTest {
+
+  private static final String PHYSICAL_TENANT_ID = "tenant";
+
+  @Mock private BrokerClient brokerClient;
+  @Mock private BrokerTopologyManager topologyManager;
+  @Mock private BrokerClusterState clusterState;
+
+  private BackupRequestHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+    when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(clusterState);
+    when(clusterState.getPartitionsCount()).thenReturn(1);
+    when(clusterState.getPartitions()).thenReturn(List.of(1));
+    handler = new BackupRequestHandler(brokerClient);
+  }
+
+  @Test
+  void shouldUseBackupRequestTimeout() {
+    // given
+    final var response = new BrokerResponse<>(new BackupListResponse(List.of()));
+    when(brokerClient.sendRequestWithRetry(any(BackupListRequest.class), any(Duration.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
+
+    // when
+    handler.listBackups(PHYSICAL_TENANT_ID, "").toCompletableFuture().join();
+
+    // then
+    final var timeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(brokerClient)
+        .sendRequestWithRetry(any(BackupListRequest.class), timeoutCaptor.capture());
+    assertThat(timeoutCaptor.getValue()).isEqualTo(Duration.ofSeconds(60));
+  }
+}


### PR DESCRIPTION
## Description

Backup retention requires one complete primary-store listing before it can delete expired backups. Provider-wide traversals can exceed remote request deadlines once a bucket contains many backups, while backup API broker requests previously inherited the generic 15-second request timeout.

This change requests and decodes 1,000-item pages inside the S3, GCS, and Azure stores while preserving the existing `BackupStore.list(...)` contract. GCS retries only the failed page and limits legacy manifest reads to 16 concurrent requests; S3 keeps manifest reads bounded and deduplicates current and legacy layouts; filesystem listing remains unchanged. Backup API broker requests now use an explicit 60-second timeout without changing the global broker-client default.

Verification:

- focused S3, GCS, Azure pagination tests
- `BackupRequestHandlerTest` and `RetentionTest`
- module verification for `zeebe/backup` and all three cloud backup stores, including emulator integration tests
- `./mvnw license:format spotless:apply -T1C`
- `./mvnw install -Dquickly -T1C`

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #61898