### PR TITLE
deps: fix spring-security patch being silently overridden by Spring Boot BOM

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -155,6 +155,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Must be declared before spring-boot-dependencies so this version wins,
+           per Maven's first-import-wins BOM merge rule. -->
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>${spring.security.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -175,13 +184,6 @@
         <version>${jackson.version}</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-bom</artifactId>
-        <version>${spring.security.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -910,6 +912,21 @@
 
   <!-- Fix for bug with downloading snapshots from Camunda Nexus using groups with RELEASE and SNAPSHOTS -->
   <repositories>
+    <!-- Reuses the "zeebe" repository id so CI's Maven mirror (authenticated) picks this
+         up too; needed to fetch NES/commercial-patched coordinates like spring-security-bom's,
+         which aren't served anonymously from the public repositories below. -->
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>zeebe</id>
+      <name>Zeebe Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
+    </repository>
+
     <repository>
       <id>camunda-nexus</id>
       <name>Camunda Nexus</name>


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/61417 never actually took effect in Optimize 8.7 builds, despite the property already being set correctly.

**Root cause:** `optimize/pom.xml` re-imports `spring-boot-dependencies` in its own `dependencyManagement`, declared *before* `spring-security-bom`. For import-scope BOMs, Maven keeps the first-declared managed version when two imports manage the same GA. That means Spring Boot's own bundled (older) `spring-security` version `6.5.11` was winning over the intended patched version on every resolution, regardless of what `spring.security.version` was set to. Same bug class already fixed for `netty-bom` in #60170.

**Fix:** move the `spring-security-bom` import above `spring-boot-dependencies`, mirroring the ordering already used for `netty-bom` just above it.

**Verification:** `mvn dependency:tree -pl optimize/backend` — before the fix all `spring-security-*` artifacts resolved to plain `6.5.11`; after the fix they resolve to the intended `6.5.11-spring-security-6.5.13`.

## Checklist

## Related issues

- [x] This PR does not need a linked issue
