### PR TITLE
test: assign dynamic port to WireMock to avoid port collisions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -107,6 +107,7 @@
     <version.snakeyaml>2.7</version.snakeyaml>
     <version.javax>1.3.2</version.javax>
     <version.wiremock>3.13.2</version.wiremock>
+    <version.wiremock-spring-boot>4.2.2</version.wiremock-spring-boot>
     <version.conscrypt>2.5.2</version.conscrypt>
     <version.asm>9.10.1</version.asm>
     <version.testcontainers>2.0.5</version.testcontainers>
@@ -1649,6 +1650,12 @@
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock-standalone</artifactId>
         <version>${version.wiremock}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wiremock.integrations</groupId>
+        <artifactId>wiremock-spring-boot</artifactId>
+        <version>${version.wiremock-spring-boot}</version>
       </dependency>
 
       <!-- Testcontainers & Docker for container based integration tests -->

--- a/testing/camunda-process-test-example/pom.xml
+++ b/testing/camunda-process-test-example/pom.xml
@@ -15,7 +15,6 @@
 
   <properties>
     <version.java>17</version.java>
-    <version.wiremock-spring-boot>4.2.2</version.wiremock-spring-boot>
   </properties>
 
   <dependencies>
@@ -54,7 +53,6 @@
     <dependency>
       <groupId>org.wiremock.integrations</groupId>
       <artifactId>wiremock-spring-boot</artifactId>
-      <version>${version.wiremock-spring-boot}</version>
       <scope>test</scope>
     </dependency>
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
@@ -45,6 +45,8 @@ import org.testcontainers.Testcontainers;
 @WireMockTest(httpPort = 9999)
 public class CamundaProcessTestConnectorsIT {
 
+  private static final int WIREMOCK_PORT = 9999;
+
   // The ID is part of the connector configuration in the BPMN element
   private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
 
@@ -54,7 +56,7 @@ public class CamundaProcessTestConnectorsIT {
           .withConnectorsEnabled(true)
           .withConnectorsSecret(
               "CONNECTORS_URL", "http://connectors:8080/actuator/health/readiness")
-          .withConnectorsSecret("BASE_URL", "http://host.testcontainers.internal:9999");
+          .withConnectorsSecret("BASE_URL", "http://host.testcontainers.internal:" + WIREMOCK_PORT);
 
   // to be injected
   private CamundaClient client;
@@ -62,7 +64,7 @@ public class CamundaProcessTestConnectorsIT {
 
   @BeforeAll
   static void setup() {
-    Testcontainers.exposeHostPorts(9999);
+    Testcontainers.exposeHostPorts(WIREMOCK_PORT);
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
@@ -25,7 +25,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import java.io.IOException;
@@ -37,35 +38,42 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.Testcontainers;
 
-@WireMockTest(httpPort = 9999)
 public class CamundaProcessTestConnectorsIT {
-
-  private static final int WIREMOCK_PORT = 9999;
 
   // The ID is part of the connector configuration in the BPMN element
   private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
 
   @RegisterExtension
-  private static final CamundaProcessTestExtension EXTENSION =
-      new CamundaProcessTestExtension()
-          .withConnectorsEnabled(true)
-          .withConnectorsSecret(
-              "CONNECTORS_URL", "http://connectors:8080/actuator/health/readiness")
-          .withConnectorsSecret("BASE_URL", "http://host.testcontainers.internal:" + WIREMOCK_PORT);
+  @Order(1)
+  private static final WireMockExtension WIREMOCK =
+      WireMockExtension.newInstance()
+          .options(WireMockConfiguration.wireMockConfig().dynamicPort())
+          .configureStaticDsl(true)
+          .build();
 
-  // to be injected
+  @RegisterExtension
+  @Order(2)
+  private static final CamundaProcessTestExtension EXTENSION =
+      new CamundaProcessTestExtension() {
+        @Override
+        public void beforeAll(final ExtensionContext context) {
+          final int wireMockPort = WIREMOCK.getRuntimeInfo().getHttpPort();
+          Testcontainers.exposeHostPorts(wireMockPort);
+          withConnectorsSecret(
+              "CONNECTORS_URL", "http://connectors:8080/actuator/health/readiness");
+          withConnectorsSecret("BASE_URL", "http://host.testcontainers.internal:" + wireMockPort);
+          super.beforeAll(context);
+        }
+      }.withConnectorsEnabled(true);
+
   private CamundaClient client;
   private CamundaProcessTestContext processTestContext;
-
-  @BeforeAll
-  static void setup() {
-    Testcontainers.exposeHostPorts(WIREMOCK_PORT);
-  }
 
   @Test
   void shouldInvokeInAndOutboundConnectors() throws IOException {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
@@ -65,12 +65,12 @@ public class CamundaProcessTestConnectorsIT {
         public void beforeAll(final ExtensionContext context) {
           final int wireMockPort = WIREMOCK.getRuntimeInfo().getHttpPort();
           Testcontainers.exposeHostPorts(wireMockPort);
-          withConnectorsSecret(
-              "CONNECTORS_URL", "http://connectors:8080/actuator/health/readiness");
           withConnectorsSecret("BASE_URL", "http://host.testcontainers.internal:" + wireMockPort);
           super.beforeAll(context);
         }
-      }.withConnectorsEnabled(true);
+      }.withConnectorsEnabled(true)
+          .withConnectorsSecret(
+              "CONNECTORS_URL", "http://connectors:8080/actuator/health/readiness");
 
   private CamundaClient client;
   private CamundaProcessTestContext processTestContext;

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
@@ -40,6 +40,7 @@ import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.Testcontainers;
@@ -59,16 +60,14 @@ public class CamundaProcessTestConnectorsIT {
 
   @RegisterExtension
   @Order(2)
+  private static final BindCamundaProcessTestExtension BIND_EXTENSION =
+      new BindCamundaProcessTestExtension();
+
+  @RegisterExtension
+  @Order(3)
   private static final CamundaProcessTestExtension EXTENSION =
-      new CamundaProcessTestExtension() {
-        @Override
-        public void beforeAll(final ExtensionContext context) {
-          final int wireMockPort = WIREMOCK.getRuntimeInfo().getHttpPort();
-          Testcontainers.exposeHostPorts(wireMockPort);
-          withConnectorsSecret("BASE_URL", "http://host.testcontainers.internal:" + wireMockPort);
-          super.beforeAll(context);
-        }
-      }.withConnectorsEnabled(true)
+      new CamundaProcessTestExtension()
+          .withConnectorsEnabled(true)
           .withConnectorsSecret(
               "CONNECTORS_URL", "http://connectors:8080/actuator/health/readiness");
 
@@ -159,5 +158,16 @@ public class CamundaProcessTestConnectorsIT {
         .hasVariable("status", "okay");
 
     verify(getRequestedFor(urlEqualTo("/test")));
+  }
+
+  private static final class BindCamundaProcessTestExtension implements BeforeAllCallback {
+
+    @Override
+    public void beforeAll(final ExtensionContext context) {
+      final int wireMockPort = WIREMOCK.getRuntimeInfo().getHttpPort();
+      Testcontainers.exposeHostPorts(wireMockPort);
+      EXTENSION.withConnectorsSecret(
+          "BASE_URL", "http://host.testcontainers.internal:" + wireMockPort);
+    }
   }
 }

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -137,8 +137,8 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <groupId>org.wiremock.integrations</groupId>
+      <artifactId>wiremock-spring-boot</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -168,8 +168,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <groupId>org.wiremock.integrations</groupId>
+      <artifactId>wiremock-spring-boot</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -213,6 +213,9 @@
           <execution>
             <id>analyze-dependencies</id>
             <configuration>
+              <ignoredUsedUndeclaredDependencies combine.children="append">
+                <dep>org.wiremock:wiremock</dep>
+              </ignoredUsedUndeclaredDependencies>
               <ignoredNonTestScopedDependencies combine.children="append">
                 <dep>org.awaitility:awaitility</dep>
                 <dep>org.apache.httpcomponents.client5:httpclient5</dep>

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.api;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -25,7 +26,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import java.io.IOException;
@@ -37,34 +39,50 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.testcontainers.Testcontainers;
 
-@WireMockTest(httpPort = 10000)
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {
       "io.camunda.process.test.connectors-enabled=true",
       "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness",
-      "io.camunda.process.test.connectors-secrets.BASE_URL=http://host.testcontainers.internal:10000"
+      "io.camunda.process.test.connectors-secrets.BASE_URL=http://host.testcontainers.internal:${cpt.wiremock.port}"
     })
 @CamundaSpringProcessTest
 public class CamundaSpringProcessTestConnectorsIT {
 
-  private static final int WIREMOCK_PORT = 10000;
+  private static final WireMockServer WIREMOCK =
+      new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+
+  static {
+    WIREMOCK.start();
+    configureFor("localhost", WIREMOCK.port());
+    System.setProperty("cpt.wiremock.port", Integer.toString(WIREMOCK.port()));
+  }
 
   // The ID is part of the connector configuration in the BPMN element
   private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
 
+  @Value("${cpt.wiremock.port}")
+  private int wireMockPort;
+
   @Autowired private CamundaClient client;
   @Autowired private CamundaProcessTestContext processTestContext;
 
-  @BeforeAll
-  static void setup() {
-    Testcontainers.exposeHostPorts(WIREMOCK_PORT);
+  @BeforeEach
+  void setup() {
+    Testcontainers.exposeHostPorts(wireMockPort);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    WIREMOCK.stop();
   }
 
   @Test

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -18,13 +18,13 @@ package io.camunda.process.test.api;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import java.io.IOException;
@@ -36,19 +36,21 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.Testcontainers;
+import org.wiremock.spring.EnableWireMock;
 
+@EnableWireMock
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {
       "io.camunda.process.test.connectors-enabled=true",
-      "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness"
+      "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness",
+      "io.camunda.process.test.connectors-secrets.BASE_URL=http://host.testcontainers.internal:${wiremock.server.port}"
     })
 @CamundaSpringProcessTest
 public class CamundaSpringProcessTestConnectorsIT {
@@ -56,26 +58,16 @@ public class CamundaSpringProcessTestConnectorsIT {
   // The ID is part of the connector configuration in the BPMN element
   private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
 
-  private static final WireMockServer WIREMOCK =
-      new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
-
-  @DynamicPropertySource
-  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
-    WIREMOCK.start();
-    final int wireMockPort = WIREMOCK.port();
-    Testcontainers.exposeHostPorts(wireMockPort);
-    registry.add(
-        "io.camunda.process.test.connectors-secrets.BASE_URL",
-        () -> "http://host.testcontainers.internal:" + wireMockPort);
-  }
-
-  @AfterAll
-  static void tearDown() {
-    WIREMOCK.stop();
-  }
+  @Value("${wiremock.server.port}")
+  private int wireMockPort;
 
   @Autowired private CamundaClient client;
   @Autowired private CamundaProcessTestContext processTestContext;
+
+  @BeforeEach
+  void exposeWireMockPort() {
+    Testcontainers.exposeHostPorts(wireMockPort);
+  }
 
   @Test
   void shouldInvokeInAndOutboundConnectors() throws IOException {
@@ -131,7 +123,7 @@ public class CamundaSpringProcessTestConnectorsIT {
   @Test
   void shouldInvokeOutboundConnectors() {
     // given
-    WIREMOCK.stubFor(
+    stubFor(
         get(urlPathMatching("/test"))
             .willReturn(
                 aResponse()
@@ -160,6 +152,6 @@ public class CamundaSpringProcessTestConnectorsIT {
         .hasCompletedElements(byName("Mocked Outbound Connector"))
         .hasVariable("status", "okay");
 
-    WIREMOCK.verify(getRequestedFor(urlEqualTo("/test")));
+    verify(getRequestedFor(urlEqualTo("/test")));
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -16,13 +16,10 @@
 package io.camunda.process.test.api;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,19 +37,18 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.Testcontainers;
 
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {
       "io.camunda.process.test.connectors-enabled=true",
-      "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness",
-      "io.camunda.process.test.connectors-secrets.BASE_URL=http://host.testcontainers.internal:${cpt.wiremock.port}"
+      "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness"
     })
 @CamundaSpringProcessTest
 public class CamundaSpringProcessTestConnectorsIT {
@@ -60,30 +56,26 @@ public class CamundaSpringProcessTestConnectorsIT {
   private static final WireMockServer WIREMOCK =
       new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
 
-  static {
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
     WIREMOCK.start();
-    configureFor("localhost", WIREMOCK.port());
-    System.setProperty("cpt.wiremock.port", Integer.toString(WIREMOCK.port()));
-  }
-
-  // The ID is part of the connector configuration in the BPMN element
-  private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
-
-  @Value("${cpt.wiremock.port}")
-  private int wireMockPort;
-
-  @Autowired private CamundaClient client;
-  @Autowired private CamundaProcessTestContext processTestContext;
-
-  @BeforeEach
-  void setup() {
+    final int wireMockPort = WIREMOCK.port();
     Testcontainers.exposeHostPorts(wireMockPort);
+    registry.add(
+        "io.camunda.process.test.connectors-secrets.BASE_URL",
+        () -> "http://host.testcontainers.internal:" + wireMockPort);
   }
 
   @AfterAll
   static void tearDown() {
     WIREMOCK.stop();
   }
+
+  // The ID is part of the connector configuration in the BPMN element
+  private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
+
+  @Autowired private CamundaClient client;
+  @Autowired private CamundaProcessTestContext processTestContext;
 
   @Test
   void shouldInvokeInAndOutboundConnectors() throws IOException {
@@ -139,7 +131,7 @@ public class CamundaSpringProcessTestConnectorsIT {
   @Test
   void shouldInvokeOutboundConnectors() {
     // given
-    stubFor(
+    WIREMOCK.stubFor(
         get(urlPathMatching("/test"))
             .willReturn(
                 aResponse()
@@ -168,6 +160,6 @@ public class CamundaSpringProcessTestConnectorsIT {
         .hasCompletedElements(byName("Mocked Outbound Connector"))
         .hasVariable("status", "okay");
 
-    verify(getRequestedFor(urlEqualTo("/test")));
+    WIREMOCK.verify(getRequestedFor(urlEqualTo("/test")));
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -43,16 +43,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.testcontainers.Testcontainers;
 
-@WireMockTest(httpPort = 9999)
+@WireMockTest(httpPort = 10000)
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {
       "io.camunda.process.test.connectors-enabled=true",
       "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness",
-      "io.camunda.process.test.connectors-secrets.BASE_URL=http://host.testcontainers.internal:9999"
+      "io.camunda.process.test.connectors-secrets.BASE_URL=http://host.testcontainers.internal:10000"
     })
 @CamundaSpringProcessTest
 public class CamundaSpringProcessTestConnectorsIT {
+
+  private static final int WIREMOCK_PORT = 10000;
 
   // The ID is part of the connector configuration in the BPMN element
   private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
@@ -62,7 +64,7 @@ public class CamundaSpringProcessTestConnectorsIT {
 
   @BeforeAll
   static void setup() {
-    Testcontainers.exposeHostPorts(9999);
+    Testcontainers.exposeHostPorts(WIREMOCK_PORT);
   }
 
   @Test

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -53,6 +53,9 @@ import org.testcontainers.Testcontainers;
 @CamundaSpringProcessTest
 public class CamundaSpringProcessTestConnectorsIT {
 
+  // The ID is part of the connector configuration in the BPMN element
+  private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
+
   private static final WireMockServer WIREMOCK =
       new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
 
@@ -70,9 +73,6 @@ public class CamundaSpringProcessTestConnectorsIT {
   static void tearDown() {
     WIREMOCK.stop();
   }
-
-  // The ID is part of the connector configuration in the BPMN element
-  private static final String INBOUND_CONNECTOR_ID = "941c5492-ab2b-4305-aa18-ac86991ff4ca";
 
   @Autowired private CamundaClient client;
   @Autowired private CamundaProcessTestContext processTestContext;


### PR DESCRIPTION
## Description
The Java and Spring connector integration tests both bind WireMock to port 9999. When the test tasks run concurrently (with `-T 2` for example), the second test class fails during initialization before exercising any connector behavior.

Assign the Spring connector test its own fixed host port and use that value consistently for the connector configuration and Testcontainers host-port exposure. This keeps the tests isolated without coupling correctness to build-tool scheduling.

<!-- Describe the goal and purpose of this PR. -->
discovered in #52869

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->


- [X] This PR does not need a linked issue

