### PR TITLE
deps: update Netty to 4.1.137.Final on stable/8.6 (HSBC ESUP)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.11</version.msgpack>
-    <version.netty>4.1.132.Final</version.netty>
+    <version.netty>4.1.137.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.9.0</version.opensearch>
     <version.opensearch.testcontainers>4.0.1</version.opensearch.testcontainers>


### PR DESCRIPTION
## Description

Bumps `version.netty` in `parent/pom.xml` from 4.1.132.Final to 4.1.137.Final on `stable/8.6` (HSBC ESUP branch), closing these CVEs:

- CVE-2026-42579 (CVSS 8.8) - DNS codec, exercised via Atomix `NettyMessagingService`
- CVE-2026-42581 (CVSS 8.3) - HTTP/1.0 request-smuggling in `HttpObjectDecoder`
- CVE-2026-42587 (CVSS 8.7) - decompression-limit bypass, reachable via Zeebe Gateway's gRPC/HTTP2 ingress
- CVE-2026-45674 (CVSS 7.0) - DNS CNAME bailiwick validation
- CVE-2026-47691 (CVSS 7.0) - DNS NS record validation
- CVE-2026-55831
- CVE-2026-42584
- CVE-2026-42585
- CVE-2026-33871



4.1.136.Final is the minimum that closes all. This PR targets 4.1.137.Final instead to match `stable/8.7`, which has run this exact version for weeks against the same `version.grpc` (1.76.3).

## Verification

`mvn dependency:tree -Dincludes=io.netty` across `dist`, `operate/webapp`, `tasklist/webapp`, `zeebe/gateway`, `zeebe/gateway-grpc`, `zeebe/atomix/cluster` and `clients/java` confirms every `io.netty:*` module (and `netty-tcnative-boringssl-static`, bom-managed) resolves uniformly to 4.1.137.Final, no split or renamed modules.

Netty-exercising tests in `zeebe/atomix/cluster`: `NettyUnicastServiceTest`, `NettyMessagingServiceCompressionTest`, `ChannelPoolTest`, `RemoteClientConnectionTest` all green. `NettyMessagingServiceTest$DualInstanceTest` and `NettyMessagingServiceTlsTest` were inconclusive locally (both hang/fail identically against unmodified `stable/8.6` too, tied to this machine's hostname resolution, not to this change) - CI is the real signal for those two.

## Note

This branch was cut before #61931 (CI unblock for the runner-image regression) merged. CI on this PR is expected red until that lands.

## Links

Closes #61975
