### PR TITLE
fix: return the cursor-adjacent page when paging backwards on RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -12,8 +12,8 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 /**
- * @param searchBefore whether the page is seeked backwards from a {@code before} cursor. The seek
- *     has to walk away from the cursor, so the mapper renders its ORDER BY reversed (see {@code
+ * @param searchBefore whether the page seeks backwards from a {@code before} cursor. The seek has
+ *     to walk away from the cursor, so the mapper renders its ORDER BY reversed (see {@code
  *     Commons.orderBy}) — otherwise LIMIT would cut the first rows of the whole filtered range
  *     instead of the rows adjacent to the cursor. The reader restores the display order afterwards.
  */

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -11,11 +11,18 @@ import io.camunda.search.sort.SortOrder;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * @param searchBefore whether the page is seeked backwards from a {@code before} cursor. The seek
+ *     has to walk away from the cursor, so the mapper renders its ORDER BY reversed (see {@code
+ *     Commons.orderBy}) — otherwise LIMIT would cut the first rows of the whole filtered range
+ *     instead of the rows adjacent to the cursor. The reader restores the display order afterwards.
+ */
 public record DbQueryPage(
     Integer size,
     @Nullable Integer from,
     @Nullable Integer maxTotalHits,
-    @Nullable List<KeySetPagination> keySetPagination) {
+    @Nullable List<KeySetPagination> keySetPagination,
+    boolean searchBefore) {
 
   public record KeySetPagination(List<KeySetPaginationFieldEntry> entries) {}
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.domain;
 
+import io.camunda.search.sort.SortOptionsBuilders;
 import io.camunda.search.sort.SortOrder;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
@@ -60,28 +61,23 @@ public record DbQueryPage(
       }
 
       public KeySetPaginationFieldEntry build() {
+        // Paging backwards over a sort is paging forwards over the reversed sort — the same
+        // equivalence the mapper's ORDER BY relies on (see Commons.orderBy). Flipping the order up
+        // front leaves a single set of comparators to reason about, for both directions.
+        final var seekOrder = isSearchAfter ? order : SortOptionsBuilders.reverseOrder(order);
+
         // NULL ordering is standardized across all supported databases (see Commons.xml orderBy):
-        // ASC sorts NULLs FIRST, DESC sorts NULLs LAST. The strict comparator for a NULL cursor
-        // value therefore depends on the direction: for the boundary where NULLs are on the far
-        // side of the traversal there is no row beyond them, which must yield NO_MATCH rather than
-        // IS_NULL (which would match every NULL row and stall the cursor).
-        final Operator operator;
-        if (isSearchAfter) {
-          operator =
-              order == SortOrder.ASC
-                  // ASC NULLs FIRST: rows after a NULL cursor are the non-NULL rows
-                  ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER
-                  // DESC NULLs LAST: nothing sorts after a NULL cursor
-                  : fieldValue == null ? Operator.NO_MATCH : Operator.LOWER;
-        } else {
-          // searchBefore: traverse the result set backwards
-          operator =
-              order == SortOrder.ASC
-                  // ASC NULLs FIRST: nothing sorts before a NULL cursor
-                  ? fieldValue == null ? Operator.NO_MATCH : Operator.LOWER
-                  // DESC NULLs LAST: rows before a NULL cursor are the non-NULL rows
-                  : fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER;
-        }
+        // ASC sorts NULLs FIRST, DESC sorts NULLs LAST, and reversing the order swaps both halves
+        // of that pairing together. The strict comparator for a NULL cursor value therefore depends
+        // only on the seek order: where the NULLs sit at the far end of the traversal there is no
+        // row beyond them, which must yield NO_MATCH rather than IS_NULL (which would match every
+        // NULL row and stall the cursor).
+        final Operator operator =
+            seekOrder == SortOrder.ASC
+                // ASC NULLs FIRST: the rows beyond a NULL cursor are the non-NULL rows
+                ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER
+                // DESC NULLs LAST: nothing sorts beyond a NULL cursor
+                : fieldValue == null ? Operator.NO_MATCH : Operator.LOWER;
         return new KeySetPaginationFieldEntry(fieldName, operator, fieldValue);
       }
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQuerySorting.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQuerySorting.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.read.domain;
 
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
+import io.camunda.search.sort.SortOptionsBuilders;
 import io.camunda.search.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
@@ -44,5 +45,11 @@ public record DbQuerySorting<T>(List<SortingEntry<T>> orderings) {
     }
   }
 
-  public record SortingEntry<T>(SearchColumn<T> column, SortOrder order) {}
+  public record SortingEntry<T>(SearchColumn<T> column, SortOrder order) {
+
+    /** Used by {@code Commons.orderBy} to render the seek direction of a {@code before} page. */
+    public SortOrder reversedOrder() {
+      return SortOptionsBuilders.reverseOrder(order);
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -91,14 +91,25 @@ abstract class AbstractEntityReader<T> {
     if (page.after() != null || page.before() != null) {
       keySetPagination = createKeySetPagination(sort, page);
     }
+    final var searchBefore = page.before() != null;
 
     if (SearchQueryResultType.UNLIMITED.equals(page.resultType())) {
       // assuming Integer.MAX_VALUE is enough
-      return new DbQueryPage(Integer.MAX_VALUE, 0, Integer.MAX_VALUE, keySetPagination);
+      return new DbQueryPage(
+          Integer.MAX_VALUE, 0, Integer.MAX_VALUE, keySetPagination, searchBefore);
     }
 
     return new DbQueryPage(
-        page.size(), page.from(), readerConfig.maxTotalHits() + 1, keySetPagination);
+        page.size(), page.from(), readerConfig.maxTotalHits() + 1, keySetPagination, searchBefore);
+  }
+
+  /**
+   * Restores the display order of a page seeked backwards from a {@code before} cursor. Such a page
+   * is queried against the display direction so that its LIMIT keeps the rows adjacent to the
+   * cursor (see {@code Commons.orderBy}), which leaves the returned rows in reverse order.
+   */
+  protected List<T> restoreDisplayOrder(final DbQueryPage page, final List<T> hits) {
+    return page.searchBefore() ? hits.reversed() : hits;
   }
 
   /**
@@ -232,7 +243,7 @@ abstract class AbstractEntityReader<T> {
       return buildSearchQueryResult(totalHits, List.of(), dbSort);
     }
     final List<T> results = executeQuery(resultsSupplier);
-    return buildSearchQueryResult(totalHits, results, dbSort);
+    return buildSearchQueryResult(totalHits, restoreDisplayOrder(page, results), dbSort);
   }
 
   /**

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -104,8 +104,8 @@ abstract class AbstractEntityReader<T> {
   }
 
   /**
-   * Restores the display order of a page seeked backwards from a {@code before} cursor. Such a page
-   * is queried against the display direction so that its LIMIT keeps the rows adjacent to the
+   * Restores the display order of a page that seeks backwards from a {@code before} cursor. Such a
+   * page is queried against the display direction so that its LIMIT keeps the rows adjacent to the
    * cursor (see {@code Commons.orderBy}), which leaves the returned rows in reverse order.
    */
   protected List<T> restoreDisplayOrder(final DbQueryPage page, final List<T> hits) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -143,7 +143,9 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
             .toList();
 
     return buildSearchQueryResult(
-        entities.size(), entities, convertSort(JOB_TYPE_STATS_FIXED_SORT));
+        entities.size(),
+        restoreDisplayOrder(dbPage, entities),
+        convertSort(JOB_TYPE_STATS_FIXED_SORT));
   }
 
   @Override
@@ -181,7 +183,8 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
                             ofNullable(result.failedCount()).orElse(0L), result.lastFailedAt())))
             .toList();
 
-    return workerStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+    return workerStatsReader.buildSearchQueryResult(
+        entities.size(), workerStatsReader.restoreDisplayOrder(dbPage, entities), dbSort);
   }
 
   @Override
@@ -221,7 +224,8 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
                             ofNullable(result.failedCount()).orElse(0L), result.lastFailedAt())))
             .toList();
 
-    return timeSeriesStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+    return timeSeriesStatsReader.buildSearchQueryResult(
+        entities.size(), timeSeriesStatsReader.restoreDisplayOrder(dbPage, entities), dbSort);
   }
 
   @Override
@@ -257,7 +261,8 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
                         ofNullable(result.workers()).orElse(0)))
             .toList();
 
-    return errorStatsReader.buildSearchQueryResult(entities.size(), entities, dbSort);
+    return errorStatsReader.buildSearchQueryResult(
+        entities.size(), errorStatsReader.restoreDisplayOrder(dbPage, entities), dbSort);
   }
 
   /** Inner reader for worker statistics to provide typed AbstractEntityReader methods. */

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionMessageSubscriptionStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionMessageSubscriptionStatisticsDbReader.java
@@ -70,6 +70,7 @@ public class ProcessDefinitionMessageSubscriptionStatisticsDbReader
 
     final var results = mapper.getProcessDefinitionStatistics(dbQuery);
 
-    return buildSearchQueryResult(results.size(), results, convertSort(FIXED_SORT));
+    return buildSearchQueryResult(
+        results.size(), restoreDisplayOrder(dbPage, results), convertSort(FIXED_SORT));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
@@ -89,6 +89,6 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
       final int partitionId, final OffsetDateTime cleanupDate, final int limit) {
     return processInstanceMapper.selectExpiredRootProcessInstances(
         new SelectExpiredRootProcessInstancesDto(
-            partitionId, cleanupDate, new DbQueryPage(limit, null, null, null)));
+            partitionId, cleanupDate, new DbQueryPage(limit, null, null, null, false)));
   }
 }

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -272,10 +272,17 @@
     </if>
   </sql>
 
+  <!--
+    A `before` page seeks backwards from its cursor, so the statement is ordered against the display
+    direction: only then does the page-size LIMIT keep the rows adjacent to the cursor instead of the
+    first rows of the whole filtered range. The reader reverses the returned rows back into display
+    order (see AbstractEntityReader#restoreDisplayOrder).
+  -->
   <sql id="orderBy">
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
       <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
-        ${item.column} ${item.order}
+        <bind name="seekOrder" value="page != null and page.searchBefore ? item.reversedOrder : item.order"/>
+        ${item.column} ${seekOrder}
       </foreach>
     </if>
   </sql>
@@ -288,18 +295,20 @@
   <sql id="orderBy" databaseId="oracle">
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
       <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
-        ${item.column} ${item.order}
-        <if test="item.order.name().equals('ASC')">NULLS FIRST</if>
-        <if test="item.order.name().equals('DESC')">NULLS LAST</if>
+        <bind name="seekOrder" value="page != null and page.searchBefore ? item.reversedOrder : item.order"/>
+        ${item.column} ${seekOrder}
+        <if test="seekOrder.name().equals('ASC')">NULLS FIRST</if>
+        <if test="seekOrder.name().equals('DESC')">NULLS LAST</if>
       </foreach>
     </if>
   </sql>
   <sql id="orderBy" databaseId="postgresql">
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
       <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
-        ${item.column} ${item.order}
-        <if test="item.order.name().equals('ASC')">NULLS FIRST</if>
-        <if test="item.order.name().equals('DESC')">NULLS LAST</if>
+        <bind name="seekOrder" value="page != null and page.searchBefore ? item.reversedOrder : item.order"/>
+        ${item.column} ${seekOrder}
+        <if test="seekOrder.name().equals('ASC')">NULLS FIRST</if>
+        <if test="seekOrder.name().equals('DESC')">NULLS LAST</if>
       </foreach>
     </if>
   </sql>

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -781,7 +781,15 @@
       GROUP BY ms.PROCESS_DEFINITION_KEY, ms.TENANT_ID
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter" />
-    ORDER BY PROCESS_DEFINITION_KEY ASC, TENANT_ID ASC
+    <!-- reversed for a `before` page so the LIMIT keeps the cursor-adjacent rows, see Commons.orderBy -->
+    <choose>
+      <when test="page != null and page.searchBefore">
+        ORDER BY PROCESS_DEFINITION_KEY DESC, TENANT_ID DESC
+      </when>
+      <otherwise>
+        ORDER BY PROCESS_DEFINITION_KEY ASC, TENANT_ID ASC
+      </otherwise>
+    </choose>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging" />
   </select>
 

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -457,6 +457,8 @@
         FROM ${prefix}PROCESS_DEFINITION pd
         WHERE pd.PROCESS_DEFINITION_ID = pi.PROCESS_DEFINITION_ID
             AND pd.TENANT_ID = pi.TENANT_ID
+        <!-- keyset-order-by-exempt: picks the highest version for this one row, it does not order
+             the paged result, so it stays DESC in both paging directions -->
         ORDER BY pd.VERSION DESC
       <choose>
         <when test="_databaseId == 'mssql'">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/domain/KeySetPaginationFieldEntryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/domain/KeySetPaginationFieldEntryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
+import io.camunda.search.sort.SortOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Pins the cursor comparator for every combination of seek direction, sort order and NULL-ness of
+ * the cursor value.
+ *
+ * <p>The backward rows are the forward rows with the sort order swapped, because paging backwards
+ * over a sort is paging forwards over the reversed sort. The comparators only look symmetric once
+ * the standardized NULL placement (ASC NULLs FIRST, DESC NULLs LAST) is taken into account, so the
+ * table is written out in full rather than derived.
+ */
+class KeySetPaginationFieldEntryTest {
+
+  @ParameterizedTest(name = "[{index}] searchAfter={0}, {1}, cursor value {2} -> {3}")
+  @CsvSource(
+      nullValues = "NULL",
+      value = {
+        // forwards
+        "true,  ASC,  cursor, GREATER",
+        "true,  ASC,  NULL,   IS_NOT_NULL",
+        "true,  DESC, cursor, LOWER",
+        "true,  DESC, NULL,   NO_MATCH",
+        // backwards: the forward rows with the order swapped
+        "false, DESC, cursor, GREATER",
+        "false, DESC, NULL,   IS_NOT_NULL",
+        "false, ASC,  cursor, LOWER",
+        "false, ASC,  NULL,   NO_MATCH",
+      })
+  void shouldPickComparatorForSeekDirection(
+      final boolean isSearchAfter,
+      final SortOrder order,
+      final String fieldValue,
+      final Operator expected) {
+    // when
+    final var entry =
+        KeySetPaginationFieldEntry.of("CREATION_DATE", fieldValue)
+            .order(order)
+            .isSearchAfter(isSearchAfter)
+            .build();
+
+    // then
+    assertThat(entry.operator()).isEqualTo(expected);
+    assertThat(entry.fieldName()).isEqualTo("CREATION_DATE");
+    assertThat(entry.fieldValue()).isEqualTo(fieldValue);
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/KeySetPaginationOrderByTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/KeySetPaginationOrderByTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.read.domain.DbQueryPage;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPagination;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
+import io.camunda.db.rdbms.read.domain.DbQuerySorting;
+import io.camunda.db.rdbms.read.domain.IncidentDbQuery;
+import io.camunda.db.rdbms.sql.columns.IncidentSearchColumn;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.sort.SortOrder;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.Properties;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * A {@code before} page seeks backwards from its cursor, so the statement must be ordered against
+ * the display direction — only then does the page-size LIMIT keep the rows adjacent to the cursor
+ * instead of the first rows of the whole filtered range.
+ */
+class KeySetPaginationOrderByTest {
+
+  private static final String MAPPER_DIRECTORY = "src/main/resources/mapper";
+  private static final List<String> REQUIRED_MAPPER_FILES =
+      List.of("Commons.xml", "IncidentMapper.xml");
+  private static final String SEARCH_STATEMENT = "io.camunda.db.rdbms.sql.IncidentMapper.search";
+
+  private static final DbQuerySorting<IncidentEntity> SORT =
+      DbQuerySorting.of(
+          b ->
+              b.addEntry(IncidentSearchColumn.CREATION_DATE, SortOrder.DESC)
+                  .addEntry(IncidentSearchColumn.INCIDENT_KEY, SortOrder.ASC));
+
+  @Test
+  void shouldKeepSortDirectionWhenPagingForward() throws Exception {
+    // given
+    final var configuration = mapperConfiguration(null);
+
+    // when
+    final var sql = renderSearch(configuration, page(false));
+
+    // then
+    assertThat(orderByClause(sql)).isEqualTo("ORDER BY CREATION_DATE DESC, INCIDENT_KEY ASC");
+  }
+
+  @Test
+  void shouldReverseSortDirectionWhenPagingBackward() throws Exception {
+    // given
+    final var configuration = mapperConfiguration(null);
+
+    // when
+    final var sql = renderSearch(configuration, page(true));
+
+    // then
+    assertThat(orderByClause(sql)).isEqualTo("ORDER BY CREATION_DATE ASC, INCIDENT_KEY DESC");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"oracle", "postgresql"})
+  void shouldReverseNullOrderingWhenPagingBackward(final String databaseId) throws Exception {
+    // given
+    final var configuration = mapperConfiguration(databaseId);
+
+    // when
+    final var forward = renderSearch(configuration, page(false));
+    final var backward = renderSearch(configuration, page(true));
+
+    // then
+    assertThat(orderByClause(forward))
+        .isEqualTo("ORDER BY CREATION_DATE DESC NULLS LAST, INCIDENT_KEY ASC NULLS FIRST");
+    assertThat(orderByClause(backward))
+        .isEqualTo("ORDER BY CREATION_DATE ASC NULLS FIRST, INCIDENT_KEY DESC NULLS LAST");
+  }
+
+  private static DbQueryPage page(final boolean searchBefore) {
+    final var keySetPagination =
+        List.of(
+            new KeySetPagination(
+                List.of(new KeySetPaginationFieldEntry("INCIDENT_KEY", Operator.GREATER, 42L))));
+    return new DbQueryPage(5, 0, 1000, keySetPagination, searchBefore);
+  }
+
+  private static String renderSearch(final Configuration configuration, final DbQueryPage page) {
+    final var query = IncidentDbQuery.of(b -> b.sort(SORT).page(page));
+    return configuration.getMappedStatement(SEARCH_STATEMENT).getBoundSql(query).getSql();
+  }
+
+  /** Extracts the single ORDER BY clause of the statement, with whitespace normalized. */
+  private static String orderByClause(final String sql) {
+    final var normalized = sql.replaceAll("\\s+", " ").replace(" ,", ",");
+    final var start = normalized.indexOf("ORDER BY");
+    assertThat(start).as("statement contains an ORDER BY clause").isNotNegative();
+    assertThat(normalized.indexOf("ORDER BY", start + 1))
+        .as("statement contains exactly one ORDER BY clause")
+        .isNegative();
+    return normalized.substring(start).trim();
+  }
+
+  private Configuration mapperConfiguration(final String databaseId) throws Exception {
+    final var configuration = new Configuration();
+    configuration.setDatabaseId(databaseId);
+    final var properties = new Properties();
+    properties.setProperty("prefix", "");
+    properties.setProperty("escapeChar", "'\\\\'");
+    properties.setProperty("keysetPaging.limit", "");
+    configuration.setVariables(properties);
+
+    for (final var mapperFileName : REQUIRED_MAPPER_FILES) {
+      final var mapperFile = new File(MAPPER_DIRECTORY, mapperFileName);
+      try (var inputStream = new FileInputStream(mapperFile)) {
+        new XMLMapperBuilder(
+                inputStream, configuration, mapperFile.getPath(), configuration.getSqlFragments())
+            .parse();
+      }
+    }
+    return configuration;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/KeySetStatementOrderByContractTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/KeySetStatementOrderByContractTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Enforces the mapper half of the backward keyset pagination contract.
+ *
+ * <p>A {@code before} page is answered by seeking against the display direction and reversing the
+ * rows back in the reader, so every ORDER BY that shapes such a statement's output has to flip with
+ * the paging direction. {@code Commons.orderBy} does that flip once, centrally, and {@link
+ * KeySetPaginationOrderByTest} pins it per dialect. This test closes the other half of that
+ * argument: it checks that every statement doing keyset pagination actually takes its ordering from
+ * that fragment, so a new mapper cannot reintroduce the defect by hardcoding an ORDER BY.
+ *
+ * <p>A statement that genuinely needs a literal ORDER BY has two ways to say so: guard it with
+ * {@code page.searchBefore} and render both directions, or — where the ordering does not shape the
+ * paged output at all, such as inside a scalar subquery — mark it with an {@value
+ * #EXEMPTION_MARKER} XML comment explaining why.
+ */
+class KeySetStatementOrderByContractTest {
+
+  static final String EXEMPTION_MARKER = "keyset-order-by-exempt";
+
+  private static final String MAPPER_DIRECTORY = "src/main/resources/mapper";
+  private static final String KEY_SET_FILTER_FRAGMENT = "Commons.keySetPageFilter";
+  private static final String ORDER_BY_FRAGMENT = "Commons.orderBy";
+  private static final String BACKWARD_FLAG = "searchBefore";
+
+  /**
+   * Guards the discovery itself: if the scan stops finding statements — a renamed fragment, a moved
+   * directory — the contract would be vacuously satisfied.
+   */
+  private static final int MINIMUM_EXPECTED_STATEMENTS = 30;
+
+  @Test
+  void shouldRenderOrderByFromTheSharedFragmentInEveryKeySetStatement() throws Exception {
+    // given
+    final var statements = keySetStatements();
+
+    // then
+    assertThat(statements)
+        .as("keyset-paginated select statements found under %s", MAPPER_DIRECTORY)
+        .hasSizeGreaterThanOrEqualTo(MINIMUM_EXPECTED_STATEMENTS);
+
+    final var softly = new SoftAssertions();
+    for (final var statement : statements) {
+      softly
+          .assertThat(statement.unguardedLiteralOrderBys())
+          .as(
+              "%s hardcodes an ORDER BY. It has to come from %s, be guarded by page.%s, or carry an"
+                  + " '%s' XML comment saying why the paging direction does not apply to it.",
+              statement.id(), ORDER_BY_FRAGMENT, BACKWARD_FLAG, EXEMPTION_MARKER)
+          .isEmpty();
+      softly
+          .assertThat(statement.hasOrdering())
+          .as(
+              "%s paginates by keyset but renders no ORDER BY, so its page boundaries are undefined",
+              statement.id())
+          .isTrue();
+    }
+    softly.assertAll();
+  }
+
+  /**
+   * A select that pulls in {@code Commons.keySetPageFilter}, with everything the contract needs to
+   * be checked: whether it orders at all, and which literal ORDER BYs are neither direction-aware
+   * nor exempt.
+   */
+  private record KeySetStatement(
+      String id, boolean hasOrdering, List<String> unguardedLiteralOrderBys) {}
+
+  private static List<KeySetStatement> keySetStatements() throws Exception {
+    final var statements = new ArrayList<KeySetStatement>();
+    for (final var mapperFile : mapperFiles()) {
+      final var mapper = parse(mapperFile);
+      final var namespace = mapper.getAttribute("namespace");
+      final var fragments = sqlFragmentsById(mapper);
+
+      for (final var select : childElements(mapper, "select")) {
+        // a databaseId-specific variant is a copy of the same statement for another vendor and is
+        // checked in its own right, so both are visited and reported under distinguishable ids
+        final var databaseId = select.getAttribute("databaseId");
+        final var id =
+            namespace
+                + "."
+                + select.getAttribute("id")
+                + (databaseId.isEmpty() ? "" : " [" + databaseId + "]");
+
+        final var scan = new StatementScan(fragments);
+        scan.walk(select, false, null);
+        if (scan.usesKeySetPagination) {
+          statements.add(
+              new KeySetStatement(
+                  id,
+                  scan.usesOrderByFragment || scan.hasDirectionAwareOrderBy,
+                  scan.unguardedLiteralOrderBys));
+        }
+      }
+    }
+    return statements;
+  }
+
+  /**
+   * Walks a statement in document order, following {@code <include>}s into the {@code <sql>}
+   * fragments of the same file, and records what the statement does about ordering.
+   */
+  private static final class StatementScan {
+
+    private final Map<String, Element> localFragments;
+    private final Set<String> visitedFragments = new HashSet<>();
+
+    private boolean usesKeySetPagination;
+    private boolean usesOrderByFragment;
+    private boolean hasDirectionAwareOrderBy;
+    private final List<String> unguardedLiteralOrderBys = new ArrayList<>();
+
+    private StatementScan(final Map<String, Element> localFragments) {
+      this.localFragments = localFragments;
+    }
+
+    /**
+     * @param directionAware whether an enclosing element branches on the paging direction
+     * @param exemption the most recent XML comment, which may exempt the next literal ORDER BY
+     */
+    private void walk(final Node node, final boolean directionAware, final String exemption) {
+      var pendingExemption = exemption;
+
+      for (final var child : childNodes(node)) {
+        switch (child.getNodeType()) {
+          case Node.COMMENT_NODE -> pendingExemption = child.getNodeValue();
+          case Node.TEXT_NODE, Node.CDATA_SECTION_NODE -> {
+            final var text = child.getNodeValue();
+            if (containsOrderBy(text)) {
+              if (directionAware) {
+                hasDirectionAwareOrderBy = true;
+              } else if (pendingExemption == null || !pendingExemption.contains(EXEMPTION_MARKER)) {
+                unguardedLiteralOrderBys.add(squash(text));
+              }
+            }
+          }
+          case Node.ELEMENT_NODE -> {
+            final var element = (Element) child;
+            if ("include".equals(element.getTagName())) {
+              visitInclude(element, directionAware, pendingExemption);
+            } else {
+              walk(element, directionAware || branchesOnPagingDirection(element), pendingExemption);
+            }
+          }
+          default -> {
+            // nothing else affects the rendered SQL
+          }
+        }
+      }
+    }
+
+    private void visitInclude(
+        final Element include, final boolean directionAware, final String exemption) {
+      final var refId = include.getAttribute("refid");
+      if (refId.endsWith(KEY_SET_FILTER_FRAGMENT)) {
+        usesKeySetPagination = true;
+      } else if (refId.endsWith(ORDER_BY_FRAGMENT)) {
+        usesOrderByFragment = true;
+      }
+
+      // follow same-file fragments so a statement cannot hide either half behind an <sql> include
+      final var localName = refId.substring(refId.lastIndexOf('.') + 1);
+      final var fragment = localFragments.get(localName);
+      if (fragment != null && visitedFragments.add(localName)) {
+        walk(fragment, directionAware, exemption);
+      }
+    }
+
+    /**
+     * True for an element that renders only for one paging direction — either it tests the flag
+     * itself, or it is the {@code <choose>} whose branches split on it, which also covers the
+     * {@code <otherwise>} carrying the forward ordering.
+     */
+    private static boolean branchesOnPagingDirection(final Element element) {
+      if (element.getAttribute("test").contains(BACKWARD_FLAG)) {
+        return true;
+      }
+      return "choose".equals(element.getTagName())
+          && childElements(element, "when").stream()
+              .anyMatch(when -> when.getAttribute("test").contains(BACKWARD_FLAG));
+    }
+  }
+
+  private static boolean containsOrderBy(final String text) {
+    return text.toUpperCase(Locale.ROOT).contains("ORDER BY");
+  }
+
+  private static String squash(final String text) {
+    return text.replaceAll("\\s+", " ").trim();
+  }
+
+  private static Map<String, Element> sqlFragmentsById(final Element mapper) {
+    return childElements(mapper, "sql").stream()
+        .collect(
+            Collectors.toMap(
+                fragment -> fragment.getAttribute("id"), fragment -> fragment, (a, b) -> a));
+  }
+
+  private static List<File> mapperFiles() {
+    final var files = new File(MAPPER_DIRECTORY).listFiles((dir, name) -> name.endsWith(".xml"));
+    assertThat(files).as("mapper files under %s", MAPPER_DIRECTORY).isNotNull().isNotEmpty();
+    return List.of(files);
+  }
+
+  private static Element parse(final File mapperFile) throws Exception {
+    final var factory = DocumentBuilderFactory.newInstance();
+    // the mybatis DTD is only referenced here, never needed, and must never be fetched
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setIgnoringComments(false);
+
+    final var builder = factory.newDocumentBuilder();
+    builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+    return builder.parse(mapperFile).getDocumentElement();
+  }
+
+  private static List<Element> childElements(final Node parent, final String tagName) {
+    return childNodes(parent).stream()
+        .filter(Element.class::isInstance)
+        .map(Element.class::cast)
+        .filter(element -> tagName.equals(element.getTagName()))
+        .toList();
+  }
+
+  private static List<Node> childNodes(final Node parent) {
+    final NodeList children = parent.getChildNodes();
+    return IntStream.range(0, children.getLength()).mapToObj(children::item).toList();
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/KeySetStatementOrderByContractTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/KeySetStatementOrderByContractTest.java
@@ -87,14 +87,6 @@ class KeySetStatementOrderByContractTest {
     softly.assertAll();
   }
 
-  /**
-   * A select that pulls in {@code Commons.keySetPageFilter}, with everything the contract needs to
-   * be checked: whether it orders at all, and which literal ORDER BYs are neither direction-aware
-   * nor exempt.
-   */
-  private record KeySetStatement(
-      String id, boolean hasOrdering, List<String> unguardedLiteralOrderBys) {}
-
   private static List<KeySetStatement> keySetStatements() throws Exception {
     final var statements = new ArrayList<KeySetStatement>();
     for (final var mapperFile : mapperFiles()) {
@@ -125,6 +117,60 @@ class KeySetStatementOrderByContractTest {
     }
     return statements;
   }
+
+  private static boolean containsOrderBy(final String text) {
+    return text.toUpperCase(Locale.ROOT).contains("ORDER BY");
+  }
+
+  private static String squash(final String text) {
+    return text.replaceAll("\\s+", " ").trim();
+  }
+
+  private static Map<String, Element> sqlFragmentsById(final Element mapper) {
+    return childElements(mapper, "sql").stream()
+        .collect(
+            Collectors.toMap(
+                fragment -> fragment.getAttribute("id"), fragment -> fragment, (a, b) -> a));
+  }
+
+  private static List<File> mapperFiles() {
+    final var files = new File(MAPPER_DIRECTORY).listFiles((dir, name) -> name.endsWith(".xml"));
+    assertThat(files).as("mapper files under %s", MAPPER_DIRECTORY).isNotNull().isNotEmpty();
+    return List.of(files);
+  }
+
+  private static Element parse(final File mapperFile) throws Exception {
+    final var factory = DocumentBuilderFactory.newInstance();
+    // the mybatis DTD is only referenced here, never needed, and must never be fetched
+    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setIgnoringComments(false);
+
+    final var builder = factory.newDocumentBuilder();
+    builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+    return builder.parse(mapperFile).getDocumentElement();
+  }
+
+  private static List<Element> childElements(final Node parent, final String tagName) {
+    return childNodes(parent).stream()
+        .filter(Element.class::isInstance)
+        .map(Element.class::cast)
+        .filter(element -> tagName.equals(element.getTagName()))
+        .toList();
+  }
+
+  private static List<Node> childNodes(final Node parent) {
+    final NodeList children = parent.getChildNodes();
+    return IntStream.range(0, children.getLength()).mapToObj(children::item).toList();
+  }
+
+  /**
+   * A select that pulls in {@code Commons.keySetPageFilter}, with everything the contract needs to
+   * be checked: whether it orders at all, and which literal ORDER BYs are neither direction-aware
+   * nor exempt.
+   */
+  private record KeySetStatement(
+      String id, boolean hasOrdering, List<String> unguardedLiteralOrderBys) {}
 
   /**
    * Walks a statement in document order, following {@code <include>}s into the {@code <sql>}
@@ -209,51 +255,5 @@ class KeySetStatementOrderByContractTest {
           && childElements(element, "when").stream()
               .anyMatch(when -> when.getAttribute("test").contains(BACKWARD_FLAG));
     }
-  }
-
-  private static boolean containsOrderBy(final String text) {
-    return text.toUpperCase(Locale.ROOT).contains("ORDER BY");
-  }
-
-  private static String squash(final String text) {
-    return text.replaceAll("\\s+", " ").trim();
-  }
-
-  private static Map<String, Element> sqlFragmentsById(final Element mapper) {
-    return childElements(mapper, "sql").stream()
-        .collect(
-            Collectors.toMap(
-                fragment -> fragment.getAttribute("id"), fragment -> fragment, (a, b) -> a));
-  }
-
-  private static List<File> mapperFiles() {
-    final var files = new File(MAPPER_DIRECTORY).listFiles((dir, name) -> name.endsWith(".xml"));
-    assertThat(files).as("mapper files under %s", MAPPER_DIRECTORY).isNotNull().isNotEmpty();
-    return List.of(files);
-  }
-
-  private static Element parse(final File mapperFile) throws Exception {
-    final var factory = DocumentBuilderFactory.newInstance();
-    // the mybatis DTD is only referenced here, never needed, and must never be fetched
-    factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-    factory.setIgnoringComments(false);
-
-    final var builder = factory.newDocumentBuilder();
-    builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
-    return builder.parse(mapperFile).getDocumentElement();
-  }
-
-  private static List<Element> childElements(final Node parent, final String tagName) {
-    return childNodes(parent).stream()
-        .filter(Element.class::isInstance)
-        .map(Element.class::cast)
-        .filter(element -> tagName.equals(element.getTagName()))
-        .toList();
-  }
-
-  private static List<Node> childNodes(final Node parent) {
-    final NodeList children = parent.getChildNodes();
-    return IntStream.range(0, children.getLength()).mapToObj(children::item).toList();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/KeySetBackwardPagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/KeySetBackwardPagingIT.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures;
+import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
+import io.camunda.it.rdbms.db.fixtures.JobMetricsBatchFixtures;
+import io.camunda.it.rdbms.db.fixtures.MessageSubscriptionFixtures;
+import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
+import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
+import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobTypeStatisticsQuery;
+import io.camunda.search.query.ProcessDefinitionMessageSubscriptionStatisticsQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.UserTaskQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.function.Function;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Regression guard for backward keyset pagination on RDBMS storage.
+ *
+ * <p>A {@code before} page has to be seeked against the display direction, otherwise the page-size
+ * LIMIT keeps the first rows of the whole preceding range instead of the rows next to the cursor,
+ * and every backward step lands on page 1 (#61712). The reversal lives in the shared {@code
+ * Commons.orderBy} fragment and in {@code AbstractEntityReader}, so it is easy to bypass by
+ * accident: a mapper that hardcodes its ORDER BY, or a reader that assembles its result without
+ * {@code executePagedQuery}, silently keeps the old behaviour.
+ *
+ * <p>The scenarios below therefore cover one reader per statement shape that the shared keyset SQL
+ * has to serve, rather than one per entity. Add a scenario whenever a new shape appears.
+ */
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class KeySetBackwardPagingIT {
+
+  private static final int PARTITION_ID = 0;
+  private static final int PAGE_SIZE = 3;
+  private static final int SEEDED_ENTRIES = 10;
+
+  @TestTemplate
+  public void shouldReturnTheForwardPagesWhenPagingBackwards(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+
+    final var scenarios =
+        List.of(
+            incidentSearch(rdbmsService, rdbmsWriters),
+            processInstanceSearch(rdbmsService, rdbmsWriters),
+            authorizationSearch(rdbmsService, rdbmsWriters),
+            userTaskSearch(rdbmsService),
+            jobTypeStatistics(rdbmsService, rdbmsWriters),
+            messageSubscriptionStatistics(rdbmsService, rdbmsWriters));
+
+    // when / then
+    final var softly = new SoftAssertions();
+    scenarios.forEach(scenario -> assertBackwardPagingRepeatsForwardPaging(softly, scenario));
+    softly.assertAll();
+  }
+
+  /**
+   * Walks three pages forwards, then walks the same cursors back, and asserts that each backward
+   * page carries the entries — in the same order — that the forward traversal produced for it.
+   */
+  private static void assertBackwardPagingRepeatsForwardPaging(
+      final SoftAssertions softly, final Scenario scenario) {
+    final var search = scenario.search();
+
+    final var firstPage = search.execute(p -> p.size(PAGE_SIZE));
+    final var secondPage = search.execute(p -> p.size(PAGE_SIZE).after(firstPage.endCursor()));
+    final var thirdPage = search.execute(p -> p.size(PAGE_SIZE).after(secondPage.endCursor()));
+
+    final var backToSecondPage =
+        search.execute(p -> p.size(PAGE_SIZE).before(thirdPage.startCursor()));
+    final var backToFirstPage =
+        search.execute(p -> p.size(PAGE_SIZE).before(backToSecondPage.startCursor()));
+
+    softly
+        .assertThat(List.of(firstPage.items(), secondPage.items(), thirdPage.items()))
+        .as("%s: the seeded entries fill three forward pages", scenario.name())
+        .allMatch(items -> items.size() == PAGE_SIZE);
+    softly
+        .assertThat(backToSecondPage.items())
+        .as("%s: paging back from page 3 returns page 2", scenario.name())
+        .isEqualTo(secondPage.items());
+    softly
+        .assertThat(backToFirstPage.items())
+        .as("%s: paging back from page 2 returns page 1", scenario.name())
+        .isEqualTo(firstPage.items());
+  }
+
+  /** Flat statement: keyset filter, ORDER BY and LIMIT all applied to one subquery. */
+  private static Scenario incidentSearch(
+      final RdbmsService rdbmsService, final RdbmsWriters rdbmsWriters) {
+    final var processDefinitionKey = nextKey();
+    IncidentFixtures.createAndSaveRandomIncidents(
+        rdbmsWriters, SEEDED_ENTRIES, b -> b.processDefinitionKey(processDefinitionKey));
+
+    final var reader = rdbmsService.getIncidentReader();
+    return new Scenario(
+        "incident search",
+        page ->
+            reader.search(
+                IncidentQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                            .sort(s -> s.state().asc().creationTime().desc())
+                            .page(page))));
+  }
+
+  /** Seek subquery plus two outer re-sorts around a tag join. */
+  private static Scenario processInstanceSearch(
+      final RdbmsService rdbmsService, final RdbmsWriters rdbmsWriters) {
+    final var processDefinition =
+        ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
+    ProcessInstanceFixtures.createAndSaveRandomProcessInstances(
+        rdbmsWriters,
+        SEEDED_ENTRIES,
+        b ->
+            b.processDefinitionKey(processDefinition.processDefinitionKey())
+                .processDefinitionId(processDefinition.processDefinitionId()));
+
+    final var reader = rdbmsService.getProcessInstanceReader();
+    return new Scenario(
+        "process instance search",
+        page ->
+            reader.search(
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(
+                                f ->
+                                    f.processDefinitionIds(processDefinition.processDefinitionId()))
+                            .sort(s -> s.startDate().desc())
+                            .page(page))));
+  }
+
+  /** Seek subquery over a DISTINCT projection plus one outer re-sort after the permission join. */
+  private static Scenario authorizationSearch(
+      final RdbmsService rdbmsService, final RdbmsWriters rdbmsWriters) {
+    final var ownerId = nextStringId();
+    AuthorizationFixtures.createAndSaveRandomAuthorizations(
+        rdbmsWriters, SEEDED_ENTRIES, b -> b.ownerId(ownerId));
+
+    final var reader = rdbmsService.getAuthorizationReader();
+    return new Scenario(
+        "authorization search",
+        page ->
+            reader.search(
+                AuthorizationQuery.of(
+                    b ->
+                        b.filter(f -> f.ownerIds(ownerId))
+                            .sort(s -> s.resourceId().desc())
+                            .page(page))));
+  }
+
+  /** Sort on a low-cardinality column, so the cursor leans on the unique key discriminator. */
+  private static Scenario userTaskSearch(final RdbmsService rdbmsService) {
+    final var processDefinitionId = nextStringId();
+    UserTaskFixtures.createAndSaveRandomUserTasks(
+        rdbmsService, SEEDED_ENTRIES, b -> b.processDefinitionId(processDefinitionId));
+
+    final var reader = rdbmsService.getUserTaskReader();
+    return new Scenario(
+        "user task search",
+        page ->
+            reader.search(
+                UserTaskQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(processDefinitionId))
+                            .sort(s -> s.priority().desc())
+                            .page(page))));
+  }
+
+  /** Aggregation: GROUP BY, and a reader that builds its result without executePagedQuery. */
+  private static Scenario jobTypeStatistics(
+      final RdbmsService rdbmsService, final RdbmsWriters rdbmsWriters) {
+    // a window five years back keeps the metrics other tests write out of the aggregation
+    final var windowStart =
+        OffsetDateTime.now(ZoneOffset.UTC).minusYears(5).truncatedTo(ChronoUnit.MILLIS);
+    final var jobTypePrefix = "job-type-" + nextStringId();
+    for (int i = 0; i < SEEDED_ENTRIES; i++) {
+      final var index = i;
+      JobMetricsBatchFixtures.createAndSaveMetric(
+          rdbmsWriters,
+          JobMetricsBatchFixtures.createRandomized(
+              b ->
+                  b.jobType("%s-%02d".formatted(jobTypePrefix, index))
+                      .startTime(windowStart.plusMinutes(index))
+                      .endTime(windowStart.plusMinutes(index + 1L))));
+    }
+
+    final var reader = rdbmsService.getJobMetricsBatchDbReader();
+    return new Scenario(
+        "job type statistics",
+        page ->
+            reader.getJobTypeStatistics(
+                JobTypeStatisticsQuery.of(
+                    b ->
+                        b.filter(
+                                f ->
+                                    f.from(windowStart.minusMinutes(1))
+                                        .to(windowStart.plusMinutes(SEEDED_ENTRIES + 1L)))
+                            .page(page)),
+                ResourceAccessChecks.disabled()));
+  }
+
+  /** Aggregation with a hardcoded ORDER BY, which the shared orderBy fragment does not reach. */
+  private static Scenario messageSubscriptionStatistics(
+      final RdbmsService rdbmsService, final RdbmsWriters rdbmsWriters) {
+    // the statistics group by process definition, so every entry needs its own definition
+    final var messageName = "message-" + nextStringId();
+    for (int i = 0; i < SEEDED_ENTRIES; i++) {
+      final var processDefinitionKey = nextKey();
+      MessageSubscriptionFixtures.createAndSaveMessageSubscription(
+          rdbmsWriters,
+          b ->
+              b.messageName(messageName)
+                  .processDefinitionKey(processDefinitionKey)
+                  .processDefinitionId("process-" + processDefinitionKey));
+    }
+
+    final var reader = rdbmsService.getProcessDefinitionMessageSubscriptionStatisticsDbReader();
+    return new Scenario(
+        "process definition message subscription statistics",
+        page ->
+            reader.aggregate(
+                new ProcessDefinitionMessageSubscriptionStatisticsQuery.Builder()
+                    .filter(f -> f.messageNames(messageName))
+                    .page(page)
+                    .build(),
+                ResourceAccessChecks.disabled()));
+  }
+
+  private record Scenario(String name, PagedSearch search) {}
+
+  @FunctionalInterface
+  private interface PagedSearch {
+    SearchQueryResult<?> execute(
+        Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> page);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/KeySetBackwardPagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/KeySetBackwardPagingIT.java
@@ -44,9 +44,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Regression guard for backward keyset pagination on RDBMS storage.
  *
- * <p>A {@code before} page has to be seeked against the display direction, otherwise the page-size
- * LIMIT keeps the first rows of the whole preceding range instead of the rows next to the cursor,
- * and every backward step lands on page 1 (#61712). The reversal lives in the shared {@code
+ * <p>A {@code before} page has to seek against the display direction, otherwise the page-size LIMIT
+ * keeps the first rows of the whole preceding range instead of the rows next to the cursor, and
+ * every backward step lands on page 1 (#61712). The reversal lives in the shared {@code
  * Commons.orderBy} fragment and in {@code AbstractEntityReader}, so it is easy to bypass by
  * accident: a mapper that hardcodes its ORDER BY, or a reader that assembles its result without
  * {@code executePagedQuery}, silently keeps the old behaviour.

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -29,17 +29,21 @@ import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByErrorEntity;
 import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByDefinitionQuery;
 import io.camunda.search.query.IncidentProcessInstanceStatisticsByErrorQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.IncidentProcessInstanceStatisticsByDefinitionSort;
 import io.camunda.search.sort.IncidentProcessInstanceStatisticsByErrorSort;
 import io.camunda.search.sort.IncidentSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.function.Function;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -313,6 +317,66 @@ public class IncidentIT {
     assertThat(nextPage.total()).isEqualTo(20);
     assertThat(nextPage.items()).hasSize(5);
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(15, 20));
+  }
+
+  @TestTemplate
+  public void shouldFindIncidentWithSearchBefore(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given - three pages traversed forwards
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final IncidentDbReader incidentReader = rdbmsService.getIncidentReader();
+
+    final var processDefinitionKey = nextKey();
+    createAndSaveRandomIncidents(rdbmsWriters, b -> b.processDefinitionKey(processDefinitionKey));
+    final var sort = IncidentSort.of(s -> s.state().asc().creationTime().desc().flowNodeId().asc());
+
+    final var firstPage =
+        searchIncidents(incidentReader, processDefinitionKey, sort, p -> p.size(5));
+    final var secondPage =
+        searchIncidents(
+            incidentReader,
+            processDefinitionKey,
+            sort,
+            p -> p.size(5).after(firstPage.endCursor()));
+    final var thirdPage =
+        searchIncidents(
+            incidentReader,
+            processDefinitionKey,
+            sort,
+            p -> p.size(5).after(secondPage.endCursor()));
+
+    // when - paging backwards from the third page
+    final var backToSecondPage =
+        searchIncidents(
+            incidentReader,
+            processDefinitionKey,
+            sort,
+            p -> p.size(5).before(thirdPage.startCursor()));
+    final var backToFirstPage =
+        searchIncidents(
+            incidentReader,
+            processDefinitionKey,
+            sort,
+            p -> p.size(5).before(backToSecondPage.startCursor()));
+
+    // then - the same entries in the same order as the forward traversal produced
+    assertThat(backToSecondPage.total()).isEqualTo(20);
+    assertThat(backToSecondPage.items()).isEqualTo(secondPage.items());
+    assertThat(backToFirstPage.items()).isEqualTo(firstPage.items());
+  }
+
+  private static SearchQueryResult<IncidentEntity> searchIncidents(
+      final IncidentDbReader incidentReader,
+      final long processDefinitionKey,
+      final IncidentSort sort,
+      final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> page) {
+    return incidentReader.search(
+        IncidentQuery.of(
+            b ->
+                b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                    .sort(sort)
+                    .page(page)));
   }
 
   private void compareIncident(final IncidentEntity instance, final IncidentDbModel original) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
@@ -27,13 +28,17 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -481,6 +486,71 @@ public class ProcessInstanceIT {
     assertThat(nextPage.total()).isEqualTo(20);
     assertThat(nextPage.items()).hasSize(10);
     assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(10, 20));
+  }
+
+  @TestTemplate
+  public void shouldFindProcessInstanceWithSearchBefore(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given - three pages traversed forwards
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
+
+    final var processDefinition =
+        ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriters, b -> b);
+    createAndSaveRandomProcessInstances(
+        rdbmsWriters,
+        b ->
+            b.processDefinitionKey(processDefinition.processDefinitionKey())
+                .processDefinitionId(processDefinition.processDefinitionId()));
+    final var sort = ProcessInstanceSort.of(s -> s.startDate().desc());
+
+    final var firstPage =
+        searchProcessInstances(processInstanceReader, processDefinition, sort, p -> p.size(5));
+    final var secondPage =
+        searchProcessInstances(
+            processInstanceReader,
+            processDefinition,
+            sort,
+            p -> p.size(5).after(firstPage.endCursor()));
+    final var thirdPage =
+        searchProcessInstances(
+            processInstanceReader,
+            processDefinition,
+            sort,
+            p -> p.size(5).after(secondPage.endCursor()));
+
+    // when - paging backwards from the third page
+    final var backToSecondPage =
+        searchProcessInstances(
+            processInstanceReader,
+            processDefinition,
+            sort,
+            p -> p.size(5).before(thirdPage.startCursor()));
+    final var backToFirstPage =
+        searchProcessInstances(
+            processInstanceReader,
+            processDefinition,
+            sort,
+            p -> p.size(5).before(backToSecondPage.startCursor()));
+
+    // then - the same entries in the same order as the forward traversal produced
+    assertThat(backToSecondPage.total()).isEqualTo(20);
+    assertThat(backToSecondPage.items()).isEqualTo(secondPage.items());
+    assertThat(backToFirstPage.items()).isEqualTo(firstPage.items());
+  }
+
+  private static SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
+      final ProcessInstanceDbReader processInstanceReader,
+      final ProcessDefinitionDbModel processDefinition,
+      final ProcessInstanceSort sort,
+      final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> page) {
+    return processInstanceReader.search(
+        ProcessInstanceQuery.of(
+            b ->
+                b.filter(f -> f.processDefinitionIds(processDefinition.processDefinitionId()))
+                    .sort(sort)
+                    .page(page)));
   }
 
   @TestTemplate

--- a/qa/archunit-tests/src/test/java/io/camunda/RdbmsBackwardPagingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/RdbmsBackwardPagingArchTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Enforces the reader half of the backward keyset pagination contract.
+ *
+ * <p>A {@code before} page is answered by seeking against the display direction, so the mapper
+ * hands the reader its rows reversed and the reader has to turn them back. {@code
+ * AbstractEntityReader#executePagedQuery} does that on its own; a reader that assembles its result
+ * some other way — the statistics readers post-process their rows — has to call {@code
+ * restoreDisplayOrder} itself. Forgetting it is silent: the page comes back in the wrong order, or
+ * from the wrong end of the range entirely.
+ *
+ * <p>The mapper half — that the ORDER BY flips at all — is covered by {@code
+ * KeySetStatementOrderByContractTest} and {@code KeySetPaginationOrderByTest} in {@code db/rdbms}.
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.db.rdbms.read",
+    importOptions = DoNotIncludeTestsOrTestJars.class)
+public final class RdbmsBackwardPagingArchTest {
+
+  private static final String READER_PACKAGE = "io.camunda.db.rdbms.read.service";
+
+  /**
+   * Builds a page but never reads it back: {@code SequenceFlowMapper.search} returns every sequence
+   * flow of one process instance and renders no keyset filter, ORDER BY or LIMIT at all, so there
+   * is no seek order to restore. Paginating that statement means removing this exemption.
+   */
+  private static final String UNPAGINATED_READER = READER_PACKAGE + ".SequenceFlowDbReader";
+
+  @ArchTest
+  static final ArchRule PAGED_READERS_MUST_RESTORE_THE_DISPLAY_ORDER =
+      ArchRuleDefinition.classes()
+          .that()
+          .resideInAPackage(READER_PACKAGE)
+          .should(restoreTheDisplayOrderOfABackwardPage())
+          .because(
+              "a reader that turns a SearchQueryPage into a DbQueryPage may be handed a `before`"
+                  + " cursor, and the rows for such a page come back from the database in reverse"
+                  + " display order (see Commons.orderBy). Route the query through"
+                  + " executePagedQuery, or call restoreDisplayOrder on the rows yourself.");
+
+  private static ArchCondition<JavaClass> restoreTheDisplayOrderOfABackwardPage() {
+    return new ArchCondition<>("restore the display order of a backward page") {
+      @Override
+      public void check(final JavaClass reader, final ConditionEvents events) {
+        if (reader.getFullName().equals(UNPAGINATED_READER)) {
+          return;
+        }
+
+        final Set<String> calledReaderMethods =
+            reader.getMethodCallsFromSelf().stream()
+                // AbstractEntityReader is package-private, so javac gives every public reader a
+                // bridge method for each public method it inherits. Those bridges delegate to
+                // convertPaging without the reader ever paging anything, and would otherwise make
+                // this rule fire on readers that do not paginate at all.
+                .filter(call -> !call.getOrigin().getModifiers().contains(JavaModifier.BRIDGE))
+                .filter(call -> call.getTargetOwner().getPackageName().startsWith(READER_PACKAGE))
+                .map(JavaCall::getName)
+                .collect(Collectors.toSet());
+
+        if (!calledReaderMethods.contains("convertPaging")
+            || calledReaderMethods.contains("executePagedQuery")
+            || calledReaderMethods.contains("restoreDisplayOrder")) {
+          return;
+        }
+
+        events.add(
+            violated(
+                reader,
+                reader.getSimpleName()
+                    + " builds a DbQueryPage with convertPaging but never restores the display"
+                    + " order of a backward page: it calls neither executePagedQuery nor"
+                    + " restoreDisplayOrder."));
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Description

Paging backwards with a `before` cursor on RDBMS storage returned the entries of the first page instead of the entries adjacent to the cursor, so stepping back from page 3 landed on page 1. Reported against `POST /v2/incidents/search`, but it affected every RDBMS-backed search endpoint using keyset pagination. ES/OS were unaffected.

The keyset `WHERE` clause was already correct — it flips its comparators for a `before` cursor, so the filtered range held exactly the rows preceding it. The `ORDER BY` did not. Mappers apply `keySetPageFilter` → `orderBy` → `paging` on the seek subquery, so the page-size `LIMIT` ran while rows were still sorted in display direction and kept the top N of that whole preceding range instead of the N rows next to the cursor.

A `before` page is now seeked against the display direction and reversed back afterwards:

- `DbQueryPage` carries a `searchBefore` flag, set in `convertPaging`.
- `Commons.orderBy` renders the reversed sort order — and, on Oracle/PostgreSQL, the correspondingly reversed `NULLS FIRST`/`LAST`.
- `AbstractEntityReader#restoreDisplayOrder` reverses the returned rows before the result is built.

This mirrors how the ES/OS backend has always handled a `before` page (`SearchClientBasedQueryExecutor`, `SortingTransformer`), which keeps the two backends' semantics aligned. The alternative — restructuring each mapper to re-sort in an extra outer `SELECT` — would have touched ~40 mappers and needed every projection to expose its sort columns to the outer query, for the same observable result.

Reversing the shared fragment covers every mapper that uses it, including the ones that render it several times per statement. An audit turned up two places it does not reach, fixed explicitly: the message subscription statistics query hardcodes its `ORDER BY`, and the job metrics and message subscription statistics readers build their results without
`executePagedQuery`.

`KeySetBackwardPagingIT` guards the behaviour by statement shape rather than by entity — flat search, seek subquery with outer re-sorts around a join, seek over a `DISTINCT` projection, low-cardinality sort leaning on the key discriminator, and both aggregation readers. All six scenarios fail against the pre-fix code. `KeySetPaginationOrderByTest` additionally pins the rendered `ORDER BY` per dialect, where the NULL ordering rules are easy to get wrong.

## Related issues

closes #61712