### PR TITLE
feat: enable Archive-by-ID by default

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -92,7 +92,7 @@ public class Archiver {
 
       final boolean archiveById = operateProperties.getArchiver().isArchiveByIdEnabled();
       if (archiveById) {
-        LOGGER.info("Archive-by-ID mode enabled (opt-in).");
+        LOGGER.info("Archive-by-ID mode enabled.");
       }
 
       final int effectiveThreadsCount = Math.min(threadsCount, partitionIds.size());

--- a/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
@@ -51,9 +51,9 @@ public class ArchiverProperties {
    */
   private int delayBetweenRuns = 2000;
 
-  private boolean archiveByIdEnabled = false;
+  private boolean archiveByIdEnabled = true;
 
-  private int archiveByIdBatchSize = 500;
+  private int archiveByIdBatchSize = 2500;
 
   private int archiveByIdMaxRetryAttempts = 3;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Enable Archive-by-ID by default and set the default batch size to 2500 to match versions `>8.7`.
Note that when Archive-by-ID is enabled and `rolloverBatchSize` is not set, the default value of 500 is used.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #60316 


