### PR TITLE
ci: cache npm dependencies in npm-ci-with-retry to survive registry blips

### DIFF
--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -30,6 +30,12 @@ inputs:
 runs:
   using: composite
   steps:
+    # per docs/monorepo-docs/ci.md §"GitHub Actions Cache": NPM/Yarn dependencies
+    # should use the shared cache action; writes only happen from main/stable*.
+    - name: Setup npm cache
+      uses: ./.github/actions/setup-npm-cache
+      with:
+        cache-dependency-path: ${{ inputs.directory }}/package-lock.json
     - name: Install node dependencies
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:

--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -45,8 +45,11 @@ runs:
         # Pin to bash so a forward-slash `directory` works consistently on
         # Linux, container images, and Windows runners (git-bash).
         shell: bash
+        # --loglevel=http surfaces each registry request/response (and where
+        # one is hanging) instead of a silent gap between the deprecation
+        # warnings and the timeout kill.
         command: |
-          cd "${{ inputs.directory }}" && npm ci
+          cd "${{ inputs.directory }}" && npm ci --loglevel=http
         # A killed attempt (timeout) can leave node_modules half-extracted,
         # which makes the next attempt fail deterministically (e.g. ENOTEMPTY)
         # instead of getting a clean retry.

--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -45,11 +45,8 @@ runs:
         # Pin to bash so a forward-slash `directory` works consistently on
         # Linux, container images, and Windows runners (git-bash).
         shell: bash
-        # --loglevel=http surfaces each registry request/response (and where
-        # one is hanging) instead of a silent gap between the deprecation
-        # warnings and the timeout kill.
         command: |
-          cd "${{ inputs.directory }}" && npm ci --loglevel=http
+          cd "${{ inputs.directory }}" && npm ci
         # A killed attempt (timeout) can leave node_modules half-extracted,
         # which makes the next attempt fail deterministically (e.g. ENOTEMPTY)
         # instead of getting a clean retry.

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -122,7 +122,7 @@ jobs:
     if: inputs.runFeTests
     name: "Unit - Front End [${{ matrix.shardIndex }}/${{ matrix.shardTotal }}]"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     strategy:
       fail-fast: false
@@ -150,7 +150,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run test -- --no-file-parallelism --maxWorkers 1 --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         name: Unit & Integration tests
         env:
@@ -180,7 +180,7 @@ jobs:
     needs: [fe-unit-tests]
     name: "Unit - Front End - Merge Reports"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Unit
@@ -201,7 +201,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -216,7 +216,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - TypeScript Type Check"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -239,7 +239,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -257,7 +257,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -280,7 +280,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -297,7 +297,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -320,7 +320,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -338,7 +338,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - a11y"
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -365,7 +365,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build frontend
         run: npm run build
       - name: Run A11y tests
@@ -390,7 +390,7 @@ jobs:
     if: inputs.runFeTests
     name: "Unit / Front End - Visual Regression [${{ matrix.shardIndex }}/${{ matrix.shardTotal }}]"
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     strategy:
       fail-fast: false
@@ -423,7 +423,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build frontend
         run: npm run build:visual-regression
       - name: Run Visual regression tests
@@ -451,7 +451,7 @@ jobs:
     needs: [operate-fe-visual-regression-tests]
     name: "Unit / Front End - Visual Regression - Merge Reports"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
@@ -475,7 +475,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -495,7 +495,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Update Screenshots"
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: screenshot-update
@@ -520,7 +520,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build frontend
         run: npm run build
       - name: Run Playwright

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -82,7 +82,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Type check"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -105,7 +105,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -122,7 +122,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -145,7 +145,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -162,7 +162,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Stylelint"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -184,7 +184,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run lint:stylelint
         name: Stylelint
       - name: Observe build status
@@ -201,7 +201,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -224,7 +224,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -278,7 +278,7 @@ jobs:
     if: inputs.runFeTests
     name: "Unit - Front End - Visual Regression"
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: visual-regression
@@ -305,7 +305,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build frontend
         run: npm run build:visual-regression
       - name: Run Playwright tests
@@ -330,7 +330,7 @@ jobs:
     if: inputs.runFeTests
     name: "Tool / Front End - a11y"
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     env:
       TEST_TYPE: Tool
@@ -357,7 +357,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build frontend
         run: npm run build
       - name: Run A11y tests

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -347,7 +347,7 @@ jobs:
     env:
       TEST_TYPE: Visual Regression
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 21
     permissions: {} # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.62.1

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -18,7 +18,7 @@ jobs:
   typecheck:
     name: "Type check"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -40,7 +40,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Type check
         run: npm run typecheck
       - name: Observe build status
@@ -56,7 +56,7 @@ jobs:
   eslint:
     name: "ESLint"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -78,7 +78,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: ESLint
         run: npm run lint:eslint
       - name: Observe build status
@@ -94,7 +94,7 @@ jobs:
   knip:
     name: "Knip"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -116,7 +116,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Knip
         run: npm run lint:knip
       - name: Observe build status
@@ -132,7 +132,7 @@ jobs:
   prettier:
     name: "Prettier"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 14
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -154,7 +154,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Prettier
         run: npm run lint:prettier
       - name: Observe build status
@@ -170,7 +170,7 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -192,7 +192,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build packages
         run: npm run build
       - name: Observe build status
@@ -210,7 +210,7 @@ jobs:
     env:
       TEST_TYPE: Unit
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.62.1
@@ -237,7 +237,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Unit tests
         env:
           # Capture failure screenshots even when CI contention delays web font loading.
@@ -323,7 +323,7 @@ jobs:
     env:
       TEST_TYPE: Accessibility
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
     permissions: {} # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.62.1
@@ -350,7 +350,7 @@ jobs:
         with:
           directory: ${{ env.CLIENT_DIR }}
           max_attempts: "2"
-          timeout_minutes: "3"
+          timeout_minutes: "6"
       - name: Build frontend
         run: npm run build -w @camunda/orchestration-cluster-webapp
       - name: Accessibility tests

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -31,10 +31,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -69,10 +65,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -107,10 +99,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -145,10 +133,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -183,10 +167,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -228,10 +208,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -287,10 +263,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -341,10 +313,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:
@@ -397,10 +365,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - name: Setup npm cache
-        uses: ./.github/actions/setup-npm-cache
-        with:
-          cache-dependency-path: ${{ env.CLIENT_DIR }}/package-lock.json
       - name: Install dependencies
         uses: ./.github/actions/npm-ci-with-retry
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2648,7 +2648,7 @@ jobs:
     name: "Lint / Renovate Config Validator"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 22
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
@@ -2660,16 +2660,18 @@ jobs:
         with:
           node-version: 24
       # Retry to absorb transient npm-registry resolution failures when npx resolves
-      # renovate@latest and its transitive deps on a fresh run (see INC-6869).
+      # renovate@latest and its transitive deps on a fresh run (see INC-6869, INC-7810).
       - name: Validate Renovate config
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
           retry_on: error
           retry_wait_seconds: 15
-          # 2 min/attempt keeps all 3 attempts (~6.5 min worst case) within the
-          # 10-min job timeout; validation normally completes in well under a minute.
-          timeout_minutes: 2
+          # 6 min/attempt keeps all 3 attempts (~18.5 min worst case) within
+          # the 22-min job timeout; validation normally completes in well
+          # under a minute. Widened from 2min (10min job timeout) because a
+          # registry-wide slowdown (INC-7810) left no margin at that budget.
+          timeout_minutes: 6
           command: npx --yes --package "renovate@latest" -- renovate-config-validator --no-global .github/renovate.json* .github/renovate/*
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## What & why

Incident: [INC-7810](https://app.incident.io/camunda/incidents/7810) — "Job CI: operate-fe-visual-regression-tests has high failure rate in merge queue to stable/8.8", Slack channel [#inc-7810-job-ci-operate-fe-visual-regression-tests-has-high-failure-rate-in](https://camunda.slack.com/archives/C0BUST298CD). Several related CI-failure incidents (e.g. INC-7824, INC-7840) have since merged into this one as the umbrella incident for this failure class.

`npm-ci-with-retry` wraps `npm ci` in `nick-fields/retry`, but does no
caching — every job re-downloads every package from the registry on
every run, with only a 3min/2-attempt retry budget to absorb a
transient failure. That wasn't enough during the npm registry
degradation on 2026-09-03/04: install duration across the whole fleet
(GitHub-hosted and self-hosted, multiple regions) shifted from a
healthy p100 of ~42s to a tail past 366s, well past npm's own stated
incident window (`status.npmjs.org` b6958bgj1sm3, 21:42–23:21 UTC).
Both retry attempts hung repeatedly, fanning out across ~15
Operate/Tasklist frontend jobs per run, blocking merges into
`stable/8.8` and `main` for hours after the public incident was marked
resolved.

Two changes, addressing two different parts of this:

**1. Cache** — adds `./.github/actions/setup-npm-cache` before the
install step in `npm-ci-with-retry`, per `docs/monorepo-docs/ci.md`'s
GitHub Actions Cache guidance for NPM/Yarn dependencies. Caches npm's
global download cache (`~/.npm`) keyed on `package-lock.json`, same
action already used in `ci-webapp-client.yml` (and now no longer
duplicated there — see below). Speeds up installs and cuts registry
load on every run, not just during incidents. Cache writes only happen
from `main`/`stable*`, so PR/merge-queue runs only restore.

**2. Widened retry timeout** — of the ~46 call sites of
`npm-ci-with-retry`, 22 (all in `ci-operate.yml`, `ci-tasklist.yml`,
`ci-webapp-client.yml` — exactly the population that failed in the
incident) had overridden the action's own defaults down to
`timeout_minutes: "3"` / `max_attempts: "2"`, leaving zero margin
against the kind of registry slowdown seen here. Doubled to `"6"`, and
bumped each affected job's own `timeout-minutes` by the same +6 delta
so the outer job budget keeps the same headroom for its non-install
steps as before. The other ~24 call sites already ran on the action's
sane defaults (10min/3 attempts) and didn't need touching.

Also removed 9 now-redundant standalone `setup-npm-cache` calls in
`ci-webapp-client.yml` that would otherwise double-invoke the cache
action per Copilot's review on this PR.

(A `--loglevel=http` attempt to make a future stall show registry
request activity was tried and reverted — it logs every request, which
added enough volume/overhead to slow installs down further without
giving a clearer picture. No npm log level between the default and
`http` adds network visibility without that per-request noise.)

## Related issues

- [x] This PR does not need a linked issue

## Test plan

- [ ] Confirm cache restore step runs cleanly in CI on this PR (restore-only, since not `main`/`stable*`)
- [ ] Confirm `npm ci` install time drops on subsequent runs once cache is warm from a `main` run
- [ ] Spot-check one Operate and one Tasklist frontend job (e.g. `Tool / Front End - a11y`) completes successfully
- [ ] Confirm no job's overall `timeout-minutes` regressed for its non-install steps after the +6min bump