### PR TITLE
test: enable MultiDbPhysicalTenants for ES/OS

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantAuthorizationIT.java
@@ -40,25 +40,15 @@ import java.util.List;
 import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Multi-physical-tenant authorization ITs converted to the {@link MultiDbTest} + {@link
- * MultiDbPhysicalTenants} framework. Validates cross-tenant isolation on RDBMS backends with a
- * single broker hosting {@code default}, {@code tenanta}, and {@code tenantb}, each isolated by its
- * own secondary storage: a dedicated in-memory database on H2, a dedicated schema or database on
- * PostgreSQL/Aurora, MySQL/MariaDB and SQL Server, or a per-tenant table prefix in the shared
- * schema on Oracle.
- *
- * <p>RDBMS only — test is disabled for ES/OS because per-PT secondary-storage schema init and
- * per-PT writer are not yet available for those backends.
+ * MultiDbPhysicalTenants} framework. Validates cross-tenant isolation a single broker hosting
+ * {@code default}, {@code tenanta}, and {@code tenantb}, each isolated by its own secondary
+ * storage.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({"tenanta", "tenantb"})
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class MultiPhysicalTenantAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantClientHappyPathIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantClientHappyPathIT.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Multi-client happy path over a real runtime: two clients, each scoped to its own physical tenant,
@@ -35,16 +34,9 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * <p>Complements the client-side WireMock integration tests in {@code camunda-spring-boot-starter}
  * (per-client REST routing, base-URL modes, {@code @JobWorker} fan-out) with an end-to-end check
  * against a running broker.
- *
- * <p>RDBMS only — physical-tenant secondary storage is RDBMS-only, matching the other
- * physical-tenant acceptance tests.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({"tenanta", "tenantb"})
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class MultiPhysicalTenantClientHappyPathIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantAuthorizationEnablementIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantAuthorizationEnablementIT.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * IT-6 — per-physical-tenant authorization enablement, converted to the {@link MultiDbTest} +
@@ -42,20 +41,12 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * <p>The per-PT authorization override is applied by the test on its own
  * {@code @MultiDbTestApplication} broker via {@code BROKER.withPtConfig(TENANT_OFF, ...)}, which
  * merges into the same per-PT config the framework stamps storage and the admin user into.
- *
- * <p>RDBMS only — Elasticsearch/OpenSearch variants are skipped because per-PT secondary-storage
- * schema init and the per-PT writer are not yet available, so non-default PTs have no ES/OS indices
- * to authorize against.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({
   PhysicalTenantAuthorizationEnablementIT.TENANT_OFF_ID,
   PhysicalTenantAuthorizationEnablementIT.TENANT_ON_ID
 })
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class PhysicalTenantAuthorizationEnablementIT {
 
   // Declared before BROKER so the per-PT override below can reference TENANT_OFF_ID by name rather

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthIT.java
@@ -26,7 +26,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Verifies BASIC-auth isolation across physical tenants over gRPC.
@@ -42,10 +41,6 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({"tenanta", "tenantb"})
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class PhysicalTenantGrpcBasicAuthIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantLogicalTenantScopingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantLogicalTenantScopingIT.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * IT-3b — logical-tenant scoping within physical tenants, converted to the {@link MultiDbTest} +
@@ -35,17 +34,9 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  *
  * <p>Multi-tenancy is a cluster-wide toggle (not per-PT); the per-PT containment comes from each
  * PT's independent schema.
- *
- * <p>RDBMS only — Elasticsearch/OpenSearch variants are skipped because per-PT secondary-storage
- * schema init and the per-PT writer are not yet available, so non-default PTs have no ES/OS indices
- * to read from.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({"tenanta", "tenantb"})
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class PhysicalTenantLogicalTenantScopingIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantSessionCookieIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantSessionCookieIsolationIT.java
@@ -19,7 +19,6 @@ import java.net.HttpCookie;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  * Regression guard for per-physical-tenant session-cookie isolation with persistent web sessions.
@@ -30,19 +29,12 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
  * {@code camunda-session-physical-tenants-<id>} bound to {@code Path=/physical-tenants/<id>}, and
  * must not set the unscoped default {@code camunda-session} at {@code Path=/}. An unscoped cookie
  * would be sent across every tenant's path and collapse session isolation.
- *
- * <p>Physical-tenant secondary storage is RDBMS-only, so this test is gated to RDBMS backends. Each
- * tenant is provisioned with isolated storage and a seeded {@code <id>-admin} user.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({
   PhysicalTenantSessionCookieIsolationIT.TENANT_A,
   PhysicalTenantSessionCookieIsolationIT.TENANT_B
 })
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Per-physical-tenant secondary storage is only supported on RDBMS backends")
 public class PhysicalTenantSessionCookieIsolationIT {
 
   static final String TENANT_A = "tenanta";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionCommitRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionCommitRoutingIT.java
@@ -28,7 +28,6 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -51,18 +50,12 @@ import org.springframework.http.HttpStatus;
  * under each physical tenant's prefix by {@code PhysicalTenantRequestMappingHandlerMapping}, so
  * {@code /physical-tenants/<id>/v2/authentication/me} reaches the same controller as the unprefixed
  * route.
- *
- * <p>Physical-tenant secondary storage is RDBMS-only, so this test is gated to RDBMS backends.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({
   PhysicalTenantWebSessionCommitRoutingIT.TENANT_A,
   PhysicalTenantWebSessionCommitRoutingIT.TENANT_B
 })
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Per-physical-tenant secondary storage is only supported on RDBMS backends")
 public class PhysicalTenantWebSessionCommitRoutingIT {
 
   static final String TENANT_A = "tenanta";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
@@ -26,7 +26,6 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -42,10 +41,6 @@ import org.springframework.http.HttpStatus;
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({PhysicalTenantWebSessionUnprotectedApiIT.TENANT_A})
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Per-physical-tenant secondary storage is only supported on RDBMS backends")
 public class PhysicalTenantWebSessionUnprotectedApiIT {
 
   static final String TENANT_A = "tenanta";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MultiPhysicalTenantDocumentAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MultiPhysicalTenantDocumentAuthorizationIT.java
@@ -29,14 +29,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @MultiDbTest
 @MultiDbPhysicalTenants({"tenanta", "tenantb"})
-@EnabledIfSystemProperty(
-    named = "test.integration.camunda.database.type",
-    matches = "rdbms.*$",
-    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
 final class MultiPhysicalTenantDocumentAuthorizationIT {
 
   @MultiDbTestApplication


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As discussed in [Slack](https://camunda.slack.com/archives/C0AF7LM7CGK/p1788426853125669?thread_ts=1788426837.904109&cid=C0AF7LM7CGK)
> All 10 @MultiDbPhysicalTenants classes carry
  @EnabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$", disabledReason = "Physical-tenant secondary storage is RDBMS-only").

- Enabled 9 tests for ES/OS
- `TableRowCountMetricsMultiPhysicalTenantIT` is kept only for RDBMS_H2 (applicable only for RDBMS)
- 8 tests are run by identity ES/OS/H2 multidb jobs (the ones under `/auth` path)
- 1 test is run by the general ES/OS/H2 multidb jobs


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

