### PR TITLE
test: skip Process Instance Filters due to bug 62004, 60856 pending

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceHistory.spec.ts
@@ -71,7 +71,8 @@ test.describe('Process Instance History', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  test('Verify history of instance with an incident', async ({
+  // Skipped due to bug 60856: https://github.com/camunda/camunda/issues/60856
+  test.skip('Verify history of instance with an incident', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -126,7 +126,8 @@ test.describe('Process Instance Variables', () => {
     });
   });
 
-  test('Add variables', async ({
+  // Skipped due to bug 60856: https://github.com/camunda/camunda/issues/60856
+  test.skip('Add variables', async ({
     page,
     operateProcessInstancePage,
     operateHomePage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -336,7 +336,8 @@ test.describe('Process Instances Filters', () => {
     });
   });
 
-  test('Filter process instances by parent key, date range, and error message', async ({
+  // Skipped due to bug 62004: https://github.com/camunda/camunda/issues/62004
+  test.skip('Filter process instances by parent key, date range, and error message', async ({
     page,
     operateProcessesPage,
     operateFiltersPanelPage,
@@ -674,8 +675,7 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.clickResetFilters();
     });
 
-    // Skipped due to bug 62004: https://github.com/camunda/camunda/issues/62004
-    await test.step.skip('Filter by variable and batch operation key and assert results', async () => {
+    await test.step('Filter by variable and batch operation key and assert results', async () => {
       const processToCancelMeowInstance = {
         processInstanceKey: Number(
           (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -674,7 +674,8 @@ test.describe('Process Instances Filters', () => {
       await operateFiltersPanelPage.clickResetFilters();
     });
 
-    await test.step('Filter by variable and batch operation key and assert results', async () => {
+    // Skipped due to bug 62004: https://github.com/camunda/camunda/issues/62004
+    await test.step.skip('Filter by variable and batch operation key and assert results', async () => {
       const processToCancelMeowInstance = {
         processInstanceKey: Number(
           (await createSingleInstance('ProcessToCancel', 1, {sound: 'meow'}))


### PR DESCRIPTION
## Description

This PR skips tests in 

- Process Instance Filters > Filter process instances by parent key, date range, and error message test
- Process Instance History > Verify history of instance with an incident
- Process Instance Variable > Add varaibles

During on demand [workflow run](https://github.com/camunda/camunda/actions/runs/33881730637) noticed new admin UI drift 😫  requires small changes, will handle in [separate PR](https://github.com/camunda/camunda/pull/62031)
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

related #62004, #60856

- [ ] This PR does not need a linked issue

