### PR TITLE
deps: update Spring Boot to 3.5.15 and Spring Framework to 6.2.19

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,11 +98,11 @@
     <version.feel-scala>1.18.5</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.7</version.rest-assured>
-    <version.spring>6.2.17</version.spring>
+    <version.spring>6.2.19</version.spring>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
     <version.spring-security>6.5.9</version.spring-security>
-    <version.spring-boot>3.5.13</version.spring-boot>
+    <version.spring-boot>3.5.15</version.spring-boot>
     <version.tomcat>10.1.53</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
## Description

Brings `stable/8.6` in line with the Spring Boot version already used on
the newer branches.

`parent/pom.xml`, two properties:

| Property | From | To |
|---|---|---|
| `version.spring-boot` | 3.5.13 | 3.5.15 |
| `version.spring` | 6.2.17 | 6.2.19 |

`version.spring` moves in the same commit because `parent/pom.xml` imports
`spring-framework-bom` at `${version.spring}`, and that import takes
precedence over the Spring Boot BOM. Bumping Boot alone would leave
Framework at 6.2.17 and pair 3.5.15 with a Framework version it was not
built against, so the two move in lockstep. `stable/8.7` applied the same
pair.

`version.spring-security` is deliberately held at 6.5.9 even though Boot
3.5.15 would otherwise manage 6.5.11 — the `spring-security.version` alias
directly above it force-pins the value regardless of BOM import order, and
`stable/8.7` held it back the same way. Revisiting that pin is a separate
change.

### Blast radius

Wider than the two edited lines: bumping the Boot BOM also moves every
managed version the repository does not pin itself. In the `dist` runtime
classpath, comparing resolved trees before and after:

- `spring-ldap-core` 3.3.6 → 3.3.8
- `spring-session` 3.5.5 → 3.5.7
- `spring-data` 3.5.10 → 3.5.12
- `reactor-core` 3.7.17 → 3.7.19, `reactor-netty` 1.2.16 → 1.2.18
- `caffeine` 3.2.3 → 3.2.4
- `thymeleaf-spring6` 3.1.3 → 3.1.5
- `jakarta.xml.bind-api` 4.0.4 → 4.0.5, `jakarta.json.bind-api` 3.0.1 → 3.0.2

All are patch-level moves within the same minor. `spring-session` is the
one worth a reviewer's attention, since Operate's `SessionService` builds
on it directly. `netty`, `micrometer`, `jackson`, `slf4j`, `tomcat` and
`spring-security` are pinned explicitly in `parent/pom.xml` and were
verified not to move.

`library-parent` overrides `version.spring-boot` to 3.4.12 for the
user-facing SDK artifacts and is left alone. Note that this does not fully
insulate them: it overrides only the Boot version, not `version.spring`, so
those modules now build against Framework 6.2.19 while their Boot BOM
expects 6.2.14. That skew already existed at 6.2.17 and stays within 6.2.x.

### Verification

`stable/8.6` CI is currently red for unrelated infra reasons (see #61931),
so this was verified locally:

- `dependency:tree` on `operate/webapp` — `spring-core` 6.2.19, with
  `spring-security-ldap` confirmed still at 6.5.9
- `./mvnw clean install -Dquickly -T1C` — full repository, all modules green
- Operate `ldap-auth` integration tests — 5 tests, 0 failures
  (`AuthenticationIT` via the `rroemhild/test-openldap` container,
  `AuthenticationWrongParametersIT` via embedded UnboundID)
- Wider Operate security integration suite — 107 tests, 0 failures
- The `Java checks` command CI uses
  (`-P '!autoFormat,checkFormat,spotbugs,skipFrontendBuild' verify`) — green,
  exercising dependency convergence, banned duplicate versions and
  `maven-dependency-plugin` `analyze` with `failOnWarning` across 136
  modules, plus revapi API compatibility

Opened as a draft while #61931 is pending, so it is not reviewed or
merge-queued against unrelated red checks.

## Related issues

- [x] This PR does not need a linked issue
