### PR TITLE
feat: track metric for count of pending incident updates

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -34,6 +34,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
       meterName("since.last.flush.seconds");
   private static final String PROCESS_INSTANCES_AWAITING_ARCHIVAL_METER_NAME =
       meterName("process.instances.awaiting.archival");
+  private static final String PENDING_INCIDENT_UPDATES_METER_NAME =
+      meterName("incident.updates.pending");
   private static final String FLUSH_FAILURE_TYPE_METER_NAME = meterName("flush.failure.type");
   private final MeterRegistry meterRegistry;
   private final InstantSource streamClock;
@@ -132,6 +134,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   private final AtomicReference<Instant> lastFlushTime = new AtomicReference<>(Instant.now());
   private final AtomicInteger processInstancesAwaitingArchival = new AtomicInteger(0);
+  private final AtomicInteger pendingIncidentUpdatesCount = new AtomicInteger(0);
 
   public CamundaExporterMetrics(final MeterRegistry meterRegistry) {
     this(meterRegistry, InstantSource.system());
@@ -375,6 +378,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
             AtomicInteger::get)
         .description("Number of process instances awaiting archival (approximate)")
         .register(meterRegistry);
+
+    Gauge.builder(
+            PENDING_INCIDENT_UPDATES_METER_NAME, pendingIncidentUpdatesCount, AtomicInteger::get)
+        .description("Number of incident updates pending (approximate)")
+        .register(meterRegistry);
   }
 
   public void recordFlushReasonBatchSize() {
@@ -532,6 +540,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
     processInstancesAwaitingArchival.set(count);
   }
 
+  public void setPendingIncidentUpdatesCount(final int count) {
+    pendingIncidentUpdatesCount.set(count);
+  }
+
   /**
    * For each record write timestamp, observes the export latency by subtracting the timestamp from
    * the current stream clock.
@@ -654,6 +666,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(SINCE_LAST_FLUSH_SECONDS_METER_NAME);
     removeGaugeIfExists(PROCESS_INSTANCES_AWAITING_ARCHIVAL_METER_NAME);
+    removeGaugeIfExists(PENDING_INCIDENT_UPDATES_METER_NAME);
   }
 
   private void removeGaugeIfExists(final String meterName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -46,6 +46,7 @@ import io.camunda.exporter.tasks.incident.ElasticsearchIncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
 import io.camunda.exporter.tasks.incident.OpenSearchIncidentUpdateRepository;
+import io.camunda.exporter.tasks.incident.PendingIncidentUpdateCountTask;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
@@ -268,6 +269,7 @@ public final class CamundaBackgroundTaskManagerFactory {
     final List<RunnableTask> tasks = new ArrayList<>();
 
     tasks.add(buildIncidentMarkerTask());
+    tasks.add(buildPendingIncidentCountTask());
     if (config.getHistory().isProcessInstanceEnabled()) {
       tasks.add(buildProcessInstanceArchiverJob());
       if (config.getHistory().isTrackArchivalMetricsForProcessInstance()) {
@@ -391,6 +393,16 @@ public final class CamundaBackgroundTaskManagerFactory {
         1,
         postExport.getDelayBetweenRuns(),
         postExport.getMaxDelayBetweenRuns(),
+        executor,
+        logger);
+  }
+
+  private ReschedulingTask buildPendingIncidentCountTask() {
+    return new ReschedulingTask(
+        new PendingIncidentUpdateCountTask(metrics, metadata, incidentRepository, logger),
+        0,
+        PendingIncidentUpdateCountTask.DELAY_BETWEEN_RUNS,
+        PendingIncidentUpdateCountTask.MAX_DELAY_BETWEEN_RUNS,
         executor,
         logger);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -14,6 +14,7 @@ import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
@@ -87,6 +88,21 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     this.listViewFullQualifiedName = listViewFullQualifiedName;
     this.flowNodeAlias = flowNodeAlias;
     this.operationAlias = operationAlias;
+  }
+
+  @Override
+  public CompletionStage<Integer> getCountOfPendingIncidentUpdates(final long fromPosition) {
+    final var query = createPendingIncidentsBatchQuery(fromPosition);
+
+    final CountRequest countRequest =
+        new CountRequest.Builder()
+            .index(pendingUpdateAlias)
+            .query(query)
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .build();
+
+    return client.count(countRequest).thenApplyAsync(r -> Math.toIntExact(r.count()), executor);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
  */
 public interface IncidentUpdateRepository extends AutoCloseable {
 
+  CompletionStage<Integer> getCountOfPendingIncidentUpdates(final long fromPosition);
+
   /**
    * Returns the next batch of sorted pending incident updates.
    *
@@ -192,6 +194,11 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       long highestPosition, Map<Long, IncidentState> newIncidentStates) {}
 
   class NoopIncidentUpdateRepository implements IncidentUpdateRepository {
+
+    @Override
+    public CompletionStage<Integer> getCountOfPendingIncidentUpdates(final long fromPosition) {
+      return CompletableFuture.completedFuture(0);
+    }
 
     @Override
     public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -40,6 +40,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
@@ -89,6 +90,25 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     this.listViewFullQualifiedName = listViewFullQualifiedName;
     this.flowNodeAlias = flowNodeAlias;
     this.operationAlias = operationAlias;
+  }
+
+  @Override
+  public CompletionStage<Integer> getCountOfPendingIncidentUpdates(final long fromPosition) {
+    final var query = createPendingIncidentsBatchQuery(fromPosition);
+
+    final CountRequest request =
+        new CountRequest.Builder()
+            .index(pendingUpdateAlias)
+            .query(query)
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .build();
+
+    try {
+      return client.count(request).thenApplyAsync(r -> Math.toIntExact(r.count()), executor);
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/PendingIncidentUpdateCountTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/PendingIncidentUpdateCountTask.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.zeebe.exporter.common.tasks.BackgroundTask;
+import java.util.concurrent.CompletionStage;
+import org.slf4j.Logger;
+
+public class PendingIncidentUpdateCountTask implements BackgroundTask {
+  public static final int DELAY_BETWEEN_RUNS = 60000;
+  public static final int MAX_DELAY_BETWEEN_RUNS = 300000;
+
+  private final CamundaExporterMetrics metrics;
+  private final ExporterMetadata metadata;
+  private final IncidentUpdateRepository repository;
+  private final Logger logger;
+
+  public PendingIncidentUpdateCountTask(
+      final CamundaExporterMetrics metrics,
+      final ExporterMetadata metadata,
+      final IncidentUpdateRepository repository,
+      final Logger logger) {
+    this.metrics = metrics;
+    this.metadata = metadata;
+    this.repository = repository;
+    this.logger = logger;
+  }
+
+  @Override
+  public CompletionStage<Integer> execute() {
+    return repository
+        .getCountOfPendingIncidentUpdates(metadata.getLastIncidentUpdatePosition())
+        .whenCompleteAsync(
+            (res, err) -> {
+              if (err == null) {
+                metrics.setPendingIncidentUpdatesCount(res);
+              } else {
+                logger.warn("Failed to count number of pending incident updates", err);
+              }
+            });
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaCamundaBackgroundTaskManagerFactoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaCamundaBackgroundTaskManagerFactoryTest.java
@@ -27,6 +27,7 @@ import io.camunda.exporter.tasks.archiver.UsageMetricTUArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionJob;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
+import io.camunda.exporter.tasks.incident.PendingIncidentUpdateCountTask;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.tasks.BackgroundTask;
@@ -190,8 +191,9 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should always schedule incident and usage metrics tasks regardless of PI config")
-        .hasSize(10)
+        .hasSize(11)
         .anyMatch(task -> isTaskOfType(task, IncidentUpdateTask.class))
+        .anyMatch(task -> isTaskOfType(task, PendingIncidentUpdateCountTask.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, UsageMetricTUArchiverJob.class))
         .anyMatch(task -> isTaskOfType(task, JobBatchMetricsArchiverJob.class))
@@ -215,7 +217,7 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should not schedule ApplyRolloverPeriodJob when retention is disabled")
-        .hasSize(11)
+        .hasSize(12)
         .noneMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
   }
 
@@ -231,7 +233,7 @@ class CamundaCamundaBackgroundTaskManagerFactoryTest {
     final var tasks = getTasksFromManager(taskManager);
     assertThat(tasks)
         .as("Should schedule ApplyRolloverPeriodJob when retention is enabled")
-        .hasSize(12)
+        .hasSize(13)
         .anyMatch(task -> isTaskOfType(task, ApplyRolloverPeriodJob.class));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ErrorInjectingIncidentUpdateRepository.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.exporter.tasks.incident;
 
-import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +24,11 @@ class ErrorInjectingIncidentUpdateRepository implements IncidentUpdateRepository
 
   void setFailFlowNodeBulkUpdates(final boolean failFlowNodeBulkUpdates) {
     this.failFlowNodeBulkUpdates = failFlowNodeBulkUpdates;
+  }
+
+  @Override
+  public CompletionStage<Integer> getCountOfPendingIncidentUpdates(final long fromPosition) {
+    return realUpdateRepository.getCountOfPendingIncidentUpdates(fromPosition);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -184,6 +184,39 @@ abstract class IncidentUpdateRepositoryIT {
     batchRequest.executeWithRefresh();
   }
 
+  private PostImporterQueueEntity newPendingUpdate() {
+    return new PostImporterQueueEntity()
+        .setActionType(PostImporterActionType.INCIDENT)
+        .setIntent(IncidentIntent.CREATED.name())
+        .setKey(1L)
+        .setPartitionId(PARTITION_ID)
+        .setProcessInstanceKey(1L)
+        .setPosition(1L);
+  }
+
+  private void setupIncidentUpdates(final long fromPosition, final long toPosition)
+      throws PersistenceException {
+    setupIncidentUpdates(fromPosition, toPosition, ignored -> {});
+  }
+
+  private void setupIncidentUpdates(
+      final long fromPosition,
+      final long toPosition,
+      final Consumer<PostImporterQueueEntity> modifier)
+      throws PersistenceException {
+    final var updates =
+        LongStream.rangeClosed(fromPosition, toPosition)
+            .mapToObj(position -> newPendingUpdate().setPosition(position).setKey(position))
+            .peek(modifier)
+            .toList();
+    final var batchRequest = clientAdapter.createBatchRequest();
+    updates.forEach(
+        e ->
+            batchRequest.add(
+                TargetIndex.mainIndex(postImporterQueueTemplate.getFullQualifiedName()), e));
+    batchRequest.executeWithRefresh();
+  }
+
   protected record RoutedDocument(String id, String routing) {}
 
   @DisabledIfSystemProperty(
@@ -391,39 +424,6 @@ abstract class IncidentUpdateRepositoryIT {
           .containsExactly(-1L, Collections.emptyMap());
     }
 
-    private PostImporterQueueEntity newPendingUpdate() {
-      return new PostImporterQueueEntity()
-          .setActionType(PostImporterActionType.INCIDENT)
-          .setIntent(IncidentIntent.CREATED.name())
-          .setKey(1L)
-          .setPartitionId(PARTITION_ID)
-          .setProcessInstanceKey(1L)
-          .setPosition(1L);
-    }
-
-    private void setupIncidentUpdates(final long fromPosition, final long toPosition)
-        throws PersistenceException {
-      setupIncidentUpdates(fromPosition, toPosition, ignored -> {});
-    }
-
-    private void setupIncidentUpdates(
-        final long fromPosition,
-        final long toPosition,
-        final Consumer<PostImporterQueueEntity> modifier)
-        throws PersistenceException {
-      final var updates =
-          LongStream.rangeClosed(fromPosition, toPosition)
-              .mapToObj(position -> newPendingUpdate().setPosition(position).setKey(position))
-              .peek(modifier)
-              .toList();
-      final var batchRequest = clientAdapter.createBatchRequest();
-      updates.forEach(
-          e ->
-              batchRequest.add(
-                  TargetIndex.mainIndex(postImporterQueueTemplate.getFullQualifiedName()), e));
-      batchRequest.executeWithRefresh();
-    }
-
     @Test
     void shouldUpdateLastIncidentUpdatePositionEvenIfBatchMakesNoUpdates() {
       // given
@@ -470,6 +470,35 @@ abstract class IncidentUpdateRepositoryIT {
         Awaitility.await()
             .until(() -> metadata.getLastIncidentUpdatePosition() == incidentUpdatePosition);
       }
+    }
+  }
+
+  @DisabledIfSystemProperty(
+      named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+      matches = "^(?=\\s*\\S).*$",
+      disabledReason = "Excluding from AWS OS IT CI")
+  @Nested
+  final class GetCountOfPendingIncidentUpdatesTest {
+
+    @Test
+    void shouldGetCountsByPosition() throws PersistenceException {
+      // given
+      final var repository = createRepository();
+      setupIncidentUpdates(1, 3);
+
+      // when
+      final var countStart = repository.getCountOfPendingIncidentUpdates(-1L);
+      final var countPos1 = repository.getCountOfPendingIncidentUpdates(1L);
+      final var countPos2 = repository.getCountOfPendingIncidentUpdates(2L);
+      final var countPos3 = repository.getCountOfPendingIncidentUpdates(3L);
+      final var countPos4 = repository.getCountOfPendingIncidentUpdates(4L);
+
+      // then
+      assertThat(countStart).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(3);
+      assertThat(countPos1).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(2);
+      assertThat(countPos2).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(1);
+      assertThat(countPos3).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(0);
+      assertThat(countPos4).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(0);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/PendingIncidentUpdateCountTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/PendingIncidentUpdateCountTaskTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.search.test.utils.TestObjectMapper;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PendingIncidentUpdateCountTaskTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PendingIncidentUpdateCountTaskTest.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+  private final IncidentUpdateRepository repository = Mockito.mock(IncidentUpdateRepository.class);
+  private final CamundaExporterMetrics metrics = Mockito.mock(CamundaExporterMetrics.class);
+
+  private PendingIncidentUpdateCountTask task;
+
+  @BeforeEach
+  void setUp() {
+    task = new PendingIncidentUpdateCountTask(metrics, metadata, repository, LOGGER);
+  }
+
+  @Test
+  void shouldUpdateMetricsWithPendingIncidentCount() {
+    // given
+    when(repository.getCountOfPendingIncidentUpdates(anyLong()))
+        .thenReturn(CompletableFuture.completedFuture(1234));
+
+    // when
+    final var res = task.execute();
+
+    // then
+    assertThat(res).succeedsWithin(TIMEOUT).isEqualTo(1234);
+
+    verify(metrics).setPendingIncidentUpdatesCount(1234);
+  }
+
+  @Test
+  void shouldNotUpdateMetricsWhenTaskFails() {
+    // given
+    when(repository.getCountOfPendingIncidentUpdates(anyLong()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("test exception")));
+
+    // when
+    final var res = task.execute();
+
+    // then
+    assertThat(res).failsWithin(TIMEOUT);
+
+    verifyNoInteractions(metrics);
+  }
+}


### PR DESCRIPTION
## Description

This adds a metric to track how many incident updates are pending.

## Related issues

refs #61390

