### PR TITLE
fix: add zone label to grafana metrics 

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/metrics/ZoneMetricsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/ZoneMetricsConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.metrics;
+
+import io.camunda.configuration.Camunda;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class ZoneMetricsConfiguration {
+
+  private static final String ZONE_TAG = "zone";
+
+  @Bean
+  public MeterRegistryCustomizer<MeterRegistry> zoneMeterRegistryCustomizer(final Camunda camunda) {
+    final var zone = camunda.getCluster().getZone();
+    return registry -> {
+      if (zone != null) {
+        registry.config().commonTags(ZONE_TAG, zone);
+      }
+    };
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/metrics/ZoneMetricsConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/metrics/ZoneMetricsConfigurationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class ZoneMetricsConfigurationTest {
+
+  private final ZoneMetricsConfiguration configuration = new ZoneMetricsConfiguration();
+
+  @Test
+  void shouldApplyConfiguredZoneThroughSpringMeterRegistryCustomization() {
+    // given
+    final var camunda = new Camunda();
+    camunda.getCluster().setZone("zone-a");
+
+    // when / then
+    new ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                MetricsAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class))
+        .withBean(Camunda.class, () -> camunda)
+        .withUserConfiguration(ZoneMetricsConfiguration.class)
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(MeterRegistry.class);
+              final var counter = context.getBean(MeterRegistry.class).counter("test.counter");
+              assertThat(counter.getId().getTag("zone")).isEqualTo("zone-a");
+            });
+  }
+
+  @Test
+  void shouldAddConfiguredZoneToMetrics() {
+    // given
+    final var camunda = new Camunda();
+    camunda.getCluster().setZone("zone-a");
+    final var registry = new SimpleMeterRegistry();
+
+    // when
+    configuration.zoneMeterRegistryCustomizer(camunda).customize(registry);
+    final var counter = registry.counter("test.counter");
+
+    // then
+    assertThat(counter.getId().getTag("zone")).isEqualTo("zone-a");
+  }
+
+  @Test
+  void shouldAddConfiguredZoneToMetricsFromWrappedRegistries() {
+    // given
+    final var camunda = new Camunda();
+    camunda.getCluster().setZone("zone-a");
+    final var registry = new SimpleMeterRegistry();
+    configuration.zoneMeterRegistryCustomizer(camunda).customize(registry);
+    final var brokerRegistry = MicrometerUtil.wrap(registry, Tags.of("nodeId", "zone-a_0"));
+    final var partitionRegistry = MicrometerUtil.wrap(brokerRegistry, Tags.of("partition", "1"));
+
+    // when
+    partitionRegistry.counter("test.counter");
+
+    // then
+    assertThat(registry.get("test.counter").counter().getId().getTag("zone")).isEqualTo("zone-a");
+  }
+
+  @Test
+  void shouldOmitZoneFromMetricsWhenNotConfigured() {
+    // given
+    final var camunda = new Camunda();
+    final var registry = new SimpleMeterRegistry();
+
+    // when
+    configuration.zoneMeterRegistryCustomizer(camunda).customize(registry);
+    final var counter = registry.counter("test.counter");
+
+    // then
+    assertThat(counter.getId().getTag("zone")).isNull();
+  }
+}

--- a/monitor/grafana/zeebe-overview.json
+++ b/monitor/grafana/zeebe-overview.json
@@ -255,11 +255,11 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"} ",
+          "expr": "zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", partition=~\"$partition\", pod=~\"$pod\"} ",
           "format": "table",
           "instant": true,
           "interval": "",
-          "legendFormat": "Partition {{pod}} {{partition}}",
+          "legendFormat": "{{zone}} Partition {{pod}} {{partition}}",
           "refId": "A"
         },
         {
@@ -267,7 +267,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"} ",
+          "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\", partition=~\"$partition\"} ",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -291,6 +291,7 @@
           "options": {
             "include": {
               "names": [
+                "zone",
                 "partition",
                 "pod",
                 "Value #B",
@@ -304,8 +305,9 @@
           "options": {
             "excludeByName": {},
             "indexByName": {
-              "Value": 2,
-              "partition": 1,
+              "Value": 3,
+              "zone": 1,
+              "partition": 2,
               "pod": 0
             },
             "renameByName": {}
@@ -419,12 +421,12 @@
             "uid": "$DS_PROMETHEUS"
           },
           "editorMode": "code",
-          "expr": "1 - kube_pod_container_status_ready{pod=~\"$pod\", cluster=~\"$cluster\", container!~\"curator|curl\", namespace=~\"$namespace\"}",
+          "expr": "1 - kube_pod_container_status_ready{pod=~\"$pod\", cluster=~\"$cluster\", container!~\"curator|curl\", namespace=~\"$namespace\", zone=~\"$zone\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "{{pod}} restart",
+          "legendFormat": "{{zone}} {{pod}} restart",
           "refId": "A"
         }
       ],
@@ -493,13 +495,13 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+          "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\", partition=~\"$partition\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{pod}} p{{partition}} ",
+          "legendFormat": "{{zone}} {{pod}} p{{partition}} ",
           "refId": "A"
         }
       ],
@@ -614,9 +616,9 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", container=\"zeebe\"}",
+          "expr": "kube_pod_container_status_last_terminated_reason{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", container=\"zeebe\"}",
           "interval": "",
-          "legendFormat": "{{ pod }}",
+          "legendFormat": "{{ zone }} {{ pod }}",
           "refId": "A"
         }
       ],
@@ -736,7 +738,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "(sum(rate(zeebe_dropped_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_received_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (partition) ) * 100",
+          "expr": "(sum(rate(zeebe_dropped_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", partition=~\"$partition\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_received_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", partition=~\"$partition\"}[$__rate_interval])) by (partition) ) * 100",
           "interval": "",
           "legendFormat": "Partition {{partition}}",
           "refId": "A"
@@ -814,20 +816,20 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"skipped|processed\"}[$__rate_interval])) by (pod, partition, processor)",
+          "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",partition=~\"$partition\",pod=~\"$pod\", action=~\"skipped|processed\"}[$__rate_interval])) by (zone, pod, partition, processor)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{pod}}-{{partition}}-{{processor}}-processed",
+          "legendFormat": "{{zone}} {{pod}}-{{partition}}-{{processor}}-processed",
           "refId": "A"
         },
         {
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"written\"}[$__rate_interval])) by (pod, partition, processor)",
+          "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",partition=~\"$partition\",pod=~\"$pod\", action=~\"written\"}[$__rate_interval])) by (zone, pod, partition, processor)",
           "interval": "",
-          "legendFormat": "{{pod}}-{{partition}}-{{processor}}-written",
+          "legendFormat": "{{zone}} {{pod}}-{{partition}}-{{processor}}-written",
           "refId": "C"
         }
       ],
@@ -933,7 +935,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", type!=\"PROCESS\", action!=\"activated\"}[$__rate_interval]))",
+          "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\", type!=\"PROCESS\", action!=\"activated\"}[$__rate_interval]))",
           "instant": true,
           "interval": "",
           "legendFormat": "Partition {{partition}} FNI per s",
@@ -1002,12 +1004,12 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum(rate(zeebe_exporter_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (pod, partition, exporter)",
+          "expr": "sum(rate(zeebe_exporter_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (zone, pod, partition, exporter)",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{pod}}-{{partition}}-exported",
+          "legendFormat": "{{zone}} {{pod}}-{{partition}}-exported",
           "refId": "B"
         }
       ],
@@ -1109,7 +1111,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"SERVICE_TASK\"}[$__rate_interval]))",
+          "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"SERVICE_TASK\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{type}} {{action}}",
@@ -1186,7 +1188,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"PROCESS\"}[$__rate_interval]))",
+          "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"PROCESS\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{type}} {{action}}",
@@ -1249,9 +1251,9 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", cluster=~\"$cluster\", namespace=~\"$namespace\", image!=\"\", pod_name=~\"$pod\", container_name!=\"POD\"}[$__rate_interval]))",
+          "expr": "sum by (zone, pod) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", image!=\"\", pod_name=~\"$pod\", container_name!=\"POD\"}[$__rate_interval]))",
           "interval": "",
-          "legendFormat": "{{pod}}",
+          "legendFormat": "{{zone}} {{pod}}",
           "refId": "A"
         }
       ],
@@ -1348,7 +1350,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (method, statusCode)",
+          "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__rate_interval])) by (method, statusCode)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1455,19 +1457,19 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"}",
+          "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",pod=~\"$pod\", container=~\"zeebe.*\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{pod}} RSS",
+          "legendFormat": "{{zone}} {{pod}} RSS",
           "refId": "A"
         },
         {
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"})",
+          "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",pod=~\"$pod\", container=~\"zeebe.*\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "limit",
@@ -1477,7 +1479,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"})",
+          "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",zone=~\"$zone\",pod=~\"$pod\", container=~\"zeebe.*\"})",
           "interval": "",
           "legendFormat": "request",
           "refId": "C"
@@ -1579,7 +1581,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"elastic.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\"elastic.*\"})",
+          "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", persistentvolumeclaim=~\"elastic.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", persistentvolumeclaim=~\"elastic.*\"})",
           "legendFormat": "{{persistentvolumeclaim}}",
           "refId": "B"
         }
@@ -1689,7 +1691,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*zeebe.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", persistentvolumeclaim=~\".*zeebe.*\"})",
+          "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", persistentvolumeclaim=~\".*zeebe.*\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", persistentvolumeclaim=~\".*zeebe.*\"})",
           "legendFormat": "{{persistentvolumeclaim}}",
           "refId": "B"
         }
@@ -1820,7 +1822,34 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
+        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, zone)",
+        "description": "Cluster zone",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "zone",
+        "options": [],
+        "query": {
+          "query": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, zone)",
+          "refId": "Prometheus-zone-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}, pod)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
@@ -1846,14 +1875,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\"}, partition)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "partition",
         "options": [],
         "query": {
-          "query": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+          "query": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\"}, partition)",
           "refId": "Prometheus-partition-Variable-Query"
         },
         "refresh": 2,

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -25,7 +25,7 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "enable": true,
-        "expr": "max(zeebe_cluster_changes_status{zeebe_cluster_changes_status=\"IN_PROGRESS\", namespace=~\"$namespace\", pod=~\"$pod\"}) > 0",
+        "expr": "max(zeebe_cluster_changes_status{zeebe_cluster_changes_status=\"IN_PROGRESS\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) > 0",
         "hide": false,
         "iconColor": "light-blue",
         "name": "Scaling",
@@ -37,7 +37,7 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "enable": true,
-        "expr": "increase(zeebe_cluster_rebalance_elapsed_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__interval]) > 0",
+        "expr": "increase(zeebe_cluster_rebalance_elapsed_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__interval]) > 0",
         "hide": false,
         "iconColor": "purple",
         "name": "Rebalancing",
@@ -49,7 +49,7 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "enable": false,
-        "expr": "zeebe_flow_control_write_rate_maximum{namespace=~\"$namespace\", pod=~\"$pod\"} > zeebe_flow_control_write_rate_limit{namespace=~\"$namespace\", pod=~\"$pod\"}",
+        "expr": "zeebe_flow_control_write_rate_maximum{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"} > zeebe_flow_control_write_rate_limit{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}",
         "hide": false,
         "iconColor": "orange",
         "name": "Throttling",
@@ -174,12 +174,12 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}} ",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}} ",
               "range": false,
               "refId": "A"
             }
@@ -272,7 +272,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (namespace, physicalTenant, partition))\nor sum(max(zeebe_banned_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (namespace, physicalTenant, partition))",
+              "expr": "sum(max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (namespace, physicalTenant, partition))\nor sum(max(zeebe_banned_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (namespace, physicalTenant, partition))",
               "legendFormat": "{{namespace}}",
               "range": true,
               "refId": "A"
@@ -347,7 +347,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_active_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_active_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} Partition-{{partition}}",
               "range": true,
               "refId": "A"
@@ -454,7 +454,7 @@
               "format": "time_series",
               "instant": false,
               "interval": "",
-              "legendFormat": "{{pod}} restart",
+              "legendFormat": "{{zone}} {{pod}} restart",
               "refId": "A"
             }
           ],
@@ -541,7 +541,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (physicalTenant, partition)",
+              "expr": "min(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "instant": true,
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
@@ -643,11 +643,11 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=~\"skipped|processed\"}[$__rate_interval])) by (pod, physicalTenant, partition, processor)",
+              "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=~\"skipped|processed\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition, processor)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}}-{{partition}}-{{processor}}-processed",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}-{{partition}}-{{processor}}-processed",
               "range": true,
               "refId": "A"
             },
@@ -655,9 +655,9 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=~\"written\"}[$__rate_interval])) by (pod, physicalTenant, partition, processor)",
+              "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=~\"written\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition, processor)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}-{{partition}}-{{processor}}-written",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}-{{partition}}-{{processor}}-written",
               "refId": "C"
             }
           ],
@@ -755,11 +755,11 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_exporter_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition, exporter)",
+              "expr": "sum(rate(zeebe_exporter_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition, exporter)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}}-{{partition}}-exported",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}-{{partition}}-exported",
               "refId": "B"
             }
           ],
@@ -856,7 +856,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\") or on(method) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (method)",
+              "expr": "sum(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\") or on(method) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__rate_interval])) by (method)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -869,7 +869,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    method!~\"GET|OPTIONS|HEAD\",\n    namespace=~\"$namespace\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\",\n    uri!~\".*/search.*|.*/statistics.*\",\n  }[$__rate_interval]) != 0\n)",
+              "expr": "sum by (uri, method) (\n  rate(http_server_requests_seconds_count{\n    method!~\"GET|OPTIONS|HEAD\",\n    namespace=~\"$namespace\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|.*/mcp.*\",\n    uri!~\".*/search.*|.*/statistics.*\",\n    zone=~\"$zone\",\n  }[$__rate_interval]) != 0\n)",
               "instant": false,
               "legendFormat": "{{method}}: {{uri}}",
               "range": true,
@@ -952,7 +952,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", type!=\"PROCESS\", action!=\"activated\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", type!=\"PROCESS\", action!=\"activated\", zone=~\"$zone\"}[$__rate_interval]))",
               "instant": true,
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}} FNI per s",
@@ -1053,7 +1053,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (type, action, eventType)",
+              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (type, action, eventType)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}} {{action}} {{eventType}}",
@@ -1133,7 +1133,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"SERVICE_TASK\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"SERVICE_TASK\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}} {{action}}",
@@ -1213,7 +1213,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"PROCESS\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", action=\"completed\", type=\"PROCESS\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}} {{action}}",
@@ -1294,7 +1294,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_archived_process_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_camunda_exporter_archived_process_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}} {{action}}",
@@ -1510,7 +1510,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "(sum(rate(zeebe_dropped_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_received_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition) ) * 100",
+              "expr": "(sum(rate(zeebe_dropped_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_received_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) ) * 100",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -1593,7 +1593,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg(zeebe_flow_control_partition_load{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} > 0)",
+              "expr": "avg(zeebe_flow_control_partition_load{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} > 0)",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -1740,7 +1740,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} RSS",
+              "legendFormat": "{{zone}} {{pod}} RSS",
               "refId": "A"
             },
             {
@@ -1867,7 +1867,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_broker_health_nodes{namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "zeebe_broker_health_nodes{namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": false,
               "legendFormat": "{{path}}",
@@ -1985,7 +1985,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_appended_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) - max by (physicalTenant, partition) (zeebe_stream_processor_last_processed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_appended_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) - max by (physicalTenant, partition) (zeebe_stream_processor_last_processed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -2064,7 +2064,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_commands_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_commands_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "{{le}}",
               "range": true,
@@ -2164,7 +2164,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_stream_processor_batch_processing_retry_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_stream_processor_batch_processing_retry_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -2267,12 +2267,12 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max by (exporter, pod, physicalTenant, partition) (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) - max by (exporter, pod, physicalTenant, partition) (zeebe_exporter_last_updated_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (exporter, zone, pod, physicalTenant, partition) (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) - max by (exporter, zone, pod, physicalTenant, partition) (zeebe_exporter_last_updated_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{exporter}} {{partition}} {{pod}}",
+"legendFormat": "{{physicalTenant}} {{exporter}} {{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -2385,7 +2385,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_stream_processor_error_handling_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} > 0",
+              "expr": "zeebe_stream_processor_error_handling_phase{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} > 0",
               "format": "table",
               "instant": false,
               "legendFormat": "__auto",
@@ -2508,7 +2508,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition) - max (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition)",
+              "expr": "max (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition) - max (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -2635,7 +2635,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (exporter, physicalTenant, partition) (zeebe_exporter_last_updated_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (exporter, physicalTenant, partition) (zeebe_exporter_last_updated_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -2767,7 +2767,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_appended_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_appended_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -2898,7 +2898,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -3033,7 +3033,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition) (zeebe_stream_processor_last_processed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (physicalTenant, partition) (zeebe_stream_processor_last_processed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -3168,7 +3168,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition, pod) (zeebe_replay_last_source_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (physicalTenant, partition, zone, pod) (zeebe_replay_last_source_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -3277,7 +3277,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) - max by (physicalTenant, partition) (zeebe_stream_processor_last_processed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "max by (physicalTenant, partition) (zeebe_log_appender_last_committed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) - max by (physicalTenant, partition) (zeebe_stream_processor_last_processed_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -3406,7 +3406,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition) (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", exporter=\"elasticsearch\"})",
+              "expr": "max by (physicalTenant, partition) (zeebe_exporter_last_exported_position{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", exporter=\"elasticsearch\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -3531,12 +3531,12 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_stream_processor_state{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_stream_processor_state{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}} ",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}} ",
               "range": false,
               "refId": "A"
             }
@@ -3655,12 +3655,12 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_exporter_state{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_exporter_state{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}} ",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}} ",
               "range": false,
               "refId": "A"
             }
@@ -3773,7 +3773,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (namespace, physicalTenant, partition)\nor max(zeebe_banned_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (namespace, physicalTenant, partition)",
+              "expr": "max(zeebe_blacklisted_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (namespace, physicalTenant, partition)\nor max(zeebe_banned_instances_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (namespace, physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} {{namespace}} {{partition}}",
               "range": true,
               "refId": "A"
@@ -3872,12 +3872,12 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_buffered_messages_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition, pod)",
+              "expr": "max(zeebe_buffered_messages_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition, zone, pod)",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} partition:{{partition}} {{pod}}",
+"legendFormat": "{{physicalTenant}} partition:{{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -3975,9 +3975,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_stream_processor_scheduled_command_cache_size{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (pod, physicalTenant, partition, intent)",
+              "expr": "max(zeebe_stream_processor_scheduled_command_cache_size{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition, intent)",
               "instant": false,
-              "legendFormat": "{{physicalTenant}} {{intent}} p{{partition}} {{pod}}",
+              "legendFormat": "{{physicalTenant}} {{intent}} p{{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -4081,7 +4081,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", type=\"PROCESS\"}[$__rate_interval])) by (action)",
+              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", type=\"PROCESS\", zone=~\"$zone\"}[$__rate_interval])) by (action)",
               "format": "table",
               "instant": true,
               "intervalFactor": 1,
@@ -4219,7 +4219,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (action)",
+              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (action)",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -4328,7 +4328,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", type=\"PROCESS\"}[$__rate_interval])) by (action)",
+              "expr": "sum(rate(zeebe_element_instance_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", type=\"PROCESS\", zone=~\"$zone\"}[$__rate_interval])) by (action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Process Instance ({{action}})",
@@ -4339,7 +4339,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (action)",
+              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (action)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Job ({{action}})",
@@ -4439,7 +4439,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (action, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_stream_processor_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (action, physicalTenant, partition)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -4540,11 +4540,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_exporter_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition, pod)",
+              "expr": "sum(rate(zeebe_exporter_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, zone, pod)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} Partition {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Partition {{partition}}",
               "refId": "A"
             }
           ],
@@ -4641,11 +4641,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_replay_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition, pod)",
+              "expr": "sum(rate(zeebe_replay_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, zone, pod)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} Partition {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Partition {{partition}}",
               "refId": "A"
             }
           ],
@@ -4742,7 +4742,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_executed_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"activated\"}[$__rate_interval])) by (namespace)",
+              "expr": "sum(rate(zeebe_executed_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"activated\", zone=~\"$zone\"}[$__rate_interval])) by (namespace)",
               "interval": "",
               "legendFormat": "Process instance creation {{namespace}}",
               "refId": "A"
@@ -4841,7 +4841,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_executed_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"completed\"}[$__rate_interval])) by (namespace)",
+              "expr": "sum(rate(zeebe_executed_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"completed\", zone=~\"$zone\"}[$__rate_interval])) by (namespace)",
               "interval": "",
               "legendFormat": "Process instance completion {{namespace}}",
               "refId": "A"
@@ -4940,7 +4940,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"created\"}[$__rate_interval])) by (namespace)",
+              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"created\", zone=~\"$zone\"}[$__rate_interval])) by (namespace)",
               "interval": "",
               "legendFormat": "Job creation {{namespace}}",
               "refId": "A"
@@ -5039,7 +5039,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"completed\"}[$__rate_interval])) by (namespace)",
+              "expr": "sum(rate(zeebe_job_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", action=\"completed\", zone=~\"$zone\"}[$__rate_interval])) by (namespace)",
               "interval": "",
               "legendFormat": "Job completion {{namespace}}",
               "refId": "A"
@@ -5151,9 +5151,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])",
+              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "refId": "A"
             }
           ],
@@ -5234,7 +5234,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -5246,7 +5246,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -5347,8 +5347,8 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\"}",
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\", zone=~\"$zone\"}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "refId": "A"
             }
           ],
@@ -5428,7 +5428,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_snapshot_file_size_megabytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_file_size_megabytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap!=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "{{le}}",
               "refId": "A"
@@ -5526,9 +5526,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_snapshot_chunks_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", bootstrap!=\"true\"}",
+              "expr": "zeebe_snapshot_chunks_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", bootstrap!=\"true\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}}",
               "refId": "A"
             }
           ],
@@ -5693,7 +5693,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} RSS",
+              "legendFormat": "{{zone}} {{pod}} RSS",
               "range": true,
               "refId": "A"
             },
@@ -5865,11 +5865,11 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "camunda_memory_nmt_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", state=~\"$memory_state\"}",
+              "expr": "camunda_memory_nmt_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", state=~\"$memory_state\", zone=~\"$zone\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} {{type}} {{memory_state}}",
+              "legendFormat": "{{zone}} {{pod}} {{type}} {{memory_state}}",
               "range": true,
               "refId": "A"
             },
@@ -5879,11 +5879,11 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "camunda_memory_nmt_total_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", state=~\"$memory_state\"}",
+              "expr": "camunda_memory_nmt_total_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", state=~\"$memory_state\", zone=~\"$zone\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} {{type}} {{memory_state}}",
+              "legendFormat": "{{zone}} {{pod}} {{type}} {{memory_state}}",
               "range": true,
               "refId": "B"
             }
@@ -5988,10 +5988,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(jvm_memory_bytes_used{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\"}) by (pod)",
+              "expr": "sum(jvm_memory_bytes_used{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\", zone=~\"$zone\"}) by (zone, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} used",
+              "legendFormat": "{{zone}} {{pod}} used",
               "range": true,
               "refId": "C"
             },
@@ -6000,10 +6000,10 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(jvm_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\"}) by (pod)",
+              "expr": "sum(jvm_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\", zone=~\"$zone\"}) by (zone, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} used",
+              "legendFormat": "{{zone}} {{pod}} used",
               "range": true,
               "refId": "D"
             },
@@ -6013,10 +6013,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(jvm_memory_committed_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\"}) by (pod)",
+              "expr": "sum(jvm_memory_committed_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\", zone=~\"$zone\"}) by (zone, pod)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} committed",
+              "legendFormat": "{{zone}} {{pod}} committed",
               "range": true,
               "refId": "E"
             },
@@ -6026,8 +6026,8 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(jvm_memory_max_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", area=\"heap\"}) by (pod)",
-              "legendFormat": "{{pod}} max",
+              "expr": "sum(jvm_memory_max_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", area=\"heap\", zone=~\"$zone\"}) by (zone, pod)",
+              "legendFormat": "{{zone}} {{pod}} max",
               "range": true,
               "refId": "F"
             }
@@ -6124,10 +6124,10 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum (jvm_buffer_pool_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}) by (namespace,pod,pool)",
+              "expr": "sum (jvm_buffer_pool_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}) by (namespace,zone, pod,pool)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Used {{pod}}:{{pool}}",
+              "legendFormat": "Used {{zone}} {{pod}}:{{pool}}",
               "refId": "A"
             },
             {
@@ -6136,10 +6136,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum (jvm_buffer_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}) by (namespace,pod,id)",
+              "expr": "sum (jvm_buffer_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}) by (namespace,zone, pod,id)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Used {{pod}}:{{id}}",
+              "legendFormat": "Used {{zone}} {{pod}}:{{id}}",
               "range": true,
               "refId": "B"
             }
@@ -6234,8 +6234,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(netty_allocator_memory_used{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", allocator_type=\"PooledByteBufAllocator\"}) by (pod)",
-              "legendFormat": "{{pod}}",
+              "expr": "sum(netty_allocator_memory_used{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", allocator_type=\"PooledByteBufAllocator\", zone=~\"$zone\"}) by (zone, pod)",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -6330,8 +6330,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(netty_allocator_memory_used{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", allocator_type=\"UnpooledByteBufAllocator\"}) by (pod)",
-              "legendFormat": "{{pod}}",
+              "expr": "sum(netty_allocator_memory_used{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", allocator_type=\"UnpooledByteBufAllocator\", zone=~\"$zone\"}) by (zone, pod)",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -6430,9 +6430,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(jvm_gc_collection_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (gc, pod)",
+              "expr": "sum(rate(jvm_gc_collection_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (gc, zone, pod)",
               "interval": "",
-              "legendFormat": "{{pod}} {{gc}}",
+              "legendFormat": "{{zone}} {{pod}} {{gc}}",
               "range": true,
               "refId": "A"
             },
@@ -6442,8 +6442,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(jvm_gc_pause_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (gc, pod)",
-              "legendFormat": "{{pod}} {{gc}}",
+              "expr": "sum(rate(jvm_gc_pause_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (gc, zone, pod)",
+              "legendFormat": "{{zone}} {{pod}} {{gc}}",
               "range": true,
               "refId": "B"
             }
@@ -6542,10 +6542,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "rate(jvm_gc_collection_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(jvm_gc_collection_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "instant": false,
               "interval": "",
-              "legendFormat": "{{pod}} {{gc}}",
+              "legendFormat": "{{zone}} {{pod}} {{gc}}",
               "refId": "A"
             },
             {
@@ -6554,10 +6554,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "rate(jvm_gc_pause_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(jvm_gc_pause_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "instant": false,
               "interval": "",
-              "legendFormat": "{{pod}} {{gc}}",
+              "legendFormat": "{{zone}} {{pod}} {{gc}}",
               "refId": "B"
             }
           ],
@@ -6673,7 +6673,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(container_cpu_cfs_throttled_periods_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod) / sum(rate(container_cpu_cfs_periods_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+              "expr": "sum(rate(container_cpu_cfs_throttled_periods_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (zone, pod) / sum(rate(container_cpu_cfs_periods_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (zone, pod)",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -6778,9 +6778,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (pod, container, service) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", container!~\"\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (zone, pod, container, service) (rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\", container!~\"\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
               "interval": "",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -6879,9 +6879,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "jvm_threads_current{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "expr": "jvm_threads_current{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-              "legendFormat": "JVM threads on {{pod}}",
+              "legendFormat": "JVM threads on {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             },
@@ -6890,9 +6890,9 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "jvm_threads_daemon{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "expr": "jvm_threads_daemon{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-              "legendFormat": "JVM daemon threads on {{pod}}",
+              "legendFormat": "JVM daemon threads on {{zone}} {{pod}}",
               "range": true,
               "refId": "B"
             },
@@ -6902,8 +6902,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(jvm_threads_daemon_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)",
-              "legendFormat": "JVM daemon threads on {{pod}}",
+              "expr": "sum(jvm_threads_daemon_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)",
+              "legendFormat": "JVM daemon threads on {{zone}} {{pod}}",
               "range": true,
               "refId": "C"
             },
@@ -6913,8 +6913,8 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(jvm_threads_live_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod) - sum(jvm_threads_daemon_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)",
-              "legendFormat": "JVM threads {{pod}}",
+              "expr": "sum(jvm_threads_live_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod) - sum(jvm_threads_daemon_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)",
+              "legendFormat": "JVM threads {{zone}} {{pod}}",
               "range": true,
               "refId": "E"
             }
@@ -7122,7 +7122,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "ceil(sum by(pod, service, container) (rate(container_fs_reads_total{cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval])))",
+              "expr": "ceil(sum by (zone, pod, service, container) (rate(container_fs_reads_total{cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval])))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -7219,7 +7219,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by(pod, container, service) (rate(container_fs_writes_total{cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval]))",
+              "expr": "sum by (zone, pod, container, service) (rate(container_fs_writes_total{cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval]))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -7340,11 +7340,11 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "process_files_open_files{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}",
+              "expr": "process_files_open_files{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} use fds",
+              "legendFormat": "{{zone}} {{pod}} use fds",
               "refId": "B"
             },
             {
@@ -7352,9 +7352,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "process_files_max_files{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}",
+              "expr": "process_files_max_files{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-              "legendFormat": "{{pod}} limit",
+              "legendFormat": "{{zone}} {{pod}} limit",
               "refId": "A"
             }
           ],
@@ -7551,9 +7551,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(container_fs_reads_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval])) by (pod, service, container)",
+              "expr": "sum(rate(container_fs_reads_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval])) by (zone, pod, service, container)",
               "interval": "",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -7652,9 +7652,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval])) by (pod, service, container)",
+              "expr": "sum(rate(container_fs_writes_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\"}[$__rate_interval])) by (zone, pod, service, container)",
               "interval": "",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -7750,9 +7750,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(container_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, container, service)",
+              "expr": "sum(rate(container_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (zone, pod, container, service)",
               "interval": "",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -7848,9 +7848,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(container_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, container, service)",
+              "expr": "sum(rate(container_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (zone, pod, container, service)",
               "interval": "",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -7946,7 +7946,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or increase(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or increase(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8042,7 +8042,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8155,7 +8155,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (topic, le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (topic, le))",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8169,7 +8169,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (topic, le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (topic, le))",
               "legendFormat": "p90 {{topic}}",
               "range": true,
               "refId": "B"
@@ -8180,7 +8180,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (topic, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (topic, le))",
               "legendFormat": "p99 {{topic}}",
               "range": true,
               "refId": "C"
@@ -8279,7 +8279,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (topic, le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (topic, le))",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8293,7 +8293,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (topic, le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (topic, le))",
               "legendFormat": "p90 {{topic}}",
               "range": true,
               "refId": "B"
@@ -8304,7 +8304,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (topic, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_messaging_request_size_kb_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (topic, le))",
               "legendFormat": "p99 {{topic}}",
               "range": true,
               "refId": "C"
@@ -8401,8 +8401,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_messaging_inflight_requests) by (pod, address)",
-              "legendFormat": "{{pod}} => {{address}} ",
+              "expr": "sum(zeebe_messaging_inflight_requests{zone=~\"$zone\"}) by (zone, pod, address)",
+              "legendFormat": "{{zone}} {{pod}} => {{address}} ",
               "range": true,
               "refId": "A"
             }
@@ -8498,8 +8498,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_messaging_request_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, address, topic)",
-              "legendFormat": "{{topic}}: {{pod}} => {{address}}",
+              "expr": "sum(rate(zeebe_messaging_request_count_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, address, topic)",
+              "legendFormat": "{{topic}}: {{zone}} {{pod}} => {{address}}",
               "range": true,
               "refId": "A"
             }
@@ -8593,7 +8593,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_messaging_response_count_total{namespace=~\"$namespace\", pod=~\"$pod\", outcome!=\"SUCCESS\"}[$__rate_interval])) by (address, topic, outcome)",
+              "expr": "sum(rate(zeebe_messaging_response_count_total{namespace=~\"$namespace\", pod=~\"$pod\", outcome!=\"SUCCESS\", zone=~\"$zone\"}[$__rate_interval])) by (address, topic, outcome)",
               "legendFormat": "{{topic}} {{address}} {{outcome}}",
               "range": true,
               "refId": "A"
@@ -8689,7 +8689,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_messaging_request_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (type)",
+              "expr": "sum(rate(zeebe_messaging_request_count_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (type)",
               "legendFormat": "{{type}}",
               "range": true,
               "refId": "A"
@@ -8783,7 +8783,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "heatmap",
               "fromExploreMetrics": true,
               "interval": "",
@@ -8888,7 +8888,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])))",
+              "expr": "histogram_quantile(0.99,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])))",
               "fromExploreMetrics": true,
               "interval": "",
               "legendFormat": "99th Percentile",
@@ -8902,7 +8902,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.9,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])))",
+              "expr": "histogram_quantile(0.9,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])))",
               "fromExploreMetrics": true,
               "interval": "",
               "legendFormat": "90th Percentile",
@@ -8916,7 +8916,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.5,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])))",
+              "expr": "histogram_quantile(0.5,sum by (le) (rate(starter_data_availability_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])))",
               "fromExploreMetrics": true,
               "interval": "",
               "legendFormat": "50th Percentile",
@@ -9018,7 +9018,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9032,7 +9032,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "interval": "",
               "legendFormat": "quantile-99th",
               "range": true,
@@ -9044,7 +9044,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.5, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))) > 0",
+              "expr": "histogram_quantile(0.5, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))) > 0",
               "instant": false,
               "legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-50th",
               "range": true,
@@ -9056,7 +9056,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.9, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))) > 0",
+              "expr": "histogram_quantile(0.9, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))) > 0",
               "instant": false,
               "legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-90th",
               "range": true,
@@ -9068,7 +9068,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))) > 0",
+              "expr": "histogram_quantile(0.99, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))) > 0",
               "instant": false,
               "legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-99th",
               "range": true,
@@ -9152,7 +9152,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_job_activation_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_job_activation_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9166,7 +9166,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_job_activation_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_job_activation_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -9250,7 +9250,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_job_life_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_job_life_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9264,7 +9264,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_job_life_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_job_life_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -9349,7 +9349,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or increase(zeebe_stream_processor_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or increase(zeebe_stream_processor_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9451,7 +9451,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, valueType, intent))",
+              "expr": "histogram_quantile(0.50, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, valueType, intent))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9464,7 +9464,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, valueType, intent))",
+              "expr": "histogram_quantile(0.90, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, valueType, intent))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9478,7 +9478,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, valueType, intent))",
+              "expr": "histogram_quantile(0.99, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, valueType, intent))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9564,7 +9564,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9648,7 +9648,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_replay_event_batch_replay_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or increase(zeebe_replay_event_batch_replay_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_replay_event_batch_replay_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or increase(zeebe_replay_event_batch_replay_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9733,7 +9733,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_feel_expression_evaluation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(zeebe_feel_expression_evaluation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9819,7 +9819,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_feel_expression_parsing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(zeebe_feel_expression_parsing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -9902,7 +9902,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_post_commit_tasks_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_post_commit_tasks_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_post_commit_tasks_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_post_commit_tasks_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",
@@ -9984,7 +9984,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",
@@ -10084,7 +10084,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_sequencer_lock_hold_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (writer)",
+              "expr": "max(zeebe_sequencer_lock_hold_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "max {{writer}}",
@@ -10096,7 +10096,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.99\"}) by (writer)",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.99\", zone=~\"$zone\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "p99 {{writer}}",
@@ -10108,7 +10108,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.9\"}) by (writer)",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.9\", zone=~\"$zone\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "p90 {{writer}}",
@@ -10120,7 +10120,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.5\"}) by (writer)",
+              "expr": "avg(zeebe_sequencer_lock_hold_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.5\", zone=~\"$zone\"}) by (writer)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "p50 {{writer}}",
@@ -10242,7 +10242,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_sequencer_lock_wait_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (waiter)",
+              "expr": "max(zeebe_sequencer_lock_wait_time_seconds_max{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "max {{waiter}}",
@@ -10254,7 +10254,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.99\"}) by (waiter)",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.99\", zone=~\"$zone\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "p99 {{waiter}}",
@@ -10266,7 +10266,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.9\"}) by (waiter)",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.9\", zone=~\"$zone\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "p90 {{waiter}}",
@@ -10278,7 +10278,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.5\"}) by (waiter)",
+              "expr": "avg(zeebe_sequencer_lock_wait_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", quantile=\"0.5\", zone=~\"$zone\"}) by (waiter)",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "p50 {{waiter}}",
@@ -10290,7 +10290,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_sequencer_lock_wait_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (waiter) / on(waiter) label_replace(sum(rate(zeebe_sequencer_lock_hold_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (writer), \"waiter\", \"$1\", \"writer\", \"(.*)\")",
+              "expr": "sum(rate(zeebe_sequencer_lock_wait_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (waiter) / on(waiter) label_replace(sum(rate(zeebe_sequencer_lock_hold_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (writer), \"waiter\", \"$1\", \"writer\", \"(.*)\")",
               "format": "time_series",
               "interval": "30s",
               "legendFormat": "contention ratio {{waiter}}",
@@ -10387,7 +10387,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -10398,7 +10398,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p99 partition {{partition}}",
               "refId": "B"
@@ -10408,7 +10408,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} MEDIAN partition {{partition}} ",
               "refId": "C"
@@ -10417,7 +10417,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_log_appender_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) or sum(rate(zeebe_log_appender_commit_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_commit_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) ",
+              "expr": "sum(rate(zeebe_log_appender_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) or sum(rate(zeebe_log_appender_commit_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_commit_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) ",
               "interval": "",
 "legendFormat": "{{physicalTenant}} AVG partition {{partition}}",
               "refId": "D"
@@ -10513,7 +10513,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -10525,7 +10525,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p99 partition {{partition}}",
               "refId": "B"
@@ -10534,7 +10534,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} MEDIAN partition {{partition}} ",
               "refId": "C"
@@ -10544,7 +10544,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_log_appender_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) or sum(rate(zeebe_log_appender_append_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_append_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition)  ",
+              "expr": "sum(rate(zeebe_log_appender_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) or sum(rate(zeebe_log_appender_append_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(zeebe_log_appender_append_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)  ",
               "interval": "",
 "legendFormat": "{{physicalTenant}} AVG partition {{partition}}",
               "refId": "D"
@@ -10625,7 +10625,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le) or sum(increase(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -10708,7 +10708,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le) or sum(increase(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -10822,11 +10822,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode, pod) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (method, statusCode, pod)",
+              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode, zone, pod) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (method, statusCode, zone, pod)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{method}} ({{statusCode}}) in {{pod}}",
+              "legendFormat": "{{method}} ({{statusCode}}) in {{zone}} {{pod}}",
               "refId": "A"
             }
           ],
@@ -10921,7 +10921,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (method, statusCode)",
+              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode, zone, pod) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (method, statusCode)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -10932,7 +10932,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode, zone, pod) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total requests completed",
@@ -11013,7 +11013,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", grpc_method=\"CreateProcessInstance\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", grpc_method=\"CreateProcessInstance\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -11025,7 +11025,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(grpc_server_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", method=\"CreateProcessInstance\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(grpc_server_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", method=\"CreateProcessInstance\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -11108,7 +11108,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", grpc_method=\"ActivateJobs\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", grpc_method=\"ActivateJobs\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -11119,7 +11119,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(grpc_server_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", method=\"ActivateJobs\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(grpc_server_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", method=\"ActivateJobs\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -11201,7 +11201,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", grpc_method=\"CompleteJob\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", grpc_method=\"CompleteJob\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -11213,7 +11213,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(grpc_server_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", method=\"CompleteJob\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(grpc_server_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", method=\"CompleteJob\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -11311,7 +11311,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_gateway_request_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_gateway_request_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",
@@ -11321,7 +11321,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(zeebe_gateway_request_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_gateway_request_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",
@@ -11443,7 +11443,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "rate(zeebe_gateway_failed_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", error=~\".*\"}[$__rate_interval]) / rate(zeebe_gateway_total_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])",
+              "expr": "rate(zeebe_gateway_failed_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", error=~\".*\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_gateway_total_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{error}}",
               "refId": "A"
@@ -11564,7 +11564,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum by (requestType) (rate(zeebe_gateway_failed_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / \nsum by (requestType) (rate(zeebe_gateway_total_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum by (requestType) (rate(zeebe_gateway_failed_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / \nsum by (requestType) (rate(zeebe_gateway_total_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{requestType}}",
               "refId": "A"
@@ -11719,9 +11719,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_raft_messages_send_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (physicalTenant, partition, to, type)",
+              "expr": "sum(rate(atomix_raft_messages_send_total{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, to, type)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}} send {{type}} to {{to}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}} send {{type}} to {{to}}",
               "range": true,
               "refId": "A"
             }
@@ -11860,9 +11860,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "atomix_raft_messages_send_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"InstallRequest\"}",
+              "expr": "atomix_raft_messages_send_total{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"InstallRequest\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}} send {{type}} to {{to}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}} send {{type}} to {{to}}",
               "refId": "A"
             }
           ],
@@ -11960,7 +11960,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_commit_entries_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(atomix_commit_entries_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} p{{partition}}",
               "range": true,
               "refId": "A"
@@ -12060,7 +12060,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_append_entries_data_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition, follower)",
+              "expr": "sum(rate(atomix_append_entries_data_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, follower)",
 "legendFormat": "{{physicalTenant}} p{{partition}} to {{follower}}",
               "range": true,
               "refId": "A"
@@ -12160,7 +12160,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_append_entries_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition, follower)",
+              "expr": "sum(rate(atomix_append_entries_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, follower)",
 "legendFormat": "{{physicalTenant}} p{{partition}} to {{follower}}",
               "range": true,
               "refId": "A"
@@ -12258,11 +12258,11 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "atomix_snapshot_replication_duration_milliseconds{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_snapshot_replication_duration_milliseconds{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "refId": "A"
             }
           ],
@@ -12358,9 +12358,9 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "atomix_snapshot_replication_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_snapshot_replication_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partitionGroupName}}-{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partitionGroupName}}-{{partition}}",
               "refId": "A"
             }
           ],
@@ -12438,7 +12438,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "intervalFactor": 1,
@@ -12537,7 +12537,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(atomix_append_entries_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_second_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(atomix_append_entries_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(atomix_append_entries_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_append_entries_latency_second_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(rate(atomix_append_entries_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Avg",
               "refId": "A"
@@ -12547,7 +12547,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Median - ({{partition}})",
               "refId": "C"
@@ -12644,7 +12644,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.90, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.90, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p90 - ({{partition}})",
               "refId": "C"
@@ -12741,7 +12741,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.99, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.99, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p99 - ({{partition}})",
               "refId": "C"
@@ -12821,7 +12821,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(atomix_heartbeat_time_in_s_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_heartbeat_time_in_s_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_heartbeat_time_in_s_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(atomix_heartbeat_time_in_s_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "1m",
@@ -12943,11 +12943,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(atomix_heartbeat_miss_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(increase(atomix_heartbeat_miss_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} - {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} - {{partition}}",
               "refId": "A"
             }
           ],
@@ -13049,12 +13049,12 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}} ",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}} ",
               "refId": "A"
             }
           ],
@@ -13192,12 +13192,12 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}} ",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}} ",
               "refId": "A"
             }
           ],
@@ -13308,11 +13308,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "atomix_partition_raft_commit_index{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_partition_raft_commit_index{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": true,
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}} ",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}} ",
               "refId": "A"
             }
           ],
@@ -13436,11 +13436,11 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "atomix_partition_raft_append_index{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_partition_raft_append_index{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "instant": true,
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}-p{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}-p{{partition}}",
               "refId": "A"
             }
           ],
@@ -13514,7 +13514,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(atomix_non_committed_entries{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition)",
+              "expr": "sum(atomix_non_committed_entries{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p {{partition}}",
               "range": true,
@@ -13580,7 +13580,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(atomix_non_replicated_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition, follower)",
+              "expr": "sum(atomix_non_replicated_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition, follower)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p{{partition}} f{{follower}}",
               "range": true,
@@ -13677,7 +13677,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_raft_replication_lag_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition, follower)",
+              "expr": "max(zeebe_raft_replication_lag_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition, follower)",
               "instant": false,
               "legendFormat": "{{physicalTenant}} p{{partition}} f{{follower}}",
               "range": true,
@@ -13773,7 +13773,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -13872,9 +13872,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "atomix_segment_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "expr": "atomix_segment_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}}",
               "refId": "A"
             }
           ],
@@ -13972,8 +13972,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_journal_append_data_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}}",
+              "expr": "sum(rate(atomix_journal_append_data_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -14072,8 +14072,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_journal_append_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}}",
+              "expr": "sum(rate(atomix_journal_append_rate_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -14171,9 +14171,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_journal_flush_time_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod) / sum(rate(atomix_journal_flush_time_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))  by (pod) or sum(rate(atomix_journal_flush_time_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod) / sum(rate(atomix_journal_flush_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))  by (pod)",
+              "expr": "sum(rate(atomix_journal_flush_time_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod) / sum(rate(atomix_journal_flush_time_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))  by (zone, pod) or sum(rate(atomix_journal_flush_time_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod) / sum(rate(atomix_journal_flush_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))  by (zone, pod)",
               "interval": "",
-              "legendFormat": "Avg {{ pod }}",
+              "legendFormat": "Avg {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             },
@@ -14183,7 +14183,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "interval": "",
               "legendFormat": "Median",
               "range": true,
@@ -14283,7 +14283,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.90, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p90 - ({{partition}})",
               "range": true,
@@ -14383,7 +14383,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.99, sum(rate(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p99 - ({{partition}})",
               "range": true,
@@ -14466,7 +14466,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_journal_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(atomix_journal_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -14550,7 +14550,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -14650,7 +14650,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, rate(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.90, rate(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -14664,7 +14664,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, rate(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.99, rate(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p99 partition {{partition}}",
               "range": true,
@@ -14675,7 +14675,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, rate(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.50, rate(atomix_journal_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} MEDIAN partition {{partition}} ",
               "range": true,
@@ -14686,7 +14686,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(atomix_journal_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(atomix_journal_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) or sum(rate(atomix_journal_append_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(atomix_journal_append_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition) ",
+              "expr": "sum(rate(atomix_journal_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(atomix_journal_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) or sum(rate(atomix_journal_append_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) / sum(rate(atomix_journal_append_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition) ",
               "interval": "",
 "legendFormat": "{{physicalTenant}} AVG partition {{partition}}",
               "refId": "D"
@@ -14766,7 +14766,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(atomix_segment_creation_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_segment_creation_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_segment_creation_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(atomix_segment_creation_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -14851,7 +14851,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(atomix_segment_allocation_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_segment_allocation_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_segment_allocation_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(atomix_segment_allocation_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -14934,7 +14934,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -15033,9 +15033,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(atomix_segment_flush_time_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod) / sum(rate(atomix_segment_flush_time_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))  by (pod)",
+              "expr": "sum(rate(atomix_segment_flush_time_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod) / sum(rate(atomix_segment_flush_time_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))  by (zone, pod)",
               "interval": "",
-              "legendFormat": "Avg {{ pod }}",
+              "legendFormat": "Avg {{zone}} {{pod}}",
               "refId": "A"
             },
             {
@@ -15043,7 +15043,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Median - ({{partition}})",
               "refId": "C"
@@ -15141,7 +15141,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.90, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.90, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p90 - ({{partition}})",
               "refId": "C"
@@ -15239,7 +15239,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.99, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le,physicalTenant, partition))",
+              "expr": "histogram_quantile(0.99, sum(rate(atomix_segment_flush_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_segment_flush_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le,physicalTenant, partition))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} p99 - ({{partition}})",
               "refId": "C"
@@ -15338,9 +15338,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_last_flushed_index_update_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod) / sum(rate(atomix_last_flushed_index_update_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))  by (pod) or sum(rate(atomix_last_flushed_index_update_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod) / sum(rate(atomix_last_flushed_index_update_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))  by (pod)",
+              "expr": "sum(rate(atomix_last_flushed_index_update_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod) / sum(rate(atomix_last_flushed_index_update_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))  by (zone, pod) or sum(rate(atomix_last_flushed_index_update_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod) / sum(rate(atomix_last_flushed_index_update_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))  by (zone, pod)",
               "interval": "",
-              "legendFormat": "Avg {{ pod }}",
+              "legendFormat": "Avg {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             },
@@ -15350,7 +15350,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_last_flushed_index_update_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_last_flushed_index_update_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "interval": "",
               "legendFormat": "Median",
               "range": true,
@@ -15434,7 +15434,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le) or sum(increase(atomix_last_flushed_index_update_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(atomix_last_flushed_index_update_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -15517,7 +15517,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",
@@ -15613,9 +15613,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(atomix_journal_seek_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_journal_seek_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(atomix_journal_seek_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) or rate(atomix_journal_seek_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-              "legendFormat": "{{ pod }} - p{{ partition }}",
+              "legendFormat": "{{zone}} {{pod}} - p{{ partition }}",
               "range": true,
               "refId": "A"
             }
@@ -15725,11 +15725,11 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_sequencer_queue_size{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_sequencer_queue_size{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}}-{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}-{{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -15810,7 +15810,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_sequencer_batch_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_sequencer_batch_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -15896,7 +15896,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_sequencer_batch_length_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_sequencer_batch_length_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -15995,7 +15995,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\"}[$__rate_interval])) by (valueType, intent)",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\", zone=~\"$zone\"}[$__rate_interval])) by (valueType, intent)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -16094,7 +16094,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\"}[$__rate_interval])) by (valueType, intent)",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\", zone=~\"$zone\"}[$__rate_interval])) by (valueType, intent)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -16193,7 +16193,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\"}[$__rate_interval])) by (valueType, intent)",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\", zone=~\"$zone\"}[$__rate_interval])) by (valueType, intent)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -16293,7 +16293,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "rate(zeebe_deferred_append_count_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])",
+              "expr": "rate(zeebe_deferred_append_count_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -16394,7 +16394,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "zeebe_backpressure_inflight_append_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_backpressure_inflight_append_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -16409,7 +16409,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_backpressure_append_limit{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_backpressure_append_limit{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Limit for partition {{partition}}",
               "range": true,
@@ -16503,7 +16503,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (context, physicalTenant, partition) (rate(zeebe_flow_control_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"accepted\"}[$__rate_interval]))",
+              "expr": "sum by (context, physicalTenant, partition) (rate(zeebe_flow_control_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"accepted\", zone=~\"$zone\"}[$__rate_interval]))",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Partition {{partition}}: {{context}}",
               "range": true,
@@ -16597,7 +16597,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (context, physicalTenant, partition, outcome) (rate(zeebe_flow_control_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome!=\"accepted\"}[$__rate_interval]))",
+              "expr": "sum by (context, physicalTenant, partition, outcome) (rate(zeebe_flow_control_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome!=\"accepted\", zone=~\"$zone\"}[$__rate_interval]))",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Partition {{partition}} rejected {{context}}: {{outcome}}",
               "range": true,
@@ -16695,7 +16695,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_flow_control_write_rate_limit{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} != 0",
+              "expr": "zeebe_flow_control_write_rate_limit{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} != 0",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Current limit on {{partition}}",
               "range": true,
@@ -16707,7 +16707,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_flow_control_write_rate_maximum{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} != 0",
+              "expr": "zeebe_flow_control_write_rate_maximum{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} != 0",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Maximum limit on {{partition}}",
               "range": true,
@@ -16806,7 +16806,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_flow_control_exporting_rate{namespace=~\"$namespace\", pod=~\"$partition\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} != 0",
+              "expr": "zeebe_flow_control_exporting_rate{namespace=~\"$namespace\", pod=~\"$partition\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} != 0",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Exporting rate for {{partition}}",
               "range": true,
@@ -16876,7 +16876,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\"}[$__rate_interval])) by (recordType, valueType, intent)",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND\", zone=~\"$zone\"}[$__rate_interval])) by (recordType, valueType, intent)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -16948,7 +16948,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\"}[$__rate_interval])) by (valueType, intent)",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"EVENT\", zone=~\"$zone\"}[$__rate_interval])) by (valueType, intent)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -17021,7 +17021,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\"}[$__rate_interval])) by (valueType, intent)",
+              "expr": "sum(rate(zeebe_log_appender_record_appended_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", recordType=\"COMMAND_REJECTION\", zone=~\"$zone\"}[$__rate_interval])) by (valueType, intent)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -17096,7 +17096,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_flow_control_partition_load{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} > 0",
+              "expr": "zeebe_flow_control_partition_load{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} > 0",
               "instant": true,
 "legendFormat": "{{physicalTenant}} Partition: {{partition}}",
               "range": false,
@@ -17211,9 +17211,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "(((sum(zeebe_rocksdb_memory_estimate_table_readers_mem{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)) + (sum(zeebe_rocksdb_memory_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}) by (pod)) + (max(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)) + (sum(rate(zeebe_rocksdb_live_estimate_num_keys{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (pod) * 10)) \nand on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}) )\nor\n( ((sum(zeebe_rocksdb_memory_estimate_table_readers_mem{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (pod, physicalTenant, partition)) + (sum(zeebe_rocksdb_memory_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",  physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (pod, physicalTenant, partition)) + (sum(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (pod, physicalTenant, partition)) + (sum(rate(zeebe_rocksdb_live_estimate_num_keys{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",  physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (pod, physicalTenant, partition) * 10)) \nunless on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}))",
+              "expr": "(((sum(zeebe_rocksdb_memory_estimate_table_readers_mem{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)) + (sum(zeebe_rocksdb_memory_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)) + (max(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)) + (sum(rate(zeebe_rocksdb_live_estimate_num_keys{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod) * 10)) \nand on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}) )\nor\n( ((sum(zeebe_rocksdb_memory_estimate_table_readers_mem{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)) + (sum(zeebe_rocksdb_memory_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",  physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)) + (sum(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)) + (sum(rate(zeebe_rocksdb_live_estimate_num_keys{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",  physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition) * 10)) \nunless on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}))",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} memory {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} memory {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -17310,9 +17310,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_rocksdb_live_estimate_num_keys{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "zeebe_rocksdb_live_estimate_num_keys{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} {{partition}} keys {{columnFamilyName}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} {{partition}} keys {{columnFamilyName}}",
               "refId": "A"
             }
           ],
@@ -17495,11 +17495,11 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "expr": "zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}",
               "format": "table",
               "instant": true,
               "interval": "",
-              "legendFormat": "{{pod}} Strategy: {{strategy}}",
+              "legendFormat": "{{zone}} {{pod}} Strategy: {{strategy}}",
               "range": false,
               "refId": "A"
             }
@@ -17596,9 +17596,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_live_estimate_live_data_size{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_live_estimate_live_data_size{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} live data {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} live data {{partition}}",
               "refId": "A"
             }
           ],
@@ -17695,9 +17695,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_memory_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_memory_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} All Memtable's {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} All Memtable's {{partition}}",
               "refId": "A"
             }
           ],
@@ -17794,9 +17794,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_memory_cur_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_memory_cur_size_all_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Memtable {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Memtable {{partition}}",
               "refId": "A"
             }
           ],
@@ -17893,9 +17893,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_memory_cur_size_active_mem_table{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_memory_cur_size_active_mem_table{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Memtable {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Memtable {{partition}}",
               "refId": "A"
             }
           ],
@@ -17993,9 +17993,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "((max(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)) and on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}) )\nor\n( (sum(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)) unless on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}))",
+              "expr": "((max(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)) and on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}) )\nor\n( (sum(zeebe_rocksdb_memory_block_cache_capacity{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)) unless on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}))",
               "interval": "",
-              "legendFormat": "{{pod}} Block cache",
+              "legendFormat": "{{zone}} {{pod}} Block cache",
               "range": true,
               "refId": "A"
             }
@@ -18094,9 +18094,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "( (max(zeebe_rocksdb_memory_block_cache_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)) and on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}) )\nor\n( (sum(zeebe_rocksdb_memory_block_cache_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)) unless on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}) )",
+              "expr": "( (max(zeebe_rocksdb_memory_block_cache_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)) and on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}) )\nor\n( (sum(zeebe_rocksdb_memory_block_cache_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)) unless on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}) )",
               "interval": "",
-              "legendFormat": "{{pod}} Block cache usage",
+              "legendFormat": "{{zone}} {{pod}} Block cache usage",
               "range": true,
               "refId": "A"
             }
@@ -18194,9 +18194,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "( (max(zeebe_rocksdb_memory_block_cache_pinned_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (pod)) and on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}) )\nor\n( (sum(zeebe_rocksdb_memory_block_cache_pinned_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)) unless on(pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\"}) )",
+              "expr": "( (max(zeebe_rocksdb_memory_block_cache_pinned_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod)) and on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}) )\nor\n( (sum(zeebe_rocksdb_memory_block_cache_pinned_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)) unless on(zone, pod) (zeebe_rocksdb_memory_allocation_strategy{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", strategy=~\"BROKER|FRACTION\", zone=~\"$zone\"}) )",
               "interval": "",
-              "legendFormat": "{{pod}} pinned cache",
+              "legendFormat": "{{zone}} {{pod}} pinned cache",
               "range": true,
               "refId": "A"
             }
@@ -18293,9 +18293,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_sst_live_sst_files_size{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_sst_live_sst_files_size{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  live sst {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  live sst {{partition}}",
               "refId": "A"
             }
           ],
@@ -18391,9 +18391,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_sst_total_sst_files_size{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_sst_total_sst_files_size{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  total sst {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  total sst {{partition}}",
               "refId": "A"
             }
           ],
@@ -18487,10 +18487,10 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_writes_is_write_stopped{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_writes_is_write_stopped{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "instant": true,
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  stopped write {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  stopped write {{partition}}",
               "refId": "A"
             }
           ],
@@ -18584,9 +18584,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_writes_background_errors{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_writes_background_errors{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  background errors {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  background errors {{partition}}",
               "refId": "A"
             }
           ],
@@ -18682,9 +18682,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_rocksdb_writes_actual_delayed_write_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "zeebe_rocksdb_writes_actual_delayed_write_rate{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  delayed write {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  delayed write {{partition}}",
               "refId": "A"
             }
           ],
@@ -18780,7 +18780,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_rocksdb_live_num_entries_imm_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "zeebe_rocksdb_live_num_entries_imm_mem_tables{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
               "legendFormat": "{{columnFamilyName}}",
               "refId": "A"
@@ -18878,9 +18878,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_writes_num_running_flushes{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_writes_num_running_flushes{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  flush {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  flush {{partition}}",
               "refId": "A"
             }
           ],
@@ -18976,9 +18976,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_writes_num_running_compactions{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_writes_num_running_compactions{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  compaction {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  compaction {{partition}}",
               "refId": "A"
             }
           ],
@@ -19075,9 +19075,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_memory_estimate_table_readers_mem{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_memory_estimate_table_readers_mem{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Table Reader {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Table Reader {{partition}}",
               "refId": "A"
             }
           ],
@@ -19177,7 +19177,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum by (le, operation, columnFamily, physicalTenant, partition) (rate(zeebe_rocksdb_latency_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])))",
+              "expr": "histogram_quantile(0.99, sum by (le, operation, columnFamily, physicalTenant, partition) (rate(zeebe_rocksdb_latency_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])))",
               "fullMetaSearch": false,
               "includeNullMetadata": false,
               "instant": false,
@@ -19279,9 +19279,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  memtable {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  memtable {{partition}}",
               "refId": "A"
             },
             {
@@ -19289,9 +19289,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  L0 file count {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  L0 file count {{partition}}",
               "refId": "B"
             },
             {
@@ -19299,9 +19299,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_stop{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  pending compaction bytes {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  pending compaction bytes {{partition}}",
               "refId": "C"
             }
           ],
@@ -19397,9 +19397,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_memtable_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  memtable {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  memtable {{partition}}",
               "refId": "A"
             },
             {
@@ -19407,9 +19407,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_l0_file_count_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  L0 file count {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  L0 file count {{partition}}",
               "refId": "B"
             },
             {
@@ -19417,9 +19417,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (pod, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_rocksdb_writes_io_stalls_pending_compaction_bytes_slowdown{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  pending compaction bytes {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  pending compaction bytes {{partition}}",
               "refId": "C"
             }
           ],
@@ -19515,9 +19515,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_writes_estimate_pending_compaction_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_writes_estimate_pending_compaction_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  {{partition}}",
               "refId": "A"
             }
           ],
@@ -19613,9 +19613,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_memory_num_immutable_mem_table{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_memory_num_immutable_mem_table{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  pending flush {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  pending flush {{partition}}",
               "refId": "A"
             },
             {
@@ -19623,9 +19623,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_rocksdb_memory_num_immutable_mem_table_flushed{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (pod, physicalTenant, partition)",
+              "expr": "sum(zeebe_rocksdb_memory_num_immutable_mem_table_flushed{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (zone, pod, physicalTenant, partition)",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}  flushed {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}  flushed {{partition}}",
               "refId": "B"
             }
           ],
@@ -19704,7 +19704,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "sum(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", action=\"COMPLETED\"})",
+              "expr": "sum(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", action=\"COMPLETED\", zone=~\"$zone\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -19777,7 +19777,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "sum by(type) (zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", action=\"COMPLETED\"})",
+              "expr": "sum by (type) (zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", action=\"COMPLETED\", zone=~\"$zone\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -19850,7 +19850,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "sum by(type) (zeebe_batchoperations_items_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"})",
+              "expr": "sum by (type) (zeebe_batchoperations_items_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -19952,10 +19952,10 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum by (physicalTenant, partition, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (physicalTenant, partition, zone, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-"legendFormat": "{{physicalTenant}} {{pod}} Partition {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Partition {{partition}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -20052,7 +20052,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (physicalTenant, partition, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", queryStatus=\"failed\"}[$__rate_interval]))",
+              "expr": "sum by (physicalTenant, partition, zone, pod) (increase(zeebe_batchoperations_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", queryStatus=\"failed\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -20132,7 +20132,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_QUERY_LATENCY\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_QUERY_LATENCY\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -20216,7 +20216,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_EXECUTION_LATENCY\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"TOTAL_EXECUTION_LATENCY\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "__auto",
               "range": true,
@@ -20301,7 +20301,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "sum by(le) (increase(zeebe_batchoperations_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum by (le) (increase(zeebe_batchoperations_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "heatmap",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -20404,7 +20404,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum by(type) (increase(zeebe_batchoperations_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum by (type) (increase(zeebe_batchoperations_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -20489,7 +20489,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"START_EXECUTE_LATENCY\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"START_EXECUTE_LATENCY\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -20573,7 +20573,7 @@
               "disableTextWrap": false,
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum by(le) (increase(zeebe_batchoperations_items_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum by (le) (increase(zeebe_batchoperations_items_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "heatmap",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -20658,7 +20658,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"EXECUTE_CYCLE_LATENCY\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_batchoperations_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", batchOperationLatency=\"EXECUTE_CYCLE_LATENCY\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "__auto",
               "range": true,
@@ -20758,7 +20758,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum by(action) (increase(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (action) (increase(zeebe_batchoperations_events_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -20856,7 +20856,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_elasticsearch_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_elasticsearch_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -20958,9 +20958,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(zeebe_elasticsearch_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_elasticsearch_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(zeebe_elasticsearch_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_elasticsearch_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Exporter {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Exporter {{partition}}",
               "refId": "A"
             }
           ],
@@ -21039,7 +21039,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_elasticsearch_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_elasticsearch_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -21139,11 +21139,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_elasticsearch_exporter_bulk_memory_size{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_elasticsearch_exporter_bulk_memory_size{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "refId": "A"
             }
           ],
@@ -21345,7 +21345,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_opensearch_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_opensearch_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -21447,9 +21447,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(zeebe_opensearch_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_opensearch_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(zeebe_opensearch_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_opensearch_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Exporter {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Exporter {{partition}}",
               "refId": "A"
             }
           ],
@@ -21528,7 +21528,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_opensearch_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_opensearch_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -21628,11 +21628,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_opensearch_exporter_bulk_memory_size{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_opensearch_exporter_bulk_memory_size{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "refId": "A"
             }
           ],
@@ -21835,7 +21835,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_camunda_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_camunda_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -21908,9 +21908,9 @@
               },
               "editorMode": "builder",
               "exemplar": true,
-              "expr": "rate(zeebe_camunda_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(zeebe_camunda_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Exporter {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Exporter {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -22012,9 +22012,9 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(zeebe_camunda_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} Exporter {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Exporter {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -22095,7 +22095,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_camunda_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_camunda_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -22198,7 +22198,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Cache access {{partition}}",
               "range": true,
@@ -22210,7 +22210,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition, type)",
+              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_result_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, type)",
               "instant": false,
 "legendFormat": "{{physicalTenant}} P{{partition}} - {{type}}",
               "range": true,
@@ -22309,7 +22309,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_evictions_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_evictions_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Evictions {{partition}}",
               "range": true,
@@ -22394,7 +22394,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -22409,7 +22409,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "30",
@@ -22510,7 +22510,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_success_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -22524,7 +22524,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_camunda_exporter_cache_process_load_duration_failure_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Failure p{{partition}}",
               "range": true,
@@ -22627,7 +22627,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition, state)",
+              "expr": "sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, state)",
               "instant": false,
 "legendFormat": "{{physicalTenant}} {{state}} process instances [p{{partition}}]",
               "range": true,
@@ -22639,7 +22639,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_archiver_batch_operations_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (physicalTenant, partition, state)",
+              "expr": "sum(rate(zeebe_camunda_exporter_archiver_batch_operations_total{namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition, state)",
               "instant": false,
 "legendFormat": "{{physicalTenant}} {{state}} batch operations [p{{partition}}]",
               "range": true,
@@ -22720,7 +22720,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_archiver_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(zeebe_camunda_exporter_archiver_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "30",
@@ -22819,7 +22819,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(zeebe_camunda_exporter_archiver_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", type=\"search\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(zeebe_camunda_exporter_archiver_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", type=\"search\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -22901,7 +22901,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_archiver_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", type=\"reindex\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(zeebe_camunda_exporter_archiver_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", type=\"reindex\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -22983,7 +22983,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_camunda_exporter_archiver_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", type=\"delete\"}[$__rate_interval])) by (le)",
+              "expr": "sum(rate(zeebe_camunda_exporter_archiver_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", type=\"delete\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -23081,7 +23081,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_rdbms_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_rdbms_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -23178,9 +23178,9 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(zeebe_rdbms_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) > 0",
+              "expr": "rate(zeebe_rdbms_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) > 0",
               "interval": "1",
-"legendFormat": "{{physicalTenant}} {{pod}} Exporter {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Exporter {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -23241,7 +23241,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -23256,7 +23256,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(increase(zeebe_rdbms_exporter_merged_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(increase(zeebe_rdbms_exporter_merged_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "time_series",
               "instant": false,
               "interval": "30s",
@@ -23341,7 +23341,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_rdbms_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_rdbms_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -23437,9 +23437,9 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(zeebe_rdbms_exporter_record_exporting_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_record_exporting_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) > 0",
+              "expr": "rate(zeebe_rdbms_exporter_record_exporting_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_record_exporting_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) > 0",
               "interval": "1",
-"legendFormat": "{{physicalTenant}} {{pod}} Exporter {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} Exporter {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -23545,7 +23545,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg(rate(zeebe_rdbms_exporter_flush_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) > 0)",
+              "expr": "avg(rate(zeebe_rdbms_exporter_flush_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) > 0)",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -23563,7 +23563,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "avg(rate(zeebe_rdbms_exporter_historyCleanup_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) > 0)",
+              "expr": "avg(rate(zeebe_rdbms_exporter_historyCleanup_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) > 0)",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -23690,7 +23690,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort(max by(statementId) (increase(zeebe_rdbms_exporter_executed_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])))",
+              "expr": "sort(max by (statementId) (increase(zeebe_rdbms_exporter_executed_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])))",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -23710,7 +23710,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort(max by(statementId) (increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])))",
+              "expr": "sort(max by (statementId) (increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])))",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -23730,7 +23730,7 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sort(max by(statementId) (increase(zeebe_rdbms_exporter_merged_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])))",
+              "expr": "sort(max by (statementId) (increase(zeebe_rdbms_exporter_merged_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])))",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -23872,7 +23872,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "max by (table) (zeebe_rdbms_table_row_count{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+              "expr": "max by (table) (zeebe_rdbms_table_row_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"})",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -23967,7 +23967,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max by (table) (zeebe_rdbms_table_row_count{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+              "expr": "max by (table) (zeebe_rdbms_table_row_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
               "interval": "30s",
@@ -24069,7 +24069,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_rdbms_exporter_historyCleanup_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_rdbms_exporter_historyCleanup_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -24172,7 +24172,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "builder",
-              "expr": "zeebe_rdbms_exporter_historyCleanup_backoffDuration{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_rdbms_exporter_historyCleanup_backoffDuration{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -24257,7 +24257,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_rdbms_exporter_historyCleanup_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_rdbms_exporter_historyCleanup_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -24360,7 +24360,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(zeebe_rdbms_exporter_queue_memory_bytes_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_queue_memory_bytes_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+              "expr": "rate(zeebe_rdbms_exporter_queue_memory_bytes_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_queue_memory_bytes_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -24478,7 +24478,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "max by (exporter, pod, partition) (\n    zeebe_rdbms_exporter_replication_pending_positions{\n      cluster=~\"$cluster\",\n      namespace=~\"$namespace\",\n      partition=~\"$partition\"}\n)",
+              "expr": "max by (exporter, zone, pod, partition) (\n    zeebe_rdbms_exporter_replication_pending_positions{\n      cluster=~\"$cluster\",\n      namespace=~\"$namespace\",\n      partition=~\"$partition\", zone=~\"$zone\"}\n)",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -24578,7 +24578,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "max by (exporter, pod, partition) (\n    zeebe_rdbms_exporter_replication_lag_ms{\n      cluster=~\"$cluster\",\n      namespace=~\"$namespace\",\n      partition=~\"$partition\"}\n)",
+              "expr": "max by (exporter, zone, pod, partition) (\n    zeebe_rdbms_exporter_replication_lag_ms{\n      cluster=~\"$cluster\",\n      namespace=~\"$namespace\",\n      partition=~\"$partition\", zone=~\"$zone\"}\n)",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -24679,7 +24679,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "max by (exporter, pod, partition) (\n    zeebe_rdbms_exporter_replication_connected_replicas{\n      cluster=~\"$cluster\",\n      namespace=~\"$namespace\",\n      partition=~\"$partition\"}\n)",
+              "expr": "max by (exporter, zone, pod, partition) (\n    zeebe_rdbms_exporter_replication_connected_replicas{\n      cluster=~\"$cluster\",\n      namespace=~\"$namespace\",\n      partition=~\"$partition\", zone=~\"$zone\"}\n)",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -24778,7 +24778,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "zeebe_rdbms_exporter_replication_paused{namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "zeebe_rdbms_exporter_replication_paused{namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -24871,9 +24871,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "atomix_partition_server_startup_time{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_partition_server_startup_time{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}}  Start {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}}  Start {{zone}} {{pod}} p{{partition}}",
               "refId": "A"
             },
             {
@@ -24881,9 +24881,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "atomix_partition_server_bootstrap_time{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "atomix_partition_server_bootstrap_time{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} Bootstrap  {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}} Bootstrap  {{zone}} {{pod}} p{{partition}}",
               "refId": "B"
             }
           ],
@@ -24959,9 +24959,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_stream_processor_startup_recovery_time{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "zeebe_stream_processor_startup_recovery_time{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}}:Partition {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}}:Partition {{partition}}",
               "refId": "A"
             }
           ],
@@ -25036,9 +25036,9 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_leader_transition_latency{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "expr": "zeebe_leader_transition_latency{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}",
               "interval": "",
-              "legendFormat": "{{pod}}: Partition {{ partition }}",
+              "legendFormat": "{{zone}} {{pod}}: Partition {{ partition }}",
               "refId": "A"
             }
           ],
@@ -25110,7 +25110,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": false,
-              "expr": "max(zeebe_backup_operations_in_progress{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", operation=\"take\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_backup_operations_in_progress{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", operation=\"take\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "instant": false,
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
@@ -25167,7 +25167,7 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
-              "expr": "camunda_checkpoint_scheduler_next_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"MARKER\"}",
+              "expr": "camunda_checkpoint_scheduler_next_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"MARKER\", zone=~\"$zone\"}",
               "refId": "A"
             }
           ],
@@ -25221,7 +25221,7 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
-              "expr": "camunda_checkpoint_scheduler_last_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"MARKER\"}",
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"MARKER\", zone=~\"$zone\"}",
               "refId": "A"
             }
           ],
@@ -25275,7 +25275,7 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
-              "expr": "camunda_checkpoint_scheduler_next_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"SCHEDULED_BACKUP\"}",
+              "expr": "camunda_checkpoint_scheduler_next_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"SCHEDULED_BACKUP\", zone=~\"$zone\"}",
               "refId": "A"
             }
           ],
@@ -25329,7 +25329,7 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
-              "expr": "camunda_checkpoint_scheduler_last_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"SCHEDULED_BACKUP\"}",
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_time_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"SCHEDULED_BACKUP\", zone=~\"$zone\"}",
               "refId": "A"
             }
           ],
@@ -25386,7 +25386,7 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
-              "expr": "camunda_checkpoint_scheduler_last_checkpoint_id{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"MARKER\"}",
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_id{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"MARKER\", zone=~\"$zone\"}",
               "refId": "A"
             }
           ],
@@ -25443,7 +25443,7 @@
           "pluginVersion": "12.1.0",
           "targets": [
             {
-              "expr": "camunda_checkpoint_scheduler_last_checkpoint_id{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"SCHEDULED_BACKUP\"}",
+              "expr": "camunda_checkpoint_scheduler_last_checkpoint_id{cluster=~\"$cluster\", namespace=~\"$namespace\", type=\"SCHEDULED_BACKUP\", zone=~\"$zone\"}",
               "refId": "A"
             }
           ],
@@ -25507,7 +25507,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "camunda_backup_retention_backups_deleted_round{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "camunda_backup_retention_backups_deleted_round{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Backups deleted - {{partition}}",
               "range": true,
@@ -25519,7 +25519,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "camunda_backup_retention_ranges_deleted_round{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "camunda_backup_retention_ranges_deleted_round{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Ranges deleted - p{{partition}}",
               "range": true,
@@ -25531,7 +25531,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "camunda_backup_retention_earliest_backup_id{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}",
+              "expr": "camunda_backup_retention_earliest_backup_id{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}",
               "instant": false,
 "legendFormat": "{{physicalTenant}} Earliest backup - p{{partition}}",
               "range": true,
@@ -25600,7 +25600,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "camunda_backup_retention_last_execution_millis{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+              "expr": "camunda_backup_retention_last_execution_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}",
               "instant": false,
               "interval": "",
               "legendFormat": "Last retention execution",
@@ -25613,7 +25613,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "builder",
-              "expr": "camunda_backup_retention_next_execution_millis{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+              "expr": "camunda_backup_retention_next_execution_millis{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}",
               "instant": false,
               "legendFormat": "Next retention execution",
               "range": true,
@@ -25680,7 +25680,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max(zeebe_backup_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"take\", result=\"completed\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_backup_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"take\", result=\"completed\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -25762,7 +25762,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_backup_operations_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"status\"}[$__interval]) or increase(zeebe_backup_operations_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"status\"}[$__interval])) by (le)",
+              "expr": "sum(increase(zeebe_backup_operations_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"status\", zone=~\"$zone\"}[$__interval]) or increase(zeebe_backup_operations_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"status\", zone=~\"$zone\"}[$__interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -25832,7 +25832,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max by (physicalTenant, partition) ((rate(zeebe_backup_operations_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\"}[1h]) / rate(zeebe_backup_operations_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\"}[1h])) or (rate(zeebe_backup_operations_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\"}[1h]) / rate(zeebe_backup_operations_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\"}[1h])))",
+              "expr": "max by (physicalTenant, partition) ((rate(zeebe_backup_operations_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\", zone=~\"$zone\"}[1h]) / rate(zeebe_backup_operations_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\", zone=~\"$zone\"}[1h])) or (rate(zeebe_backup_operations_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\", zone=~\"$zone\"}[1h]) / rate(zeebe_backup_operations_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", operation=\"take\", zone=~\"$zone\"}[1h])))",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -25926,7 +25926,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(zeebe_backup_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (operation, result)",
+              "expr": "sum(zeebe_backup_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (operation, result)",
               "interval": "",
               "legendFormat": "{{operation}}: {{result}}",
               "refId": "B"
@@ -25991,7 +25991,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max(zeebe_backup_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"take\", result=\"failed\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_backup_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", operation=\"take\", result=\"failed\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -26083,7 +26083,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max(zeebe_checkpoint_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_checkpoint_records_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -26145,7 +26145,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max(zeebe_checkpoint_position{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_checkpoint_position{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -26207,7 +26207,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "max(zeebe_checkpoint_id{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}) by (physicalTenant, partition)",
+              "expr": "max(zeebe_checkpoint_id{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\", zone=~\"$zone\"}) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "refId": "A"
@@ -26303,7 +26303,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_actor_task_execution_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le) or sum(increase(zeebe_actor_task_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_actor_task_execution_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(zeebe_actor_task_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -26388,7 +26388,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_actor_job_scheduling_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le) or sum(increase(zeebe_actor_job_scheduling_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_actor_job_scheduling_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le) or sum(increase(zeebe_actor_job_scheduling_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -26490,7 +26490,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_actor_task_execution_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, actorName) or sum(rate(zeebe_actor_task_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, actorName))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_actor_task_execution_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, actorName) or sum(rate(zeebe_actor_task_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, actorName))",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -26504,7 +26504,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_actor_task_execution_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, actorName) or sum(rate(zeebe_actor_task_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, actorName))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_actor_task_execution_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, actorName) or sum(rate(zeebe_actor_task_execution_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, actorName))",
               "interval": "",
               "legendFormat": "p99 {{actorName}}",
               "range": true,
@@ -26604,7 +26604,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_actor_job_scheduling_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, subscriptionType) or sum(rate(zeebe_actor_job_scheduling_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, subscriptionType))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_actor_job_scheduling_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, subscriptionType) or sum(rate(zeebe_actor_job_scheduling_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, subscriptionType))",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -26617,7 +26617,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_actor_job_scheduling_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, subscriptionType) or sum(rate(zeebe_actor_job_scheduling_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, subscriptionType))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_actor_job_scheduling_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, subscriptionType) or sum(rate(zeebe_actor_job_scheduling_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, subscriptionType))",
               "interval": "",
               "legendFormat": "p99 {{subscriptionType}}",
               "range": true,
@@ -26716,7 +26716,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_actor_task_execution_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (actorName)",
+              "expr": "sum(rate(zeebe_actor_task_execution_count_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[1m])) by (actorName)",
               "legendFormat": "{{actorName}}",
               "range": true,
               "refId": "A"
@@ -26814,8 +26814,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_actor_task_queue_length{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (actorName)",
-              "legendFormat": "{{topic}}: {{pod}} => {{address}}",
+              "expr": "sum(rate(zeebe_actor_task_queue_length{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[1m])) by (actorName)",
+              "legendFormat": "{{topic}}: {{zone}} {{pod}} => {{address}}",
               "range": true,
               "refId": "A"
             }
@@ -26910,7 +26910,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", topic=~\"atomix-membership-probe-request\"}[$__rate_interval]) or increase(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", topic=~\"atomix-membership-probe-request\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_messaging_request_response_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", topic=~\"atomix-membership-probe-request\", zone=~\"$zone\"}[$__rate_interval]) or increase(zeebe_messaging_request_response_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", topic=~\"atomix-membership-probe-request\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -27012,9 +27012,9 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "zeebe_smp_members_incarnation_number{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}",
+              "expr": "zeebe_smp_members_incarnation_number{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}",
               "instant": false,
-              "legendFormat": "{{pod}} member: {{memberId}}",
+              "legendFormat": "{{zone}} {{pod}} member: {{memberId}}",
               "range": true,
               "refId": "A"
             }
@@ -27454,7 +27454,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_backpressure_inflight_requests_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition)",
+              "expr": "sum(zeebe_backpressure_inflight_requests_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} Partition: {{partition}}",
               "range": true,
               "refId": "B"
@@ -27554,7 +27554,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_dropped_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]) ) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_dropped_request_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]) ) by (physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} Partition: {{partition}}",
               "range": true,
               "refId": "B"
@@ -27654,7 +27654,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_backpressure_requests_limit{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} and on(namespace, partition, pod, instance) (atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"} == 3)) by (physicalTenant, partition)",
+              "expr": "sum(zeebe_backpressure_requests_limit{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} and on(namespace, partition, pod, instance) (atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"} == 3)) by (physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} Partition: {{partition}}",
               "range": true,
               "refId": "B"
@@ -27786,8 +27786,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_broker_jobs_pushed_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod)",
-              "legendFormat": "✅ {{pod}}",
+              "expr": "sum(rate(zeebe_broker_jobs_pushed_count_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (namespace, zone, pod)",
+              "legendFormat": "✅ {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             },
@@ -27797,8 +27797,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_broker_jobs_push_fail_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (namespace, pod)",
-              "legendFormat": "❌ {{pod}}",
+              "expr": "sum(rate(zeebe_broker_jobs_push_fail_count_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (namespace, zone, pod)",
+              "legendFormat": "❌ {{zone}} {{pod}}",
               "range": true,
               "refId": "B"
             }
@@ -27915,8 +27915,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_gateway_job_stream_push_total{namespace=~\"$namespace\", pod=~\"$pod\", status=\"success\"}[$__rate_interval])) by (namespace, pod)",
-              "legendFormat": "✅ {{pod}}",
+              "expr": "sum(rate(zeebe_gateway_job_stream_push_total{namespace=~\"$namespace\", pod=~\"$pod\", status=\"success\", zone=~\"$zone\"}[$__rate_interval])) by (namespace, zone, pod)",
+              "legendFormat": "✅ {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             },
@@ -27926,8 +27926,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_gateway_job_stream_push_total{namespace=~\"$namespace\", pod=~\"$pod\", status=\"failure\"}[$__rate_interval])) by (namespace, pod)",
-              "legendFormat": "❌ {{pod}}",
+              "expr": "sum(rate(zeebe_gateway_job_stream_push_total{namespace=~\"$namespace\", pod=~\"$pod\", status=\"failure\", zone=~\"$zone\"}[$__rate_interval])) by (namespace, zone, pod)",
+              "legendFormat": "❌ {{zone}} {{pod}}",
               "range": true,
               "refId": "B"
             }
@@ -28032,9 +28032,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_broker_jobs_push_fail_try_count_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, code)",
+              "expr": "sum(rate(zeebe_broker_jobs_push_fail_try_count_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, code)",
               "instant": false,
-              "legendFormat": "❌ {{pod}} {{code}}",
+              "legendFormat": "❌ {{zone}} {{pod}} {{code}}",
               "range": true,
               "refId": "A"
             }
@@ -28139,9 +28139,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_gateway_job_stream_push_fail_try_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, code)",
+              "expr": "sum(rate(zeebe_gateway_job_stream_push_fail_try_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, code)",
               "instant": false,
-              "legendFormat": "❌ {{pod}} {{code}}",
+              "legendFormat": "❌ {{zone}} {{pod}} {{code}}",
               "range": true,
               "refId": "A"
             }
@@ -28235,7 +28235,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_job_events_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", action=\"pushed\"}[$__rate_interval])) by (namespace, physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_job_events_total{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", action=\"pushed\", zone=~\"$zone\"}[$__rate_interval])) by (namespace, physicalTenant, partition)",
 "legendFormat": "{{physicalTenant}} p{{partition}}",
               "range": true,
               "refId": "A"
@@ -28347,9 +28347,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_gateway_job_stream_clients{namespace=~\"$namespace\", pod=~\"$pod\"}) by (namespace, pod)",
+              "expr": "sum(zeebe_gateway_job_stream_clients{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (namespace, zone, pod)",
               "format": "heatmap",
-              "legendFormat": "{{pod}}",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -28455,8 +28455,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_gateway_job_stream_streams{namespace=~\"$namespace\", pod=~\"$pod\"}) by (namespace, pod)",
-              "legendFormat": "{{pod}}",
+              "expr": "sum(zeebe_gateway_job_stream_streams{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (namespace, zone, pod)",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -28562,8 +28562,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_broker_open_job_stream_count{namespace=~\"$namespace\", pod=~\"$pod\"}) by (namespace, pod)",
-              "legendFormat": "{{pod}}",
+              "expr": "sum(zeebe_broker_open_job_stream_count{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (namespace, zone, pod)",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -28660,8 +28660,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(zeebe_gateway_job_stream_servers{namespace=~\"$namespace\", pod=~\"$pod\"}) by (namespace, pod)",
-              "legendFormat": "{{pod}}",
+              "expr": "sum(zeebe_gateway_job_stream_servers{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}) by (namespace, zone, pod)",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -28769,8 +28769,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_dns_success_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
-              "legendFormat": "{{pod}}",
+              "expr": "sum(rate(zeebe_dns_success_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod)",
+              "legendFormat": "{{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -28864,8 +28864,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_dns_failed_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod, code)",
-              "legendFormat": "{{pod}} {{code}}",
+              "expr": "sum(rate(zeebe_dns_failed_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod, code)",
+              "legendFormat": "{{zone}} {{pod}} {{code}}",
               "range": true,
               "refId": "B"
             }
@@ -28959,8 +28959,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_dns_error_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
-              "legendFormat": "{{pod}} errors",
+              "expr": "sum(rate(zeebe_dns_error_total{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval])) by (zone, pod)",
+              "legendFormat": "{{zone}} {{pod}} errors",
               "range": true,
               "refId": "C"
             }
@@ -29067,7 +29067,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_cluster_changes_operations_pending{namespace=~\"$namespace\", pod=~\"$pod\"})",
+              "expr": "max(zeebe_cluster_changes_operations_pending{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"})",
               "instant": false,
               "legendFormat": "Pending",
               "range": true,
@@ -29079,7 +29079,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_cluster_changes_operations_completed{namespace=~\"$namespace\", pod=~\"$pod\"})",
+              "expr": "max(zeebe_cluster_changes_operations_completed{namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"})",
               "instant": false,
               "legendFormat": "Completed",
               "range": true,
@@ -29167,10 +29167,10 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (pod, operation) (zeebe_cluster_changes_operation_attempts_total{outcome=\"failed\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+              "expr": "sum by (zone, pod, operation) (zeebe_cluster_changes_operation_attempts_total{outcome=\"failed\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
-              "legendFormat": "{{operation}} on {{pod}}",
+              "legendFormat": "{{operation}} on {{zone}} {{pod}}",
               "range": false,
               "refId": "A"
             }
@@ -29249,7 +29249,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (increase(zeebe_cluster_changes_operation_duration_bucket[$__rate_interval])) or sum by (le) (increase(zeebe_cluster_changes_operation_duration_seconds_bucket[$__rate_interval]))",
+              "expr": "sum by (le) (increase(zeebe_cluster_changes_operation_duration_bucket{zone=~\"$zone\"}[$__rate_interval])) or sum by (le) (increase(zeebe_cluster_changes_operation_duration_seconds_bucket{zone=~\"$zone\"}[$__rate_interval]))",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "__auto",
@@ -29360,10 +29360,10 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (pod, operation) (zeebe_cluster_changes_operation_attempts_total{outcome=\"applied\", namespace=~\"$namespace\", pod=~\"$pod\"})",
+              "expr": "sum by (zone, pod, operation) (zeebe_cluster_changes_operation_attempts_total{outcome=\"applied\", namespace=~\"$namespace\", pod=~\"$pod\", zone=~\"$zone\"})",
               "format": "table",
               "instant": true,
-              "legendFormat": "{{operation}} on {{pod}}",
+              "legendFormat": "{{operation}} on {{zone}} {{pod}}",
               "range": false,
               "refId": "A"
             }
@@ -29450,7 +29450,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(min by (physicalTenant, partition) (zeebe_cluster_partition_balanced{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}))",
+              "expr": "avg(min by (physicalTenant, partition) (zeebe_cluster_partition_balanced{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}))",
               "instant": true,
               "legendFormat": "Balanced",
               "range": false,
@@ -29548,7 +29548,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "avg(min by (physicalTenant, partition) (zeebe_cluster_partition_balanced{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}))",
+              "expr": "avg(min by (physicalTenant, partition) (zeebe_cluster_partition_balanced{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}))",
               "instant": false,
               "legendFormat": "Balanced",
               "range": true,
@@ -29642,7 +29642,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "label_replace(label_replace(label_replace(min by (physicalTenant, partition) (zeebe_cluster_partition_balanced{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}), \"partitionSort\", \"00$1\", \"partition\", \"([0-9])\"), \"partitionSort\", \"0$1\", \"partition\", \"([0-9][0-9])\"), \"partitionSort\", \"$1\", \"partition\", \"([0-9][0-9][0-9])\")",
+              "expr": "label_replace(label_replace(label_replace(min by (physicalTenant, partition) (zeebe_cluster_partition_balanced{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}), \"partitionSort\", \"00$1\", \"partition\", \"([0-9])\"), \"partitionSort\", \"0$1\", \"partition\", \"([0-9][0-9])\"), \"partitionSort\", \"$1\", \"partition\", \"([0-9][0-9][0-9])\")",
               "instant": false,
               "legendFormat": "{{physicalTenant}} p{{partitionSort}}",
               "range": true,
@@ -29755,7 +29755,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "label_replace(label_replace(label_replace(max by (physicalTenant, partition) (zeebe_cluster_rebalance_partition_state{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}), \"partitionSort\", \"00$1\", \"partition\", \"([0-9])\"), \"partitionSort\", \"0$1\", \"partition\", \"([0-9][0-9])\"), \"partitionSort\", \"$1\", \"partition\", \"([0-9][0-9][0-9])\")",
+              "expr": "label_replace(label_replace(label_replace(max by (physicalTenant, partition) (zeebe_cluster_rebalance_partition_state{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}), \"partitionSort\", \"00$1\", \"partition\", \"([0-9])\"), \"partitionSort\", \"0$1\", \"partition\", \"([0-9][0-9])\"), \"partitionSort\", \"$1\", \"partition\", \"([0-9][0-9][0-9])\")",
               "instant": false,
               "legendFormat": "{{physicalTenant}} p{{partitionSort}}",
               "range": true,
@@ -29858,7 +29858,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "round(sum by (result) (increase(zeebe_cluster_rebalance_elapsed_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__range])))",
+              "expr": "round(sum by (result) (increase(zeebe_cluster_rebalance_elapsed_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__range])))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -29872,7 +29872,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (result) (increase(zeebe_cluster_rebalance_elapsed_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__range])) / (sum by (result) (increase(zeebe_cluster_rebalance_elapsed_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__range])) > 0)",
+              "expr": "sum by (result) (increase(zeebe_cluster_rebalance_elapsed_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__range])) / (sum by (result) (increase(zeebe_cluster_rebalance_elapsed_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}[$__range])) > 0)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -29989,7 +29989,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "round(sum by (physicalTenant, partition, result) (increase(zeebe_cluster_rebalance_partition_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__range])))",
+              "expr": "round(sum by (physicalTenant, partition, result) (increase(zeebe_cluster_rebalance_partition_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__range])))",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -30084,7 +30084,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "label_replace(label_replace(label_replace(max(zeebe_cluster_rebalance_partition_paused{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition), \"partitionSort\", \"00$1\", \"partition\", \"([0-9])\"), \"partitionSort\", \"0$1\", \"partition\", \"([0-9][0-9])\"), \"partitionSort\", \"$1\", \"partition\", \"([0-9][0-9][0-9])\")",
+              "expr": "label_replace(label_replace(label_replace(max(zeebe_cluster_rebalance_partition_paused{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition), \"partitionSort\", \"00$1\", \"partition\", \"([0-9])\"), \"partitionSort\", \"0$1\", \"partition\", \"([0-9][0-9])\"), \"partitionSort\", \"$1\", \"partition\", \"([0-9][0-9][0-9])\")",
               "instant": false,
               "legendFormat": "{{physicalTenant}} p{{partitionSort}}",
               "range": true,
@@ -30179,7 +30179,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (increase(zeebe_cluster_rebalance_partition_pause_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum by (le) (increase(zeebe_cluster_rebalance_partition_pause_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -30261,7 +30261,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (clamp_min((zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"} - (zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"} offset $__rate_interval)) or zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\"}, 0))",
+              "expr": "sum by (le) (clamp_min((zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\", zone=~\"$zone\"} - (zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\", zone=~\"$zone\"} offset $__rate_interval)) or zeebe_cluster_rebalance_partition_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result!~\"ALREADY_LEADER|CANCELLED|PHYSICAL_TENANT_DISABLED\", zone=~\"$zone\"}, 0))",
               "format": "heatmap",
               "instant": false,
               "legendFormat": "{{le}}",
@@ -30377,9 +30377,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])",
+              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\", zone=~\"$zone\"}[$__rate_interval])",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -30478,8 +30478,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=\"1\", bootstrap=\"true\"}",
-"legendFormat": "{{physicalTenant}} {{pod}} p{{partition}}",
+              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=\"1\", bootstrap=\"true\", zone=~\"$zone\"}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} p{{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -30561,7 +30561,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"1\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"1\", bootstrap=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -30574,7 +30574,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -30659,7 +30659,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -30671,7 +30671,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", bootstrap=\"true\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -30762,7 +30762,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_process_definitions_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) \n",
+              "expr": "max(zeebe_process_definitions_count{namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) \n",
 "legendFormat": "{{physicalTenant}} Partition-{{partition}}",
               "range": true,
               "refId": "A"
@@ -30864,9 +30864,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(sum(zeebe_process_definition_resource_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (physicalTenant, partition))",
+              "expr": "max(sum(zeebe_process_definition_resource_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (physicalTenant, partition))",
               "interval": "",
-"legendFormat": "{{physicalTenant}} {{pod}} memory {{partition}}",
+"legendFormat": "{{physicalTenant}} {{zone}} {{pod}} memory {{partition}}",
               "range": true,
               "refId": "A"
             }
@@ -30968,7 +30968,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_variable_created_size_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_variable_created_size_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "range": true,
@@ -31054,7 +31054,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum by (le) (rate(zeebe_variable_created_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "sum by (le) (rate(zeebe_variable_created_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",physicalTenant=~\"$physicalTenant\", partition=~\"$partition\",pod=~\"$pod\", zone=~\"$zone\"}[$__rate_interval]))",
               "format": "heatmap",
               "fromExploreMetrics": true,
               "interval": "",
@@ -31159,7 +31159,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_variable_created_size_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (physicalTenant, partition)",
+              "expr": "sum(rate(zeebe_variable_created_size_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (physicalTenant, partition)",
               "interval": "",
 "legendFormat": "{{physicalTenant}} Partition {{partition}}",
               "range": true,
@@ -31270,7 +31270,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (outcome)",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (outcome)",
               "legendFormat": "{{outcome}}",
               "range": true,
               "refId": "A"
@@ -31366,7 +31366,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (outcome)",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (outcome)",
               "legendFormat": "{{outcome}}",
               "range": true,
               "refId": "A"
@@ -31462,7 +31462,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "request decisions (P_B)",
               "range": true,
               "refId": "A"
@@ -31473,7 +31473,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "replies processed (P_K)",
               "range": true,
               "refId": "B"
@@ -31484,7 +31484,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "reply-loss gap",
               "range": true,
               "refId": "C"
@@ -31580,7 +31580,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "initial asks",
               "range": true,
               "refId": "A"
@@ -31591,7 +31591,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_retries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_retries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "retries",
               "range": true,
               "refId": "B"
@@ -31687,7 +31687,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_dedup_swept_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_dedup_swept_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "swept",
               "range": true,
               "refId": "A"
@@ -31797,8 +31797,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_message_start_cross_partition_asks_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (partition, pod)",
-              "legendFormat": "pending asks p{{partition}} {{pod}}",
+              "expr": "max(zeebe_message_start_cross_partition_asks_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (partition, zone, pod)",
+              "legendFormat": "pending asks p{{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             },
@@ -31808,8 +31808,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_message_start_cross_partition_locks{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (partition, pod)",
-              "legendFormat": "held locks p{{partition}} {{pod}}",
+              "expr": "max(zeebe_message_start_cross_partition_locks{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (partition, zone, pod)",
+              "legendFormat": "held locks p{{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "B"
             },
@@ -31819,8 +31819,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_buffered_messages_business_id_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (partition, pod)",
-              "legendFormat": "business-id buffered p{{partition}} {{pod}}",
+              "expr": "max(zeebe_buffered_messages_business_id_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (partition, zone, pod)",
+              "legendFormat": "business-id buffered p{{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "C"
             }
@@ -31915,8 +31915,8 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "max(zeebe_message_start_cross_partition_dedup_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}) by (partition, pod)",
-              "legendFormat": "dedup entries p{{partition}} {{pod}}",
+              "expr": "max(zeebe_message_start_cross_partition_dedup_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}) by (partition, zone, pod)",
+              "legendFormat": "dedup entries p{{partition}} {{zone}} {{pod}}",
               "range": true,
               "refId": "A"
             }
@@ -32011,7 +32011,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_blocked_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (reason)",
+              "expr": "sum(rate(zeebe_message_start_blocked_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (reason)",
               "legendFormat": "{{reason}}",
               "range": true,
               "refId": "A"
@@ -32107,7 +32107,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_release_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_release_queries_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "reconciliation queries",
               "range": true,
               "refId": "A"
@@ -32188,7 +32188,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_message_start_cross_partition_lock_release_query_batch_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_message_start_cross_partition_lock_release_query_batch_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "legendFormat": "{{le}}",
               "range": true,
               "refId": "A",
@@ -32285,7 +32285,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (trigger)",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (trigger)",
               "legendFormat": "{{trigger}}",
               "range": true,
               "refId": "A"
@@ -32381,7 +32381,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (result)",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (result)",
               "legendFormat": "{{result}}",
               "range": true,
               "refId": "A"
@@ -32477,7 +32477,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "sent (P_B->P_K)",
               "range": true,
               "refId": "A"
@@ -32488,7 +32488,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "processed (P_K)",
               "range": true,
               "refId": "B"
@@ -32499,7 +32499,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "lost release commands",
               "range": true,
               "refId": "C"
@@ -32594,7 +32594,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "legendFormat": "{{le}}",
               "range": true,
               "refId": "A",
@@ -32691,7 +32691,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, outcome))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, outcome))",
               "legendFormat": "p50 {{outcome}}",
               "range": true,
               "refId": "A"
@@ -32702,7 +32702,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, outcome))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, outcome))",
               "legendFormat": "p90 {{outcome}}",
               "range": true,
               "refId": "B"
@@ -32713,7 +32713,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, outcome))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, outcome))",
               "legendFormat": "p99 {{outcome}}",
               "range": true,
               "refId": "C"
@@ -32794,7 +32794,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "legendFormat": "{{le}}",
               "range": true,
               "refId": "A",
@@ -32891,7 +32891,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, outcome))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, outcome))",
               "legendFormat": "p50 {{outcome}}",
               "range": true,
               "refId": "A"
@@ -32902,7 +32902,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, outcome))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, outcome))",
               "legendFormat": "p90 {{outcome}}",
               "range": true,
               "refId": "B"
@@ -32913,7 +32913,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le, outcome))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le, outcome))",
               "legendFormat": "p99 {{outcome}}",
               "range": true,
               "refId": "C"
@@ -32994,7 +32994,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le)",
               "legendFormat": "{{le}}",
               "range": true,
               "refId": "A",
@@ -33091,7 +33091,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "legendFormat": "p50",
               "range": true,
               "refId": "A"
@@ -33102,7 +33102,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "legendFormat": "p90",
               "range": true,
               "refId": "B"
@@ -33113,7 +33113,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_message_start_cross_partition_release_to_start_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) by (le))",
               "legendFormat": "p99",
               "range": true,
               "refId": "C"
@@ -33209,7 +33209,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "mean ask duration (M7)",
               "range": true,
               "refId": "A"
@@ -33220,7 +33220,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "mean round-trip (M17)",
               "range": true,
               "refId": "B"
@@ -33231,7 +33231,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_round_trip_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "mean retry + contention (M7 - M17, approx)",
               "range": true,
               "refId": "C"
@@ -33341,7 +33341,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"started\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"started\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "started",
               "range": true,
               "refId": "A"
@@ -33352,7 +33352,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"expired\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"expired\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "expired",
               "range": true,
               "refId": "B"
@@ -33457,7 +33457,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"expired\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"expired\", zone=~\"$zone\"}[$__rate_interval])) / sum(rate(zeebe_message_start_cross_partition_asks_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "expired share",
               "range": true,
               "refId": "A"
@@ -33552,7 +33552,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"dedup_hit\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", outcome=\"dedup_hit\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "dedup_hit (STARTED reply lost, retried)",
               "range": true,
               "refId": "A"
@@ -33563,7 +33563,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval])) - sum(rate(zeebe_message_start_cross_partition_replies_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "request-reply gap (loss)",
               "range": true,
               "refId": "B"
@@ -33659,7 +33659,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", trigger=\"reconciliation\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_sent_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", trigger=\"reconciliation\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "reconciliation release (push lost / holder gone)",
               "range": true,
               "refId": "A"
@@ -33670,7 +33670,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result=\"redundant\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_message_start_cross_partition_lock_releases_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", result=\"redundant\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "redundant release (push x poll race)",
               "range": true,
               "refId": "B"
@@ -33765,7 +33765,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(deriv(zeebe_message_start_cross_partition_asks_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(deriv(zeebe_message_start_cross_partition_asks_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "pending asks (M4, P_K)",
               "range": true,
               "refId": "A"
@@ -33776,7 +33776,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(deriv(zeebe_message_start_cross_partition_locks{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(deriv(zeebe_message_start_cross_partition_locks{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "held locks (M5, P_K)",
               "range": true,
               "refId": "B"
@@ -33787,7 +33787,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(deriv(zeebe_message_start_cross_partition_dedup_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(deriv(zeebe_message_start_cross_partition_dedup_entries{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "dedup entries (M6, P_B)",
               "range": true,
               "refId": "C"
@@ -33798,7 +33798,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(deriv(zeebe_buffered_messages_business_id_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(deriv(zeebe_buffered_messages_business_id_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", zone=~\"$zone\"}[$__rate_interval]))",
               "legendFormat": "business-id buffered (M15, msg partition)",
               "range": true,
               "refId": "D"
@@ -33894,13 +33894,39 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
+        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, zone)",
+        "description": "Cluster zone",
+        "includeAll": true,
+        "multi": true,
+        "name": "zone",
+        "options": [],
+        "query": {
+          "query": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, zone)",
+          "refId": "Prometheus-zone-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "regexApplyTo": "value",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}, pod)",
         "includeAll": true,
         "multi": true,
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
+          "query": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\"}, pod)",
           "refId": "Prometheus-pod-Variable-Query"
         },
         "refresh": 2,
@@ -33919,13 +33945,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}, physicalTenant)",
+        "definition": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\"}, physicalTenant)",
         "includeAll": true,
         "multi": true,
         "name": "physicalTenant",
         "options": [],
         "query": {
-          "query": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}, physicalTenant)",
+          "query": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\"}, physicalTenant)",
           "refId": "Prometheus-physicalTenant-Variable-Query"
         },
         "refresh": 2,
@@ -33944,13 +33970,13 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}, partition)",
+        "definition": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}, partition)",
         "includeAll": true,
         "multi": true,
         "name": "partition",
         "options": [],
         "query": {
-          "query": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}, partition)",
+          "query": "label_values(zeebe_health{cluster=~\"$cluster\", namespace=~\"$namespace\", zone=~\"$zone\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\"}, partition)",
           "refId": "Prometheus-partition-Variable-Query"
         },
         "refresh": 2,


### PR DESCRIPTION
## Description
With PR #58777 we added `nodeId` label to the metrics, but it's not possible to use it in the grafana dashboard because it's impossible to add it without breaking compatibility with versions < 8.10.
For this reason we add a `zone` label to all metrics exported. 
Then we can use `(zone, pod)` in all metrics so that we properly segregate each pod metrics: in a multi-region scenario `pod` is not unique and that would lead to wrong results in the dashboard.

Because `zone` is more generic, it can also be exported by standalone gateways, given that it's properly configured: for this reason we can use a `MeterRegistryCustomizer` instead of adding the label in `SystemContext` like in PR #58777 

In the dashboard all metrics now use the tuple `(zone, pod)`


Dashboard is currently deployed [here](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard-zoned/zeebe-zoned?from=now-30m&to=now&timezone=browser&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-namespace=c8-medic-2026-34-c9128ca4-realistic&var-zone=$__all&var-pod=$__all&var-physicalTenant=$__all&var-partition=$__all&var-memory_state=committed&refresh=auto) in the load-tests grafana

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #57612

- [ ] This PR does not need a linked issue

