### PR TITLE
ci: load-test: remove "test-type" option while profiling

### DIFF
--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -152,8 +152,6 @@ jobs:
     secrets: inherit
     with:
       name: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}
-      pod: ''
-      test-type: ${{ needs.sanitize-branch-name.outputs.storage-type }}
 
   resolve-daily-namespace:
     name: Resolve last completed daily-on-main run

--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -6,7 +6,7 @@
 #              to fixed intermediate paths on the pod -- profiling the same pod with two
 #              events at once would collide.
 #              Uploads flamegraph artifacts named
-#              flamegraph-{test-type}-{event}-{pod}-{date}.
+#              {name-prefix}{pod}, where name-prefix defaults to flamegraph-{name}-{date}-.
 # called-by: camunda-pr-load-test.yml, stress-load-test.yml (itself called by
 #            camunda-daily-load-tests.yml)
 # type: CI
@@ -28,10 +28,6 @@ on:
         description: 'Optional additional flags for async-profiler (e.g., "-t" for flamegraph format)'
         default: ''
         required: false
-      test-type:
-        description: 'Short label identifying the calling test/database variant (e.g. "grpc", "rest", "elasticsearch", "opensearch"), used to disambiguate artifact/file names when multiple variants run in the same workflow.'
-        required: true
-        type: string
       duration-seconds:
         description: 'Profiling duration in seconds'
         default: '100'
@@ -51,10 +47,6 @@ on:
         description: 'Optional additional flags for async-profiler (e.g., "-t" for flamegraph format)'
         default: ''
         required: false
-        type: string
-      test-type:
-        description: 'Short label identifying the calling test/database variant (e.g. "grpc", "rest", "elasticsearch", "opensearch"), used to disambiguate artifact/file names when multiple variants run in the same workflow.'
-        required: true
         type: string
       duration-seconds:
         description: 'Profiling duration in seconds'
@@ -76,23 +68,25 @@ env:
   NAME: ${{ inputs.name }}
   PROFILER_OPTIONS: ${{ inputs.profiler_options }}
   PROFILING_DURATION: ${{ inputs.duration-seconds }}
-  TEST_TYPE: ${{ inputs.test-type }}
 
 jobs:
-  compute-pods:
-    name: Compute pods matrix
+  init:
+    name: Compute metadata
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
-      pods: ${{ steps.compute.outputs.pods }}
+      pods: ${{ steps.metadata.outputs.pods }}
+      name-prefix: ${{ steps.metadata.outputs.name-prefix }}
     env:
       POD: ${{ inputs.pod }}
     steps:
       # A specific pod (inputs.pod set) becomes the matrix's single entry; otherwise the
       # matrix defaults to all three pods. Every pod in the matrix gets all 3 events (cpu,
-      # wall, alloc) below.
-      - name: Compute pods matrix
-        id: compute
+      # wall, alloc) below. name-prefix is computed once here so every "Profile ..." step
+      # below (across every pod in the matrix) writes its flamegraph with the same prefix,
+      # matching the date in the uploaded artifact name.
+      - name: Compute metadata
+        id: metadata
         run: |
           if [ -n "${POD}" ]; then
             pods=$(jq -cn --arg pod "${POD}" '[$pod]')
@@ -101,9 +95,12 @@ jobs:
           fi
           echo "pods=${pods}" >> "$GITHUB_OUTPUT"
 
+          date="$(date +%Y%m%d)"
+          echo "name-prefix=flamegraph-${NAME}-${date}-" >> "$GITHUB_OUTPUT"
+
   profile:
     name: Profile ${{ matrix.pod }}
-    needs: compute-pods
+    needs: init
     runs-on: ubuntu-latest
     # INVARIANT: timeout-minutes * 60 must stay > duration-seconds * 3, since this job
     # profiles cpu, wall and alloc *sequentially* against its pod (see the matrix comment
@@ -134,7 +131,7 @@ jobs:
         # at the same time would collide (attach failures and/or one event's
         # cleanup deleting files the other event is still using). Events are
         # instead run via separate sequential steps below.
-        pod: ${{ fromJSON(needs.compute-pods.outputs.pods) }}
+        pod: ${{ fromJSON(needs.init.outputs.pods) }}
 
     env:
       POD: ${{ matrix.pod }}
@@ -144,7 +141,7 @@ jobs:
       # Give enough time for a preempted pod to come back, if any.
       PROFILE_RETRY_WAIT_SECONDS: 120
       PROFILE_RETRY_TIMEOUT_MINUTES: 15
-      OUTPUT_DIR: profiling/${{ matrix.pod }}
+      OUTPUT_DIR: profiling/${{ inputs.name }}/${{ matrix.pod }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -172,9 +169,6 @@ jobs:
       - name: Set right namespace
         run: |
           kubectl config set-context --current --namespace="${NAME}"
-      - name: Compute run date
-        id: run-date
-        run: echo "date=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
       # Profiling is best-effort: continue-on-error keeps a permanently-failing event from
       # failing this job, so a single flaky/preempted pod doesn't spuriously fail the whole
@@ -188,7 +182,7 @@ jobs:
           retry_on: error
           retry_wait_seconds: ${{ env.PROFILE_RETRY_WAIT_SECONDS }}
           timeout_minutes: ${{ env.PROFILE_RETRY_TIMEOUT_MINUTES }}
-          command: ./load-tests/docs/scripts/executeProfiling.sh "${POD}" cpu "${PROFILER_OPTIONS}" "${TEST_TYPE}"
+          command: ./load-tests/docs/scripts/executeProfiling.sh --prefix "${{ needs.init.outputs.name-prefix }}" "${POD}" cpu "${PROFILER_OPTIONS}"
       - name: Profile wall on ${{ matrix.pod }}
         continue-on-error: true
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -197,7 +191,7 @@ jobs:
           retry_on: error
           retry_wait_seconds: ${{ env.PROFILE_RETRY_WAIT_SECONDS }}
           timeout_minutes: ${{ env.PROFILE_RETRY_TIMEOUT_MINUTES }}
-          command: ./load-tests/docs/scripts/executeProfiling.sh "${POD}" wall "${PROFILER_OPTIONS}" "${TEST_TYPE}"
+          command: ./load-tests/docs/scripts/executeProfiling.sh --prefix "${{ needs.init.outputs.name-prefix }}" "${POD}" wall "${PROFILER_OPTIONS}"
       - name: Profile alloc on ${{ matrix.pod }}
         continue-on-error: true
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -206,12 +200,12 @@ jobs:
           retry_on: error
           retry_wait_seconds: ${{ env.PROFILE_RETRY_WAIT_SECONDS }}
           timeout_minutes: ${{ env.PROFILE_RETRY_TIMEOUT_MINUTES }}
-          command: ./load-tests/docs/scripts/executeProfiling.sh "${POD}" alloc "${PROFILER_OPTIONS}" "${TEST_TYPE}"
+          command: ./load-tests/docs/scripts/executeProfiling.sh --prefix "${{ needs.init.outputs.name-prefix }}" "${POD}" alloc "${PROFILER_OPTIONS}"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: upload-artifact
         with:
-          name: flamegraph-${{ inputs.test-type }}-${{ matrix.pod }}-${{ steps.run-date.outputs.date }}
+          name: "${{ needs.init.outputs.name-prefix }}${{ matrix.pod }}"
           # The name of the directory in which the profiling output has been written.
           # This is set in executeProfiling.sh.
           path: ${{ env.OUTPUT_DIR }}

--- a/.github/workflows/stress-load-test.yml
+++ b/.github/workflows/stress-load-test.yml
@@ -140,8 +140,6 @@ jobs:
     secrets: inherit
     with:
       name: c8-${{ inputs.name }}
-      pod: ''
-      test-type: ${{ inputs.name }}
       duration-seconds: '600'
 
   # Wait 3 hours, anchored to this variant's own setup completion, before taking its metrics

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -10,8 +10,11 @@ Run executeProfiling.sh with a pod name, optional event type, and optional profi
 **Syntax:**
 
 ```
-./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]
+./executeProfiling.sh [-p|--prefix PREFIX] <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]
 ```
+
+**Options:**
+- `-p`, `--prefix` - Filename prefix for the generated report. Default: `flamegraph-`
 
 **Event Types:**
 - `cpu` - CPU profiling (default)
@@ -33,7 +36,7 @@ Example with CPU profiling (default):
 ...
 Profiling for 100 seconds
 Done
-+ kubectl cp release-8-8-0-alpha6-zeebe-2:/usr/local/camunda/data/flamegraph-cpu-2025-07-11_19-02-52.html release-8-8-0-alpha6-zeebe-2-flamegraph-cpu-2025-07-11_19-02-52.html
++ kubectl cp release-8-8-0-alpha6-zeebe-2:/usr/local/camunda/data/flamegraph-cpu.html release-8-8-0-alpha6-zeebe-2-flamegraph-cpu.html
 tar: Removing leading `/' from member names
 
 ```
@@ -45,7 +48,7 @@ Example with wall clock profiling:
 ...
 Profiling for 100 seconds
 Done
-+ kubectl cp release-8-8-0-alpha6-zeebe-2:/usr/local/camunda/data/flamegraph-wall-2025-07-11_19-05-23.html release-8-8-0-alpha6-zeebe-2-flamegraph-wall-2025-07-11_19-05-23.html
++ kubectl cp release-8-8-0-alpha6-zeebe-2:/usr/local/camunda/data/flamegraph-wall.html release-8-8-0-alpha6-zeebe-2-flamegraph-wall.html
 ```
 
 Example with additional profiler options:

--- a/load-tests/docs/scripts/executeProfiling.sh
+++ b/load-tests/docs/scripts/executeProfiling.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xeu
 # Usage:
-#  ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS] [TEST-TYPE]
-#  PROFILING_DURATION=200 ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS] [TEST-TYPE]
+#  ./executeProfiling.sh [-p|--prefix PREFIX] <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]
+#  PROFILING_DURATION=200 ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]
 #
 # EVENT-TYPE can be:
 #   cpu   - CPU profiling (default)
@@ -9,24 +9,32 @@
 #   alloc - Memory allocation profiling
 # ADDITIONAL-OPTIONS: Optional additional flags to pass to async-profiler (e.g., "-t" to profile threads separately)
 # See https://github.com/async-profiler/async-profiler/blob/master/docs/ProfilerOptions.md for potential options
-# TEST-TYPE: Short label identifying the calling test/database variant (e.g. "grpc", "rest",
-#            "elasticsearch", "opensearch"), included in the output filename to disambiguate
-#            runs. Leave empty to omit it.
+# -p, --prefix: Filename prefix for the generated report (default: flamegraph-)
 #
 # Environment variables:
 #   PROFILING_DURATION - profiling duration in seconds (default: 100)
 set -oxe pipefail
 
-if [ -z "$1" ]; then
+prefix="flamegraph-"
+if [ "${1:-}" = "-p" ] || [ "${1:-}" = "--prefix" ]; then
+  if [ -z "${2:-}" ]; then
+    echo "Error: ${1} requires a value."
+    echo "Usage: ./executeProfiling.sh [-p|--prefix PREFIX] <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]"
+    exit 1
+  fi
+  prefix="$2"
+  shift 2
+fi
+
+if [ -z "${1:-}" ]; then
   echo "Error: Missing required argument <POD-NAME>."
-  echo "Usage: ./executeProfiling.sh <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS] [TEST-TYPE]"
+  echo "Usage: ./executeProfiling.sh [-p|--prefix PREFIX] <POD-NAME> [EVENT-TYPE] [ADDITIONAL-OPTIONS]"
   exit 1
 fi
 pod_name=$1
 
 profiler_event="${2:-cpu}"
 additional_options="${3:-}"
-test_type="${4:-}"
 
 OUTPUT_DIR="${OUTPUT_DIR:-"profiling"}"
 echo "Profiling reports will be saved to $OUTPUT_DIR"
@@ -60,14 +68,7 @@ then
   kubectl exec "$pod_name" -- chmod +x "$containerPath/asprof"
 fi
 
-# Run profiling
-# Build the filename incrementally so an empty test_type doesn't leave behind
-# stray/doubled separators, e.g. flamegraph--cpu-20260710.html.
-filename="flamegraph"
-if [ -n "$test_type" ]; then
-  filename="$filename-$test_type"
-fi
-filename="$filename-$profiler_event-$(date +%Y%m%d).html"
+filename="${prefix}${profiler_event}.html"
 # Extracting the PID:
 #
 #  $ k exec camunda-0 -it -- ps -ax

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -316,7 +316,8 @@ After ~5 min, download flamegraph artifacts:
 gh run download <run-id> --repo camunda/camunda
 ```
 
-Artifact names: `flamegraph-cpu-camunda-0`, `flamegraph-wall-camunda-1`, `flamegraph-alloc-camunda-2`
+Artifact names: one per pod, containing the cpu/wall/alloc reports for that pod, e.g.
+`flamegraph-<name>-<date>-camunda-0`, `flamegraph-<name>-<date>-camunda-1`, `flamegraph-<name>-<date>-camunda-2`
 
 ---
 


### PR DESCRIPTION
## Description

`TEST TYPE` was injected into the filenames produced by the profiling:

1. The name of the variable was confusing, it was more "tag / "name marker" / "name suffix" than an actual "test type"
2. The current code [can fail](https://camunda.slack.com/archives/C0807665N8G/p1788503020508929) due to invalid quoting
3. The usage is inconsistent ("sometimes a protocol, sometimes a storage backend, sometimes a scenario description, and at least once meaningless (`xxx`)") and not super clear (see confusion in [the Slack thread](https://camunda.slack.com/archives/C0807665N8G/p1788503020508929))

The input was added in https://github.com/camunda/camunda/pull/57905 to prevent profiling ran on different namespaces to collide with each other.

The generated artifacts/profiling files are now named after the load test they execute against (also there are less assumptions from the surrounding context on how the files are named):

1. This should keep preventing collisions that were fixed in https://github.com/camunda/camunda/pull/57905
2. When downloaded locally, the profiling files should also be collision-free (unless ran multiple times on the same namespace, but the usage analysis seems to say this doesn't happen. If it does, we can still switch the date to output seconds)

I think providing the namespace name by default is enough and we don't need to expose that option anymore.

Sample run: https://github.com/camunda/camunda/actions/runs/33878003900

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

