### PR TITLE
docs: load-test: document what should be done for new releases

### DIFF
--- a/.claude/skills/new-stable-load-test
+++ b/.claude/skills/new-stable-load-test
@@ -1,0 +1,1 @@
+../../load-tests/skills/new-stable-load-test

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -6,11 +6,11 @@ For background on goals and test variants, see the [reliability testing document
 
 ## Directory Layout
 
-|   Directory    |                                                            Description                                                            |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `setup/`       | Makefiles, shell scripts, and Helm values for deploying load tests ([README](setup/README.md))                                    |
-| `load-tester/` | Java load test applications (starters and workers) ([README](load-tester/README.md))                                              |
-| `docs/`        | Additional documentation: [metrics](docs/metrics.md), [scripts](docs/scripts/README.md), [past failures](docs/failures/README.md) |
+|   Directory    |                                                                                         Description                                                                                         |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `setup/`       | Makefiles, shell scripts, and Helm values for deploying load tests ([README](setup/README.md))                                                                                              |
+| `load-tester/` | Java load test applications (starters and workers) ([README](load-tester/README.md))                                                                                                        |
+| `docs/`        | Additional documentation: [metrics](docs/metrics.md), [scripts](docs/scripts/README.md), [past failures](docs/failures/README.md), [new stable branch checklist](docs/new-stable-branch.md) |
 
 ## Quick Start
 

--- a/load-tests/docs/new-stable-branch.md
+++ b/load-tests/docs/new-stable-branch.md
@@ -1,0 +1,189 @@
+# New Stable Branch Checklist
+
+This document lists the steps to take after you cut a new stable branch (for example
+`stable/8.10` from `main`).
+
+Without these steps, the new branch keeps testing the `main` configuration. The cross-branch
+schedulers on `main` do not know about the new branch.
+
+See [issue #60970](https://github.com/camunda/camunda/issues/60970) for the background. See the
+[reference PRs](#reference-prs) below for a full example (8.10).
+
+This document interpolates the following variables:
+
+|     Variable      |                                       Description                                        |    Example    |    Shape     |
+|-------------------|------------------------------------------------------------------------------------------|---------------|--------------|
+| `$VERSION`        | The stable version number                                                                | `8.10`        | `X.Y`        |
+| `$VERSION_BRANCH` | The branch name for this version                                                         | `stable/8.10` | `stable/X.Y` |
+| `$VERSION_FOLDER` | The *load test* folder name (in `load-tests/setup`) for this version                     | `stable-810`  | `stable-XY`  |
+| `$VERSION_TAG`    | A short safe name to be used in identifier. Only use alphanumerical and dash characters. | `8-10`        | `X-Y`        |
+
+## On the new stable branch
+
+Do these steps right after you cut the branch.
+
+### Point workflows at the branch itself
+
+In [`camunda-load-test.yml`](../../.github/workflows/camunda-load-test.yml) and
+[`camunda-release-load-test.yaml`](../../.github/workflows/camunda-release-load-test.yaml):
+
+- Change the `ref` default from `main` to `$VERSION_BRANCH`
+- Remove the `target-version` input  (`main` tests several setup versions through a matrix. A stable branch tests only one version.)
+- In the `newLoadTest.sh --target-version` call, hardcode the value to `$VERSION_FOLDER`
+
+**Example:** [PR #60997](https://github.com/camunda/camunda/pull/60997):
+[`camunda-load-test.yml`](https://github.com/camunda/camunda/blob/caef873789e668e37495d822791fa16fe25c3c42/.github/workflows/camunda-load-test.yml#L29)
+and
+[`camunda-release-load-test.yaml`](https://github.com/camunda/camunda/blob/caef873789e668e37495d822791fa16fe25c3c42/.github/workflows/camunda-release-load-test.yaml#L113)
+ref defaults, and the
+[`newLoadTest.sh --target-version` call](https://github.com/camunda/camunda/blob/caef873789e668e37495d822791fa16fe25c3c42/.github/workflows/camunda-load-test.yml#L575).
+
+**Result:** the branch's own load-test workflow run triggers using the single hardcoded version,
+not the `main` matrix.
+
+### Fetch the setup files from main at runtime
+
+The folder
+[`load-tests/setup/$VERSION_FOLDER`](https://github.com/camunda/camunda/tree/main/load-tests/setup)
+lives only on `main` (see [On `main`](#on-main) below). In
+[`camunda-load-test.yml`](../../.github/workflows/camunda-load-test.yml):
+
+- Add a `sparse-checkout` step to the job that renders the setup.
+- Set `ref: main` on that step.
+- Check out [`load-tests/`](https://github.com/camunda/camunda/tree/main/load-tests),
+  [`.github`](https://github.com/camunda/camunda/tree/main/.github), and
+  [`.tool-versions`](https://github.com/camunda/camunda/blob/main/.tool-versions).
+
+**Example:** [PR #60997](https://github.com/camunda/camunda/pull/60997):
+[`camunda-load-test.yml`](https://github.com/camunda/camunda/blob/caef873789e668e37495d822791fa16fe25c3c42/.github/workflows/camunda-load-test.yml#L538-L545).
+
+### Delete the branch's own setup folder
+
+- The branch no longer needs `load-tests/setup/`: delete this folder.
+- Update [`load-tests/README.md`](../README.md) with:
+
+  ```
+  > [!CAUTION]
+  > The `setup` folder in the branch `$VERSION_BRANCH` does not exist.
+  > To deploy a load test for the Camunda Platform $VERSION, use the `$VERSION_FOLDER` folder from the `main` branch instead.
+  ```
+
+**Example:** [PR #61295](https://github.com/camunda/camunda/pull/61295):
+[`load-tests/setup/`](https://github.com/camunda/camunda/tree/343b6cd748a93247989864da294360e0eb2e7823/load-tests/setup)
+as it looked right before removal, and the
+[`load-tests/README.md` note](https://github.com/camunda/camunda/blob/eecf96d57a026913d44986d8b5a49d8e3751e067/load-tests/README.md#L14-L16).
+
+**Result:** nothing in the branch's workflow files still references the removed
+`load-tests/setup/` path.
+
+### Delete workflows that only apply to main
+
+These workflows coordinate tests across all branches. A copy on the stable branch serves no
+purpose.
+
+- Delete
+  [`camunda-load-test-smoke-dispatch.yml`](../../.github/workflows/camunda-load-test-smoke-dispatch.yml).
+  This workflow dispatches smoke tests for every setup version changed in a PR. The branch has
+  only one version, so it does not need this.
+- Delete
+  [`camunda-scheduled-release-load-tests.yml`](../../.github/workflows/camunda-scheduled-release-load-tests.yml).
+  This is the cross-branch release-test scheduler.
+- Simplify [`camunda-load-test-smoke.yml`](../../.github/workflows/camunda-load-test-smoke.yml).
+  Trigger it directly on `pull_request` and `workflow_dispatch`. Remove the `target-version`
+  input.
+
+**Example:** [PR #60997](https://github.com/camunda/camunda/pull/60997):
+[`camunda-load-test-smoke-dispatch.yml`](https://github.com/camunda/camunda/blob/15d5eb12ed80512d6f368bf7dbe0bce4e770c336/.github/workflows/camunda-load-test-smoke-dispatch.yml)
+and
+[`camunda-scheduled-release-load-tests.yml`](https://github.com/camunda/camunda/blob/15d5eb12ed80512d6f368bf7dbe0bce4e770c336/.github/workflows/camunda-scheduled-release-load-tests.yml)
+as they looked right before removal, and the
+[`camunda-load-test-smoke.yml` simplification](https://github.com/camunda/camunda/blob/caef873789e668e37495d822791fa16fe25c3c42/.github/workflows/camunda-load-test-smoke.yml#L10-L27).
+
+### Drop the unused CI jobs
+
+In [`ci.yml`](../../.github/workflows/ci.yml):
+
+- Remove `load-test-golden-tests` and `load-test-helm-lockfile`. These jobs test the deleted
+  `load-tests/setup/` folder.
+- Remove their entries from any `needs:` lists.
+
+**Example:** [PR #61295](https://github.com/camunda/camunda/pull/61295):
+[`ci.yml`](https://github.com/camunda/camunda/blob/343b6cd748a93247989864da294360e0eb2e7823/.github/workflows/ci.yml#L242-L322)
+as it looked right before removal.
+
+**Result:** nothing in `ci.yml` still references the removed `load-tests/setup/` path.
+
+## On `main`
+
+### Add the setup folder
+
+- Add a `load-tests/setup/$VERSION_FOLDER` folder.
+- Copy
+  [`load-tests/setup/main/`](https://github.com/camunda/camunda/tree/main/load-tests/setup/main)
+  as a starting point.
+
+**Example:** [PR #60980](https://github.com/camunda/camunda/pull/60980):
+[`load-tests/setup/stable-810`](https://github.com/camunda/camunda/tree/580faf8a8e8627f7034146b531a6d0c2a8125529/load-tests/setup/stable-810).
+
+### Add the branch to the weekly load tests
+
+In [`camunda-weekly-load-tests.yml`](../../.github/workflows/camunda-weekly-load-tests.yml):
+
+- Add a job that calls `camunda-load-test.yml@$VERSION_BRANCH` through a cross-branch `uses:`. Match
+  the existing `weekly-$VERSION_TAG` jobs.
+- Add the new job to the `notify` job's `needs:` list, so a failure still triggers the Slack
+  notification.
+
+This step needs no later backport. Each stable branch's own copy of `camunda-load-test.yml`
+already fetches its own `$VERSION_FOLDER` setup folder from `main`.
+
+**Example:** [PR #61511](https://github.com/camunda/camunda/pull/61511):
+[the new jobs](https://github.com/camunda/camunda/blob/43292fc30aec697f880b1f23be1491e7f90a1d2e/.github/workflows/camunda-weekly-load-tests.yml#L273-L311)
+and the
+[`notify` job's `needs:` list](https://github.com/camunda/camunda/blob/43292fc30aec697f880b1f23be1491e7f90a1d2e/.github/workflows/camunda-weekly-load-tests.yml#L316-L325).
+
+**Result:** the new job is present in the workflow file and included in the `notify` job's
+`needs:` list. It only actually runs on the next scheduled trigger.
+
+### Add the branch to the scheduled release load tests
+
+In
+[`camunda-scheduled-release-load-tests.yml`](../../.github/workflows/camunda-scheduled-release-load-tests.yml):
+
+- Add a `release-load-test-$VERSION_TAG` job. Pin it to the branch's current patch tag.
+  **Note**: this current patch tag can still be an *alpha* version when the stable branch is created.
+- Add the matching `verify-and-cleanup-$VERSION_TAG` job.
+- Add `verify-and-cleanup-$VERSION_TAG` to the `notify-on-success` and `notify-on-failure` jobs' `needs:`
+  lists and to their `if:` success/failure conditions.
+- Add the branch to the Slack "Tested versions" message in both notifications.
+
+**Example:** [PR #61002](https://github.com/camunda/camunda/pull/61002):
+[`release-load-test-8-10`](https://github.com/camunda/camunda/blob/ef9285267a5556b6f16bd8bb74e263dffb8defc6/.github/workflows/camunda-scheduled-release-load-tests.yml#L62-L68),
+[`verify-and-cleanup-8-10`](https://github.com/camunda/camunda/blob/ef9285267a5556b6f16bd8bb74e263dffb8defc6/.github/workflows/camunda-scheduled-release-load-tests.yml#L110-L117),
+[`notify-on-success`](https://github.com/camunda/camunda/blob/ef9285267a5556b6f16bd8bb74e263dffb8defc6/.github/workflows/camunda-scheduled-release-load-tests.yml#L131-L143),
+and
+[`notify-on-failure`](https://github.com/camunda/camunda/blob/ef9285267a5556b6f16bd8bb74e263dffb8defc6/.github/workflows/camunda-scheduled-release-load-tests.yml#L202-L214).
+
+**Result:** the new jobs are present in the workflow file and included in the
+`notify-on-success` and `notify-on-failure` jobs' `needs:` lists and `if:` conditions. They only
+actually run on the next scheduled trigger.
+
+### Update the release tag
+
+`main` no longer tracks the branched-off version. Bump the `release-load-test-main` tag to the
+next alpha line (for example `8.11.0-alphaN`).
+
+## Reference PRs
+
+- [PR #60997](https://github.com/camunda/camunda/pull/60997): points `stable/8.10`'s own
+  workflows at itself. Adds the sparse checkout of `main`'s setup folder.
+- [PR #61295](https://github.com/camunda/camunda/pull/61295): removes the unused
+  `load-tests/setup/` folder and its CI jobs from `stable/8.10`.
+- [PR #60980](https://github.com/camunda/camunda/pull/60980): adds the
+  `load-tests/setup/stable-810` folder on `main`.
+- [PR #61511](https://github.com/camunda/camunda/pull/61511): adds `stable/8.7`, `8.8`, and
+  `8.9` to `main`'s weekly load tests. `stable/8.10` follows the same pattern.
+- [PR #61002](https://github.com/camunda/camunda/pull/61002): adds `stable/8.10`'s
+  `release-load-test-8-10` and `verify-and-cleanup-8-10` jobs to `main`'s scheduled release load
+  tests.
+

--- a/load-tests/skills/new-stable-load-test/SKILL.md
+++ b/load-tests/skills/new-stable-load-test/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: new-stable-load-test
+description: Configures a new Camunda stable branch into the load test workflows.
+---
+
+# Configuring load test for a new stable branch
+
+The full step-by-step checklist to configure a newly `stable/X.Y` branch into
+the load test workflows, with linked reference PRs for every step, lives in
+[`load-tests/docs/new-stable-branch.md`](../../load-tests/docs/new-stable-branch.md).
+
+Use this skill when a new `stable/X.Y` branch was just branched off the `main`
+branch and the new branch needs to be reconfigured to run as a "stable" branch,
+rather than as the "main" branch.
+
+## Naming conventions
+
+The doc uses different variables to reference the new stable branch version, in different contexts.
+Make sure to interpolate these variables with the correct values.
+
+## How to proceed
+
+1. Read `load-tests/docs/new-stable-branch.md` in full before making any change. It lists the
+   exact files to edit, in order, split into different sections. Each section states the
+   observable result to check before moving on to the next one — the doc itself only states the
+   file to change, not the effect, so verify against that stated result rather than the diff alone.
+2. ["On the new stable branch"](../../../load-tests/docs/new-stable-branch.md#on-the-new-stable-branch)
+   and ["On `main`"](../../../load-tests/docs/new-stable-branch.md#on-main) are two independent
+   changes against two different base branches. Open them as two separate PRs;
+   they can be done in either order.
+3. Use the linked reference PRs in the doc as the template for each change: they show the exact
+   diff shape for that step on a prior branch (8.10). Those links pin an old commit — confirm the
+   referenced file/line still exists in the current version before matching
+   against it. The code from the `main` branch may also have changed since
+   these reference PRs.


### PR DESCRIPTION
## Description

Document the steps we had to do when creating the stable branch for `stable/8.10`.

There is room for improvements, but this is the current status.

Closes: https://github.com/camunda/camunda/issues/60970

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->


* https://github.com/camunda/camunda/issues/60970