### PR TITLE
fix: label business value per-process tiles with process names

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueAutomationRateTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueAutomationRateTilesIT.java
@@ -20,10 +20,13 @@ import static io.camunda.optimize.BusinessValueInstanceFixtures.userTaskNode;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_AGGREGATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.AUTOMATION_RATE_BY_PROCESS_REPORT_ID;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.util.List;
@@ -151,5 +154,34 @@ class BusinessValueAutomationRateTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(result)
         .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getValue)
         .containsExactly(tuple(allAutomated, 100.0), tuple(half, 50.0), tuple(mostlyHuman, 25.0));
+  }
+
+  @Test
+  void shouldLabelPerProcessAutomationRateBarsWithTheProcessName() {
+    // given a fully automated instance of a process whose BPMN id is not human-readable, plus a
+    // later definition version carrying the name
+    final String processKey = "order-fulfilment-v2";
+    persistProcessInstances(
+        List.of(bvdInstanceWithFlowNodes(processKey, serviceTaskNode(), serviceTaskNode())));
+    persistProcessDefinitions(
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(processKey + ":2:2")
+                .key(processKey)
+                .version("2")
+                .name("Order fulfilment")
+                .dataSource(new ZeebeDataSourceDto("test-source", 1))
+                .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                .bpmn20Xml("<definitions/>")
+                .build()));
+
+    // when evaluating the per-process automation rate tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(AUTOMATION_RATE_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then the bar is keyed by the BPMN process id and labelled with the process name
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getLabel)
+        .containsExactly(tuple(processKey, "Order fulfilment"));
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueCycleTimeTilesIT.java
@@ -13,10 +13,13 @@ import static io.camunda.optimize.service.dashboard.BusinessValueDashboardServic
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_DATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_BY_PROCESS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.DURATION_PERCENTILES_REPORT_ID;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.util.List;
@@ -132,5 +135,33 @@ class BusinessValueCycleTimeTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     assertThat(nonNullValues)
         .extracting(MapResultEntryDto::getValue)
         .allMatch(value -> value == (double) duration);
+  }
+
+  @Test
+  void shouldLabelPerProcessCycleTimeBarsWithTheProcessName() {
+    // given a completed instance of a process whose BPMN id is not human-readable, plus a later
+    // definition version carrying the name
+    final String processKey = "order-fulfilment-v2";
+    persistProcessInstances(List.of(bvdInstanceWithDuration(processKey, 5_000L).build()));
+    persistProcessDefinitions(
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(processKey + ":2:2")
+                .key(processKey)
+                .version("2")
+                .name("Order fulfilment")
+                .dataSource(new ZeebeDataSourceDto("test-source", 1))
+                .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                .bpmn20Xml("<definitions/>")
+                .build()));
+
+    // when evaluating the per-process cycle time tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(DURATION_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then the bar is keyed by the BPMN process id and labelled with the process name
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getLabel)
+        .containsExactly(tuple(processKey, "Order fulfilment"));
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueVolumeTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/BusinessValueVolumeTilesIT.java
@@ -12,12 +12,15 @@ import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtra
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_DATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.COUNT_BY_PROCESS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.BusinessValueDashboardService.WORK_HANDLED_TOTAL_REPORT_ID;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.time.OffsetDateTime;
@@ -133,5 +136,49 @@ class BusinessValueVolumeTilesIT extends AbstractBrokerlessZeebeCCSMIT {
             .mapToDouble(Double::doubleValue)
             .sum();
     assertThat(bucketed).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldLabelPerProcessVolumeBarsWithTheProcessName() {
+    // given completed instances of a process whose BPMN id is not human-readable, plus a later
+    // definition version carrying the name (the auto-seeded v1 defaults its name to the key)
+    final String processKey = "order-fulfilment-v2";
+    persistProcessInstances(List.of(bvdInstanceWithDuration(processKey, 100L).build()));
+    persistProcessDefinitions(
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(processKey + ":2:2")
+                .key(processKey)
+                .version("2")
+                .name("Order fulfilment")
+                .dataSource(new ZeebeDataSourceDto("test-source", 1))
+                .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                .bpmn20Xml("<definitions/>")
+                .build()));
+
+    // when evaluating the per-process count tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(COUNT_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then the bar is still keyed by the BPMN process id but labelled with the process name
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getLabel)
+        .containsExactly(tuple(processKey, "Order fulfilment"));
+  }
+
+  @Test
+  void shouldFallBackToTheProcessIdWhenNoDefinitionNameIsAvailable() {
+    // given a process with no named definition version beyond the auto-seeded one
+    final String processKey = "vol-unnamed-process";
+    persistProcessInstances(List.of(bvdInstanceWithDuration(processKey, 100L).build()));
+
+    // when evaluating the per-process count tile
+    final List<MapResultEntryDto> result =
+        reports.evaluateMapData(COUNT_BY_PROCESS_REPORT_ID, noExtraFilters());
+
+    // then the label is never blank — it falls back to the id
+    assertThat(result)
+        .extracting(MapResultEntryDto::getKey, MapResultEntryDto::getLabel)
+        .containsExactly(tuple(processKey, processKey));
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
@@ -22,7 +22,7 @@ import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.interpreter.util.AgenticProcessDefinitionNameResolver;
+import io.camunda.optimize.service.db.report.interpreter.util.ProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -111,7 +111,7 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     super.addQueryResult(compositeCommandResult, response, context);
     // Label each bar with the definition's latest-version name instead of the raw BPMN process id.
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(
         compositeCommandResult, definitionService);
     topNPagination(context)
         .ifPresent(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
@@ -22,7 +22,6 @@ import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.interpreter.util.ProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -40,8 +39,8 @@ import org.springframework.stereotype.Component;
  * supplied, returns only the top N process definitions by the configured measure. The top N is
  * computed server-side (terms aggregation with {@code size=limit} ordered by the primary measure
  * plus a cardinality sub-aggregation for the total count) so it scales to large data sets. All
- * other behaviour is inherited from {@link ProcessGroupByProcessDefinitionKeyInterpreterES}, which
- * is left untouched for every non-agentic process-definition-key report.
+ * other behaviour, including labelling each group with the definition's name, is inherited from
+ * {@link ProcessGroupByProcessDefinitionKeyInterpreterES}.
  */
 @Component
 @Conditional(ElasticSearchCondition.class)
@@ -53,15 +52,12 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
   private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
       "processDefinitionKeyCountAgg";
 
-  private final DefinitionService definitionService;
-
   public AgenticProcessDefinitionKeyGroupByInterpreterES(
       final ConfigurationService configurationService,
       final ProcessDistributedByInterpreterFacadeES distributedByInterpreter,
       final ProcessViewInterpreterFacadeES viewInterpreter,
       final DefinitionService definitionService) {
-    super(configurationService, distributedByInterpreter, viewInterpreter);
-    this.definitionService = definitionService;
+    super(configurationService, distributedByInterpreter, viewInterpreter, definitionService);
   }
 
   @Override
@@ -110,9 +106,6 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
       final ResponseBody<?> response,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     super.addQueryResult(compositeCommandResult, response, context);
-    // Label each bar with the definition's latest-version name instead of the raw BPMN process id.
-    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(
-        compositeCommandResult, definitionService);
     topNPagination(context)
         .ifPresent(
             pagination -> {
@@ -122,6 +115,14 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
                 pagination.setTotal((long) countAggregation.cardinality().value());
               }
             });
+  }
+
+  @Override
+  protected boolean shouldResolveDefinitionNames(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    // Every report on this path is one Optimize generates for an agentic dashboard, whether or
+    // not it also carries the business value flag, so names are always wanted here.
+    return true;
   }
 
   private Optional<PaginationDto> topNPagination(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterES.java
@@ -21,9 +21,11 @@ import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import co.elastic.clients.util.NamedValue;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.interpreter.util.ProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -44,14 +46,17 @@ public class ProcessGroupByProcessDefinitionKeyInterpreterES
   private final ConfigurationService configurationService;
   private final ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
   private final ProcessViewInterpreterFacadeES viewInterpreter;
+  private final DefinitionService definitionService;
 
   public ProcessGroupByProcessDefinitionKeyInterpreterES(
       final ConfigurationService configurationService,
       final ProcessDistributedByInterpreterFacadeES distributedByInterpreter,
-      final ProcessViewInterpreterFacadeES viewInterpreter) {
+      final ProcessViewInterpreterFacadeES viewInterpreter,
+      final DefinitionService definitionService) {
     this.configurationService = configurationService;
     this.distributedByInterpreter = distributedByInterpreter;
     this.viewInterpreter = viewInterpreter;
+    this.definitionService = definitionService;
   }
 
   @Override
@@ -99,6 +104,21 @@ public class ProcessGroupByProcessDefinitionKeyInterpreterES
     compositeCommandResult.setGroups(groupedData);
     compositeCommandResult.setDistributedByKeyOfNumericType(
         distributedByInterpreter.isKeyOfNumericType(context));
+    if (shouldResolveDefinitionNames(context)) {
+      ProcessDefinitionNameResolver.applyLatestVersionNameLabels(
+          compositeCommandResult, definitionService);
+    }
+  }
+
+  /**
+   * Whether each group's label should be the definition's name instead of the raw BPMN process id.
+   * Only reports Optimize generates itself opt in, because a user-built report grouped by process
+   * is filtered, sorted and CSV-exported on the id today, and silently relabelling it would change
+   * those outputs. Subclasses serving a system dashboard override this.
+   */
+  protected boolean shouldResolveDefinitionNames(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return context.getReportData().isBusinessValueReport();
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
@@ -20,7 +20,6 @@ import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
 import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.interpreter.util.ProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -43,8 +42,8 @@ import org.springframework.stereotype.Component;
  * supplied, returns only the top N process definitions by the configured measure. The top N is
  * computed server-side (terms aggregation with {@code size=limit} ordered by the primary measure
  * plus a cardinality sub-aggregation for the total count) so it scales to large data sets. All
- * other behaviour is inherited from {@link ProcessGroupByProcessDefinitionKeyInterpreterOS}, which
- * is left untouched for every non-agentic process-definition-key report.
+ * other behaviour, including labelling each group with the definition's name, is inherited from
+ * {@link ProcessGroupByProcessDefinitionKeyInterpreterOS}.
  */
 @Component
 @Conditional(OpenSearchCondition.class)
@@ -56,15 +55,12 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
   private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
       "processDefinitionKeyCountAgg";
 
-  private final DefinitionService definitionService;
-
   public AgenticProcessDefinitionKeyGroupByInterpreterOS(
       final ConfigurationService configurationService,
       final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter,
       final ProcessViewInterpreterFacadeOS viewInterpreter,
       final DefinitionService definitionService) {
-    super(configurationService, distributedByInterpreter, viewInterpreter);
-    this.definitionService = definitionService;
+    super(configurationService, distributedByInterpreter, viewInterpreter, definitionService);
   }
 
   @Override
@@ -108,9 +104,6 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
       final SearchResponse<RawResult> response,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     super.addQueryResult(compositeCommandResult, response, context);
-    // Label each bar with the definition's latest-version name instead of the raw BPMN process id.
-    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(
-        compositeCommandResult, definitionService);
     topNPagination(context)
         .ifPresent(
             pagination -> {
@@ -120,6 +113,14 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
                 pagination.setTotal(countAggregation.cardinality().value());
               }
             });
+  }
+
+  @Override
+  protected boolean shouldResolveDefinitionNames(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    // Every report on this path is one Optimize generates for an agentic dashboard, whether or
+    // not it also carries the business value flag, so names are always wanted here.
+    return true;
   }
 
   private Optional<PaginationDto> topNPagination(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
@@ -20,7 +20,7 @@ import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
 import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
-import io.camunda.optimize.service.db.report.interpreter.util.AgenticProcessDefinitionNameResolver;
+import io.camunda.optimize.service.db.report.interpreter.util.ProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -109,7 +109,7 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     super.addQueryResult(compositeCommandResult, response, context);
     // Label each bar with the definition's latest-version name instead of the raw BPMN process id.
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(
         compositeCommandResult, definitionService);
     topNPagination(context)
         .ifPresent(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOS.java
@@ -16,10 +16,12 @@ import static io.camunda.optimize.service.db.report.result.CompositeCommandResul
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
 
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
 import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.interpreter.util.ProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -46,14 +48,17 @@ public class ProcessGroupByProcessDefinitionKeyInterpreterOS
   private final ConfigurationService configurationService;
   private final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
   private final ProcessViewInterpreterFacadeOS viewInterpreter;
+  private final DefinitionService definitionService;
 
   public ProcessGroupByProcessDefinitionKeyInterpreterOS(
       final ConfigurationService configurationService,
       final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter,
-      final ProcessViewInterpreterFacadeOS viewInterpreter) {
+      final ProcessViewInterpreterFacadeOS viewInterpreter,
+      final DefinitionService definitionService) {
     this.configurationService = configurationService;
     this.distributedByInterpreter = distributedByInterpreter;
     this.viewInterpreter = viewInterpreter;
+    this.definitionService = definitionService;
   }
 
   @Override
@@ -93,6 +98,21 @@ public class ProcessGroupByProcessDefinitionKeyInterpreterOS
     compositeCommandResult.setGroups(groupedData);
     compositeCommandResult.setDistributedByKeyOfNumericType(
         distributedByInterpreter.isKeyOfNumericType(context));
+    if (shouldResolveDefinitionNames(context)) {
+      ProcessDefinitionNameResolver.applyLatestVersionNameLabels(
+          compositeCommandResult, definitionService);
+    }
+  }
+
+  /**
+   * Whether each group's label should be the definition's name instead of the raw BPMN process id.
+   * Only reports Optimize generates itself opt in, because a user-built report grouped by process
+   * is filtered, sorted and CSV-exported on the id today, and silently relabelling it would change
+   * those outputs. Subclasses serving a system dashboard override this.
+   */
+  protected boolean shouldResolveDefinitionNames(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return context.getReportData().isBusinessValueReport();
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/util/ProcessDefinitionNameResolver.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/util/ProcessDefinitionNameResolver.java
@@ -14,18 +14,17 @@ import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
 
 /**
- * Shared, database-agnostic helper for the agentic process-definition-key group-by interpreters
+ * Shared, database-agnostic helper for the process-definition-key group-by interpreters
  * (Elasticsearch and OpenSearch). It replaces each group's label with the human-readable name of
- * the definition's latest version, so the agentic "top token consumers" tile shows process names
- * instead of the raw BPMN process id (which, under Optimize's C7 naming, is what {@code
- * processDefinitionKey} holds).
+ * the definition's latest version, so per-process tiles show process names instead of the raw BPMN
+ * process id (which, under Optimize's C7 naming, is what {@code processDefinitionKey} holds).
  *
  * <p>The group key is left untouched. When no name can be resolved for a key, the label is left
  * as-is and {@link GroupByResult#getLabel()} keeps falling back to the key.
  */
-public final class AgenticProcessDefinitionNameResolver {
+public final class ProcessDefinitionNameResolver {
 
-  private AgenticProcessDefinitionNameResolver() {}
+  private ProcessDefinitionNameResolver() {}
 
   public static void applyLatestVersionNameLabels(
       final CompositeCommandResult result, final DefinitionService definitionService) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterESTest.java
@@ -12,8 +12,10 @@ import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITIO
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
@@ -23,8 +25,11 @@ import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
@@ -34,6 +39,7 @@ import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +53,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   @Mock private ElasticSearchConfiguration elasticSearchConfiguration;
   @Mock private ProcessDistributedByInterpreterFacadeES distributedByInterpreter;
   @Mock private ProcessViewInterpreterFacadeES viewInterpreter;
+  @Mock private DefinitionService definitionService;
 
   @SuppressWarnings("rawtypes")
   @Mock
@@ -58,7 +65,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
   void setUp() {
     underTest =
         new ProcessGroupByProcessDefinitionKeyInterpreterES(
-            configurationService, distributedByInterpreter, viewInterpreter);
+            configurationService, distributedByInterpreter, viewInterpreter, definitionService);
   }
 
   @Test
@@ -102,6 +109,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
 
     final CompositeCommandResult result =
         new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    givenReportIsNotBusinessValueReport();
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups())
@@ -119,6 +127,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
 
     final CompositeCommandResult result =
         new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    givenReportIsNotBusinessValueReport();
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups()).isEmpty();
@@ -136,10 +145,109 @@ class ProcessGroupByProcessDefinitionKeyInterpreterESTest {
 
     final CompositeCommandResult result =
         new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    givenReportIsNotBusinessValueReport();
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups()).hasSize(1);
     assertThat(result.getGroups().get(0).getKey()).isEqualTo("single-process");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldLabelGroupsWithDefinitionNameForBusinessValueReports() {
+    // given
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(
+                PROCESS_DEFINITION_KEY_AGGREGATION,
+                stringTermsAggregate("order-fulfilment-v2", "invoice-process")));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "order-fulfilment-v2"))
+        .thenReturn(Optional.of(definitionWithName("Order fulfilment")));
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "invoice-process"))
+        .thenReturn(Optional.of(definitionWithName("Invoice approval")));
+    givenReportIsBusinessValueReport();
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    // then the bars are labelled with the process names while the keys stay untouched
+    assertThat(result.getGroups())
+        .extracting(
+            CompositeCommandResult.GroupByResult::getKey,
+            CompositeCommandResult.GroupByResult::getLabel)
+        .containsExactly(
+            tuple("order-fulfilment-v2", "Order fulfilment"),
+            tuple("invoice-process", "Invoice approval"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldFallBackToProcessIdWhenNameIsUnresolvable() {
+    // given a business value report whose definition is not in the cache
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate("orphan-process")));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "orphan-process"))
+        .thenReturn(Optional.empty());
+    givenReportIsBusinessValueReport();
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    // then no label is ever blank
+    assertThat(result.getGroups().get(0).getLabel()).isEqualTo("orphan-process");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldKeepProcessIdAsLabelForRegularReports() {
+    // given a user-built report, not one Optimize generated for a system dashboard
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(
+                PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate("order-fulfilment-v2")));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+    givenReportIsNotBusinessValueReport();
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    // then the label stays the process id and no definition lookup happens
+    assertThat(result.getGroups().get(0).getLabel()).isEqualTo("order-fulfilment-v2");
+    verifyNoInteractions(definitionService);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenReportIsBusinessValueReport() {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setBusinessValueReport(true);
+    when(context.getReportData()).thenReturn(reportData);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenReportIsNotBusinessValueReport() {
+    when(context.getReportData()).thenReturn(new ProcessReportDataDto());
+  }
+
+  private static ProcessDefinitionOptimizeDto definitionWithName(final String name) {
+    return ProcessDefinitionOptimizeDto.builder().key("ignored").version("1").name(name).build();
   }
 
   private static Aggregate stringTermsAggregate(final String... keys) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/ProcessGroupByProcessDefinitionKeyInterpreterOSTest.java
@@ -12,12 +12,17 @@ import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_DEFINITIO
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_PROCESS_DEFINITION_KEY;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.PROCESS_DEFINITION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ViewProperty;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
 import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
@@ -28,6 +33,7 @@ import io.camunda.optimize.service.util.configuration.OpenSearchConfiguration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +53,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
   @Mock private OpenSearchConfiguration openSearchConfiguration;
   @Mock private ProcessDistributedByInterpreterFacadeOS distributedByInterpreter;
   @Mock private ProcessViewInterpreterFacadeOS viewInterpreter;
+  @Mock private DefinitionService definitionService;
 
   @SuppressWarnings("rawtypes")
   @Mock
@@ -58,7 +65,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
   void setUp() {
     underTest =
         new ProcessGroupByProcessDefinitionKeyInterpreterOS(
-            configurationService, distributedByInterpreter, viewInterpreter);
+            configurationService, distributedByInterpreter, viewInterpreter, definitionService);
   }
 
   @Test
@@ -96,6 +103,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
 
     final CompositeCommandResult result =
         new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    givenReportIsNotBusinessValueReport();
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups())
@@ -113,6 +121,7 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
 
     final CompositeCommandResult result =
         new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    givenReportIsNotBusinessValueReport();
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups()).isEmpty();
@@ -130,10 +139,109 @@ class ProcessGroupByProcessDefinitionKeyInterpreterOSTest {
 
     final CompositeCommandResult result =
         new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    givenReportIsNotBusinessValueReport();
     underTest.addQueryResult(result, response, context);
 
     assertThat(result.getGroups()).hasSize(1);
     assertThat(result.getGroups().get(0).getKey()).isEqualTo("single-process");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldLabelGroupsWithDefinitionNameForBusinessValueReports() {
+    // given
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(
+                PROCESS_DEFINITION_KEY_AGGREGATION,
+                stringTermsAggregate("order-fulfilment-v2", "invoice-process")));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "order-fulfilment-v2"))
+        .thenReturn(Optional.of(definitionWithName("Order fulfilment")));
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "invoice-process"))
+        .thenReturn(Optional.of(definitionWithName("Invoice approval")));
+    givenReportIsBusinessValueReport();
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    // then the bars are labelled with the process names while the keys stay untouched
+    assertThat(result.getGroups())
+        .extracting(
+            CompositeCommandResult.GroupByResult::getKey,
+            CompositeCommandResult.GroupByResult::getLabel)
+        .containsExactly(
+            tuple("order-fulfilment-v2", "Order fulfilment"),
+            tuple("invoice-process", "Invoice approval"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldFallBackToProcessIdWhenNameIsUnresolvable() {
+    // given a business value report whose definition is not in the cache
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate("orphan-process")));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "orphan-process"))
+        .thenReturn(Optional.empty());
+    givenReportIsBusinessValueReport();
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    // then no label is ever blank
+    assertThat(result.getGroups().get(0).getLabel()).isEqualTo("orphan-process");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldKeepProcessIdAsLabelForRegularReports() {
+    // given a user-built report, not one Optimize generated for a system dashboard
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(
+                PROCESS_DEFINITION_KEY_AGGREGATION, stringTermsAggregate("order-fulfilment-v2")));
+    when(distributedByInterpreter.retrieveResult(any(), any(), any())).thenReturn(List.of());
+    when(distributedByInterpreter.isKeyOfNumericType(any())).thenReturn(false);
+    givenReportIsNotBusinessValueReport();
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.FREQUENCY);
+    underTest.addQueryResult(result, response, context);
+
+    // then the label stays the process id and no definition lookup happens
+    assertThat(result.getGroups().get(0).getLabel()).isEqualTo("order-fulfilment-v2");
+    verifyNoInteractions(definitionService);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenReportIsBusinessValueReport() {
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setBusinessValueReport(true);
+    when(context.getReportData()).thenReturn(reportData);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenReportIsNotBusinessValueReport() {
+    when(context.getReportData()).thenReturn(new ProcessReportDataDto());
+  }
+
+  private static ProcessDefinitionOptimizeDto definitionWithName(final String name) {
+    return ProcessDefinitionOptimizeDto.builder().key("ignored").version("1").name(name).build();
   }
 
   private static Aggregate stringTermsAggregate(final String... keys) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/interpreter/util/ProcessDefinitionNameResolverTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/interpreter/util/ProcessDefinitionNameResolverTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class AgenticProcessDefinitionNameResolverTest {
+class ProcessDefinitionNameResolverTest {
 
   @Mock private DefinitionService definitionService;
 
@@ -38,7 +38,7 @@ class AgenticProcessDefinitionNameResolverTest {
         .thenReturn(Optional.of(definitionWithName("Invoice Approval")));
 
     // when
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
 
     // then
     final GroupByResult group = result.getGroups().getFirst();
@@ -55,7 +55,7 @@ class AgenticProcessDefinitionNameResolverTest {
         .thenReturn(Optional.empty());
 
     // when
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
 
     // then the label falls back to the key
     assertThat(result.getGroups().getFirst().getLabel()).isEqualTo("orphan-process");
@@ -70,7 +70,7 @@ class AgenticProcessDefinitionNameResolverTest {
         .thenReturn(Optional.of(definitionWithName("   ")));
 
     // when
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
 
     // then the blank name is ignored and the label falls back to the key
     assertThat(result.getGroups().getFirst().getLabel()).isEqualTo("unnamed-process");
@@ -88,7 +88,7 @@ class AgenticProcessDefinitionNameResolverTest {
         .thenReturn(Optional.empty());
 
     // when
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
 
     // then each group is resolved on its own; unresolved keys keep the key as label
     assertThat(result.getGroups())
@@ -105,7 +105,7 @@ class AgenticProcessDefinitionNameResolverTest {
         .thenReturn(Optional.of(definitionWithName(null)));
 
     // when
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
 
     // then the null name is ignored and the label falls back to the key
     assertThat(result.getGroups().getFirst().getLabel()).isEqualTo("nameless-process");
@@ -117,7 +117,7 @@ class AgenticProcessDefinitionNameResolverTest {
     final CompositeCommandResult result = resultWithGroups("   ");
 
     // when
-    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+    ProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
 
     // then the definition service is never consulted
     verifyNoInteractions(definitionService);


### PR DESCRIPTION
## What

The business value dashboard's three per-process charts — "Work handled by process", "Cycle time by process", "Automation rate by process" — now label each bar with the process name ("Order fulfilment") instead of the raw BPMN process id (`order-fulfilment-v2`). Unresolvable names fall back to the id, so no label is blank. Group keys are unchanged; only the label. Hub needs no change.

## Why

A process id is an internal identifier, often machine-generated, so a user cannot tell which process a bar belongs to. "Agentic presence" on the same screen already showed names — one page labelled the same process two different ways.

Cause: all four per-process tiles group by process definition key, but only the agentic one routed to an interpreter that resolved names. The plain interpreter emitted key-only groups, so the label fell back to the key. The plain interpreter now resolves names too, gated on a hook so only Optimize's own system reports opt in — user-built reports keep the id their sorting and CSV export assume.

First commit is a pure rename: the resolver is no longer agentic-only.

## How to verify

- `./mvnw verify -pl optimize/backend -Dtest='ProcessGroupByProcessDefinitionKeyInterpreter*Test,ProcessDefinitionNameResolverTest'` — 22 green, three new cases per backend (name applied, id fallback, regular reports untouched).
- `./mvnw verify -pl optimize/backend -Dit.test='BusinessValue*TilesIT,BusinessValueAgenticPresenceTileIT,AgenticTokenUsageKpiTilesIT' -DskipUTs` — 37 green. Ran on Elasticsearch; OpenSearch is the symmetric change, covered by unit tests.
- Manually: open the business value dashboard in Hub — all four per-process charts show names, and the same reports opened in Optimize show identical labels.

## Related issues

closes camunda/camunda-hub#27217