### PR TITLE
docs: add extend-vs-new-variant decision guide to load-tests README

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -558,3 +558,18 @@ One use case for manually creating load tests is running them against a SaaS clu
 As a precondition for such tests, you need to create a cluster in SaaS (the stage doesn't matter, may it be **DEV**, **INT,** or **PROD**). Additionally, we need client credentials deployed with the SaaS load tests, such that the starters and workers can connect to the right cluster.
 
 For further details on this topic, follow the [README](setup/README.md#load-testing-camunda-saas) in our `load-tests/setup` directory.
+
+## Extending Load Tests
+
+> [!Note]
+>
+> Builds on the endurance/stress variants and release/weekly/daily schedule described in [Test Scenarios](#test-scenarios) above; read that first if these terms are unfamiliar.
+
+When a new feature lands, work through these questions:
+
+- **What should this new test or variant achieve?** Name the goal, the specific reliability or performance property to validate, before deciding on infrastructure. This also decides which test type to run: an endurance run (release/weekly) for reliability under sustained load, or a stress run (daily) for performance under short-burst load; pick both if it's unclear which applies. See the [reliability testing documentation](../docs/testing/reliability-testing.md) for the full definitions.
+- **Is the change foundational or functional?** This follows from what the change touches, not a judgment call:
+  - **Foundational**: the feature changes what we need to run against, not just what we run through it. Examples: new secondary-storage support, different low-level storage mechanics. This likely means changing the [Helm setup](setup/README.md) and adding a new variant, covered by both an endurance and a stress run.
+  - **Functional**: the feature is exercised through the existing engine/API surface. Check whether it's already covered by extending the load tester's process models or payloads; if not, add a new workload to the [load tester](load-tester/README.md), still using the existing variant infrastructure. Only do this when it is worth a dedicated test: a new feature not yet covered, and something customers or users commonly rely on. Reliability testing is non-functional testing, see the [reliability testing documentation](../docs/testing/reliability-testing.md), so we do not add a dedicated test for every connector or task type. For example, adding a new task type or connector to the realistic workload's process model is a functional extension, not a new variant.
+- **Is it automated?** Wire the new coverage into the existing release/weekly/daily schedule rather than validating it manually once; a one-off run catches today's bug but not next release's regression.
+

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -563,7 +563,7 @@ For further details on this topic, follow the [README](setup/README.md#load-test
 
 > [!Note]
 >
-> Builds on the endurance/stress variants and release/weekly/daily schedule described in [Test Scenarios](#test-scenarios) above; read that first if these terms are unfamiliar. See the [Reliability coverage Miro board](https://miro.com/app/board/uXjVJRlgaXU=/) for a visual overview of what's already covered before deciding whether something new is needed.
+> Builds on the endurance/stress variants and release/weekly/daily schedule described in [When Load Tests Run](#when-load-tests-run) above; read that first if these terms are unfamiliar. See the [Reliability coverage Miro board](https://miro.com/app/board/uXjVJRlgaXU=/) for a visual overview of what's already covered before deciding whether something new is needed.
 
 When a new feature lands, work through these questions:
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -563,7 +563,7 @@ For further details on this topic, follow the [README](setup/README.md#load-test
 
 > [!Note]
 >
-> Builds on the endurance/stress variants and release/weekly/daily schedule described in [Test Scenarios](#test-scenarios) above; read that first if these terms are unfamiliar.
+> Builds on the endurance/stress variants and release/weekly/daily schedule described in [Test Scenarios](#test-scenarios) above; read that first if these terms are unfamiliar. See the [Reliability coverage Miro board](https://miro.com/app/board/uXjVJRlgaXU=/) for a visual overview of what's already covered before deciding whether something new is needed.
 
 When a new feature lands, work through these questions:
 


### PR DESCRIPTION
## Description

There was no guidance for engineers deciding whether a new feature needs new test infrastructure or can reuse an existing load test variant. Adds a decision guide to `load-tests/README.md` covering the test's goal, whether the change is foundational or functional, and wiring new coverage into the existing schedule instead of validating it manually once.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #59326

- [ ] This PR does not need a linked issue