### PR TITLE
fix: report pendingChange under the same id as lastChange and the change endpoints

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -17,10 +17,8 @@ import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
-import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -64,7 +62,9 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncar
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Global;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Groups;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
@@ -243,39 +243,86 @@ final class ClusterApiUtils {
         .map(ClusterApiUtils::mapConfigurationChange);
   }
 
-  /**
-   * Maps a pending plan's operations to completed/pending, using the actual progress of whichever
-   * sub-config (global or physical tenant) the currently active phase targets: phases before {@code
-   * currentPhaseIndex} are fully done, phases after it are entirely untouched, but the active
-   * phase's own operations may be partially done already — activating a phase copies its operations
-   * into the target sub-config's {@link ClusterChangePlan}, which independently tracks which of
-   * those operations have completed so far.
-   */
   private static ConfigurationChange mapConfigurationChange(
+      final CurrentClusterConfiguration configuration, final PhasedChangePlan plan) {
+    final var progress = progressOf(configuration, plan);
+    return new ConfigurationChange()
+        .id(plan.id())
+        .status(ConfigurationChange.StatusEnum.IN_PROGRESS)
+        .startedAt(mapInstantToDateTime(plan.startedAt()))
+        .completed(
+            progress.completed().stream().map(CompletedOperationProgress::operation).toList())
+        .pending(progress.pending());
+  }
+
+  /**
+   * The pending phased plan, if any, that {@code GET /actuator/cluster} reports as {@code
+   * pendingChange} when {@code groupId} is the one group in view: the plan that touches that group,
+   * either directly or by being cluster-wide. {@link PhasedChangeState#initPlan} rejects
+   * overlapping scopes, so at most one pending plan can match.
+   */
+  private static Optional<PhasedChangePlan> pendingPlanFor(
+      final CurrentClusterConfiguration configuration, final String groupId) {
+    return configuration.phasedChangeState().pending().values().stream()
+        .filter(
+            plan ->
+                switch (plan.scope()) {
+                  case final Global ignored -> true;
+                  case final Groups groups -> groups.groupIds().contains(groupId);
+                })
+        .findFirst();
+  }
+
+  /**
+   * Maps a pending phased plan to the topology endpoint's {@code pendingChange}. The id is the
+   * phased plan's, the same id {@code POST /actuator/cluster/...} returned when the change was
+   * submitted, that {@code GET /actuator/cluster/changes/{id}} accepts, and that {@code lastChange}
+   * will report once the plan completes — never the id of the sub-config plan currently executing
+   * one of its phases, which comes from an unrelated counter.
+   */
+  private static TopologyChange mapPendingChange(
+      final CurrentClusterConfiguration configuration, final PhasedChangePlan plan) {
+    final var progress = progressOf(configuration, plan);
+    return new TopologyChange()
+        .id(plan.id())
+        .status(StatusEnum.IN_PROGRESS)
+        .startedAt(mapInstantToDateTime(plan.startedAt()))
+        .completed(
+            progress.completed().stream()
+                .map(op -> mapCompletedOperation(op.operation(), op.completedAt()))
+                .toList())
+        .pending(progress.pending());
+  }
+
+  /**
+   * Splits a pending plan's operations into completed/pending, using the actual progress of
+   * whichever sub-config (global or physical tenant) the currently active phase targets: phases
+   * before {@code currentPhaseIndex} are fully done, phases after it are entirely untouched, but
+   * the active phase's own operations may be partially done already — activating a phase copies its
+   * operations into the target sub-config's {@link ClusterChangePlan}, which independently tracks
+   * which of those operations have completed so far, and when.
+   */
+  private static ChangeProgress progressOf(
       final CurrentClusterConfiguration configuration, final PhasedChangePlan plan) {
     final var phases = plan.phases();
     final var completedPhases = phases.subList(0, plan.currentPhaseIndex());
     final var remainingPhases = phases.subList(plan.currentPhaseIndex(), phases.size());
 
-    final List<Operation> completed = new ArrayList<>(mapPhaseOperations(completedPhases));
+    final List<CompletedOperationProgress> completed = new ArrayList<>();
+    mapPhaseOperations(completedPhases)
+        .forEach(operation -> completed.add(new CompletedOperationProgress(operation, null)));
     final List<Operation> pending = new ArrayList<>();
     if (!remainingPhases.isEmpty()) {
       splitActivePhase(configuration, remainingPhases.get(0), completed, pending);
       pending.addAll(mapPhaseOperations(remainingPhases.subList(1, remainingPhases.size())));
     }
-
-    return new ConfigurationChange()
-        .id(plan.id())
-        .status(ConfigurationChange.StatusEnum.IN_PROGRESS)
-        .startedAt(mapInstantToDateTime(plan.startedAt()))
-        .completed(completed)
-        .pending(pending);
+    return new ChangeProgress(completed, pending);
   }
 
   private static void splitActivePhase(
       final CurrentClusterConfiguration configuration,
       final Phase activePhase,
-      final List<Operation> completed,
+      final List<CompletedOperationProgress> completed,
       final List<Operation> pending) {
     switch (activePhase) {
       case final GlobalPhase globalPhase ->
@@ -294,7 +341,7 @@ final class ClusterApiUtils {
       final CurrentClusterConfiguration configuration,
       final Map<String, ? extends List<? extends ClusterConfigurationChangeOperation>>
           groupOperations,
-      final List<Operation> completed,
+      final List<CompletedOperationProgress> completed,
       final List<Operation> pending) {
     groupOperations.forEach(
         (groupId, operations) ->
@@ -318,7 +365,7 @@ final class ClusterApiUtils {
       final String physicalTenantId,
       final List<? extends ClusterConfigurationChangeOperation> phaseOperations,
       final Optional<? extends ChangePlan> subConfigPlan,
-      final List<Operation> completed,
+      final List<CompletedOperationProgress> completed,
       final List<Operation> pending) {
     if (subConfigPlan.isEmpty()) {
       pending.addAll(mapOperations(physicalTenantId, phaseOperations));
@@ -328,7 +375,10 @@ final class ClusterApiUtils {
     plan.completedOperations()
         .forEach(
             completedOperation ->
-                completed.add(mapOperation(physicalTenantId, completedOperation.operation())));
+                completed.add(
+                    new CompletedOperationProgress(
+                        mapOperation(physicalTenantId, completedOperation.operation()),
+                        completedOperation.completedAt())));
     pending.addAll(mapOperations(physicalTenantId, plan.pendingOperations()));
   }
 
@@ -764,12 +814,14 @@ final class ClusterApiUtils {
    * <ul>
    *   <li>at most one group in view (an unscoped request against a single-tenant cluster, a request
    *       scoped to one physical tenant, or an uninitialized configuration with zero groups):
-   *       {@code version}, {@code lastChange} and {@code pendingChange} are populated from {@link
-   *       CurrentClusterConfiguration#toLegacy}'s cluster-wide projection — {@code version} is the
-   *       higher of the global and this one group's version, {@code lastChange} always reflects the
-   *       cluster-wide change history regardless of which group is in view, and {@code
-   *       pendingChange} prefers the global pending change and falls back to this group's own; only
-   *       {@code routing} is genuinely this one group's own state.
+   *       {@code version} is populated from {@link CurrentClusterConfiguration#toLegacy}'s
+   *       cluster-wide projection as the higher of the global and this one group's version; {@code
+   *       lastChange} and {@code pendingChange} both come from the {@link PhasedChangeState} so
+   *       that they share one id space with each other and with the change endpoints — {@code
+   *       lastChange} always reflects the cluster-wide change history regardless of which group is
+   *       in view, and {@code pendingChange} is the pending plan that touches this group, whether
+   *       cluster-wide or group-scoped; only {@code routing} is genuinely this one group's own
+   *       state.
    *   <li>more than one group in view (an unscoped request against a multi-tenant cluster): none of
    *       {@code version}, {@code lastChange}, {@code pendingChange} or {@code routing} are
    *       populated at the top level — reporting any one group's routing state there would
@@ -814,11 +866,19 @@ final class ClusterApiUtils {
               : groupsInView.keySet().iterator().next();
       final var legacy = configuration.toLegacy(groupId);
       response.version(legacy.version());
-      legacy.lastChange().ifPresent(change -> response.lastChange(mapCompletedChange(change)));
-      legacy.pendingChanges().ifPresent(change -> response.pendingChange(mapOngoingChange(change)));
       legacy
           .routingState()
           .ifPresent(routingState -> response.routing(mapRoutingState(routingState)));
+      // change ids must come from the phased change state, not the legacy projection: the legacy
+      // pendingChanges is whichever sub-config plan is executing the active phase, and sub-config
+      // plan ids are counted independently of phased plan ids (and of each other). See
+      // mapPendingChange.
+      configuration
+          .phasedChangeState()
+          .lastChange()
+          .ifPresent(change -> response.lastChange(mapCompletedChange(change)));
+      pendingPlanFor(configuration, groupId)
+          .ifPresent(plan -> response.pendingChange(mapPendingChange(configuration, plan)));
     }
 
     if (physicalTenant == null && singleTenantShape) {
@@ -931,7 +991,7 @@ final class ClusterApiUtils {
   }
 
   private static io.camunda.zeebe.management.cluster.CompletedChange mapCompletedChange(
-      final CompletedChange completedChange) {
+      final CompletedPhasedChange completedChange) {
     return new io.camunda.zeebe.management.cluster.CompletedChange()
         .id(completedChange.id())
         .status(mapCompletedChangeStatus(completedChange.status()))
@@ -939,36 +999,13 @@ final class ClusterApiUtils {
         .completedAt(mapInstantToDateTime(completedChange.completedAt()));
   }
 
-  private static TopologyChange mapOngoingChange(final ChangePlan changePlan) {
-    return new TopologyChange()
-        .id(changePlan.id())
-        .status(mapChangeStatus(changePlan.status()))
-        .pending(mapOperations(changePlan.pendingOperations()))
-        .completed(mapCompletedOperations(changePlan.completedOperations()));
-  }
-
   private static io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum
-      mapCompletedChangeStatus(final Status status) {
+      mapCompletedChangeStatus(final PhasedChangePlanStatus status) {
     return switch (status) {
       case COMPLETED -> io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.COMPLETED;
       case FAILED -> io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.FAILED;
       case CANCELLED -> io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.CANCELLED;
-      case IN_PROGRESS -> throw new IllegalStateException("Completed change cannot be in progress");
     };
-  }
-
-  private static StatusEnum mapChangeStatus(final Status status) {
-    return switch (status) {
-      case IN_PROGRESS -> StatusEnum.IN_PROGRESS;
-      case COMPLETED -> StatusEnum.COMPLETED;
-      case FAILED -> StatusEnum.FAILED;
-      case CANCELLED -> StatusEnum.CANCELLED;
-    };
-  }
-
-  private static List<TopologyChangeCompletedInner> mapCompletedOperations(
-      final List<CompletedOperation> completedOperations) {
-    return completedOperations.stream().map(ClusterApiUtils::mapCompletedOperation).toList();
   }
 
   static TopologyChangeCompletedInner mapCompletedOperation(final CompletedOperation operation) {
@@ -1129,4 +1166,15 @@ final class ClusterApiUtils {
               .status(ExporterStatus.StatusEnum.CONFIG_NOT_FOUND);
     };
   }
+
+  /** A pending plan's operations, split by whether they have run yet. See {@link #progressOf}. */
+  private record ChangeProgress(
+      List<CompletedOperationProgress> completed, List<Operation> pending) {}
+
+  /**
+   * A completed operation and when it completed. {@code completedAt} is only known for operations
+   * of the active phase, whose sub-config plan records completion times; a phase that has been
+   * advanced past leaves no such record, so its operations are reported without one.
+   */
+  private record CompletedOperationProgress(Operation operation, @Nullable Instant completedAt) {}
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -972,167 +972,34 @@ final class ClusterApiUtils {
   }
 
   static TopologyChangeCompletedInner mapCompletedOperation(final CompletedOperation operation) {
-    final var mappedOperation =
-        switch (operation.operation()) {
-          case final MemberJoinOperation join ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_ADD)
-                  .brokerId(brokerIdValue(join.memberId()));
-          case final MemberLeaveOperation leave ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_REMOVE)
-                  .brokerId(brokerIdValue(leave.memberId()));
-          case final PartitionJoinOperation join ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_JOIN)
-                  .brokerId(brokerIdValue(join.memberId()))
-                  .partitionId(join.partitionId())
-                  .priority(join.priority());
-          case final PartitionLeaveOperation leave ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_LEAVE)
-                  .brokerId(brokerIdValue(leave.memberId()))
-                  .partitionId(leave.partitionId());
-          case final PartitionPromoteOperation promote ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_PROMOTE)
-                  .brokerId(brokerIdValue(promote.memberId()))
-                  .partitionId(promote.partitionId());
-          case final PartitionDemoteOperation demote ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_DEMOTE)
-                  .brokerId(brokerIdValue(demote.memberId()))
-                  .partitionId(demote.partitionId());
-          case final PartitionReconfigurePriorityOperation reconfigure ->
-              new TopologyChangeCompletedInner()
-                  .operation(
-                      TopologyChangeCompletedInner.OperationEnum.PARTITION_RECONFIGURE_PRIORITY)
-                  .brokerId(brokerIdValue(reconfigure.memberId()))
-                  .partitionId(reconfigure.partitionId())
-                  .priority(reconfigure.priority());
-          case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_FORCE_RECONFIGURE)
-                  .brokerId(brokerIdValue(partitionForceReconfigureOperation.memberId()))
-                  .partitionId(partitionForceReconfigureOperation.partitionId())
-                  .brokers(
-                      partitionForceReconfigureOperation.members().stream()
-                          .map(ClusterApiUtils::brokerIdValue)
-                          .toList());
-          case final MemberRemoveOperation memberRemoveOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_REMOVE)
-                  .brokerId(brokerIdValue(memberRemoveOperation.memberId()))
-                  .brokers(List.of(brokerIdValue(memberRemoveOperation.memberToRemove())));
-          case final PartitionDisableExporterOperation disableExporterOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_DISABLE_EXPORTER)
-                  .brokerId(brokerIdValue(disableExporterOperation.memberId()))
-                  .partitionId(disableExporterOperation.partitionId())
-                  .exporterId(disableExporterOperation.exporterId());
-          case final PartitionEnableExporterOperation enableExporterOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_ENABLE_EXPORTER)
-                  .brokerId(brokerIdValue(enableExporterOperation.memberId()))
-                  .partitionId(enableExporterOperation.partitionId())
-                  .exporterId(enableExporterOperation.exporterId());
-          case final PartitionDeleteExporterOperation deleteExporterOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_DELETE_EXPORTER)
-                  .brokerId(brokerIdValue(deleteExporterOperation.memberId()))
-                  .partitionId(deleteExporterOperation.partitionId())
-                  .exporterId(deleteExporterOperation.exporterId());
-          case final StartPartitionScaleUp startScaleUp ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.START_PARTITION_SCALE_UP)
-                  .brokerId(brokerIdValue(startScaleUp.memberId()));
-          case final PartitionBootstrapOperation bootstrapOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_BOOTSTRAP)
-                  .brokerId(brokerIdValue(bootstrapOperation.memberId()))
-                  .partitionId(bootstrapOperation.partitionId())
-                  .priority(bootstrapOperation.priority());
-          case final PartitionPreRestoreOperation preRestoreOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_PRE_RESTORE)
-                  .brokerId(brokerIdValue(preRestoreOperation.memberId()))
-                  .partitionId(preRestoreOperation.partitionId());
-          case final PartitionRestoreOperation restoreOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_RESTORE)
-                  .brokerId(brokerIdValue(restoreOperation.memberId()))
-                  .partitionId(restoreOperation.partitionId());
-          case final DeleteHistoryOperation deleteHistoryOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.DELETE_HISTORY);
-          case final AwaitRedistributionCompletion redistributionCompletion ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.AWAIT_REDISTRIBUTION)
-                  .brokerId(brokerIdValue(redistributionCompletion.memberId()));
-          case final AwaitRelocationCompletion relocationCompletion ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.AWAIT_RELOCATION)
-                  .brokerId(brokerIdValue(relocationCompletion.memberId()));
-          case final UpdateRoutingState updateRoutingState ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.UPDATE_ROUTING_STATE)
-                  .brokerId(brokerIdValue(updateRoutingState.memberId()));
-          case final UpdateIncarnationNumberOperation updateIncarnationNumberOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.UPDATE_INCARNATION_NUMBER)
-                  .brokerId(brokerIdValue(updateIncarnationNumberOperation.memberId()));
-          case final PreScalingOperation preScalingOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.PRE_SCALING)
-                  .brokerId(brokerIdValue(preScalingOperation.memberId()))
-                  .brokers(
-                      preScalingOperation.clusterMembers().stream()
-                          .map(ClusterApiUtils::brokerIdValue)
-                          .toList());
-          case final PostScalingOperation postScalingOperation ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.POST_SCALING)
-                  .brokerId(brokerIdValue(postScalingOperation.memberId()))
-                  .brokers(
-                      postScalingOperation.clusterMembers().stream()
-                          .map(ClusterApiUtils::brokerIdValue)
-                          .toList());
-          case final UpdatePartitionDistributorConfigOperation
-                  updatePartitionDistributorConfigOperation ->
-              new TopologyChangeCompletedInner()
-                  .brokerId(brokerIdValue(updatePartitionDistributorConfigOperation.memberId()))
-                  .operation(
-                      TopologyChangeCompletedInner.OperationEnum
-                          .UPDATE_PARTITION_DISTRIBUTOR_CONFIG)
-                  .partitionDistributionConfig(
-                      toPartitionDistributionConfig(updatePartitionDistributorConfigOperation));
-          case final ModeChangeOperation modeChange ->
-              switch (modeChange.mode()) {
-                case RECOVERING ->
-                    new TopologyChangeCompletedInner()
-                        .operation(TopologyChangeCompletedInner.OperationEnum.ENTER_RECOVERY)
-                        .brokerId(brokerIdValue(modeChange.memberId()));
-                case PROCESSING ->
-                    new TopologyChangeCompletedInner()
-                        .operation(TopologyChangeCompletedInner.OperationEnum.EXIT_RECOVERY)
-                        .brokerId(brokerIdValue(modeChange.memberId()));
-              };
-          case final AwaitModeChangeOperation modeChange ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.AWAIT_MODE_CHANGE)
-                  .brokerId(brokerIdValue(modeChange.memberId()));
-          case final RemovePhysicalTenantOperation removal ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.REMOVE_PHYSICAL_TENANT)
-                  .brokerId(brokerIdValue(removal.memberId()));
-          default ->
-              new TopologyChangeCompletedInner()
-                  .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);
-        };
+    return mapCompletedOperation(
+        mapOperation(null, operation.operation()), operation.completedAt());
+  }
 
-    mappedOperation.completedAt(mapInstantToDateTime(operation.completedAt()));
-
-    return mappedOperation;
+  /**
+   * Re-tags an already mapped operation as a completed one. The generated {@code
+   * TopologyChangeCompletedInner} is {@code Operation} plus {@code completedAt}, so every field
+   * carries over unchanged and there is no second per-operation-type mapping to keep in sync.
+   */
+  private static TopologyChangeCompletedInner mapCompletedOperation(
+      final Operation operation, final @Nullable Instant completedAt) {
+    final var completed =
+        new TopologyChangeCompletedInner()
+            .operation(
+                TopologyChangeCompletedInner.OperationEnum.fromValue(
+                    operation.getOperation().getValue()))
+            .brokerId(operation.getBrokerId())
+            .partitionId(operation.getPartitionId())
+            .physicalTenant(operation.getPhysicalTenant())
+            .priority(operation.getPriority())
+            .brokers(operation.getBrokers())
+            .exporterId(operation.getExporterId())
+            .partitionDistributionConfig(operation.getPartitionDistributionConfig())
+            .exportingState(operation.getExportingState());
+    if (completedAt != null) {
+      completed.completedAt(mapInstantToDateTime(completedAt));
+    }
+    return completed;
   }
 
   private static io.camunda.zeebe.management.cluster.PartitionDistributionConfig

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -18,8 +18,10 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.Cu
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse.LegacyConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DependencyChangePlan;
@@ -86,6 +88,7 @@ import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.PhysicalTenantState;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
+import io.camunda.zeebe.management.cluster.TopologyChange;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
 import io.camunda.zeebe.util.Either;
 import java.time.Instant;
@@ -98,6 +101,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -1332,6 +1336,167 @@ final class ClusterApiUtilsTest {
             tuple(3L, ConfigurationChange.StatusEnum.IN_PROGRESS),
             tuple(1L, ConfigurationChange.StatusEnum.COMPLETED),
             tuple(4L, ConfigurationChange.StatusEnum.CANCELLED));
+  }
+
+  /**
+   * Regression test for <a href="https://github.com/camunda/camunda/issues/61586">#61586</a>: a
+   * client that reads {@code pendingChange.id} while a change runs must find that same id in {@code
+   * lastChange} once it completes. The three counters are set apart the way they were on the
+   * failing cluster: global sub-config plan 61, default group sub-config plan 40, phased plan 20.
+   */
+  @Test
+  void shouldReportPendingAndLastChangeUnderTheSamePhasedPlanId() {
+    // given: a three-phase scale-up in its partition-group phase, with one of the two joins done.
+    // The global phase already ran as global plan 61; the active group phase runs as group plan 40.
+    final var member1 = member(1);
+    final var startedAt = Instant.ofEpochSecond(1000);
+    final var graphBuilder = OperationGraph.builder();
+    final var join1Id = graphBuilder.add(new PartitionJoinOperation(member1, 1, 1, true));
+    graphBuilder.add(new PartitionJoinOperation(member1, 2, 1, true), Set.of(join1Id));
+    final var groupGraph = graphBuilder.build();
+    final List<Phase> phases =
+        List.of(
+            new GlobalPhase(List.of(new MemberJoinOperation(member1))),
+            new PartitionGroupPhase(Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, groupGraph)),
+            new GlobalPhase(
+                List.of(new PostScalingOperation(member1, new TreeSet<>(Set.of(member1))))));
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            61,
+            Optional.empty(),
+            new TreeMap<>(
+                Map.of(
+                    member1,
+                    io.camunda.zeebe.dynamic.config.state.BrokerState.initializeAsActive())),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(
+                new CompletedChange(61, Status.COMPLETED, startedAt, startedAt.plusSeconds(1))));
+    final var defaultGroup =
+        new PartitionGroupConfiguration(
+                39, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty())
+            .startGraphConfigurationChange(groupGraph)
+            .completeOperation(join1Id, UnaryOperator.identity());
+    assertThat(defaultGroup.pendingChanges().orElseThrow().id()).isEqualTo(40);
+    final var running =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            globalConfiguration,
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, defaultGroup),
+            new PhasedChangeState(
+                21, Map.of(20L, new PhasedChangePlan(20, 1, phases, startedAt)), List.of()));
+
+    // when
+    final var whileRunning = ClusterApiUtils.mapClusterTopology(running);
+    final var afterCompletion =
+        ClusterApiUtils.mapClusterTopology(
+            running.completePlan(20, PhasedChangePlanStatus.COMPLETED));
+
+    // then: the running change is reported under the phased plan id, with the progress of every
+    // phase so far, not under the id of the sub-config plan executing the active phase
+    final var pendingChange = whileRunning.getPendingChange();
+    assertThat(pendingChange).isNotNull();
+    assertThat(pendingChange.getId()).isEqualTo(20L);
+    assertThat(pendingChange.getStatus()).isEqualTo(TopologyChange.StatusEnum.IN_PROGRESS);
+    assertThat(pendingChange.getStartedAt()).isEqualTo(startedAt.atOffset(ZoneOffset.UTC));
+    assertThat(pendingChange.getCompleted())
+        .extracting(
+            TopologyChangeCompletedInner::getOperation,
+            TopologyChangeCompletedInner::getPartitionId)
+        .containsExactly(
+            tuple(TopologyChangeCompletedInner.OperationEnum.BROKER_ADD, null),
+            tuple(TopologyChangeCompletedInner.OperationEnum.PARTITION_JOIN, 1));
+    // only the active phase's sub-config plan records when its operations completed
+    assertThat(pendingChange.getCompleted().get(0).getCompletedAt()).isNull();
+    assertThat(pendingChange.getCompleted().get(1).getCompletedAt()).isNotNull();
+    assertThat(pendingChange.getPending())
+        .extracting(Operation::getOperation, Operation::getPartitionId)
+        .containsExactly(tuple(PARTITION_JOIN, 2), tuple(OperationEnum.POST_SCALING, null));
+    assertThat(whileRunning.getLastChange()).isNull();
+
+    // and the completed change is found under the very same id
+    assertThat(afterCompletion.getPendingChange()).isNull();
+    assertThat(afterCompletion.getLastChange()).isNotNull();
+    assertThat(afterCompletion.getLastChange().getId()).isEqualTo(pendingChange.getId());
+    assertThat(afterCompletion.getLastChange().getStatus())
+        .isEqualTo(io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.COMPLETED);
+  }
+
+  @Test
+  void shouldReportThePendingChangeOfThePhysicalTenantInView() {
+    // given: two physical tenants, each running its own change
+    final var member1 = member(1);
+    final var startedAt = Instant.ofEpochSecond(1000);
+    final var planA =
+        new PhasedChangePlan(
+            2,
+            0,
+            List.of(
+                PartitionGroupPhase.sequential(
+                    "tenant-a", List.of(new PartitionJoinOperation(member1, 1, 1, true)))),
+            startedAt);
+    final var planB =
+        new PhasedChangePlan(
+            3,
+            0,
+            List.of(
+                PartitionGroupPhase.sequential(
+                    "tenant-b", List.of(new PartitionLeaveOperation(member1, 1, 0)))),
+            startedAt);
+    final var config =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", emptyGroup(), "tenant-b", emptyGroup()),
+            new PhasedChangeState(4, Map.of(2L, planA, 3L, planB), List.of()));
+
+    // when
+    final var tenantA = ClusterApiUtils.mapClusterTopology(config, "tenant-a");
+    final var tenantB = ClusterApiUtils.mapClusterTopology(config, "tenant-b");
+
+    // then
+    assertThat(tenantA.getPendingChange()).isNotNull();
+    assertThat(tenantA.getPendingChange().getId()).isEqualTo(2L);
+    assertThat(tenantA.getPendingChange().getPending())
+        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
+        .containsExactly(tuple(PARTITION_JOIN, "tenant-a"));
+    assertThat(tenantB.getPendingChange()).isNotNull();
+    assertThat(tenantB.getPendingChange().getId()).isEqualTo(3L);
+    assertThat(tenantB.getPendingChange().getPending())
+        .extracting(Operation::getOperation, Operation::getPhysicalTenant)
+        .containsExactly(tuple(Operation.OperationEnum.PARTITION_LEAVE, "tenant-b"));
+  }
+
+  @Test
+  void shouldReportAClusterWidePendingChangeForEveryPhysicalTenantInView() {
+    // given: a change with a global phase touches every tenant
+    final var plan =
+        new PhasedChangePlan(
+            2,
+            0,
+            List.of(new GlobalPhase(List.of(new MemberJoinOperation(member(1))))),
+            Instant.ofEpochSecond(1000));
+    final var config =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            GlobalConfiguration.init(),
+            Map.of("tenant-a", emptyGroup(), "tenant-b", emptyGroup()),
+            new PhasedChangeState(3, Map.of(2L, plan), List.of()));
+
+    // when
+    final var tenantA = ClusterApiUtils.mapClusterTopology(config, "tenant-a");
+    final var tenantB = ClusterApiUtils.mapClusterTopology(config, "tenant-b");
+
+    // then
+    assertThat(tenantA.getPendingChange()).isNotNull();
+    assertThat(tenantA.getPendingChange().getId()).isEqualTo(2L);
+    assertThat(tenantB.getPendingChange()).isNotNull();
+    assertThat(tenantB.getPendingChange().getId()).isEqualTo(2L);
+  }
+
+  private static PartitionGroupConfiguration emptyGroup() {
+    return new PartitionGroupConfiguration(
+        1, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   @Test


### PR DESCRIPTION
## Description

`GET /actuator/cluster` reported `pendingChange.id` and `lastChange.id` from two unrelated counters. `lastChange` was already the phased plan id, the id space the `POST /actuator/cluster/...` response and `GET /actuator/cluster/changes/{id}` use. `pendingChange` however came from the legacy projection, which reports whichever sub-configuration plan is executing the active phase (the global configuration's or a partition group's). Each sub-configuration counts its own plans, so a client that reads `pendingChange.id` while a change runs can never find that id in `lastChange` once it finishes. This is what made `zbchaos cluster wait` time out in the multiregion chaos experiment.

This PR follows the direction agreed in the issue comments:

- `pendingChange` is now derived from the phased change state, like `lastChange` and the change endpoints: the pending phased plan whose scope covers the group in view, either directly or by being cluster-wide. All four surfaces (`POST` response, `/changes/{id}`, `pendingChange.id`, `lastChange.id`) now share one id space.
- Its operations are split into completed/pending the same way `/changes/{id}` already does it, so `pendingChange.completed` now also lists operations of phases already advanced past. Only the active phase's operations carry `completedAt`, since only the sub-configuration plan executing that phase records completion times.
- The multi-tenant response shape is unchanged: it never reported either field at the top level.
- `toLegacy` itself is left alone, its `pendingChanges` is still gossiped to brokers that only read the legacy model. Removing it (and gossiping the new format only) stays a follow-up, as noted in the issue.

The first commit is a structural change: `mapCompletedOperation` carried a second per-operation-type switch duplicating `mapOperation`. The generated `TopologyChangeCompletedInner` is `Operation` plus `completedAt`, so it is now derived by mapping once and copying fields. The fix needs that conversion, and it removes a switch that had already drifted (`UNKNOWN` fallback, no physical tenant tag).

Behaviour changes worth a look:

- `pendingChange.completed` grows to include earlier phases' operations, without `completedAt`.
- During a restore, `pendingChange.id` is the phased plan's sentinel (`0`) rather than the legacy `-2`.

The regression test pins the ids of one change across its lifecycle with the three counters set apart the way they were on the failing cluster (global 61, default group 40, phased 20). Against the old mapping it fails with `expected: 20L but was: 40L`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #61586
