### PR TITLE
fix: apply spring-security patch that was silently overridden by Spring Boot

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -155,6 +155,17 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Override Spring Boot's spring-security version to resolve CVE-2026-41707.
+           Must be declared before spring-boot-dependencies so this version wins;
+           otherwise Spring Boot's own (vulnerable) spring-security version silently
+           overrides this pin, per Maven's first-import-wins BOM merge rule. -->
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>${spring.security.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -175,13 +186,6 @@
         <version>${jackson.version}</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-bom</artifactId>
-        <version>${spring.security.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
## Description

CVE-2026-41707 (Spring Security DPoP proof replay, CVSS 7.4) is still present in Optimize 8.7 releases (e.g. `8.7.27-optimize`), even though #61417 already bumped `spring.security.version` to the patched `6.5.11-spring-security-6.5.13` coordinate.

**Root cause:** `optimize/pom.xml` re-imports `spring-boot-dependencies` in its own `dependencyManagement`, declared *before* `spring-security-bom`. For import-scope BOMs, Maven keeps the first-declared managed version when two imports manage the same GA. That means Spring Boot's own bundled (vulnerable) `spring-security` version `6.5.11` was winning over the intended patch on every resolution — regardless of what `spring.security.version` was set to. Same bug class already fixed for `netty-bom` in #60170.

**Fix:** move the `spring-security-bom` import above `spring-boot-dependencies`, mirroring the ordering already used for `netty-bom` just above it.

**Verification:** `mvn dependency:tree -pl optimize/backend` — before the fix all `spring-security-*` artifacts resolved to plain `6.5.11`; after the fix they resolve to the patched `6.5.11-spring-security-6.5.13`.

Scope: this dependencyManagement duplication only exists on `stable/optimize-8.7` — later branches (`stable/8.8`+) unified Optimize's dependency versions into `parent/pom.xml`, which already orders `spring-security-bom` correctly, so no backport is needed.

## Checklist

## Related issues

- [x] This PR does not need a linked issue
