### PR TITLE
ci: fix deploy-snapshots hitting a too-tight timeout with dead retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2884,9 +2884,9 @@ jobs:
     name: Deploy snapshot artifacts
     needs: [ check-results, build-platform-frontend, utils-get-concurrency-group-for-maven-snapshot ]
     runs-on: gcp-perf-core-8-default
-    # 30 min (the policy ceiling) covers the one-time checkout/setup/build overhead plus up to 2
-    # attempts of the deploy step below; the retry only re-runs that step, not this whole job.
-    timeout-minutes: 30
+    # Exceeds the 30min Unified CI ceiling (docs/monorepo-docs/ci.md); pending EngOps exception.
+    # Covers ~6min setup + up to 2x20min deploy attempts; retry only re-runs the deploy step.
+    timeout-minutes: 48
     permissions: { }  # GITHUB_TOKEN unused in this job
     if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
@@ -2933,15 +2933,17 @@ jobs:
       # POM whose parent chain (zeebe-parent) must be resolved by external consumers to build the
       # effective model; the flattened POM is self-contained, exactly as published releases are.
       # Artifactory intermittently returns a transient 500 on artifact/metadata upload (INC-6737,
-      # INC-7541); a bare re-run of this exact command succeeded both times with no other change, so
-      # retrying automates that recovery. Deploying the same SNAPSHOT version twice is safe/idempotent.
+      # INC-7541); retrying automates recovery. Deploying the same SNAPSHOT twice is safe/idempotent.
+      # retry_on: any, not error — nick-fields/retry treats a timeout_minutes kill as a distinct event
+      # that retry_on: error does NOT retry. timeout_minutes needs real margin for this to be useful,
+      # else every run just hits the timeout wall on attempt 1 (see incident 2026-09-02).
       - name: Compile and deploy snapshot artifacts
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 2
-          retry_on: error
+          retry_on: any
           retry_wait_seconds: 15
-          timeout_minutes: 13
+          timeout_minutes: 20
           command: ./mvnw -B -T1C -D skipTests -D skipChecks -PskipFrontendBuild -Dflatten.updatePomFile=true compile generate-sources source:jar javadoc:jar deploy
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## What

`deploy-snapshots`' "Compile and deploy snapshot artifacts" step has been hitting its 13-minute timeout on every run since 2026-09-02 (30+ consecutive failures, e.g. [run 33723643006](https://github.com/camunda/camunda/actions/runs/33723643006/job/100553352051)). Reported/discussed in [this Slack incident thread](https://camunda.slack.com/archives/C0C03EBHA3S).

## Why

Not a code regression. The step's baseline runtime was already ~12-13 min before `7d65355ca4` (2026-08-31) added a 13-minute `timeout_minutes` with no margin over that baseline. Normal runtime variance has been enough to tip it over ever since.

Worse: the `nick-fields/retry` wrapper (`max_attempts: 2`) never actually retried this. `retry_on: error` only matches a non-zero exit from the command; a `timeout_minutes` kill is a distinct code path in the action (process killed via `tree-kill` before it exits, so the action's internal `done` flag is never set), which `retry_on: error` explicitly excludes:

```js
if (!done && inputs.retry_on === 'error') {
  throw error; // no retry, even though max_attempts is 2
}
```

Every one of the 30+ failures ran exactly one 13-minute attempt, not two. Verified live on this branch's own CI: a disposable job running the same pinned `nick-fields/retry` action with a guaranteed timeout showed `Attempt 1` → warning → `Attempt 2` with `retry_on: any`, versus an immediate throw after attempt 1 with `retry_on: error`.

## Changes

- `retry_on: error → any` so a timeout also gets a 2nd attempt.
- `timeout_minutes: 13 → 20` on the deploy step — real margin instead of ~0.
- job `timeout-minutes: 30 → 48` to fit checkout/setup + 2×20min deploy attempts.

An earlier revision also split "Compile and deploy" into two steps for separate compile/deploy timing. Reverted after review found it ran `source:jar javadoc:jar deploy` as bare goals *before* `deploy` re-expanded the lifecycle back to `generate-sources` — so `build-helper-maven-plugin:add-source` (bound to `generate-sources` in `zeebe/protocol`, `zeebe/journal`, `zeebe/transport`, `zeebe/broker`, etc.) never ran first, meaning generated sources (e.g. SBE types) could silently be missing from the deployed `-sources.jar`/`-javadoc.jar` while the step stayed green. Also, `deploy` is a lifecycle phase, so even a correctly-ordered split wouldn't produce disjoint compile/deploy timings anyway.

## Open question — job timeout vs. the 30min Unified CI policy

`docs/monorepo-docs/ci.md` documents a 30min ceiling for job `timeout-minutes`, enforced (as a non-blocking warning, not a hard fail) by `.github/conftest-unified-ci-rules.rego` — confirmed firing on this branch's own CI. This job was already at that ceiling before this PR (`timeout-minutes: 30`, no margin — part of the root cause).

Real numbers: observed setup overhead is ~5:40 (checkout + Vault setup + artifact downloads + inline frontend build, from run 33723643006). Real margin (20min/attempt) for 2 attempts is `20 + 0:15 + 20 = 40:15`, plus setup ≈ 46min minimum — doesn't fit in 30min at all, since the step's own ~13min baseline already consumes most of a 30min budget for a single attempt. A thinner interim value was tried and dropped: the conftest warning fires the same regardless of the exact number, so there's no benefit to a smaller margin.

Discussing the 30min ceiling with stakeholders. Once resolved:
- if approved as an exception: no further change needed, this already reflects real margin.
- if not approved: fall back to `max_attempts: 1` (loses the Artifactory-500 auto-recovery this retry was originally added for) or investigate shrinking the step's actual ~13min baseline.

## Testing

- `retry_on: any` retrying a timeout: verified live on this branch's own CI (see Why section).
- The restored single-invocation command: not exercisable pre-merge (`deploy-snapshots` only runs on `main`/`stable/*` pushes, needs real Artifactory creds). This is the original, previously-working goal ordering, so risk is low; will confirm on the first real run on `main` after merge.

## Related issues

- [x] This PR does not need a linked issue
