### PR TITLE
ci: assign clients ownership to C8 API team

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -58,7 +58,7 @@ zeebe/qa/pom.xml            @camunda/orchestration-cluster
 buf.yaml                    @camunda/orchestration-cluster
 
 # Camunda Client & SB Starter
-/clients/                   @camunda/core-features
+/clients/                   @camunda/c8-api-team
 
 # Spring utilities
 /spring-utils/              @camunda/core-features

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -176,7 +176,7 @@
 #################
 ## Camunda Ex  ##
 #################
-/clients/        @camunda/c8-java-sdk
+/clients/        @camunda/c8-api-team
 /library-parent/ @camunda/c8-java-sdk
 /testing/        @camunda/c8-testing
 


### PR DESCRIPTION
## Description
The clients directory was still attributed to the legacy Core Features and C8 Java SDK ownership groups, which sent review and ownership notifications to the wrong team. 
Assign both ownership files to the C8 API team so client changes are routed consistently with the API and process automation ownership model.


Not sure if it needs to be backported to all branches or not :shrug: 
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

