### PR TITLE
deps: update micrometer to 1.15.12 (ESUP backport, CVE-2026-40983/40984)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,7 +82,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.31.1</version.protobuf>
     <version.protobuf-common>2.59.2</version.protobuf-common>
-    <version.micrometer>1.15.10</version.micrometer>
+    <version.micrometer>1.15.12</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.18</version.scala>


### PR DESCRIPTION
## Description

ESUP backport for `stable/8.6`: bump Micrometer **1.15.10 -> 1.15.12** (single property change in `parent/pom.xml`).

Closes two CVEs on the 1.15 line:
- **CVE-2026-40983** (CVSS 8.7) - DoS via gRPC server instrumentation (`MetricCollectingServerInterceptor`).
- **CVE-2026-40984** (CVSS 8.2) - DoS via HTTP observation instrumentation.

Affected range **1.15.0-1.15.11** is fixed in **1.15.12** (the 1.16 line is fixed in 1.16.6).

### Reachability on stable/8.6
Zeebe's gateway unconditionally wraps **both** the gateway gRPC service and the health service with `MetricCollectingServerInterceptor` in `Gateway#buildServer` (`zeebe/gateway-grpc/.../Gateway.java`), applied outside the security/auth path - so unauthenticated gRPC requests reach the vulnerable instrumentation (CVE-2026-40983 directly reachable).

All Micrometer artifacts in the monorepo are pinned by `micrometer-bom` (imported before `spring-boot-dependencies`), so this one property bump upgrades every module. No `1.16.x` is pinned in this repo.

### Upstream references
No `stable/8.6` backport previously existed. Equivalent merged changes:
- main -> 1.16.6 (#55718)
- stable/8.9 -> 1.16.6 (#55719)
- stable/8.8 -> 1.15.12 (#55720)
- stable/8.7 -> 1.15.12 (#55721)

## Notes
- Draft: pending ESUP approval / CI.
- If the shipped 8.6.x image bundles a component (sourced outside this monorepo) that carries Micrometer 1.16.5, that copy is not affected by this change and needs its own bump to 1.16.6.
