### PR TITLE
deps: bump Bouncy Castle to fix GOST CTR cipher vulnerability

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -38,7 +38,8 @@
     <version.agrona>1.23.1</version.agrona>
     <version.assertj>3.26.3</version.assertj>
     <version.awaitility>4.2.2</version.awaitility>
-    <version.bouncycastle>1.81</version.bouncycastle>
+    <version.bouncycastle-bcpkix>1.85</version.bouncycastle-bcpkix>
+    <version.bouncycastle-bcprov>1.85.2</version.bouncycastle-bcprov>
     <version.camunda>7.22.0</version.camunda>
     <version.camunda-license-check>2.9.0</version.camunda-license-check>
     <version.checkstyle>10.18.2</version.checkstyle>
@@ -1644,13 +1645,13 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
-        <version>${version.bouncycastle}</version>
+        <version>${version.bouncycastle-bcpkix}</version>
       </dependency>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-        <version>${version.bouncycastle}</version>
+        <version>${version.bouncycastle-bcprov}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

ESUP backport for `stable/8.6`: bump Bouncy Castle to fix **CVE-2025-14813** (CVSS 8.7) — the `G3413CTRBlockCipher` GOST 28147 CTR-mode implementation uses a single-byte counter, so it silently reuses its keystream after 255 blocks, breaking confidentiality of anything encrypted through it.

`stable/8.6` ships `bcprov-jdk18on` **1.81**, which is affected. No designed or documented use of GOST CTR was found in Zeebe, Operate, Tasklist, TLS, or JWT flows — the only Bouncy Castle usage in the repo is `Pkcs1SupportTest.java` (unrelated PKCS#1 support) — so reachability from normal traffic is unconfirmed and likely absent. The dependency ships regardless, so it's fixed here rather than left for a hypothetical future extension to trip over.

### Why bump to 1.85.2 and not the minimal 1.84/1.81.1 fix

The advisory says BC-JAVA is affected from **1.59 up to (not including) 1.84**, with the fix also backported into point releases **1.80.2** and **1.81.1**. Rather than take the narrowest patch, this follows what every other branch already did: bump straight to the version already running on `main`/`stable/8.7`/`8.8`/`8.9`/`8.10`, so `stable/8.6` doesn't carry a Bouncy Castle version nothing else in the repo uses. That version also happens to close four *other* CVEs fixed in 1.84 (CVE-2026-0636, CVE-2026-3505, CVE-2026-5588, CVE-2026-5598) as a side effect.

Is a jump from 1.81 to 1.85 safe? Yes:
- `bc-java` maintains strong backward compatibility within the 1.8x (`jdk18on`) line; this range is additive (post-quantum/ML-DSA, composite signatures, PKI/CMP work).
- The only breaking-adjacent changes are *deprecations*, not removals: `CMCEKey`, `Dilithium{Key,PrivateKey,PublicKey}` (superseded by ML-DSA), `DSAEncoder`, `ElGamalPublicKey`. None of these are referenced anywhere in this repo.
- No API removals were found between 1.81 and 1.85.

### Why the property split

`bcprov-jdk18on` and `bcpkix-jdk18on` used to release in lockstep under the single `version.bouncycastle` property. That stopped being true at the patch level: bcprov got an out-of-band `1.85.2` release that bcpkix never received (Maven Central tops out at `bcpkix-jdk18on:1.85`). Pointing both artifacts at `1.85.2` fails dependency resolution outright:

```
Could not resolve dependencies for project io.camunda:zeebe-broker:jar:8.6.40-SNAPSHOT
Failed to read artifact descriptor for org.bouncycastle:bcpkix-jdk18on:jar:1.85.2
```

This isn't a new problem — `stable/8.7` and `stable/8.10` hit exactly this and both split the property to let the two artifacts version independently (see precedents below). `stable/8.6` still had the old single-property shape, so this PR applies the same split while bumping.

`parent/pom.xml`, one property becomes two:

| Property | Before | After |
|---|---|---|
| `version.bouncycastle` | `1.81` | *(removed)* |
| `version.bouncycastle-bcpkix` | — | `1.85` |
| `version.bouncycastle-bcprov` | — | `1.85.2` |

### Precedents (other branches)

Bouncy Castle was already fixed everywhere except `stable/8.6`:

- **main** → `1.85`: #57889
- **stable/8.7** → `1.85`: #59463 (backport of #57889), later → property split + `1.85.2`: #59810
- **stable/8.8** → `1.85`: #59465 (backport of #57889)
- **stable/8.9** → `1.85`: #59466 (backport of #57889)
- **stable/optimize-8.7** → `1.85`: #59464 (backport of #57889)
- **stable/8.10** → property split + `1.85.2`: #60923

`stable/8.6` never received the original `1.85` bump (#57889 was never backported this far), so this PR does both steps — the minor bump `main`/`8.7`/`8.8`/`8.9` already have, and the patch-level split `8.7`/`8.10` already needed — in one change.

### Verification done locally

- `dependency:tree` on `zeebe-broker` resolves cleanly: `bcpkix-jdk18on:1.85`, `bcprov-jdk18on:1.85.2`.
- `./mvnw license:format spotless:apply -pl parent` — clean, no diff.
- `./mvnw install -pl parent -Dquickly -T1C` — green.
- `./mvnw install -Dquickly -T1C` — full repository compile — green.

## Related issues

- [x] This PR does not need a linked issue
