### PR TITLE
test: isolate exporter authentication test configuration

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -29,7 +29,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class CamundaExporterAuthenticationIT {
 
   private static final String ELASTIC_PASSWORD = "PASSWORD";
-  private static final ExporterConfiguration CONFIG = new ExporterConfiguration();
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
@@ -37,15 +36,16 @@ public class CamundaExporterAuthenticationIT {
           .withPassword(ELASTIC_PASSWORD)
           .withEnv("xpack.security.enabled", "true");
 
+  private final ExporterConfiguration config = new ExporterConfiguration();
   private final ProtocolFactory factory = new ProtocolFactory();
   private final ExporterTestController controller = new ExporterTestController();
 
   @BeforeEach
   void beforeEach() throws IOException {
-    CONFIG.getConnect().setUsername("elastic");
-    CONFIG.getConnect().setPassword(ELASTIC_PASSWORD);
-    CONFIG.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-    createSchemas(CONFIG);
+    config.getConnect().setUsername("elastic");
+    config.getConnect().setPassword(ELASTIC_PASSWORD);
+    config.getConnect().setUrl(CONTAINER.getHttpHostAddress());
+    createSchemas(config);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class CamundaExporterAuthenticationIT {
 
     final var context =
         new ExporterTestContext()
-            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
+            .setConfiguration(new ExporterTestConfiguration<>("elastic", config));
 
     // when
     exporter.configure(context);
@@ -68,11 +68,11 @@ public class CamundaExporterAuthenticationIT {
   void shouldFailToAuthenticateForWrongCredentials() {
     // given
     final var exporter = new CamundaExporter();
-    CONFIG.getConnect().setPassword("123");
+    config.getConnect().setPassword("123");
 
     final var context =
         new ExporterTestContext()
-            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
+            .setConfiguration(new ExporterTestConfiguration<>("elastic", config));
 
     // when
     exporter.configure(context);


### PR DESCRIPTION
## Description
The authentication integration tests mutate a shared static ExporterConfiguration while exercising valid and invalid credentials. When JUnit runs methods concurrently, the invalid password can reach the valid test's schema setup or exporter startup and produce misleading 401 failures.

Use an instance-scoped configuration so JUnit's default per-method test lifecycle gives each scenario independent mutable state while retaining shared container setup.

Discovered in #52869

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

- [X] This PR does not need a linked issue

