### PR TITLE
ci: fix preview environment external URLs and cluster health

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.lock
+++ b/.ci/preview-environments/charts/c8sm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: infra-preview-environments-gateway-api
   repository: oci://registry.camunda.cloud/library
-  version: 1.1.0
+  version: 1.2.0
 - name: camunda-platform
   repository: https://helm.camunda.io
   version: 15.0.0-alpha4
-digest: sha256:918061ff9c22e216bfda5120fc5d11f0c26df0718b23edb95444c7262b598367
-generated: "2026-08-08T17:25:22.880133146Z"
+digest: sha256:2d061e181ecdcbed0cbceb9ff3d833bb55e2e1f1bb05d4342612609550438948
+generated: "2026-09-04T14:31:00.468692+02:00"

--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -11,7 +11,7 @@ version: 0.1.0
 dependencies:
 - name: infra-preview-environments-gateway-api
   repository: oci://registry.camunda.cloud/library
-  version: 1.1.0
+  version: 1.2.0
 - name: camunda-platform
   repository: https://helm.camunda.io
   version: 15.0.0-alpha4

--- a/.ci/preview-environments/charts/c8sm/templates/_helpers.tpl
+++ b/.ci/preview-environments/charts/c8sm/templates/_helpers.tpl
@@ -15,23 +15,3 @@ camunda.cloud/created-by: "{{ .Values.global.preview.git.repoUrl }}/blob/{{ .Val
 {{- printf "%s.%s" $baseName .Values.global.preview.ingress.domain -}}
 {{- end -}}
 
-# Temporary override the following (existing) template blocks
-# TODO: remove these workarounds once the corresponding issues are resolved
-
-# Fallback to default .publicHost if ingress is disabled
-{{- define "webModeler.publicWebsocketHost" -}}
-  {{- if and .Values.global.ingress.enabled .Values.webModeler.contextPath }}
-    {{- .Values.global.ingress.host }}
-  {{- else }}
-    {{- .Values.webModeler.websockets.publicHost }}
-  {{- end }}
-{{- end -}}
-
-# Disable TLS for WebSocket
-{{- define "webModeler.websocketTlsEnabled" -}}
-  {{- if and .Values.global.ingress.enabled .Values.webModeler.contextPath }}
-    {{- .Values.global.ingress.tls.enabled }}
-  {{- else }}
-    {{- false }}
-  {{- end }}
-{{- end -}}

--- a/.ci/preview-environments/charts/c8sm/templates/keycloak.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/keycloak.yml
@@ -76,7 +76,7 @@ spec:
     limits:
       memory: 512Mi
 ---
-apiVersion: k8s.keycloak.org/v2alpha1
+apiVersion: k8s.keycloak.org/v2beta1
 kind: Keycloak
 metadata:
   name: {{ .Release.Name }}-kc

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -17,11 +17,6 @@ global:
     - name: dockerhub-registry
     - name: registry-camunda-cloud
 
-  # still required by some subcharts (e.g. elasticsearch)
-  imagePullSecrets:
-  - name: dockerhub-registry
-  - name: registry-camunda-cloud
-
   # Preview environment configurations
   preview:
     git:
@@ -52,6 +47,15 @@ global:
     secrets:
       name: camunda-credentials
 
+  # Drives the chart's external URLs (Console links, Web Modeler websocket client).
+  # external=true keeps them derived while leaving routing to the Gateway API HTTPRoutes.
+  host: '{{ include "ingress.domain" . }}'
+  ingress:
+    enabled: true
+    external: true
+    tls:
+      enabled: true
+
   identity:
     auth:
       # Enable Camunda Identity-based authentication
@@ -63,11 +67,6 @@ global:
         secret:
           existingSecret: camunda-credentials
           existingSecretKey: identity-admin-client-token
-      console:
-        redirectUrl: https://{{ include "ingress.domain" . }}/console
-        secret:
-          existingSecret: camunda-credentials
-          existingSecretKey: identity-console-client-token
       optimize:
         redirectUrl: https://{{ include "ingress.domain" . }}/optimize
         secret:
@@ -350,6 +349,10 @@ camunda-platform:
     enabled: true
     fullnameOverride: web-modeler
     contextPath: /modeler
+    # Without this the chart-generated cluster entry falls back to BASIC.
+    security:
+      authentication:
+        method: oidc
     restapi:
       # image:
       #   repository: camunda/web-modeler-restapi
@@ -366,20 +369,6 @@ camunda-platform:
       mail:
         # This value is required, otherwise, the restapi pod won't start.
         fromAddress: noreply@example.com
-      # Override cluster configuration to provide valid version and complete config
-      # The Helm chart would auto-generate cluster config but uses the image tag as version
-      # which fails validation for PR builds (e.g., "pr-abc123...")
-      # When providing clusters override, ALL fields must be specified
-      clusters:
-        - id: "default-cluster"
-          name: "Default Cluster"
-          version: "8.10.0-alphax"
-          authentication: "BEARER_TOKEN"
-          authorizations:
-            enabled: true
-          url:
-            grpc: "grpc://orchestration-gateway:26500"
-            rest: "http://orchestration-gateway:8080/orchestration"
       resources:
         limits:
           cpu: "1"

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -73,7 +73,11 @@ jobs:
       id: resolve
       run: |
         SHA=$(git rev-parse HEAD)
-        echo "image-tag=pr-${SHA}" >> "$GITHUB_OUTPUT"
+        # Web Modeler derives the preview cluster version from this tag and rejects
+        # anything that does not parse as semver >= 8.8, hence the version prefix.
+        # Taken from the root pom, which inherits its version from the parent.
+        VERSION=$(grep -m1 -oE '<version>[^<]+</version>' pom.xml | sed -E 's:</?version>::g')
+        echo "image-tag=${VERSION}-pr-${SHA:0:12}" >> "$GITHUB_OUTPUT"
         echo "checkout-ref=${SHA}" >> "$GITHUB_OUTPUT"
 
   build-camunda:


### PR DESCRIPTION
## Description

Backports preview-environment fixes found while reviving the connectors preview env. Two things were broken for anyone using a preview: Console's in-app links and Web Modeler's websocket client pointed at `localhost`, and Console reported every cluster as unhealthy.

- Derive the chart's external URLs from the preview domain (`global.host` + `global.ingress`), using `external: true` so routing stays with the Gateway API HTTPRoutes and no Ingress object is rendered.
- Drop the two `_helpers.tpl` websocket overrides — they only existed because ingress was disabled, and they read a value (`global.ingress.host`) that isn't in the chart schema.
- Let the chart generate the Web Modeler cluster config again, so Console has component readiness endpoints to probe. The override carried none, which is why the health badge was always red.
- Prefix the preview image tag with a version (`8.10.0-pr-<sha>`): Web Modeler validates the cluster version and rejects anything that doesn't parse as semver >= 8.8, which is what forced the override in the first place.
- Remove `global.imagePullSecrets` and `global.identity.auth.console.*`; the chart reads neither since the 15.x/8.10 consolidation, and the latter emits a deprecation warning on every render.
- Align the Keycloak CR with `k8s.keycloak.org/v2beta1` and pick up infra gateway chart 1.2.0, both already in use by the connectors preview.

Validated against a live preview: with the plain `pr-<sha>` tag the restapi refuses to start (`must not have a component of type 'orchestration' if 'version' is lower than 8.8`); with the prefixed tag it starts, syncs both clusters and Console's readiness probes succeed.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #

- [x] This PR does not need a linked issue
