### PR TITLE
docs: link RT team handbook page from load-tests README

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -2,7 +2,7 @@
 
 Load tests validate the reliability and performance of Camunda 8 across releases and development branches. They can be created via automated GitHub Actions workflows or manually (via Makefiles) on a GKE cluster (`camunda-benchmark-prod`), deploying the [Camunda Platform Helm Chart](https://github.com/camunda/camunda-platform-helm) and a custom [load test Helm chart](https://github.com/camunda/camunda-load-tests-helm).
 
-For background on goals and test variants, see the [reliability testing documentation](../docs/testing/reliability-testing.md).
+For background on goals and test variants, see the [reliability testing documentation](../docs/testing/reliability-testing.md). For the Reliability Testing team's mission, scope, and responsibilities, see the [team handbook page](https://github.com/camunda/company-handbook/blob/main/departments/products/engineering/organization-teams-in-r-d/qa-engineering/reliability-testing/index.md).
 
 ## Directory Layout
 


### PR DESCRIPTION
## Description

The Reliability Testing team's mission, scope, and responsibilities are documented in the [company handbook](https://github.com/camunda/company-handbook/blob/main/departments/products/engineering/organization-teams-in-r-d/qa-engineering/reliability-testing/index.md), but nothing in `load-tests/` pointed to it. Adds a one-line link from the `load-tests/README.md` intro so readers can find the team's scope without already knowing the handbook page exists.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #59326

- [ ] This PR does not need a linked issue