### PR TITLE
test: close client resources after worker tests

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -103,7 +103,9 @@ final class JobWorkerImplTest {
   // checks that its channel has been released; @AutoClose runs too late for this mixed test.
   @AfterEach
   void tearDown() {
-    client.close();
+    if (client != null) {
+      client.close();
+    }
   }
 
   @BeforeEach
@@ -216,20 +218,21 @@ final class JobWorkerImplTest {
     Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "false");
 
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-    builder.applyEnvironmentVariableOverrides(true).build();
-    final CamundaClient camundaClient =
-        new CamundaClientImpl(builder, channel, GatewayGrpc.newStub(channel));
+    try (final CamundaClient configurationClient =
+            builder.applyEnvironmentVariableOverrides(true).build();
+        final CamundaClient camundaClient =
+            new CamundaClientImpl(builder, channel, GatewayGrpc.newStub(channel))) {
+      final JobWorkerBuilderStep3 jobWorkerBuilderStep3 =
+          camundaClient.newWorker().jobType("test").handler(NOOP_JOB_HANDLER).streamEnabled(true);
 
-    final JobWorkerBuilderStep3 jobWorkerBuilderStep3 =
-        camundaClient.newWorker().jobType("test").handler(NOOP_JOB_HANDLER).streamEnabled(true);
-
-    // when
-    try (final JobWorker ignored = jobWorkerBuilderStep3.open()) {
-      // then
-      Awaitility.await("until a stream is open")
-          .pollInterval(Duration.ofMillis(100))
-          .atMost(Duration.ofSeconds(5))
-          .untilAsserted(() -> assertThat(gateway.openStreams).hasSize(1));
+      // when
+      try (final JobWorker ignored = jobWorkerBuilderStep3.open()) {
+        // then
+        Awaitility.await("until a stream is open")
+            .pollInterval(Duration.ofMillis(100))
+            .atMost(Duration.ofSeconds(5))
+            .untilAsserted(() -> assertThat(gateway.openStreams).hasSize(1));
+      }
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -76,6 +76,7 @@ import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,6 +98,13 @@ final class JobWorkerImplTest {
   private MockedGateway gateway;
   private CamundaClient client;
   private ManagedChannel channel;
+
+  // Keep this explicit teardown so the client closes before the migrated JUnit 4 GrpcCleanupRule
+  // checks that its channel has been released; @AutoClose runs too late for this mixed test.
+  @AfterEach
+  void tearDown() {
+    client.close();
+  }
 
   @BeforeEach
   void setup() throws IOException {
@@ -184,8 +192,6 @@ final class JobWorkerImplTest {
 
     // since stream is enabled then we expect the poll to backoff
     assertThat(gateway.getTimeBetweenLatestPolls()).isGreaterThan(SLOW_POLL_THRESHOLD);
-
-    client.close();
   }
 
   @Test


### PR DESCRIPTION
## Description
JobWorkerImplTest creates its own CamundaClient, so the shared test  rule does not close it after each test. An open worker can continue polling and emit WARN logs while another test is inspecting the same logger.

Close the client in an explicit JUnit 5 teardown before the migrated GrpcCleanupRule checks channel resources. This also keeps cleanup active when a test fails.

Discovered in #52869
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

