### PR TITLE
feat: coalesce raft log flushes without giving up durability

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -34,6 +34,7 @@ public class Raft {
       "zeebe.broker.cluster.raft.enablePriorityElection";
   private static final String LEGACY_FLUSH_ENABLED = "zeebe.broker.cluster.raft.flush.enabled";
   private static final String LEGACY_FLUSH_DELAY = "zeebe.broker.cluster.raft.flush.delay";
+  private static final String LEGACY_FLUSH_COALESCED = "zeebe.broker.cluster.raft.flush.coalesced";
   private static final String LEGACY_MAX_APPENDS_PER_FOLLOWER =
       "zeebe.broker.experimental.maxAppendsPerFollower";
   private static final String LEGACY_MAX_APPEND_BATCH_SIZE =
@@ -104,6 +105,15 @@ public class Raft {
    * follower append in a synchronous fashion.
    */
   private Duration flushDelay = Duration.ZERO;
+
+  /**
+   * If true, flushes of the Raft log are coalesced: flushes for records which are already durable
+   * are skipped, and concurrent flush requests are covered together by a single flush. Unlike
+   * flush-delay, this does not give up durability - appends are still only acknowledged and commits
+   * still only advance once covered by a flush. This improves performance on disks with high flush
+   * latency, e.g. network-attached storage. Cannot be combined with flush-delay.
+   */
+  private boolean flushCoalesced = false;
 
   /** Sets the maximum of appends which are send per follower. */
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
@@ -272,6 +282,19 @@ public class Raft {
 
   public void setFlushDelay(final Duration flushDelay) {
     this.flushDelay = flushDelay;
+  }
+
+  public boolean isFlushCoalesced() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".flush-coalesced",
+        flushCoalesced,
+        Boolean.class,
+        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+        Set.of(LEGACY_FLUSH_COALESCED));
+  }
+
+  public void setFlushCoalesced(final boolean flushCoalesced) {
+    this.flushCoalesced = flushCoalesced;
   }
 
   public int getMaxAppendsPerFollower() {

--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -284,13 +284,27 @@ public class Raft {
     this.flushDelay = flushDelay;
   }
 
+  /**
+   * @throws UnifiedConfigurationException if coalesced flushing is combined with a flush delay
+   */
   public boolean isFlushCoalesced() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
-        PREFIX + ".flush-coalesced",
-        flushCoalesced,
-        Boolean.class,
-        UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
-        Set.of(LEGACY_FLUSH_COALESCED));
+    final boolean coalesced =
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+            PREFIX + ".flush-coalesced",
+            flushCoalesced,
+            Boolean.class,
+            UnifiedConfigurationHelper.BackwardsCompatibilityMode.SUPPORTED,
+            Set.of(LEGACY_FLUSH_COALESCED));
+    final Duration delay = getFlushDelay();
+    if (coalesced && delay != null && !delay.isZero()) {
+      throw new UnifiedConfigurationException(
+          ("%1$s.flush-coalesced and %1$s.flush-delay are mutually exclusive, but "
+                  + "coalesced flushing is enabled together with a flush delay of %2$s. "
+                  + "Remove one of them: flush-coalesced reduces flush overhead without giving up "
+                  + "durability, flush-delay trades durability for performance.")
+              .formatted(PREFIX, delay));
+    }
+    return coalesced;
   }
 
   public void setFlushCoalesced(final boolean flushCoalesced) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -635,7 +635,8 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().getRaft().setEnablePriorityElection(raft.isPriorityElectionEnabled());
 
     // Set flush configuration
-    final var flushConfig = new FlushConfig(raft.isFlushEnabled(), raft.getFlushDelay());
+    final var flushConfig =
+        new FlushConfig(raft.isFlushEnabled(), raft.getFlushDelay(), raft.isFlushCoalesced());
     override.getCluster().getRaft().setFlush(flushConfig);
 
     override.getExperimental().setMaxAppendsPerFollower(raft.getMaxAppendsPerFollower());

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -38,6 +38,7 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.priority-election-enabled=false",
         "camunda.cluster.raft.flush-enabled=false",
         "camunda.cluster.raft.flush-delay=5s",
+        "camunda.cluster.raft.flush-coalesced=true",
         "camunda.cluster.raft.max-appends-per-follower=7",
         "camunda.cluster.raft.max-append-batch-size=64",
         "camunda.cluster.raft.request-timeout=5s",
@@ -89,6 +90,11 @@ public class ClusterRaftTest {
     }
 
     @Test
+    void shouldSetFlushCoalesced() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
+    }
+
+    @Test
     void shouldSetExperimental() {
       assertThat(brokerCfg.getExperimental())
           .returns(7, ExperimentalCfg::getMaxAppendsPerFollower)
@@ -128,6 +134,7 @@ public class ClusterRaftTest {
         "zeebe.broker.cluster.raft.enablePriorityElection=false",
         "zeebe.broker.cluster.raft.flush.enabled=false",
         "zeebe.broker.cluster.raft.flush.delay=10s",
+        "zeebe.broker.cluster.raft.flush.coalesced=true",
         "zeebe.broker.experimental.maxAppendsPerFollower=8",
         "zeebe.broker.experimental.maxAppendBatchSize=96",
         "zeebe.broker.experimental.raft.requestTimeout=10s",
@@ -173,6 +180,11 @@ public class ClusterRaftTest {
     }
 
     @Test
+    void shouldSetFlushCoalescedFromLegacy() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
+    }
+
+    @Test
     void shouldSetExperimentalFromLegacy() {
       assertThat(brokerCfg.getExperimental())
           .returns(8, ExperimentalCfg::getMaxAppendsPerFollower)
@@ -202,6 +214,7 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.priority-election-enabled=true",
         "camunda.cluster.raft.flush-enabled=true",
         "camunda.cluster.raft.flush-delay=15s",
+        "camunda.cluster.raft.flush-coalesced=true",
         "camunda.cluster.raft.max-appends-per-follower=7",
         "camunda.cluster.raft.max-append-batch-size=64",
         "camunda.cluster.raft.request-timeout=5s",
@@ -218,6 +231,7 @@ public class ClusterRaftTest {
         "zeebe.broker.cluster.raft.enablePriorityElection=false",
         "zeebe.broker.cluster.raft.flush.enabled=false",
         "zeebe.broker.cluster.raft.flush.delay=99s",
+        "zeebe.broker.cluster.raft.flush.coalesced=false",
         "zeebe.broker.experimental.maxAppendsPerFollower=8",
         "zeebe.broker.experimental.maxAppendBatchSize=96",
         "zeebe.broker.experimental.raft.requestTimeout=10s",
@@ -260,6 +274,11 @@ public class ClusterRaftTest {
     void shouldSetFlushDelayFromNew() {
       assertThat(brokerCfg.getCluster().getRaft().getFlush().delayTime())
           .isEqualTo(Duration.ofSeconds(15));
+    }
+
+    @Test
+    void shouldSetFlushCoalescedFromNew() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
     }
 
     @Test

--- a/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterRaftTest.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -30,6 +31,21 @@ import org.springframework.util.unit.DataSize;
 })
 @ActiveProfiles("broker")
 public class ClusterRaftTest {
+
+  @Test
+  void shouldRejectFlushCoalescedCombinedWithFlushDelay() {
+    // given
+    final var raft = new Raft();
+    raft.setFlushCoalesced(true);
+    raft.setFlushDelay(Duration.ofSeconds(5));
+
+    // when / then
+    assertThatThrownBy(raft::isFlushCoalesced)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("camunda.cluster.raft.flush-coalesced")
+        .hasMessageContaining("camunda.cluster.raft.flush-delay");
+  }
+
   @Nested
   @TestPropertySource(
       properties = {
@@ -38,7 +54,6 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.priority-election-enabled=false",
         "camunda.cluster.raft.flush-enabled=false",
         "camunda.cluster.raft.flush-delay=5s",
-        "camunda.cluster.raft.flush-coalesced=true",
         "camunda.cluster.raft.max-appends-per-follower=7",
         "camunda.cluster.raft.max-append-batch-size=64",
         "camunda.cluster.raft.request-timeout=5s",
@@ -90,11 +105,6 @@ public class ClusterRaftTest {
     }
 
     @Test
-    void shouldSetFlushCoalesced() {
-      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
-    }
-
-    @Test
     void shouldSetExperimental() {
       assertThat(brokerCfg.getExperimental())
           .returns(7, ExperimentalCfg::getMaxAppendsPerFollower)
@@ -134,7 +144,6 @@ public class ClusterRaftTest {
         "zeebe.broker.cluster.raft.enablePriorityElection=false",
         "zeebe.broker.cluster.raft.flush.enabled=false",
         "zeebe.broker.cluster.raft.flush.delay=10s",
-        "zeebe.broker.cluster.raft.flush.coalesced=true",
         "zeebe.broker.experimental.maxAppendsPerFollower=8",
         "zeebe.broker.experimental.maxAppendBatchSize=96",
         "zeebe.broker.experimental.raft.requestTimeout=10s",
@@ -180,11 +189,6 @@ public class ClusterRaftTest {
     }
 
     @Test
-    void shouldSetFlushCoalescedFromLegacy() {
-      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
-    }
-
-    @Test
     void shouldSetExperimentalFromLegacy() {
       assertThat(brokerCfg.getExperimental())
           .returns(8, ExperimentalCfg::getMaxAppendsPerFollower)
@@ -214,7 +218,6 @@ public class ClusterRaftTest {
         "camunda.cluster.raft.priority-election-enabled=true",
         "camunda.cluster.raft.flush-enabled=true",
         "camunda.cluster.raft.flush-delay=15s",
-        "camunda.cluster.raft.flush-coalesced=true",
         "camunda.cluster.raft.max-appends-per-follower=7",
         "camunda.cluster.raft.max-append-batch-size=64",
         "camunda.cluster.raft.request-timeout=5s",
@@ -231,7 +234,6 @@ public class ClusterRaftTest {
         "zeebe.broker.cluster.raft.enablePriorityElection=false",
         "zeebe.broker.cluster.raft.flush.enabled=false",
         "zeebe.broker.cluster.raft.flush.delay=99s",
-        "zeebe.broker.cluster.raft.flush.coalesced=false",
         "zeebe.broker.experimental.maxAppendsPerFollower=8",
         "zeebe.broker.experimental.maxAppendBatchSize=96",
         "zeebe.broker.experimental.raft.requestTimeout=10s",
@@ -277,11 +279,6 @@ public class ClusterRaftTest {
     }
 
     @Test
-    void shouldSetFlushCoalescedFromNew() {
-      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
-    }
-
-    @Test
     void shouldSetExperimentalFromNew() {
       assertThat(brokerCfg.getExperimental())
           .returns(7, ExperimentalCfg::getMaxAppendsPerFollower)
@@ -299,6 +296,46 @@ public class ClusterRaftTest {
           .returns(5, ExperimentalRaftCfg::getMinStepDownFailureCount)
           .returns(110, ExperimentalRaftCfg::getPreferSnapshotReplicationThreshold)
           .returns(false, ExperimentalRaftCfg::isPreallocateSegmentFiles);
+    }
+  }
+
+  /**
+   * Coalesced flushing needs its own property sets: it is mutually exclusive with a flush delay, so
+   * it cannot be added to the sets above, which all configure a flush delay.
+   */
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.cluster.raft.flush-coalesced=true",
+        // legacy
+        "zeebe.broker.cluster.raft.flush.coalesced=false"
+      })
+  class WithFlushCoalescedSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithFlushCoalescedSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFlushCoalescedFromNew() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.broker.cluster.raft.flush.coalesced=true"})
+  class WithOnlyLegacyFlushCoalescedSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacyFlushCoalescedSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetFlushCoalescedFromLegacy() {
+      assertThat(brokerCfg.getCluster().getRaft().getFlush().coalesced()).isTrue();
     }
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -63,6 +63,7 @@ cluster.partitioning.scheme
 cluster.partitioning.zone-aware.zones
 cluster.raft.configuration-change-timeout
 cluster.raft.election-timeout
+cluster.raft.flush-coalesced
 cluster.raft.flush-delay
 cluster.raft.flush-enabled
 cluster.raft.heartbeat-interval

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -230,6 +230,12 @@ camunda: # Type: io.camunda.configuration.Camunda
       # leader failures and thus leading to unnecessary leader changes. If the network latency between the
       # nodes is high, it is recommended to have a higher election timeout. This is an advanced setting.
       election-timeout: "2500ms" # Type: Duration, Env: CAMUNDA_CLUSTER_RAFT_ELECTIONTIMEOUT
+      # If true, flushes of the Raft log are coalesced: flushes for records which are already durable are
+      # skipped, and concurrent flush requests are covered together by a single flush. Unlike flush-delay,
+      # this does not give up durability - appends are still only acknowledged and commits still only
+      # advance once covered by a flush. This improves performance on disks with high flush latency, e.g.
+      # network-attached storage. Cannot be combined with flush-delay.
+      flush-coalesced: false # Type: Boolean, Env: CAMUNDA_CLUSTER_RAFT_FLUSHCOALESCED
       # If the delay is > 0, then flush requests are delayed by at least the given period. It is recommended
       # that you find the smallest delay here with which you achieve your performance goals. It's also
       # likely that anything above 30s is not useful, as this is the typical default flush interval for the

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -82,7 +82,6 @@ import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
-import io.camunda.zeebe.util.CheckedRunnable;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -583,7 +582,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       if (isLeader()) {
         // leader counts itself in quorum, so in order to commit the leader must persist
         try {
-          raftLog.flush();
+          raftLog.flushSync(commitIndex);
         } catch (final FlushException e) {
           if (LOGGER.isWarnEnabled()) {
             LOGGER.warn(
@@ -690,7 +689,20 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       return CompletableFuture.completedFuture(null);
     }
 
-    return CompletableFuture.runAsync(CheckedRunnable.toUnchecked(raftLog::flush), threadContext);
+    final var flushed = new CompletableFuture<Void>();
+    threadContext.execute(
+        () ->
+            raftLog
+                .flush(raftLog.getLastIndex())
+                .whenComplete(
+                    (ignored, error) -> {
+                      if (error != null) {
+                        flushed.completeExceptionally(error);
+                      } else {
+                        flushed.complete(null);
+                      }
+                    }));
+    return flushed;
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -78,7 +78,6 @@ import io.atomix.raft.utils.StateUtil;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.cluster.PartitionId;
-import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -584,7 +583,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         // leader counts itself in quorum, so in order to commit the leader must persist
         try {
           raftLog.flushSync(commitIndex);
-        } catch (final FlushException e) {
+        } catch (final Exception e) {
+          // any flush failure, not just the expected journal exceptions, means the entries cannot
+          // be treated as durable and the leader must not commit; step down instead of crashing
+          // the raft thread
           if (LOGGER.isWarnEnabled()) {
             LOGGER.warn(
                 "Failed to flush commit at index %s, resetting journal to %s and stepping down"

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -678,14 +678,23 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
-   * Ensures everything written to the log until this point is flushed to disk, regardless of the
+   * Ensures everything written to the log until this point is flushed to disk, bypassing the
    * configured flush strategy. This is mainly used to guarantee that the log is durable before a
    * snapshot is persisted and the log is compacted: for flush strategies which acknowledge before
    * durability, this bounds the data loss on a crash to records written after the snapshot.
    *
-   * @return a future to be completed once the log is actually flushed to disk
+   * <p>With a strategy which flushes directly, everything written is already flushed synchronously
+   * on the Raft thread before it is acknowledged or committed, so there is nothing left to flush.
+   * Nothing is done then, as an optimization to ensure we are not unnecessarily blocking the Raft
+   * thread to do an i/o.
+   *
+   * @return a future to be completed once the log is durable
    */
   public CompletableFuture<Void> flushLog() {
+    if (raftLog.flushesDirectly()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
     return CompletableFuture.runAsync(
         CheckedRunnable.toUnchecked(raftLog::forceFlush), threadContext);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -82,6 +82,7 @@ import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.util.CheckedRunnable;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -675,34 +676,16 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
-   * Ensures everything written to the log until this point, is flushed to disk. If default raft
-   * flush is enabled, then this will not flush because the logs are flushed when necessary to
-   * achieve expected consistency guarantees.
+   * Ensures everything written to the log until this point is flushed to disk, regardless of the
+   * configured flush strategy. This is mainly used to guarantee that the log is durable before a
+   * snapshot is persisted and the log is compacted: for flush strategies which acknowledge before
+   * durability, this bounds the data loss on a crash to records written after the snapshot.
    *
-   * @return a future to be completed once the log is flushed to disk
+   * @return a future to be completed once the log is actually flushed to disk
    */
   public CompletableFuture<Void> flushLog() {
-    // If flush operations are synchronous on the Raft thread, then the log is guaranteed to be
-    // flushed by before committing. Hence, there is no need to flush them again here. This is an
-    // optimization to ensure we are not unnecessarily blocking raft thread to do an i/o.
-    if (raftLog.flushesDirectly()) {
-      return CompletableFuture.completedFuture(null);
-    }
-
-    final var flushed = new CompletableFuture<Void>();
-    threadContext.execute(
-        () ->
-            raftLog
-                .flush(raftLog.getLastIndex())
-                .whenComplete(
-                    (ignored, error) -> {
-                      if (error != null) {
-                        flushed.completeExceptionally(error);
-                      } else {
-                        flushed.complete(null);
-                      }
-                    }));
-    return flushed;
+    return CompletableFuture.runAsync(
+        CheckedRunnable.toUnchecked(raftLog::forceFlush), threadContext);
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -262,10 +262,19 @@ final class LeaderAppender {
     member.setConfigIndex(configIndex);
   }
 
-  /** Updates the match index when a response is received. */
+  /**
+   * Updates the match index when a successful response is received.
+   *
+   * <p>The match index only ever advances here: successful responses can be reordered, e.g. when a
+   * follower acknowledges a re-transmitted append of already durable records ahead of an earlier
+   * append it is still persisting. Within a term, a successful acknowledgement never invalidates an
+   * earlier one at a higher index, so taking the maximum keeps the leader's view of the follower's
+   * progress accurate instead of letting a late, lower acknowledgement regress it. Only a failed
+   * response tells the leader that the follower lost records, which is why lowering the match index
+   * is left to {@link #resetMatchIndex(RaftMemberContext, AppendResponse)}.
+   */
   private void updateMatchIndex(final RaftMemberContext member, final AppendResponse response) {
-    // If the replica returned a valid match index then update the existing match index.
-    member.setMatchIndex(response.lastLogIndex());
+    member.setMatchIndex(Math.max(member.getMatchIndex(), response.lastLogIndex()));
     observeRemainingMemberEntries(member);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -890,9 +890,10 @@ public class PassiveRole extends InactiveRole {
                   (ignored, error) -> {
                     if (error != null) {
                       log.warn(
-                          "Failed to flush when append failed: lastFlushedIndex={}, prevEntryIndex={}",
+                          "Failed to flush partially appended records up to index {} (previous entry index {})",
                           appendedIndex,
-                          request.prevLogIndex());
+                          request.prevLogIndex(),
+                          error);
                     }
                   });
           return;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -112,8 +112,13 @@ public class PassiveRole extends InactiveRole {
   }
 
   private void truncateUncommittedEntries() throws CheckedJournalException {
-    if (role() == RaftServer.Role.PASSIVE && raft.getLog().getLastIndex() > raft.getCommitIndex()) {
-      raft.getLog().deleteAfter(raft.getCommitIndex());
+    // Entries which the leader announced as committed are not uncommitted, even if the local commit
+    // index does not cover them yet because the flush covering them is still in progress. Deleting
+    // them would be refused by the log anyway.
+    final long committedIndex =
+        Math.max(raft.getCommitIndex(), raft.getLog().getAnnouncedCommitIndex());
+    if (role() == RaftServer.Role.PASSIVE && raft.getLog().getLastIndex() > committedIndex) {
+      raft.getLog().deleteAfter(committedIndex);
     }
   }
 
@@ -932,22 +937,32 @@ public class PassiveRole extends InactiveRole {
         role() == RaftServer.Role.PASSIVE ? raft.getLog().getLastIndex() : lastLogIndex;
     raft.setFirstCommitIndex(request.commitIndex(), agreedPersistedIndex);
 
+    // Tell the log which entries the leader declared committed, before waiting for durability: the
+    // context's commit index can only be advanced once they are durable, but they must not be
+    // deleted by a conflicting append handled in the meantime either.
+    raft.getLog().announceCommitIndex(commitIndex);
+
     // Make sure all entries are flushed before ack to ensure we have persisted what we
     // acknowledge. Depending on the configured flush strategy the flush may complete
     // asynchronously, in which case the response is also completed asynchronously, once a flush
     // covering the appended entries completed.
     final long appendedIndex = lastLogIndex;
+    // If the log is truncated while the flush is in progress, the appended entries ceased to exist
+    // and must not be acknowledged, see completeAppendOnceFlushed.
+    final long truncationGeneration = raft.getLog().getTruncationGeneration();
     final var flushResult = flush(appendedIndex, request.prevLogIndex());
     if (flushResult.isDone()) {
       // fast path for flush strategies which complete synchronously, e.g. the default direct
       // strategy; this keeps handling the request a single, synchronous step
-      completeAppendOnceFlushed(flushResult, request, appendedIndex, commitIndex, future);
+      completeAppendOnceFlushed(
+          flushResult, request, appendedIndex, commitIndex, truncationGeneration, future);
       return;
     }
 
     flushResult.whenCompleteAsync(
         (ignored, error) ->
-            completeAppendOnceFlushed(flushResult, request, appendedIndex, commitIndex, future),
+            completeAppendOnceFlushed(
+                flushResult, request, appendedIndex, commitIndex, truncationGeneration, future),
         raft.getThreadContext());
   }
 
@@ -956,6 +971,7 @@ public class PassiveRole extends InactiveRole {
       final InternalAppendRequest request,
       final long lastLogIndex,
       final long commitIndex,
+      final long truncationGeneration,
       final CompletableFuture<AppendResponse> future) {
     final var flushError = unwrapError(flushResult);
     if (flushError != null) {
@@ -963,6 +979,18 @@ public class PassiveRole extends InactiveRole {
           "Failed to flush appended entries to the log, cannot guarantee durability; leader will retry the append operation",
           flushError);
       // Flush failed, return error to the leader so we can retry.
+      failAppend(request.prevLogIndex(), future);
+      return;
+    }
+
+    if (raft.getLog().getTruncationGeneration() != truncationGeneration) {
+      // The log was truncated while the flush was in progress, e.g. by a conflicting append which
+      // was handled in the meantime. The records this response would acknowledge may no longer
+      // exist, so the leader must not count them as replicated; it retries the append instead.
+      log.debug(
+          "Rejected {}: the log was truncated while flushing the appended entries up to index {}",
+          request,
+          lastLogIndex);
       failAppend(request.prevLogIndex(), future);
       return;
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -64,7 +64,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -941,32 +940,27 @@ public class PassiveRole extends InactiveRole {
     if (flushResult.isDone()) {
       // fast path for flush strategies which complete synchronously, e.g. the default direct
       // strategy; this keeps handling the request a single, synchronous step
-      completeAppendOnceFlushed(
-          unwrapError(flushResult), request, appendedIndex, commitIndex, future);
+      completeAppendOnceFlushed(flushResult, request, appendedIndex, commitIndex, future);
       return;
     }
 
-    flushResult.whenComplete(
+    flushResult.whenCompleteAsync(
         (ignored, error) ->
-            raft.getThreadContext()
-                .execute(
-                    () ->
-                        completeAppendOnceFlushed(
-                            error, request, appendedIndex, commitIndex, future)));
+            completeAppendOnceFlushed(flushResult, request, appendedIndex, commitIndex, future),
+        raft.getThreadContext());
   }
 
   private void completeAppendOnceFlushed(
-      final Throwable flushError,
+      final CompletableFuture<Void> flushResult,
       final InternalAppendRequest request,
       final long lastLogIndex,
       final long commitIndex,
       final CompletableFuture<AppendResponse> future) {
+    final var flushError = unwrapError(flushResult);
     if (flushError != null) {
-      final var error =
-          flushError instanceof CompletionException ? flushError.getCause() : flushError;
       log.warn(
           "Failed to flush appended entries to the log, cannot guarantee durability; leader will retry the append operation",
-          error);
+          flushError);
       // Flush failed, return error to the leader so we can retry.
       failAppend(request.prevLogIndex(), future);
       return;
@@ -988,10 +982,12 @@ public class PassiveRole extends InactiveRole {
       return raft.getLog().flush(lastLogIndex);
     }
 
-    if (lastLogIndex <= raft.getLog().getLastFlushedIndex()) {
-      // nothing was appended, and everything acknowledged by this response is already durable;
-      // this is the common case for empty appends, e.g. heartbeats, as with a synchronous flush
-      // strategy every appended record is flushed before the next request is handled
+    if (lastLogIndex <= 0 || lastLogIndex <= raft.getLog().getLastFlushedIndex()) {
+      // nothing was appended, and the response acknowledges nothing that could be lost: either it
+      // acknowledges no records at all (e.g. a heartbeat at the start of an empty log), or
+      // everything it acknowledges is already durable. The latter is the common case for empty
+      // appends, as with a synchronous flush strategy every appended record is flushed before the
+      // next request is handled.
       return CompletableFuture.completedFuture(null);
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -984,9 +984,23 @@ public class PassiveRole extends InactiveRole {
 
   private CompletableFuture<Void> flush(final long lastLogIndex, final long previousEntryIndex) {
     if (lastLogIndex > previousEntryIndex) {
+      // this request appended new records, which must be flushed before acknowledging them
       return raft.getLog().flush(lastLogIndex);
     }
-    return CompletableFuture.completedFuture(null);
+
+    if (lastLogIndex <= raft.getLog().getLastFlushedIndex()) {
+      // nothing was appended, and everything acknowledged by this response is already durable;
+      // this is the common case for empty appends, e.g. heartbeats, as with a synchronous flush
+      // strategy every appended record is flushed before the next request is handled
+      return CompletableFuture.completedFuture(null);
+    }
+
+    // nothing was appended, but records acknowledged by this response are not durable yet, e.g. an
+    // empty append while the flush for a previous append request is still in progress. A success
+    // response acknowledges everything up to its last log index, so it must wait for durability
+    // like the append it is concurrent with; otherwise the leader could count this replica for
+    // commit based on records which a crash may still lose.
+    return raft.getLog().flush(lastLogIndex);
   }
 
   private static Throwable unwrapError(final CompletableFuture<Void> completedResult) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -64,6 +64,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -882,14 +883,19 @@ public class PassiveRole extends InactiveRole {
 
         final boolean failedToAppend = tryToAppend(future, entry, index, lastEntry);
         if (failedToAppend) {
-          try {
-            flush(lastLogIndex - 1, request.prevLogIndex());
-          } catch (final Exception e) {
-            log.warn(
-                "Failed to flush when append failed: lastFlushedIndex={}, prevEntryIndex={}",
-                lastLogIndex - 1,
-                request.prevLogIndex());
-          }
+          // the request was already completed by tryToAppend; still try to persist what was
+          // appended so far, but only on a best-effort basis
+          final long appendedIndex = lastLogIndex - 1;
+          flush(appendedIndex, request.prevLogIndex())
+              .whenComplete(
+                  (ignored, error) -> {
+                    if (error != null) {
+                      log.warn(
+                          "Failed to flush when append failed: lastFlushedIndex={}, prevEntryIndex={}",
+                          appendedIndex,
+                          request.prevLogIndex());
+                    }
+                  });
           return;
         }
 
@@ -926,14 +932,41 @@ public class PassiveRole extends InactiveRole {
         role() == RaftServer.Role.PASSIVE ? raft.getLog().getLastIndex() : lastLogIndex;
     raft.setFirstCommitIndex(request.commitIndex(), agreedPersistedIndex);
 
-    try {
-      //     Make sure all entries are flushed before ack to ensure we have persisted what we
-      //     acknowledge
-      flush(lastLogIndex, request.prevLogIndex());
-    } catch (final Exception e) {
+    // Make sure all entries are flushed before ack to ensure we have persisted what we
+    // acknowledge. Depending on the configured flush strategy the flush may complete
+    // asynchronously, in which case the response is also completed asynchronously, once a flush
+    // covering the appended entries completed.
+    final long appendedIndex = lastLogIndex;
+    final var flushResult = flush(appendedIndex, request.prevLogIndex());
+    if (flushResult.isDone()) {
+      // fast path for flush strategies which complete synchronously, e.g. the default direct
+      // strategy; this keeps handling the request a single, synchronous step
+      completeAppendOnceFlushed(
+          unwrapError(flushResult), request, appendedIndex, commitIndex, future);
+      return;
+    }
+
+    flushResult.whenComplete(
+        (ignored, error) ->
+            raft.getThreadContext()
+                .execute(
+                    () ->
+                        completeAppendOnceFlushed(
+                            error, request, appendedIndex, commitIndex, future)));
+  }
+
+  private void completeAppendOnceFlushed(
+      final Throwable flushError,
+      final InternalAppendRequest request,
+      final long lastLogIndex,
+      final long commitIndex,
+      final CompletableFuture<AppendResponse> future) {
+    if (flushError != null) {
+      final var error =
+          flushError instanceof CompletionException ? flushError.getCause() : flushError;
       log.warn(
           "Failed to flush appended entries to the log, cannot guarantee durability; leader will retry the append operation",
-          e);
+          error);
       // Flush failed, return error to the leader so we can retry.
       failAppend(request.prevLogIndex(), future);
       return;
@@ -949,11 +982,15 @@ public class PassiveRole extends InactiveRole {
     succeedAppend(lastLogIndex, future);
   }
 
-  private void flush(final long lastFlushedIndex, final long previousEntryIndex)
-      throws FlushException {
-    if (lastFlushedIndex > previousEntryIndex) {
-      raft.getLog().flush();
+  private CompletableFuture<Void> flush(final long lastLogIndex, final long previousEntryIndex) {
+    if (lastLogIndex > previousEntryIndex) {
+      return raft.getLog().flush(lastLogIndex);
     }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private static Throwable unwrapError(final CompletableFuture<Void> completedResult) {
+    return completedResult.isCompletedExceptionally() ? completedResult.exceptionNow() : null;
   }
 
   private boolean tryToAppend(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
@@ -34,10 +34,10 @@ import org.slf4j.LoggerFactory;
  *       started (group commit).
  * </ul>
  *
- * <p>Results of requests which require flushing complete in request order. A request for an already
- * durable index completes immediately, possibly ahead of pending earlier requests; this only
- * reorders responses of re-transmitted appends, which the protocol must tolerate anyway, as
- * responses can be arbitrarily delayed or their requests re-sent after a timeout.
+ * <p>Completing an already durable request ahead of pending earlier requests (see {@link
+ * #flush(Journal, long)}) only reorders responses of re-transmitted appends, which the protocol
+ * must tolerate anyway, as responses can be arbitrarily delayed or their requests re-sent after a
+ * timeout.
  *
  * <p>When a flush fails, all pending results are failed and no retry is attempted here: retries are
  * driven by the Raft protocol itself, i.e. followers respond with an error so that the leader
@@ -67,13 +67,12 @@ public final class CoalescedFlusher implements RaftLogFlusher {
   @Override
   public synchronized CompletableFuture<Void> flush(final Journal journal, final long index) {
     if (closed) {
-      return CompletableFuture.failedFuture(
-          new FlushException("Flusher is closed, cannot guarantee durability", null));
+      return CompletableFuture.failedFuture(closedError(null));
     }
 
     // fast path: the requested index is already durable, no flush is needed
     if (index <= journal.getLastFlushedIndex()) {
-      return CompletableFuture.completedFuture(null);
+      return COMPLETED;
     }
 
     final var waiter = new Waiter(index, new CompletableFuture<>());
@@ -119,7 +118,7 @@ public final class CoalescedFlusher implements RaftLogFlusher {
     }
 
     closed = true;
-    drainPending(new FlushException("Flusher is closed, cannot guarantee durability", null));
+    drainPending(closedError(null));
     return true;
   }
 
@@ -138,8 +137,12 @@ public final class CoalescedFlusher implements RaftLogFlusher {
       // pending forever
       flushing = false;
       LOGGER.debug("Failing pending flush results as the flusher is closing", e);
-      drainPending(new FlushException("Flusher is closed, cannot guarantee durability", e));
+      drainPending(closedError(e));
     }
+  }
+
+  private static FlushException closedError(final Throwable cause) {
+    return new FlushException("Flusher is closed, cannot guarantee durability", cause);
   }
 
   private void flushNext(final Journal journal) {
@@ -171,8 +174,15 @@ public final class CoalescedFlusher implements RaftLogFlusher {
   }
 
   private Exception tryFlush(final Journal journal) {
+    // a closed or empty journal silently skips flushing, so it can never advance the flushed index
+    // and cover the pending requests; fail them instead of rescheduling flushes forever. Pending
+    // requests on an empty journal are rare but possible, e.g. an empty append acknowledging
+    // records which were requested to be flushed before the log was reset.
     if (!journal.isOpen()) {
       return new FlushException("Journal is closed, cannot guarantee durability", null);
+    }
+    if (journal.isEmpty()) {
+      return new FlushException("Journal is empty, cannot flush up to the requested index", null);
     }
 
     try {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.utils.concurrent.ThreadContext;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.JournalException;
+import java.io.UncheckedIOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of {@link RaftLogFlusher} which coalesces and dedupes flushes without giving up
+ * durability. Like the {@link RaftLogFlusher.DirectFlusher}, flush results only complete once a
+ * flush covering the requested index succeeded, so acknowledgements and commits gated on the
+ * results keep their durability guarantee. Unlike it, flushing happens on a dedicated thread
+ * context, off the Raft thread, and redundant flushes are elided:
+ *
+ * <ul>
+ *   <li>a request for an index which is already durable completes immediately, without flushing;
+ *       this covers e.g. commits below an index which an earlier flush already covered, and
+ *       re-transmitted appends of already flushed records;
+ *   <li>at most one flush runs at a time; requests arriving while one is in progress are all
+ *       covered together by the next flush, as a single flush covers everything appended before it
+ *       started (group commit).
+ * </ul>
+ *
+ * <p>Results of requests which require flushing complete in request order. A request for an already
+ * durable index completes immediately, possibly ahead of pending earlier requests; this only
+ * reorders responses of re-transmitted appends, which the protocol must tolerate anyway, as
+ * responses can be arbitrarily delayed or their requests re-sent after a timeout.
+ *
+ * <p>When a flush fails, all pending results are failed and no retry is attempted here: retries are
+ * driven by the Raft protocol itself, i.e. followers respond with an error so that the leader
+ * retries the append, and a leader steps down if it cannot commit.
+ */
+public final class CoalescedFlusher implements RaftLogFlusher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CoalescedFlusher.class);
+
+  private final ThreadContext flushContext;
+
+  // waiters are queued in request order; as record indexes never decrease between consecutive
+  // appends without a truncation in between - which fails all pending waiters - completing from
+  // the head up to the flushed index preserves request order
+  private final Deque<Waiter> pending = new ArrayDeque<>();
+
+  // true while a flush is scheduled or running; used to guarantee a single in-flight flush
+  private boolean flushing;
+  private boolean closed;
+
+  /**
+   * @param flushContext the thread context on which flushes run; owned and closed by this flusher
+   */
+  public CoalescedFlusher(final ThreadContext flushContext) {
+    this.flushContext = Objects.requireNonNull(flushContext, "must specify a thread context");
+  }
+
+  @Override
+  public synchronized CompletableFuture<Void> flush(final Journal journal, final long index) {
+    if (closed) {
+      return CompletableFuture.failedFuture(
+          new FlushException("Flusher is closed, cannot guarantee durability", null));
+    }
+
+    // fast path: the requested index is already durable, no flush is needed
+    if (index <= journal.getLastFlushedIndex()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var waiter = new Waiter(index, new CompletableFuture<>());
+    pending.add(waiter);
+    scheduleFlush(journal);
+    return waiter.result();
+  }
+
+  @Override
+  public synchronized void onLogTruncation(final long newLastIndex) {
+    if (pending.isEmpty()) {
+      return;
+    }
+
+    LOGGER.debug(
+        "Log truncated to index {}, failing {} pending flush result(s)",
+        newLastIndex,
+        pending.size());
+    // fail all pending results, including those at or below the new last index: this keeps
+    // completions of pending results strictly in request order, and the leader simply retries
+    // the affected appends. Truncation only happens on leadership changes, so this is rare.
+    drainPending(
+        new FlushException(
+            "Log was truncated to index %d, pending flush results are void".formatted(newLastIndex),
+            null));
+  }
+
+  @Override
+  public void close() {
+    if (markClosed()) {
+      flushContext.close();
+    }
+  }
+
+  /**
+   * Marks the flusher as closed and fails all pending results.
+   *
+   * @return true if this call closed the flusher, false if it was already closed
+   */
+  private synchronized boolean markClosed() {
+    if (closed) {
+      return false;
+    }
+
+    closed = true;
+    drainPending(new FlushException("Flusher is closed, cannot guarantee durability", null));
+    return true;
+  }
+
+  /** Must be called while holding the monitor, with at least one pending waiter. */
+  private void scheduleFlush(final Journal journal) {
+    if (flushing) {
+      // the in-flight flush either covers the pending waiters, or reschedules once it finished
+      return;
+    }
+
+    flushing = true;
+    try {
+      flushContext.execute(() -> flushNext(journal));
+    } catch (final RejectedExecutionException e) {
+      // only possible when the flush context is closing; fail the waiters instead of leaving them
+      // pending forever
+      flushing = false;
+      LOGGER.debug("Failing pending flush results as the flusher is closing", e);
+      drainPending(new FlushException("Flusher is closed, cannot guarantee durability", e));
+    }
+  }
+
+  private void flushNext(final Journal journal) {
+    // must not hold the monitor while flushing, otherwise the Raft thread would block on new
+    // flush requests for the whole flush duration
+    completeRequests(journal, tryFlush(journal));
+  }
+
+  private synchronized void completeRequests(final Journal journal, final Exception failure) {
+    flushing = false;
+
+    if (failure != null) {
+      LOGGER.warn(
+          "Failed to flush journal, failing {} pending flush result(s)", pending.size(), failure);
+      drainPending(failure);
+      return;
+    }
+
+    final long flushedIndex = journal.getLastFlushedIndex();
+    while (!pending.isEmpty() && pending.peek().index() <= flushedIndex) {
+      pending.poll().result().complete(null);
+    }
+
+    if (!pending.isEmpty() && !closed) {
+      // records were appended and requested to be flushed while the flush was running; cover
+      // them with a single follow-up flush
+      scheduleFlush(journal);
+    }
+  }
+
+  private Exception tryFlush(final Journal journal) {
+    if (!journal.isOpen()) {
+      return new FlushException("Journal is closed, cannot guarantee durability", null);
+    }
+
+    try {
+      journal.flush();
+      return null;
+    } catch (final FlushException | JournalException | UncheckedIOException e) {
+      return e;
+    }
+  }
+
+  /** Must be called while holding the monitor. */
+  private void drainPending(final Exception error) {
+    Waiter waiter;
+    while ((waiter = pending.poll()) != null) {
+      waiter.result().completeExceptionally(error);
+    }
+  }
+
+  private record Waiter(long index, CompletableFuture<Void> result) {}
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
@@ -148,7 +148,17 @@ public final class CoalescedFlusher implements RaftLogFlusher {
   private void flushNext(final Journal journal) {
     // must not hold the monitor while flushing, otherwise the Raft thread would block on new
     // flush requests for the whole flush duration
-    completeRequests(journal, tryFlush(journal));
+    try {
+      completeRequests(journal, tryFlush(journal));
+    } catch (final Throwable t) {
+      // an Error, which tryFlush does not return, must not skip completing the pending results
+      // either, as that would leave them - and all future requests - pending forever. It is not
+      // swallowed: once the results are failed, it is rethrown so that the flush thread's uncaught
+      // exception handler still sees it, e.g. to shut the JVM down on a VirtualMachineError.
+      completeRequests(
+          journal, new FlushException("Failed to flush journal, cannot guarantee durability", t));
+      throw t;
+    }
   }
 
   private synchronized void completeRequests(final Journal journal, final Exception failure) {
@@ -189,9 +199,10 @@ public final class CoalescedFlusher implements RaftLogFlusher {
       journal.flush();
       return null;
     } catch (final Exception e) {
-      // any failure must be caught here, not just the expected journal exceptions: an escaping
+      // any exception must be caught here, not just the expected journal exceptions: an escaping
       // exception would skip completing the pending results, leaving them - and all future
-      // requests - pending forever
+      // requests - pending forever. Errors are handled by the caller, which fails the pending
+      // results before rethrowing them.
       return e;
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/CoalescedFlusher.java
@@ -10,8 +10,6 @@ package io.atomix.raft.storage.log;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
-import io.camunda.zeebe.journal.JournalException;
-import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
@@ -180,7 +178,10 @@ public final class CoalescedFlusher implements RaftLogFlusher {
     try {
       journal.flush();
       return null;
-    } catch (final FlushException | JournalException | UncheckedIOException e) {
+    } catch (final Exception e) {
+      // any failure must be caught here, not just the expected journal exceptions: an escaping
+      // exception would skip completing the pending results, leaving them - and all future
+      // requests - pending forever
       return e;
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -9,7 +9,10 @@ package io.atomix.raft.storage.log;
 
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.JournalException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -99,7 +102,12 @@ public final class DelayedFlusher implements RaftLogFlusher {
 
     try {
       journal.flush();
-    } catch (final Exception e) {
+    } catch (final CheckedJournalException | JournalException | UncheckedIOException e) {
+      // only retry the failures which are plausibly transient I/O errors; any other failure is
+      // unexpected and most likely permanent, so it must escape to the thread context's uncaught
+      // exception handler, which marks the partition unhealthy. Retrying it forever would leave
+      // the log unflushed indefinitely while appends keep being acknowledged before they are
+      // durable, reported as nothing but a repeating warning.
       LOGGER.warn("Failed to flush journal, operation will be retried after {}", delayTime, e);
       scheduleFlush(journal);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -50,9 +50,7 @@ public final class DelayedFlusher implements RaftLogFlusher {
   @Override
   public CompletableFuture<Void> flush(final Journal journal, final long index) {
     scheduleFlush(journal);
-    // this flusher trades durability for performance: callers may proceed before the data is
-    // actually on disk, so the result completes immediately
-    return CompletableFuture.completedFuture(null);
+    return COMPLETED;
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -15,16 +15,21 @@ import io.camunda.zeebe.journal.JournalException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An implementation of {@link RaftLogFlusher} which treats calls to {@link #flush(Journal)} as
- * signals that there is data to be flushed. When that happens, an asynchronous operation is
+ * An implementation of {@link RaftLogFlusher} which treats calls to {@link #flush(Journal, long)}
+ * as signals that there is data to be flushed. When that happens, an asynchronous operation is
  * scheduled with a predefined delay. If a flush was already scheduled, then the signal is ignored.
  *
  * <p>In other words, this implementation flushes at least every given period, if there is anything
  * to flush.
+ *
+ * <p>This implementation trades durability for performance: the returned flush results complete
+ * immediately, before the data is actually on disk, so callers proceed without waiting for
+ * durability.
  *
  * <p>NOTE: this class is not thread safe, and is expected to run from the same thread as the
  * journal write path, e.g. the Raft thread.
@@ -46,8 +51,17 @@ public final class DelayedFlusher implements RaftLogFlusher {
   }
 
   @Override
-  public void flush(final Journal journal) {
+  public CompletableFuture<Void> flush(final Journal journal, final long index) {
     scheduleFlush(journal);
+    // this flusher trades durability for performance: callers may proceed before the data is
+    // actually on disk, so the result completes immediately
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public void onLogTruncation(final long newLastIndex) {
+    // nothing to do - flush results complete immediately, so there are never pending results; an
+    // already scheduled flush simply flushes the truncated journal
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -9,10 +9,7 @@ package io.atomix.raft.storage.log;
 
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
-import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.Journal;
-import io.camunda.zeebe.journal.JournalException;
-import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -104,7 +101,7 @@ public final class DelayedFlusher implements RaftLogFlusher {
 
     try {
       journal.flush();
-    } catch (final CheckedJournalException | JournalException | UncheckedIOException e) {
+    } catch (final Exception e) {
       LOGGER.warn("Failed to flush journal, operation will be retried after {}", delayTime, e);
       scheduleFlush(journal);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -203,8 +203,11 @@ public final class RaftLog implements Closeable {
     journal.deleteAfter(index);
     lastAppendedEntry = null;
 
-    // we have to flush here to ensure the truncated log is represented properly
-    flushSync(index);
+    // we have to flush right away, bypassing the configured flush strategy, to ensure the
+    // truncation itself is durable: the journal already lowered its flush watermark, so records
+    // beyond it would otherwise be treated as valid partial writes on restart even though they
+    // were already acknowledged based on an earlier flush
+    forceFlush();
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -119,6 +119,14 @@ public final class RaftLog implements Closeable {
     return journal.getLastIndex();
   }
 
+  /**
+   * Returns the index of the last record which is known to be flushed to persistent storage. See
+   * {@link Journal#getLastFlushedIndex()}.
+   */
+  public long getLastFlushedIndex() {
+    return journal.getLastFlushedIndex();
+  }
+
   public IndexedRaftLogEntry getLastEntry() {
     if (lastAppendedEntry == null) {
       readLastEntry();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -45,6 +45,16 @@ public final class RaftLog implements Closeable {
   private IndexedRaftLogEntry lastAppendedEntry;
   private volatile long commitIndex;
 
+  // The highest commit index a leader announced to this member, which can be ahead of
+  // commitIndex: a follower only advances its commit index once the records it acknowledges are
+  // durable, but it must never delete records which the leader already declared committed, not even
+  // while the flush covering them is still in progress. Only used to guard truncations;
+  // commitIndex keeps its stricter meaning of "committed and durable" for committed readers.
+  private long announcedCommitIndex;
+
+  // Counts how often records were removed from this log, see #getTruncationGeneration().
+  private long truncationGeneration;
+
   RaftLog(final Journal journal, final RaftLogFlusher flusher) {
     this.journal = journal;
     this.flusher = flusher;
@@ -111,6 +121,31 @@ public final class RaftLog implements Closeable {
     commitIndex = index;
   }
 
+  /**
+   * Announces that a leader considers all entries up to the given index committed. Unlike {@link
+   * #setCommitIndex(long)}, this may be called before those entries are durable, and it does not
+   * make them visible to committed readers. It only ensures that {@link #reset(long)} and {@link
+   * #deleteAfter(long)} keep refusing to delete entries which a leader already declared committed,
+   * even while the flush covering them is still in progress. The announced index never decreases.
+   *
+   * <p>Only called on the thread which appends to and truncates the log, i.e. the Raft thread.
+   *
+   * @param index the highest index a leader declared committed
+   */
+  public void announceCommitIndex(final long index) {
+    announcedCommitIndex = Math.max(announcedCommitIndex, index);
+  }
+
+  /**
+   * Returns the highest commit index announced by a leader. This can be ahead of {@link
+   * #getCommitIndex()}, which only covers entries which are also durable.
+   *
+   * @see #announceCommitIndex(long)
+   */
+  public long getAnnouncedCommitIndex() {
+    return announcedCommitIndex;
+  }
+
   public long getFirstIndex() {
     return journal.getFirstIndex();
   }
@@ -174,8 +209,23 @@ public final class RaftLog implements Closeable {
     return lastAppendedEntry;
   }
 
+  /**
+   * Returns how often records were removed from this log, i.e. how often {@link #reset(long)} or
+   * {@link #deleteAfter(long)} was called. Operations which cover specific records but complete
+   * asynchronously can capture this before they start and compare it afterwards, to detect that the
+   * records they cover may have ceased to exist. Comparing indexes instead is not enough: a
+   * truncation followed by new appends can restore the same last index with different records.
+   *
+   * <p>Only read and updated on the thread which appends to and truncates the log, i.e. the Raft
+   * thread.
+   */
+  public long getTruncationGeneration() {
+    return truncationGeneration;
+  }
+
   public void reset(final long index) {
-    if (index < commitIndex) {
+    final long committedIndex = Math.max(commitIndex, announcedCommitIndex);
+    if (index < committedIndex) {
       throw new IllegalStateException(
           String.format(
               """
@@ -183,16 +233,18 @@ public final class RaftLog implements Closeable {
                Deleting committed entries can lead to inconsistencies and is prohibited.\
                This can happen if a quorum of nodes has experienced data loss and became leader.\
                This situation probably requires manual intervention to resume operations""",
-              index, commitIndex));
+              index, committedIndex));
     }
     // pending flush results for the deleted records must fail, they can never become durable
     flusher.onLogTruncation(index - 1);
+    truncationGeneration++;
     journal.reset(index);
     lastAppendedEntry = null;
   }
 
   public void deleteAfter(final long index) throws FlushException {
-    if (index < commitIndex) {
+    final long committedIndex = Math.max(commitIndex, announcedCommitIndex);
+    if (index < committedIndex) {
       throw new IllegalStateException(
           String.format(
               """
@@ -200,10 +252,11 @@ public final class RaftLog implements Closeable {
                  Deleting committed entries can lead to inconsistencies and is prohibited.\
                This can happen if a quorum of nodes has experienced data loss and became leader.\
                This situation probably requires manual intervention to resume operations""",
-              index, commitIndex));
+              index, committedIndex));
     }
     // pending flush results for the deleted records must fail, they can never become durable
     flusher.onLogTruncation(index);
+    truncationGeneration++;
     journal.deleteAfter(index);
     lastAppendedEntry = null;
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -146,6 +146,15 @@ public final class RaftLog implements Closeable {
     return announcedCommitIndex;
   }
 
+  /**
+   * Returns true if the configured flusher flushes synchronously and immediately, i.e. everything
+   * requested to be flushed is on disk once {@link #flush(long)} returns. See {@link
+   * RaftLogFlusher#flushesDirectly()}.
+   */
+  public boolean flushesDirectly() {
+    return flusher.flushesDirectly();
+  }
+
   public long getFirstIndex() {
     return journal.getFirstIndex();
   }
@@ -263,8 +272,12 @@ public final class RaftLog implements Closeable {
     // we have to flush right away, bypassing the configured flush strategy, to ensure the
     // truncation itself is durable: the journal already lowered its flush watermark, so records
     // beyond it would otherwise be treated as valid partial writes on restart even though they
-    // were already acknowledged based on an earlier flush
-    forceFlush();
+    // were already acknowledged based on an earlier flush. Deployments which disabled flushing
+    // entirely opted out of durability on the write path, so we don't flush - and possibly fail the
+    // truncation because of an I/O error - on their behalf.
+    if (flusher.flushesEventually()) {
+      forceFlush();
+    }
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -111,10 +111,6 @@ public final class RaftLog implements Closeable {
     commitIndex = index;
   }
 
-  public boolean flushesDirectly() {
-    return flusher.isDirect();
-  }
-
   public long getFirstIndex() {
     return journal.getFirstIndex();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -20,7 +20,6 @@ import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 
 import io.atomix.raft.protocol.PersistedRaftRecord;
 import io.atomix.raft.protocol.ReplicatableJournalRecord;
-import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer;
@@ -30,6 +29,8 @@ import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.SegmentInfo;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -180,6 +181,8 @@ public final class RaftLog implements Closeable {
                This situation probably requires manual intervention to resume operations""",
               index, commitIndex));
     }
+    // pending flush results for the deleted records must fail, they can never become durable
+    flusher.onLogTruncation(index - 1);
     journal.reset(index);
     lastAppendedEntry = null;
   }
@@ -195,19 +198,46 @@ public final class RaftLog implements Closeable {
                This situation probably requires manual intervention to resume operations""",
               index, commitIndex));
     }
+    // pending flush results for the deleted records must fail, they can never become durable
+    flusher.onLogTruncation(index);
     journal.deleteAfter(index);
     lastAppendedEntry = null;
 
     // we have to flush here to ensure the truncated log is represented properly
-    flush();
+    flushSync(index);
   }
 
   /**
-   * Flushes the underlying journal using the configured flushing strategy. For guarantees, refer to
-   * the configured {@link RaftLogFlusher}.
+   * Requests that the journal is durable at least up to the given index, using the configured
+   * flushing strategy. For guarantees, refer to the configured {@link RaftLogFlusher}.
+   *
+   * @param index the index up to which durability is requested
+   * @return a future which completes once the configured flusher's durability guarantee holds for
+   *     the given index; it may complete on a different thread
    */
-  public void flush() throws FlushException {
-    flusher.flush(journal);
+  public CompletableFuture<Void> flush(final long index) {
+    return flusher.flush(journal, index);
+  }
+
+  /**
+   * Same as {@link #flush(long)}, but blocks until the flush result is completed.
+   *
+   * @param index the index up to which durability is requested
+   * @throws FlushException if the flush failed
+   */
+  public void flushSync(final long index) throws FlushException {
+    try {
+      flush(index).join();
+    } catch (final CompletionException e) {
+      final var cause = e.getCause();
+      if (cause instanceof final FlushException flushException) {
+        throw flushException;
+      }
+      if (cause instanceof final RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new FlushException("Flush failed for an unexpected reason", cause);
+    }
   }
 
   /**
@@ -218,7 +248,7 @@ public final class RaftLog implements Closeable {
    * guarantees are required.
    */
   public void forceFlush() throws FlushException {
-    Factory.DIRECT.flush(journal);
+    journal.flush();
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -66,15 +66,6 @@ public interface RaftLogFlusher extends CloseableSilently {
    */
   void onLogTruncation(long newLastIndex);
 
-  /**
-   * If this returns true, then any calls to {@link #flush(Journal, long)} are synchronous and
-   * immediate, and any guarantees offered by the implementation will hold after a call to {@link
-   * #flush(Journal, long)}.
-   */
-  default boolean isDirect() {
-    return false;
-  }
-
   @Override
   default void close() {}
 
@@ -117,11 +108,6 @@ public interface RaftLogFlusher extends CloseableSilently {
     @Override
     public void onLogTruncation(final long newLastIndex) {
       // nothing to do - flushes are synchronous, so there are never pending flush results
-    }
-
-    @Override
-    public boolean isDirect() {
-      return true;
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -18,18 +18,25 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>The default strategy is {@link DirectFlusher}, which is the safest but slowest option.
  *
+ * <p>{@link CoalescedFlusher} keeps the {@link DirectFlusher}'s durability guarantee, but elides
+ * redundant flushes and covers concurrent flush requests with a single flush. Prefer it when
+ * flushes are slow, e.g. on network-attached storage.
+ *
  * <p>The {@link NoopFlusher} is the fastest but most dangerous option, as it will defer flushing to
  * the operating system. It's then possible to run into data corruption or data loss issues. Please
  * refer to the documentation regarding this.
  *
  * <p>{@link DelayedFlusher} can be configured to provide a trade-off between performance and
  * safety. This will cause flushes to be performed in a delayed fashion. See its documentation for
- * more. You should pick this if {@link DirectFlusher} does not provide the desired performance, but
- * you still wish a lower likelihood of corruption issues than with {@link NoopFlusher}. The
- * recommended configuration would be to find the smallest possible delay with which you achieve
- * your performance goals.
+ * more. You should pick this if the durability-preserving strategies do not provide the desired
+ * performance, but you still wish a lower likelihood of corruption issues than with {@link
+ * NoopFlusher}. The recommended configuration would be to find the smallest possible delay with
+ * which you achieve your performance goals.
  */
 public interface RaftLogFlusher extends CloseableSilently {
+
+  /** Shared result for flush requests which complete immediately. */
+  CompletableFuture<Void> COMPLETED = CompletableFuture.completedFuture(null);
 
   /**
    * Signals that the journal should be durable at least up to the given index. The returned future
@@ -39,8 +46,9 @@ public interface RaftLogFlusher extends CloseableSilently {
    * DelayedFlusher}, {@link NoopFlusher}) complete it immediately, before the data is actually on
    * disk.
    *
-   * <p>Futures returned by consecutive calls complete in call order. They may complete on a
-   * different thread than the calling thread, depending on the implementation.
+   * <p>Results of requests which require a flush complete in call order. A request for an already
+   * durable index may complete immediately, ahead of pending earlier requests. Results may complete
+   * on a different thread than the calling thread, depending on the implementation.
    *
    * @param journal the journal to flush
    * @param index the index up to which durability is requested
@@ -74,9 +82,7 @@ public interface RaftLogFlusher extends CloseableSilently {
 
     @Override
     public CompletableFuture<Void> flush(final Journal journal, final long index) {
-      // trades durability for performance: callers may proceed immediately, the operating system
-      // will eventually flush the journal
-      return CompletableFuture.completedFuture(null);
+      return COMPLETED;
     }
 
     @Override
@@ -96,7 +102,7 @@ public interface RaftLogFlusher extends CloseableSilently {
     public CompletableFuture<Void> flush(final Journal journal, final long index) {
       try {
         journal.flush();
-        return CompletableFuture.completedFuture(null);
+        return COMPLETED;
       } catch (final Exception e) {
         // any failure, not just the expected journal exceptions, means the records cannot be
         // treated as durable; callers turn this into a rejected append or a leader step-down

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -10,7 +10,10 @@ package io.atomix.raft.storage.log;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.util.CloseableSilently;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Configurable flush strategy for the {@link io.atomix.raft.storage.log.RaftLog}. You can use its
@@ -29,21 +32,44 @@ import io.camunda.zeebe.util.CloseableSilently;
  * recommended configuration would be to find the smallest possible delay with which you achieve
  * your performance goals.
  */
-@FunctionalInterface
 public interface RaftLogFlusher extends CloseableSilently {
 
   /**
-   * Signals that there is data to be flushed in the journal. The implementation may or may not
-   * immediately flush this.
+   * Signals that the journal should be durable at least up to the given index. The returned future
+   * completes once this flusher's durability guarantee holds for the given index: implementations
+   * which preserve Raft's durability contract complete it only after a flush covering the index
+   * succeeded, while implementations which trade durability for performance (e.g. {@link
+   * DelayedFlusher}, {@link NoopFlusher}) complete it immediately, before the data is actually on
+   * disk.
+   *
+   * <p>Futures returned by consecutive calls complete in call order. They may complete on a
+   * different thread than the calling thread, depending on the implementation.
    *
    * @param journal the journal to flush
+   * @param index the index up to which durability is requested
+   * @return a future which completes once records up to the given index may be treated as handled
+   *     according to this flusher's guarantees; it fails if the flush failed, in which case the
+   *     records must be assumed to not be durable
    */
-  void flush(final Journal journal) throws FlushException;
+  CompletableFuture<Void> flush(Journal journal, long index);
 
   /**
-   * If this returns true, then any calls to {@link #flush(Journal)} are synchronous and immediate,
-   * and any guarantees offered by the implementation will hold after a call to {@link
-   * #flush(Journal)}.
+   * Signals that all records with an index greater than the given index ceased to exist, e.g.
+   * because the log was truncated after a conflict, or reset when receiving a snapshot. Pending
+   * flush results for such records must be failed instead of completed, as the records can never
+   * become durable.
+   *
+   * <p>This is always called on the same thread which appends to and truncates the log, i.e. the
+   * Raft thread.
+   *
+   * @param newLastIndex the highest index which is still part of the log
+   */
+  void onLogTruncation(long newLastIndex);
+
+  /**
+   * If this returns true, then any calls to {@link #flush(Journal, long)} are synchronous and
+   * immediate, and any guarantees offered by the implementation will hold after a call to {@link
+   * #flush(Journal, long)}.
    */
   default boolean isDirect() {
     return false;
@@ -59,19 +85,38 @@ public interface RaftLogFlusher extends CloseableSilently {
   final class NoopFlusher implements RaftLogFlusher {
 
     @Override
-    public void flush(final Journal ignoredJournal) {}
+    public CompletableFuture<Void> flush(final Journal journal, final long index) {
+      // trades durability for performance: callers may proceed immediately, the operating system
+      // will eventually flush the journal
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void onLogTruncation(final long newLastIndex) {
+      // nothing to do - flush results complete immediately, so there are never pending results
+    }
   }
 
   /**
    * An implementation of {@link RaftLogFlusher} which flushes immediately in a blocking fashion.
-   * After any calls to {@link #flush(Journal)}, any data written before the call is guaranteed to
-   * be on disk.
+   * The returned future is always completed, and completed successfully only if the data written
+   * before the call is guaranteed to be on disk.
    */
   final class DirectFlusher implements RaftLogFlusher {
 
     @Override
-    public void flush(final Journal journal) throws FlushException {
-      journal.flush();
+    public CompletableFuture<Void> flush(final Journal journal, final long index) {
+      try {
+        journal.flush();
+        return CompletableFuture.completedFuture(null);
+      } catch (final FlushException | JournalException | UncheckedIOException e) {
+        return CompletableFuture.failedFuture(e);
+      }
+    }
+
+    @Override
+    public void onLogTruncation(final long newLastIndex) {
+      // nothing to do - flushes are synchronous, so there are never pending flush results
     }
 
     @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -8,11 +8,8 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.utils.concurrent.ThreadContextFactory;
-import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
-import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.util.CloseableSilently;
-import java.io.UncheckedIOException;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -100,7 +97,9 @@ public interface RaftLogFlusher extends CloseableSilently {
       try {
         journal.flush();
         return CompletableFuture.completedFuture(null);
-      } catch (final FlushException | JournalException | UncheckedIOException e) {
+      } catch (final Exception e) {
+        // any failure, not just the expected journal exceptions, means the records cannot be
+        // treated as durable; callers turn this into a rejected append or a leader step-down
         return CompletableFuture.failedFuture(e);
       }
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -71,6 +71,25 @@ public interface RaftLogFlusher extends CloseableSilently {
    */
   void onLogTruncation(long newLastIndex);
 
+  /**
+   * Returns true if {@link #flush(Journal, long)} flushes synchronously and immediately, i.e.
+   * everything written before the call is already on disk when the call returns. Callers can use
+   * this to skip flushes which would be redundant, e.g. a forced flush before taking a snapshot.
+   */
+  default boolean flushesDirectly() {
+    return false;
+  }
+
+  /**
+   * Returns true if this flusher ever flushes the journal itself, either synchronously in {@link
+   * #flush(Journal, long)} or at a later point. This is false only for the {@link NoopFlusher},
+   * which never flushes: with it, the write path deliberately performs no journal I/O at all, so
+   * callers must not flush on its behalf either.
+   */
+  default boolean flushesEventually() {
+    return true;
+  }
+
   @Override
   default void close() {}
 
@@ -88,6 +107,11 @@ public interface RaftLogFlusher extends CloseableSilently {
     @Override
     public void onLogTruncation(final long newLastIndex) {
       // nothing to do - flush results complete immediately, so there are never pending results
+    }
+
+    @Override
+    public boolean flushesEventually() {
+      return false;
     }
   }
 
@@ -113,6 +137,11 @@ public interface RaftLogFlusher extends CloseableSilently {
     @Override
     public void onLogTruncation(final long newLastIndex) {
       // nothing to do - flushes are synchronous, so there are never pending flush results
+    }
+
+    @Override
+    public boolean flushesDirectly() {
+      return true;
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -191,7 +191,9 @@ public class MetaStore implements JournalMetaStore, AutoCloseable {
     return lastFlushedIndex != MetaEncoder.lastFlushedIndexNullValue();
   }
 
-  public void storeCommitIndex(final long index) {
+  // synchronized because the shared serializer buffer may be written to file concurrently, e.g.
+  // when a flusher thread stores the last flushed index
+  public synchronized void storeCommitIndex(final long index) {
     Preconditions.checkArgument(index >= 0, "commit index must be >= 0");
     if (index == commitIndex) {
       log.trace("Skip storing same last flushed commit index {}", index);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoalescedFlushTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoalescedFlushTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftRule.Configurator;
+import io.atomix.raft.RaftServer.Builder;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.log.CoalescedFlusher;
+import java.util.Objects;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the Raft protocol against the {@link CoalescedFlusher}, which acknowledges appends and
+ * advances commits asynchronously, once a covering flush completed.
+ */
+public class CoalescedFlushTest {
+
+  @Rule
+  public RaftRule raftRule = RaftRule.withBootstrappedNodes(3, new CoalescedFlushConfigurator());
+
+  @Test
+  public void shouldCommitEntriesOnAllNodes() throws Throwable {
+    // given
+    final var entryCount = 128;
+
+    // when
+    final var lastIndex = raftRule.appendEntries(entryCount);
+
+    // then
+    raftRule.awaitCommit(lastIndex);
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
+    final var memberLogs = raftRule.getMemberLogs();
+    final var firstMemberEntries = memberLogs.values().stream().findFirst().orElseThrow();
+    assertThat(memberLogs.values())
+        .allSatisfy(entries -> assertThat(entries).containsExactlyElementsOf(firstMemberEntries));
+  }
+
+  @Test
+  public void shouldCommitEntriesAfterLeaderRestart() throws Throwable {
+    // given
+    raftRule.appendEntries(64);
+
+    // when
+    raftRule.restartLeader();
+    final var lastIndex = raftRule.appendEntries(64);
+
+    // then - all previously committed and new entries are present on all nodes
+    raftRule.awaitCommit(lastIndex);
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
+    final var memberLogs = raftRule.getMemberLogs();
+    final var firstMemberEntries = memberLogs.values().stream().findFirst().orElseThrow();
+    assertThat(firstMemberEntries.getLast().index()).isEqualTo(lastIndex);
+    assertThat(memberLogs.values())
+        .allSatisfy(entries -> assertThat(entries).containsExactlyElementsOf(firstMemberEntries));
+  }
+
+  /** Configures all members to flush their logs with the {@link CoalescedFlusher}. */
+  private static final class CoalescedFlushConfigurator implements Configurator {
+
+    @Override
+    public void configure(final MemberId id, final Builder builder) {
+      final var storage = Objects.requireNonNull(builder.storage);
+      builder.withStorage(
+          RaftStorage.builder(builder.meterRegistry)
+              .withDirectory(storage.directory())
+              .withSnapshotStore(storage.getPersistedSnapshotStore())
+              .withFlusherFactory(
+                  threadFactory -> new CoalescedFlusher(threadFactory.createContext()))
+              .build());
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoalescedFlushTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoalescedFlushTest.java
@@ -12,9 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftRule.Configurator;
 import io.atomix.raft.RaftServer.Builder;
-import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.storage.log.CoalescedFlusher;
-import java.util.Objects;
+import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -30,7 +30,7 @@ public class CoalescedFlushTest {
   @Test
   public void shouldCommitEntriesOnAllNodes() throws Throwable {
     // given
-    final var entryCount = 128;
+    final var entryCount = 32;
 
     // when
     final var lastIndex = raftRule.appendEntries(entryCount);
@@ -38,27 +38,29 @@ public class CoalescedFlushTest {
     // then
     raftRule.awaitCommit(lastIndex);
     raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
-    final var memberLogs = raftRule.getMemberLogs();
-    final var firstMemberEntries = memberLogs.values().stream().findFirst().orElseThrow();
-    assertThat(memberLogs.values())
-        .allSatisfy(entries -> assertThat(entries).containsExactlyElementsOf(firstMemberEntries));
+    assertAllMemberLogsEqual();
   }
 
   @Test
   public void shouldCommitEntriesAfterLeaderRestart() throws Throwable {
     // given
-    raftRule.appendEntries(64);
+    raftRule.appendEntries(32);
 
     // when
     raftRule.restartLeader();
-    final var lastIndex = raftRule.appendEntries(64);
+    final var lastIndex = raftRule.appendEntries(32);
 
     // then - all previously committed and new entries are present on all nodes
     raftRule.awaitCommit(lastIndex);
     raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
+    assertThat(raftRule.getMemberLogs().values())
+        .allSatisfy(entries -> assertThat(entries.getLast().index()).isEqualTo(lastIndex));
+    assertAllMemberLogsEqual();
+  }
+
+  private void assertAllMemberLogsEqual() {
     final var memberLogs = raftRule.getMemberLogs();
     final var firstMemberEntries = memberLogs.values().stream().findFirst().orElseThrow();
-    assertThat(firstMemberEntries.getLast().index()).isEqualTo(lastIndex);
     assertThat(memberLogs.values())
         .allSatisfy(entries -> assertThat(entries).containsExactlyElementsOf(firstMemberEntries));
   }
@@ -68,14 +70,18 @@ public class CoalescedFlushTest {
 
     @Override
     public void configure(final MemberId id, final Builder builder) {
-      final var storage = Objects.requireNonNull(builder.storage);
-      builder.withStorage(
-          RaftStorage.builder(builder.meterRegistry)
-              .withDirectory(storage.directory())
-              .withSnapshotStore(storage.getPersistedSnapshotStore())
-              .withFlusherFactory(
-                  threadFactory -> new CoalescedFlusher(threadFactory.createContext()))
-              .build());
+      Configurator.replaceFlusherFactory(
+          builder, threadFactory -> new CoalescedFlusher(threadFactory.createContext()));
+
+      // with coalesced flushing, acknowledgements - including those of heartbeats - wait for
+      // real fsyncs, which can stall for seconds on loaded CI runners; use generous timeouts
+      // so the test exercises replication rather than leader step-downs under load
+      final var partitionConfig =
+          new RaftPartitionConfig()
+              .setElectionTimeout(Duration.ofSeconds(5))
+              .setHeartbeatInterval(Duration.ofMillis(250));
+      partitionConfig.setMaxQuorumResponseTimeout(Duration.ofSeconds(15));
+      builder.withPartitionConfig(partitionConfig);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoalescedFlushTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/CoalescedFlushTest.java
@@ -14,7 +14,10 @@ import io.atomix.raft.RaftRule.Configurator;
 import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.storage.log.CoalescedFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher;
 import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,6 +61,32 @@ public class CoalescedFlushTest {
     assertAllMemberLogsEqual();
   }
 
+  /**
+   * Guards the fixture of the tests above: with the small segments {@link RaftRule} configures, the
+   * appended entries must roll over segments, so that flushing is exercised across segment
+   * boundaries. If the members were to run with the much larger default segment size, all entries
+   * would fit into a single segment and that path would silently not be covered.
+   */
+  @Test
+  public void shouldAppendAcrossMultipleSegments() throws Throwable {
+    // given
+    final var entryCount = 32;
+
+    // when
+    final var lastIndex = raftRule.appendEntries(entryCount);
+    raftRule.awaitCommit(lastIndex);
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
+
+    // then - nothing is compacted here, so the tail from index 1 on is the whole log
+    for (final var server : raftRule.getServers()) {
+      final var segments =
+          server.getContext().getTailSegments(1).get(30, TimeUnit.SECONDS).segmentPaths();
+      assertThat(segments)
+          .as("member %s appended across multiple segments", server.name())
+          .hasSizeGreaterThan(1);
+    }
+  }
+
   private void assertAllMemberLogsEqual() {
     final var memberLogs = raftRule.getMemberLogs();
     final var firstMemberEntries = memberLogs.values().stream().findFirst().orElseThrow();
@@ -69,10 +98,12 @@ public class CoalescedFlushTest {
   private static final class CoalescedFlushConfigurator implements Configurator {
 
     @Override
-    public void configure(final MemberId id, final Builder builder) {
-      Configurator.replaceFlusherFactory(
-          builder, threadFactory -> new CoalescedFlusher(threadFactory.createContext()));
+    public Optional<RaftLogFlusher.Factory> flusherFactory(final MemberId id) {
+      return Optional.of(threadFactory -> new CoalescedFlusher(threadFactory.createContext()));
+    }
 
+    @Override
+    public void configure(final MemberId id, final Builder builder) {
       // with coalesced flushing, acknowledgements - including those of heartbeats - wait for
       // real fsyncs, which can stall for seconds on loaded CI runners; use generous timeouts
       // so the test exercises replication rather than leader step-downs under load

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
@@ -15,6 +15,7 @@ import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -57,18 +58,30 @@ public record FaultyFlusherConfigurator(
   }
 
   @Override
+  public Optional<RaftLogFlusher.Factory> flusherFactory(final MemberId id) {
+    if (isFaulty(id)) {
+      LOG.trace("failing flusher for member {}", id);
+      return Optional.of(faultyFlusher(faultyWhen, notifyFaultyFlush));
+    }
+
+    LOG.trace("not failing flusher for member {} ", id);
+    return Optional.empty();
+  }
+
+  @Override
   public void configure(final MemberId id, final Builder builder) {
     final var numericId = Integer.parseInt(id.id());
     // Node priority is used to avoid the faulty nodes to become leaders
     final int nodePriority;
-    if (numericId <= faultyFlusherNumber) {
-      LOG.trace("failing flusher for member {}", id);
-      Configurator.replaceFlusherFactory(builder, faultyFlusher(faultyWhen, notifyFaultyFlush));
+    if (isFaulty(id)) {
       nodePriority = leaderFaulty ? Math.max(5 - numericId, 2) : numericId;
     } else {
-      LOG.trace("not failing flusher for member {} ", id);
       nodePriority = leaderFaulty ? numericId : Math.max(5 - numericId, 2);
     }
     builder.withElectionConfig(RaftElectionConfig.ofPriorityElection(5, nodePriority));
+  }
+
+  private boolean isFaulty(final MemberId id) {
+    return Integer.parseInt(id.id()) <= faultyFlusherNumber;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,16 +38,27 @@ public record FaultyFlusherConfigurator(
     return (ignored) ->
         new RaftLogFlusher() {
           @Override
-          public void flush(final Journal journal) throws FlushException {
+          public CompletableFuture<Void> flush(final Journal journal, final long index) {
             if (faultyWhen.get()) {
               notifyFaultyFlush.run();
               if (withDataLoss) {
                 journal.deleteAfter(journal.getLastIndex() - 1);
               }
-              throw new FlushException(new IOException("Failed sync"));
-            } else {
-              journal.flush();
+              return CompletableFuture.failedFuture(
+                  new FlushException(new IOException("Failed sync")));
             }
+
+            try {
+              journal.flush();
+              return CompletableFuture.completedFuture(null);
+            } catch (final FlushException e) {
+              return CompletableFuture.failedFuture(e);
+            }
+          }
+
+          @Override
+          public void onLogTruncation(final long newLastIndex) {
+            // nothing to do - flushes complete synchronously, there are never pending results
           }
         };
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
@@ -11,12 +11,10 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftRule.Configurator;
 import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.partition.RaftElectionConfig;
-import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -48,12 +46,7 @@ public record FaultyFlusherConfigurator(
                   new FlushException(new IOException("Failed sync")));
             }
 
-            try {
-              journal.flush();
-              return CompletableFuture.completedFuture(null);
-            } catch (final FlushException e) {
-              return CompletableFuture.failedFuture(e);
-            }
+            return RaftLogFlusher.Factory.DIRECT.flush(journal, index);
           }
 
           @Override
@@ -70,14 +63,7 @@ public record FaultyFlusherConfigurator(
     final int nodePriority;
     if (numericId <= faultyFlusherNumber) {
       LOG.trace("failing flusher for member {}", id);
-      final var storage = builder.storage;
-      Objects.requireNonNull(storage);
-      builder.withStorage(
-          RaftStorage.builder(builder.meterRegistry)
-              .withDirectory(storage.directory())
-              .withSnapshotStore(storage.getPersistedSnapshotStore())
-              .withFlusherFactory(faultyFlusher(faultyWhen, notifyFaultyFlush))
-              .build());
+      Configurator.replaceFlusherFactory(builder, faultyFlusher(faultyWhen, notifyFaultyFlush));
       nodePriority = leaderFaulty ? Math.max(5 - numericId, 2) : numericId;
     } else {
       LOG.trace("not failing flusher for member {} ", id);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -62,7 +62,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -572,6 +571,7 @@ public final class RaftRule extends ExternalResource {
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100)
             .withSnapshotStore(snapshotStore);
+    configurator.flusherFactory(memberId).ifPresent(builder::withFlusherFactory);
 
     return builder.build();
   }
@@ -789,18 +789,12 @@ public final class RaftRule extends ExternalResource {
     default void configure(final TestSnapshotStore snapshotStore) {}
 
     /**
-     * Rebuilds the builder's storage with the given flusher factory, keeping the directory and
-     * snapshot store.
+     * Returns the flusher factory to use for the given member's log, or {@link Optional#empty()} to
+     * keep the storage default. It is applied to the storage the rule builds, so that all other
+     * storage settings the rule configures are preserved.
      */
-    static void replaceFlusherFactory(
-        final RaftServer.Builder builder, final RaftLogFlusher.Factory flusherFactory) {
-      final var storage = Objects.requireNonNull(builder.storage);
-      builder.withStorage(
-          RaftStorage.builder(builder.meterRegistry)
-              .withDirectory(storage.directory())
-              .withSnapshotStore(storage.getPersistedSnapshotStore())
-              .withFlusherFactory(flusherFactory)
-              .build());
+    default Optional<RaftLogFlusher.Factory> flusherFactory(final MemberId id) {
+      return Optional.empty();
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -34,6 +34,7 @@ import io.atomix.raft.snapshot.InMemorySnapshot;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
@@ -61,6 +62,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -785,5 +787,20 @@ public final class RaftRule extends ExternalResource {
     default void configure(final MemberId id, final RaftServer.Builder builder) {}
 
     default void configure(final TestSnapshotStore snapshotStore) {}
+
+    /**
+     * Rebuilds the builder's storage with the given flusher factory, keeping the directory and
+     * snapshot store.
+     */
+    static void replaceFlusherFactory(
+        final RaftServer.Builder builder, final RaftLogFlusher.Factory flusherFactory) {
+      final var storage = Objects.requireNonNull(builder.storage);
+      builder.withStorage(
+          RaftStorage.builder(builder.meterRegistry)
+              .withDirectory(storage.directory())
+              .withSnapshotStore(storage.getPersistedSnapshotStore())
+              .withFlusherFactory(flusherFactory)
+              .build());
+    }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderAppenderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderAppenderTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.cluster.impl.RaftMemberContext;
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.protocol.VersionedAppendRequest;
+import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.utils.concurrent.ThreadContext;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests how the leader maintains its view of a follower's replication progress. The appender is
+ * driven through a mocked {@link RaftContext}: every append it sends is answered by completing the
+ * future the mocked protocol handed out for it, and responses are handled inline, which makes their
+ * handling order deterministic.
+ */
+final class LeaderAppenderTest {
+
+  private static final long TERM = 1L;
+  private static final long LAST_LOG_INDEX = 100L;
+  private static final long LOWER_INDEX = 10L;
+  private static final long HIGHER_INDEX = 20L;
+
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+  /** The leader's view of the follower's match index, the state under test. */
+  private final AtomicLong matchIndex = new AtomicLong();
+
+  private final CompletableFuture<AppendResponse> firstAppend = new CompletableFuture<>();
+  private final CompletableFuture<AppendResponse> secondAppend = new CompletableFuture<>();
+
+  private LeaderAppender appender;
+
+  @BeforeEach
+  void setup() {
+    final var context = mock(RaftContext.class, RETURNS_DEEP_STUBS);
+    final var threadContext = inlineThreadContext();
+    final var log = mock(RaftLog.class);
+    final var follower = followerContext();
+
+    when(context.getName()).thenReturn("leader");
+    when(context.getMeterRegistry()).thenReturn(meterRegistry);
+    when(context.getThreadContext()).thenReturn(threadContext);
+    when(context.getElectionTimeout()).thenReturn(Duration.ofMillis(100));
+    when(context.getMaxQuorumResponseTimeout()).thenReturn(Duration.ofSeconds(1));
+    when(context.getTerm()).thenReturn(TERM);
+    when(context.getCommitIndex()).thenReturn(0L);
+    when(context.getCurrentSnapshot()).thenReturn(null);
+    when(context.getLeader())
+        .thenReturn(new DefaultRaftMember(MemberId.from("0"), Type.ACTIVE, Instant.now()));
+
+    when(log.getLastIndex()).thenReturn(LAST_LOG_INDEX);
+    when(context.getLog()).thenReturn(log);
+
+    when(context.getCluster().getReplicationTargets()).thenReturn(Set.of(follower));
+    // no quorum progress, so that handling a response neither commits nor triggers new heartbeats
+    when(context.getCluster().<Long>getQuorumFor(any())).thenReturn(Optional.of(0L));
+    when(context.getProtocol().append(any(MemberId.class), any(VersionedAppendRequest.class)))
+        .thenReturn(firstAppend, secondAppend);
+
+    // the appender is only reachable through a leader role, which is not started here because the
+    // appender is driven directly
+    appender = new LeaderAppender(new LeaderRole(context));
+  }
+
+  @AfterEach
+  void tearDown() {
+    appender.close();
+    meterRegistry.close();
+  }
+
+  @Test
+  void shouldNotRegressMatchIndexOnReorderedSuccessfulResponses() {
+    // given - two appends are in flight to the same follower
+    appender.appendEntries(LOWER_INDEX);
+    appender.appendEntries(HIGHER_INDEX);
+
+    // when - the follower acknowledges the higher index first and the lower one only after, e.g.
+    // because it acknowledged already durable records ahead of records it was still persisting
+    firstAppend.complete(response(true, HIGHER_INDEX));
+    secondAppend.complete(response(true, LOWER_INDEX));
+
+    // then
+    assertThat(matchIndex)
+        .describedAs("the leader keeps the highest acknowledged index")
+        .hasValue(HIGHER_INDEX);
+  }
+
+  @Test
+  void shouldAdvanceMatchIndexOnSuccessfulResponses() {
+    // given
+    appender.appendEntries(LOWER_INDEX);
+    appender.appendEntries(HIGHER_INDEX);
+
+    // when
+    firstAppend.complete(response(true, LOWER_INDEX));
+    secondAppend.complete(response(true, HIGHER_INDEX));
+
+    // then
+    assertThat(matchIndex)
+        .describedAs("the leader follows the follower's progress")
+        .hasValue(HIGHER_INDEX);
+  }
+
+  @Test
+  void shouldLowerMatchIndexOnFailedResponse() {
+    // given
+    appender.appendEntries(LOWER_INDEX);
+    appender.appendEntries(HIGHER_INDEX);
+
+    // when - a failed response reports that the follower does not have the higher index after all
+    firstAppend.complete(response(true, HIGHER_INDEX));
+    secondAppend.complete(response(false, LOWER_INDEX));
+
+    // then
+    assertThat(matchIndex)
+        .describedAs("a failed response is the follower reporting that it lost records")
+        .hasValue(LOWER_INDEX);
+  }
+
+  private AppendResponse response(final boolean succeeded, final long lastLogIndex) {
+    return AppendResponse.builder()
+        .withStatus(Status.OK)
+        .withTerm(TERM)
+        .withSucceeded(succeeded)
+        .withLastLogIndex(lastLogIndex)
+        .withLastSnapshotIndex(0)
+        .withConfigurationIndex(0)
+        .build();
+  }
+
+  /**
+   * A thread context which runs responses inline, on the thread completing them, so that a response
+   * is fully handled once its future is completed.
+   */
+  private ThreadContext inlineThreadContext() {
+    final var threadContext = mock(ThreadContext.class);
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(threadContext)
+        .execute(any(Runnable.class));
+    return threadContext;
+  }
+
+  /**
+   * A follower which is always ready for a heartbeat and has no entries left to replicate, so that
+   * every {@code appendEntries} sends exactly one empty append to it. Its match index is stateful,
+   * as that is what the tests assert on.
+   */
+  private RaftMemberContext followerContext() {
+    final var follower = mock(RaftMemberContext.class);
+    when(follower.getMember())
+        .thenReturn(new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.now()));
+    when(follower.isOpen()).thenReturn(true);
+    when(follower.hasReplicationContext()).thenReturn(true);
+    when(follower.hasNextEntry()).thenReturn(false);
+    // an outdated configuration term keeps the appender on the configure-or-heartbeat path, where
+    // it sends an empty append without having to read from the log
+    when(follower.getConfigTerm()).thenReturn(TERM - 1);
+    when(follower.canConfigure()).thenReturn(false);
+    when(follower.canHeartbeat()).thenReturn(true);
+    when(follower.getMatchIndex()).thenAnswer(invocation -> matchIndex.get());
+    doAnswer(
+            invocation -> {
+              matchIndex.set(invocation.getArgument(0, Long.class));
+              return null;
+            })
+        .when(follower)
+        .setMatchIndex(anyLong());
+    return follower;
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -333,6 +333,71 @@ public class PassiveRoleTest {
     verify(ctx, never()).setCommitIndex(anyLong());
   }
 
+  @Test
+  public void shouldNotAckEmptyAppendWhileEarlierRecordsAreNotDurable() {
+    // given - records up to index 2 are appended but only flushed up to index 1, e.g. because the
+    // flush of a previous append request is still in progress
+    final var flushFuture = new CompletableFuture<Void>();
+    when(log.flush(anyLong())).thenReturn(flushFuture);
+    when(log.getLastFlushedIndex()).thenReturn(1L);
+    final var lastEntry = mock(IndexedRaftLogEntry.class);
+    when(lastEntry.index()).thenReturn(2L);
+    when(lastEntry.term()).thenReturn(1L);
+    when(log.getLastEntry()).thenReturn(lastEntry);
+    runThreadContextInline();
+
+    // an empty append, e.g. a heartbeat, acknowledging everything up to index 2
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(1)
+            .withPrevLogIndex(2)
+            .withEntries(List.of())
+            .withCommitIndex(2)
+            .build();
+
+    // when
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+
+    // then - the acknowledgement waits for durability of the acknowledged records
+    verify(log).flush(2L);
+    assertThat(responseFuture).isNotCompleted();
+
+    flushFuture.complete(null);
+    assertThat(responseFuture).isCompleted();
+    assertThat(responseFuture.join().succeeded()).isTrue();
+    assertThat(responseFuture.join().lastLogIndex()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldAckEmptyAppendImmediatelyWhenRecordsAreDurable() {
+    // given - everything appended is already flushed
+    when(log.getLastFlushedIndex()).thenReturn(2L);
+    final var lastEntry = mock(IndexedRaftLogEntry.class);
+    when(lastEntry.index()).thenReturn(2L);
+    when(lastEntry.term()).thenReturn(1L);
+    when(log.getLastEntry()).thenReturn(lastEntry);
+
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(1)
+            .withPrevLogIndex(2)
+            .withEntries(List.of())
+            .withCommitIndex(2)
+            .build();
+
+    // when
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+
+    // then - the acknowledgement is immediate, without any flush
+    verify(log, never()).flush(anyLong());
+    assertThat(responseFuture).isCompleted();
+    assertThat(responseFuture.join().succeeded()).isTrue();
+  }
+
   private void runThreadContextInline() {
     final var threadContext = mock(ThreadContext.class);
     doAnswer(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -100,15 +100,7 @@ public class PassiveRoleTest {
   public void shouldFailAppendWithIncorrectChecksum() {
     // given
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 12345, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(2)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(1)
-            .build();
+    final VersionedAppendRequest request = appendRequest(2, 0, 0, 1, entries);
 
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenThrow(new JournalException.InvalidChecksum("expected"));
@@ -128,15 +120,7 @@ public class PassiveRoleTest {
         List.of(
             new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
             new ReplicatableJournalRecord(1, 2, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(2)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 2, entries);
 
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class))
@@ -158,15 +142,7 @@ public class PassiveRoleTest {
         List.of(
             new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
             new ReplicatableJournalRecord(1, 2, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(2)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 2, entries);
 
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class))
@@ -185,15 +161,7 @@ public class PassiveRoleTest {
   public void shouldNotFlushIfNoEntryIsAppended() throws CheckedJournalException {
     // given
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(2)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 2, entries);
 
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
@@ -215,15 +183,7 @@ public class PassiveRoleTest {
             new ReplicatableJournalRecord(1, 1, 1, new byte[1]),
             new ReplicatableJournalRecord(1, 2, 1, new byte[1]),
             new ReplicatableJournalRecord(1, 3, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(3)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 3, entries);
 
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class))
@@ -276,15 +236,7 @@ public class PassiveRoleTest {
     runThreadContextInline();
 
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(1)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 1, entries);
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class));
 
@@ -310,15 +262,7 @@ public class PassiveRoleTest {
     runThreadContextInline();
 
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(1)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 1, entries);
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class));
 
@@ -340,22 +284,11 @@ public class PassiveRoleTest {
     final var flushFuture = new CompletableFuture<Void>();
     when(log.flush(anyLong())).thenReturn(flushFuture);
     when(log.getLastFlushedIndex()).thenReturn(1L);
-    final var lastEntry = mock(IndexedRaftLogEntry.class);
-    when(lastEntry.index()).thenReturn(2L);
-    when(lastEntry.term()).thenReturn(1L);
-    when(log.getLastEntry()).thenReturn(lastEntry);
+    givenLastEntry(2, 1);
     runThreadContextInline();
 
     // an empty append, e.g. a heartbeat, acknowledging everything up to index 2
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(1)
-            .withPrevLogIndex(2)
-            .withEntries(List.of())
-            .withCommitIndex(2)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 1, 2, 2, List.of());
 
     // when
     final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
@@ -371,23 +304,29 @@ public class PassiveRoleTest {
   }
 
   @Test
+  public void shouldAckEmptyAppendAtLogStartWithoutFlushing() {
+    // given - an empty log where nothing was ever flushed, e.g. a freshly bootstrapped follower
+    when(log.getLastFlushedIndex()).thenReturn(-1L);
+
+    // an empty append at the very start of the log, acknowledging no records at all
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 0, List.of());
+
+    // when
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+
+    // then - acknowledged immediately, nothing needs to be durable
+    verify(log, never()).flush(anyLong());
+    assertThat(responseFuture).isCompleted();
+    assertThat(responseFuture.join().succeeded()).isTrue();
+  }
+
+  @Test
   public void shouldAckEmptyAppendImmediatelyWhenRecordsAreDurable() {
     // given - everything appended is already flushed
     when(log.getLastFlushedIndex()).thenReturn(2L);
-    final var lastEntry = mock(IndexedRaftLogEntry.class);
-    when(lastEntry.index()).thenReturn(2L);
-    when(lastEntry.term()).thenReturn(1L);
-    when(log.getLastEntry()).thenReturn(lastEntry);
+    givenLastEntry(2, 1);
 
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(1)
-            .withPrevLogIndex(2)
-            .withEntries(List.of())
-            .withCommitIndex(2)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 1, 2, 2, List.of());
 
     // when
     final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
@@ -398,18 +337,6 @@ public class PassiveRoleTest {
     assertThat(responseFuture.join().succeeded()).isTrue();
   }
 
-  private void runThreadContextInline() {
-    final var threadContext = mock(ThreadContext.class);
-    doAnswer(
-            invocation -> {
-              invocation.getArgument(0, Runnable.class).run();
-              return null;
-            })
-        .when(threadContext)
-        .execute(any(Runnable.class));
-    when(ctx.getThreadContext()).thenReturn(threadContext);
-  }
-
   @Test
   public void shouldNotAbortPendingSnapshotOnEmptyAppend() throws Exception {
     // given - a pending snapshot is in progress
@@ -417,15 +344,7 @@ public class PassiveRoleTest {
     setPendingSnapshot(receivedSnapshot);
 
     // an empty append request (heartbeat)
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(List.of())
-            .withCommitIndex(0)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 0, List.of());
 
     // when
     role.handleAppend(ProtocolVersionHandler.transform(request)).join();
@@ -443,15 +362,7 @@ public class PassiveRoleTest {
 
     // an append request with entries
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
-    final VersionedAppendRequest request =
-        VersionedAppendRequest.builder()
-            .withTerm(1)
-            .withLeader(MemberId.anonymous())
-            .withPrevLogTerm(0)
-            .withPrevLogIndex(0)
-            .withEntries(entries)
-            .withCommitIndex(1)
-            .build();
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 1, entries);
 
     when(log.append(any(ReplicatableJournalRecord.class)))
         .thenReturn(mock(IndexedRaftLogEntry.class));
@@ -523,6 +434,41 @@ public class PassiveRoleTest {
     // understates the leader's log and cannot be used to detect data loss. The local log end never
     // trips the check, which is the point: an ex-leader demoted to PASSIVE tripped it spuriously.
     verify(ctx).setFirstCommitIndex(2, 120);
+  }
+
+  private static VersionedAppendRequest appendRequest(
+      final long term,
+      final long prevLogTerm,
+      final long prevLogIndex,
+      final long commitIndex,
+      final List<ReplicatableJournalRecord> entries) {
+    return VersionedAppendRequest.builder()
+        .withTerm(term)
+        .withLeader(MemberId.anonymous())
+        .withPrevLogTerm(prevLogTerm)
+        .withPrevLogIndex(prevLogIndex)
+        .withEntries(entries)
+        .withCommitIndex(commitIndex)
+        .build();
+  }
+
+  private void givenLastEntry(final long index, final long term) {
+    final var lastEntry = mock(IndexedRaftLogEntry.class);
+    when(lastEntry.index()).thenReturn(index);
+    when(lastEntry.term()).thenReturn(term);
+    when(log.getLastEntry()).thenReturn(lastEntry);
+  }
+
+  private void runThreadContextInline() {
+    final var threadContext = mock(ThreadContext.class);
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(threadContext)
+        .execute(any(Runnable.class));
+    when(ctx.getThreadContext()).thenReturn(threadContext);
   }
 
   private void setPendingSnapshot(final ReceivedSnapshot snapshot) throws Exception {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -18,6 +18,7 @@ package io.atomix.raft.roles;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -39,6 +40,7 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.system.Configuration;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
@@ -264,6 +266,83 @@ public class PassiveRoleTest {
         role.handleAppend(ProtocolVersionHandler.transform(request)).toCompletableFuture().join();
     // then
     assertThat(result.succeeded()).isFalse();
+  }
+
+  @Test
+  public void shouldAckOnlyAfterFlushCompleted() {
+    // given - a flush which does not complete immediately
+    final var flushFuture = new CompletableFuture<Void>();
+    when(log.flush(anyLong())).thenReturn(flushFuture);
+    runThreadContextInline();
+
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(1)
+            .build();
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+
+    // then - the request is only acknowledged, and the commit index only advanced, once the
+    // flush covering the appended entries completed
+    assertThat(responseFuture).isNotCompleted();
+    verify(ctx, never()).setCommitIndex(anyLong());
+
+    flushFuture.complete(null);
+    assertThat(responseFuture).isCompleted();
+    assertThat(responseFuture.join().succeeded()).isTrue();
+    verify(ctx).setCommitIndex(1);
+  }
+
+  @Test
+  public void shouldFailAppendWhenAsyncFlushFails() {
+    // given - a flush which fails asynchronously
+    final var flushFuture = new CompletableFuture<Void>();
+    when(log.flush(anyLong())).thenReturn(flushFuture);
+    runThreadContextInline();
+
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
+    final VersionedAppendRequest request =
+        VersionedAppendRequest.builder()
+            .withTerm(1)
+            .withLeader(MemberId.anonymous())
+            .withPrevLogTerm(0)
+            .withPrevLogIndex(0)
+            .withEntries(entries)
+            .withCommitIndex(1)
+            .build();
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+    flushFuture.completeExceptionally(
+        new CheckedJournalException.FlushException(new IOException("failed to sync")));
+
+    // then - the append is rejected so that the leader retries, and the commit index is untouched
+    assertThat(responseFuture).isCompleted();
+    assertThat(responseFuture.join().succeeded()).isFalse();
+    verify(ctx, never()).setCommitIndex(anyLong());
+  }
+
+  private void runThreadContextInline() {
+    final var threadContext = mock(ThreadContext.class);
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, Runnable.class).run();
+              return null;
+            })
+        .when(threadContext)
+        .execute(any(Runnable.class));
+    when(ctx.getThreadContext()).thenReturn(threadContext);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -72,7 +72,6 @@ public class PassiveRoleTest {
     ctx = mock(RaftContext.class);
 
     log = mock(RaftLog.class);
-    when(log.flushesDirectly()).thenReturn(true);
     when(log.flush(anyLong())).thenReturn(CompletableFuture.completedFuture(null));
     when(ctx.getLog()).thenReturn(log);
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.roles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -49,6 +50,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,6 +73,7 @@ public class PassiveRoleTest {
 
     log = mock(RaftLog.class);
     when(log.flushesDirectly()).thenReturn(true);
+    when(log.flush(anyLong())).thenReturn(CompletableFuture.completedFuture(null));
     when(ctx.getLog()).thenReturn(log);
 
     final PersistedSnapshot snapshot = mock(PersistedSnapshot.class);
@@ -143,7 +146,7 @@ public class PassiveRoleTest {
         role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
-    verify(log, times(1)).flush();
+    verify(log, times(1)).flush(2L);
     assertThat(response.lastLogIndex()).isEqualTo(2);
   }
 
@@ -173,7 +176,7 @@ public class PassiveRoleTest {
         role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
-    verify(log, times(1)).flush();
+    verify(log, times(1)).flush(1L);
     assertThat(response.lastLogIndex()).isOne();
   }
 
@@ -199,7 +202,7 @@ public class PassiveRoleTest {
         role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
-    verify(log, never()).flush();
+    verify(log, never()).flush(anyLong());
     assertThat(response.lastLogIndex()).isZero();
   }
 
@@ -231,7 +234,7 @@ public class PassiveRoleTest {
     role.handleAppend(ProtocolVersionHandler.transform(request)).join();
 
     // then
-    verify(log, times(1)).flush();
+    verify(log, times(1)).flush(2L);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -278,6 +278,52 @@ public class PassiveRoleTest {
   }
 
   @Test
+  public void shouldFailAppendWhenLogIsTruncatedBeforeFlushCompletes() {
+    // given - entries were appended, but the flush covering them is still in progress
+    final var flushFuture = new CompletableFuture<Void>();
+    when(log.flush(anyLong())).thenReturn(flushFuture);
+    when(log.getTruncationGeneration()).thenReturn(7L);
+    runThreadContextInline();
+
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 1, entries);
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+
+    // when - the log is truncated before the flush completes, e.g. by a conflicting append
+    when(log.getTruncationGeneration()).thenReturn(8L);
+    flushFuture.complete(null);
+
+    // then - the append is rejected instead of acknowledging entries which may no longer exist
+    assertThat(responseFuture).isCompleted();
+    assertThat(responseFuture.join().succeeded()).isFalse();
+    verify(ctx, never()).setCommitIndex(anyLong());
+  }
+
+  @Test
+  public void shouldAnnounceCommitIndexBeforeItIsDurable() {
+    // given - a flush which does not complete immediately
+    final var flushFuture = new CompletableFuture<Void>();
+    when(log.flush(anyLong())).thenReturn(flushFuture);
+    runThreadContextInline();
+
+    final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
+    final VersionedAppendRequest request = appendRequest(1, 0, 0, 1, entries);
+    when(log.append(any(ReplicatableJournalRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    final var responseFuture = role.handleAppend(ProtocolVersionHandler.transform(request));
+
+    // then - the log knows about the announced commit index right away, so that it keeps refusing
+    // to delete the committed entry, while the commit index itself is only advanced once durable
+    verify(log).announceCommitIndex(1);
+    verify(ctx, never()).setCommitIndex(anyLong());
+    assertThat(responseFuture).isNotCompleted();
+  }
+
+  @Test
   public void shouldNotAckEmptyAppendWhileEarlierRecordsAreNotDurable() {
     // given - records up to index 2 are appended but only flushed up to index 1, e.g. because the
     // flush of a previous append request is still in progress

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.agrona.CloseHelper;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 final class CoalescedFlusherTest {
@@ -46,7 +47,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldCompleteImmediatelyWhenIndexAlreadyDurable() throws CheckedJournalException {
     // given
-    setupJournal();
     lastIndex.set(5);
     lastFlushedIndex.set(5);
 
@@ -62,7 +62,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldNotCompleteBeforeFlushCovered() {
     // given
-    setupJournal();
     lastIndex.set(6);
 
     // when
@@ -77,7 +76,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldCoalescePendingFlushes() throws CheckedJournalException {
     // given - three requests queue up while no flush has run yet
-    setupJournal();
     lastIndex.set(8);
     final var first = flusher.flush(journal, 6);
     final var second = flusher.flush(journal, 7);
@@ -96,7 +94,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldCompleteInRequestOrder() {
     // given
-    setupJournal();
     lastIndex.set(8);
     final List<Integer> completionOrder = new ArrayList<>();
     flusher.flush(journal, 6).whenComplete((ok, error) -> completionOrder.add(6));
@@ -113,7 +110,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldCompleteCoveredRequestImmediatelyDespitePendingRequests() {
     // given - index 5 is already durable, and an earlier request for index 6 is still pending
-    setupJournal();
     lastIndex.set(6);
     lastFlushedIndex.set(5);
     final var pending = flusher.flush(journal, 6);
@@ -132,7 +128,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldCompleteCoveredRequestEvenWhenNextFlushFails() throws CheckedJournalException {
     // given - a pending request whose flush will fail, and an already durable index
-    setupJournal();
     lastIndex.set(6);
     lastFlushedIndex.set(5);
     doThrow(new FlushException(new IOException("failed to sync"))).when(journal).flush();
@@ -150,7 +145,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldFlushAgainForRecordsAppendedDuringFlush() throws CheckedJournalException {
     // given - a flush for index 6 is in progress while a request for index 8 arrives
-    setupJournal();
     lastIndex.set(6);
     final var first = flusher.flush(journal, 6);
 
@@ -169,7 +163,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldCoverLateRequestsWithFollowUpFlush() throws CheckedJournalException {
     // given - two requests, but the first flush only covers the first one
-    setupJournal();
     doAnswer(
             invocation -> {
               lastFlushedIndex.set(6);
@@ -200,7 +193,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldFailAllPendingWhenFlushFails() throws CheckedJournalException {
     // given
-    setupJournal();
     lastIndex.set(7);
     final var failure = new FlushException(new IOException("failed to sync"));
     doThrow(failure).when(journal).flush();
@@ -218,7 +210,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldFailPendingWhenFlushThrowsUnexpectedException() throws CheckedJournalException {
     // given - a failure outside the expected journal exceptions, e.g. from the metastore
-    setupJournal();
     lastIndex.set(6);
     doThrow(new IllegalStateException("unexpected"))
         .doAnswer(
@@ -243,7 +234,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldRecoverAfterFailedFlush() throws CheckedJournalException {
     // given - a first flush which fails
-    setupJournal();
     lastIndex.set(6);
     final var failure = new FlushException(new IOException("failed to sync"));
     doThrow(failure)
@@ -269,7 +259,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldFailPendingOnLogTruncation() {
     // given - pending requests both above and below the truncation index
-    setupJournal();
     lastIndex.set(8);
     final var below = flusher.flush(journal, 6);
     final var above = flusher.flush(journal, 8);
@@ -285,7 +274,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldFailPendingOnClose() {
     // given
-    setupJournal();
     lastIndex.set(6);
     final var pending = flusher.flush(journal, 6);
 
@@ -299,7 +287,6 @@ final class CoalescedFlusherTest {
   @Test
   void shouldFailFlushAfterClose() {
     // given
-    setupJournal();
     flusher.close();
 
     // when
@@ -310,9 +297,23 @@ final class CoalescedFlusherTest {
   }
 
   @Test
+  void shouldFailPendingWhenJournalIsEmpty() {
+    // given - a request which an empty journal can never cover, e.g. requested just before the
+    // log was reset
+    when(journal.isEmpty()).thenReturn(true);
+    final var result = flusher.flush(journal, 6);
+
+    // when
+    scheduler.runUntilIdle();
+
+    // then - the result fails instead of endlessly rescheduling flushes which the journal skips
+    assertThat(result).isCompletedExceptionally();
+    assertThat(scheduler.isIdle()).isTrue();
+  }
+
+  @Test
   void shouldFailPendingWhenJournalIsClosed() {
     // given
-    setupJournal();
     lastIndex.set(6);
     when(journal.isOpen()).thenReturn(false);
 
@@ -329,19 +330,16 @@ final class CoalescedFlusherTest {
    * everything appended so far, i.e. it advances the flushed index to the last index at the time of
    * the call.
    */
-  private void setupJournal() {
+  @BeforeEach
+  void setupJournal() throws CheckedJournalException {
     when(journal.isOpen()).thenReturn(true);
     when(journal.getLastFlushedIndex()).thenAnswer(invocation -> lastFlushedIndex.get());
-    try {
-      doAnswer(
-              invocation -> {
-                lastFlushedIndex.set(lastIndex.get());
-                return null;
-              })
-          .when(journal)
-          .flush();
-    } catch (final CheckedJournalException e) {
-      throw new RuntimeException(e);
-    }
+    doAnswer(
+            invocation -> {
+              lastFlushedIndex.set(lastIndex.get());
+              return null;
+            })
+        .when(journal)
+        .flush();
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
@@ -8,6 +8,7 @@
 package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -20,6 +21,7 @@ import io.atomix.raft.DeterministicSingleThreadContext;
 import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
+import java.io.IOError;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -226,6 +228,33 @@ final class CoalescedFlusherTest {
 
     // then - the pending result fails instead of hanging, and the flusher stays usable
     assertThat(failed).isCompletedExceptionally();
+    final var retried = flusher.flush(journal, 6);
+    scheduler.runUntilIdle();
+    assertThat(retried).isCompleted();
+  }
+
+  @Test
+  void shouldFailPendingWhenFlushThrowsError() throws CheckedJournalException {
+    // given - a flush failing with an error instead of an exception, e.g. an IOError from the
+    // memory mapped segment buffer
+    lastIndex.set(6);
+    final var error = new IOError(new IOException("failed to sync"));
+    doThrow(error)
+        .doAnswer(
+            invocation -> {
+              lastFlushedIndex.set(lastIndex.get());
+              return null;
+            })
+        .when(journal)
+        .flush();
+    final var failed = flusher.flush(journal, 6);
+
+    // when - the error is not swallowed, it still escapes to the flush thread
+    assertThatThrownBy(scheduler::runUntilIdle).isSameAs(error);
+
+    // then - the pending result fails instead of hanging, and the flusher stays usable
+    assertThat(failed).isCompletedExceptionally();
+    assertThatThrownBy(failed::join).hasCauseInstanceOf(FlushException.class);
     final var retried = flusher.flush(journal, 6);
     scheduler.runUntilIdle();
     assertThat(retried).isCompleted();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.storage.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.DeterministicSingleThreadContext;
+import io.camunda.zeebe.journal.CheckedJournalException;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+import io.camunda.zeebe.journal.Journal;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.CloseHelper;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+final class CoalescedFlusherTest {
+  private final DeterministicScheduler scheduler = new DeterministicScheduler();
+  private final CoalescedFlusher flusher =
+      new CoalescedFlusher(new DeterministicSingleThreadContext(scheduler, MemberId.from("test")));
+
+  private final AtomicLong lastIndex = new AtomicLong();
+  private final AtomicLong lastFlushedIndex = new AtomicLong(-1);
+  private final Journal journal = mock(Journal.class);
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietClose(flusher);
+  }
+
+  @Test
+  void shouldCompleteImmediatelyWhenIndexAlreadyDurable() throws CheckedJournalException {
+    // given
+    setupJournal();
+    lastIndex.set(5);
+    lastFlushedIndex.set(5);
+
+    // when
+    final var result = flusher.flush(journal, 5);
+
+    // then - no flush is scheduled at all
+    assertThat(result).isCompleted();
+    assertThat(scheduler.isIdle()).isTrue();
+    verify(journal, times(0)).flush();
+  }
+
+  @Test
+  void shouldNotCompleteBeforeFlushCovered() {
+    // given
+    setupJournal();
+    lastIndex.set(6);
+
+    // when
+    final var result = flusher.flush(journal, 6);
+
+    // then - not completed until the scheduled flush ran
+    assertThat(result).isNotCompleted();
+    scheduler.runUntilIdle();
+    assertThat(result).isCompleted();
+  }
+
+  @Test
+  void shouldCoalescePendingFlushes() throws CheckedJournalException {
+    // given - three requests queue up while no flush has run yet
+    setupJournal();
+    lastIndex.set(8);
+    final var first = flusher.flush(journal, 6);
+    final var second = flusher.flush(journal, 7);
+    final var third = flusher.flush(journal, 8);
+
+    // when
+    scheduler.runUntilIdle();
+
+    // then - a single flush covered all of them
+    verify(journal, times(1)).flush();
+    assertThat(first).isCompleted();
+    assertThat(second).isCompleted();
+    assertThat(third).isCompleted();
+  }
+
+  @Test
+  void shouldCompleteInRequestOrder() {
+    // given
+    setupJournal();
+    lastIndex.set(8);
+    final List<Integer> completionOrder = new ArrayList<>();
+    flusher.flush(journal, 6).whenComplete((ok, error) -> completionOrder.add(6));
+    flusher.flush(journal, 7).whenComplete((ok, error) -> completionOrder.add(7));
+    flusher.flush(journal, 8).whenComplete((ok, error) -> completionOrder.add(8));
+
+    // when
+    scheduler.runUntilIdle();
+
+    // then
+    assertThat(completionOrder).containsExactly(6, 7, 8);
+  }
+
+  @Test
+  void shouldCompleteCoveredRequestImmediatelyDespitePendingRequests() {
+    // given - index 5 is already durable, and an earlier request for index 6 is still pending
+    setupJournal();
+    lastIndex.set(6);
+    lastFlushedIndex.set(5);
+    final var pending = flusher.flush(journal, 6);
+
+    // when - requesting an already covered index
+    final var covered = flusher.flush(journal, 5);
+
+    // then - the covered request completes immediately, without waiting for the pending flush
+    assertThat(covered).isCompleted();
+    assertThat(pending).isNotCompleted();
+
+    scheduler.runUntilIdle();
+    assertThat(pending).isCompleted();
+  }
+
+  @Test
+  void shouldCompleteCoveredRequestEvenWhenNextFlushFails() throws CheckedJournalException {
+    // given - a pending request whose flush will fail, and an already durable index
+    setupJournal();
+    lastIndex.set(6);
+    lastFlushedIndex.set(5);
+    doThrow(new FlushException(new IOException("failed to sync"))).when(journal).flush();
+    final var pending = flusher.flush(journal, 6);
+
+    // when
+    final var covered = flusher.flush(journal, 5);
+    scheduler.runUntilIdle();
+
+    // then - the covered request stays successful, only the request requiring the flush fails
+    assertThat(covered).isCompleted();
+    assertThat(pending).isCompletedExceptionally();
+  }
+
+  @Test
+  void shouldFlushAgainForRecordsAppendedDuringFlush() throws CheckedJournalException {
+    // given - a flush for index 6 is in progress while a request for index 8 arrives
+    setupJournal();
+    lastIndex.set(6);
+    final var first = flusher.flush(journal, 6);
+
+    // when - the first flush only covers index 6, the second request needs a follow-up flush
+    scheduler.runNextPendingCommand();
+    assertThat(first).isCompleted();
+    lastIndex.set(8);
+    final var second = flusher.flush(journal, 8);
+    scheduler.runUntilIdle();
+
+    // then
+    verify(journal, times(2)).flush();
+    assertThat(second).isCompleted();
+  }
+
+  @Test
+  void shouldCoverLateRequestsWithFollowUpFlush() throws CheckedJournalException {
+    // given - two requests, but the first flush only covers the first one
+    setupJournal();
+    doAnswer(
+            invocation -> {
+              lastFlushedIndex.set(6);
+              return null;
+            })
+        .doAnswer(
+            invocation -> {
+              lastFlushedIndex.set(8);
+              return null;
+            })
+        .when(journal)
+        .flush();
+    final var first = flusher.flush(journal, 6);
+    final var second = flusher.flush(journal, 8);
+
+    // when
+    scheduler.runNextPendingCommand();
+
+    // then - the first result is completed, and a follow-up flush was scheduled for the second
+    assertThat(first).isCompleted();
+    assertThat(second).isNotCompleted();
+
+    scheduler.runUntilIdle();
+    verify(journal, times(2)).flush();
+    assertThat(second).isCompleted();
+  }
+
+  @Test
+  void shouldFailAllPendingWhenFlushFails() throws CheckedJournalException {
+    // given
+    setupJournal();
+    lastIndex.set(7);
+    final var failure = new FlushException(new IOException("failed to sync"));
+    doThrow(failure).when(journal).flush();
+    final var first = flusher.flush(journal, 6);
+    final var second = flusher.flush(journal, 7);
+
+    // when
+    scheduler.runUntilIdle();
+
+    // then
+    assertThat(first).isCompletedExceptionally();
+    assertThat(second).isCompletedExceptionally();
+  }
+
+  @Test
+  void shouldRecoverAfterFailedFlush() throws CheckedJournalException {
+    // given - a first flush which fails
+    setupJournal();
+    lastIndex.set(6);
+    final var failure = new FlushException(new IOException("failed to sync"));
+    doThrow(failure)
+        .doAnswer(
+            invocation -> {
+              lastFlushedIndex.set(lastIndex.get());
+              return null;
+            })
+        .when(journal)
+        .flush();
+    final var failed = flusher.flush(journal, 6);
+    scheduler.runUntilIdle();
+    assertThat(failed).isCompletedExceptionally();
+
+    // when - a new request arrives after the failure
+    final var retried = flusher.flush(journal, 6);
+    scheduler.runUntilIdle();
+
+    // then
+    assertThat(retried).isCompleted();
+  }
+
+  @Test
+  void shouldFailPendingOnLogTruncation() {
+    // given - pending requests both above and below the truncation index
+    setupJournal();
+    lastIndex.set(8);
+    final var below = flusher.flush(journal, 6);
+    final var above = flusher.flush(journal, 8);
+
+    // when
+    flusher.onLogTruncation(7);
+
+    // then - all pending results fail, in order, and the leader retries the appends
+    assertThat(below).isCompletedExceptionally();
+    assertThat(above).isCompletedExceptionally();
+  }
+
+  @Test
+  void shouldFailPendingOnClose() {
+    // given
+    setupJournal();
+    lastIndex.set(6);
+    final var pending = flusher.flush(journal, 6);
+
+    // when
+    flusher.close();
+
+    // then
+    assertThat(pending).isCompletedExceptionally();
+  }
+
+  @Test
+  void shouldFailFlushAfterClose() {
+    // given
+    setupJournal();
+    flusher.close();
+
+    // when
+    final var result = flusher.flush(journal, 6);
+
+    // then
+    assertThat(result).isCompletedExceptionally();
+  }
+
+  @Test
+  void shouldFailPendingWhenJournalIsClosed() {
+    // given
+    setupJournal();
+    lastIndex.set(6);
+    when(journal.isOpen()).thenReturn(false);
+
+    // when
+    final var result = flusher.flush(journal, 6);
+    scheduler.runUntilIdle();
+
+    // then - instead of retrying a journal which can never be flushed again, the result fails
+    assertThat(result).isCompletedExceptionally();
+  }
+
+  /**
+   * Sets up the mocked journal to behave like the real one w.r.t. flushing: a flush covers
+   * everything appended so far, i.e. it advances the flushed index to the last index at the time of
+   * the call.
+   */
+  private void setupJournal() {
+    when(journal.isOpen()).thenReturn(true);
+    when(journal.getLastFlushedIndex()).thenAnswer(invocation -> lastFlushedIndex.get());
+    try {
+      doAnswer(
+              invocation -> {
+                lastFlushedIndex.set(lastIndex.get());
+                return null;
+              })
+          .when(journal)
+          .flush();
+    } catch (final CheckedJournalException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/CoalescedFlusherTest.java
@@ -216,6 +216,31 @@ final class CoalescedFlusherTest {
   }
 
   @Test
+  void shouldFailPendingWhenFlushThrowsUnexpectedException() throws CheckedJournalException {
+    // given - a failure outside the expected journal exceptions, e.g. from the metastore
+    setupJournal();
+    lastIndex.set(6);
+    doThrow(new IllegalStateException("unexpected"))
+        .doAnswer(
+            invocation -> {
+              lastFlushedIndex.set(lastIndex.get());
+              return null;
+            })
+        .when(journal)
+        .flush();
+    final var failed = flusher.flush(journal, 6);
+
+    // when
+    scheduler.runUntilIdle();
+
+    // then - the pending result fails instead of hanging, and the flusher stays usable
+    assertThat(failed).isCompletedExceptionally();
+    final var retried = flusher.flush(journal, 6);
+    scheduler.runUntilIdle();
+    assertThat(retried).isCompleted();
+  }
+
+  @Test
   void shouldRecoverAfterFailedFlush() throws CheckedJournalException {
     // given - a first flush which fails
     setupJournal();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -8,10 +8,12 @@
 package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
 import io.camunda.zeebe.journal.CheckedJournalException;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -141,6 +143,42 @@ final class DelayedFlusherTest {
 
     // then
     Mockito.verify(journal, Mockito.times(2)).flush();
+  }
+
+  @Test
+  void shouldRescheduleOnJournalFlushError() throws CheckedJournalException {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.doThrow(new FlushException(new IOException("No space left on device")))
+        .when(journal)
+        .flush();
+
+    // when
+    flusher.flush(journal, 1);
+    scheduler.runNext();
+    Mockito.doNothing().when(journal).flush();
+    scheduler.runNext();
+
+    // then
+    Mockito.verify(journal, Mockito.times(2)).flush();
+  }
+
+  @Test
+  void shouldPropagateUnexpectedFlushError() throws CheckedJournalException {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.doThrow(new IllegalStateException("Metastore is in an unexpected state"))
+        .when(journal)
+        .flush();
+
+    // when
+    flusher.flush(journal, 1);
+
+    // then - unexpected failures are most likely permanent, so instead of retrying them forever
+    // they escape to the thread context's uncaught exception handler, which marks the partition
+    // unhealthy
+    assertThatThrownBy(scheduler::runNext).isInstanceOf(IllegalStateException.class);
+    assertThat(scheduler.operations).isEmpty();
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -40,13 +40,28 @@ final class DelayedFlusherTest {
     Mockito.when(journal.isOpen()).thenReturn(true);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
 
     // then
     assertThat(scheduler.operations).hasSize(1);
 
     final var scheduled = scheduler.operations.get(0);
     assertThat(scheduled.delay).isEqualTo(Duration.ofSeconds(5));
+    Mockito.verify(journal, Mockito.never()).flush();
+  }
+
+  @Test
+  void shouldCompleteResultImmediately() throws CheckedJournalException {
+    // given
+    final var journal = Mockito.mock(Journal.class);
+    Mockito.when(journal.isOpen()).thenReturn(true);
+
+    // when
+    final var result = flusher.flush(journal, 1);
+
+    // then - the flush is only scheduled, but callers may proceed immediately as this flusher
+    // trades durability for performance
+    assertThat(result).isCompleted();
     Mockito.verify(journal, Mockito.never()).flush();
   }
 
@@ -58,7 +73,7 @@ final class DelayedFlusherTest {
     Mockito.when(journal.getLastIndex()).thenReturn(5L);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
     scheduler.runNext();
 
     // then
@@ -72,9 +87,9 @@ final class DelayedFlusherTest {
     Mockito.when(journal.getLastIndex()).thenReturn(5L);
 
     // when
-    flusher.flush(journal);
-    flusher.flush(journal);
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
+    flusher.flush(journal, 1);
+    flusher.flush(journal, 1);
 
     // then
     assertThat(scheduler.operations).hasSize(1);
@@ -88,7 +103,7 @@ final class DelayedFlusherTest {
     final var journal = Mockito.mock(Journal.class);
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
     flusher.close();
 
     // then
@@ -104,7 +119,7 @@ final class DelayedFlusherTest {
 
     // when
     flusher.close();
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
 
     // then
     assertThat(scheduler.operations).isEmpty();
@@ -119,7 +134,7 @@ final class DelayedFlusherTest {
         .flush();
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
     scheduler.runNext();
     Mockito.doNothing().when(journal).flush();
     scheduler.runNext();
@@ -137,7 +152,7 @@ final class DelayedFlusherTest {
         .flush();
 
     // when
-    flusher.flush(journal);
+    flusher.flush(journal, 1);
     flusher.close();
     scheduler.runNext();
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -18,10 +18,10 @@ package io.atomix.raft.storage.log;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
@@ -35,16 +35,19 @@ import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.journal.CheckedJournalException;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -254,17 +257,47 @@ class RaftLogTest {
   @Nested
   final class FlushTest {
     @Test
-    void shouldUseFlusher() throws CheckedJournalException {
+    void shouldUseFlusher() {
       // given
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
+      when(flusher.flush(journal, 3L)).thenReturn(CompletableFuture.completedFuture(null));
       final var log = new RaftLog(journal, flusher);
 
       // when
-      log.flush();
+      final var result = log.flush(3L);
 
       // then
-      verify(flusher, times(1)).flush(journal);
+      verify(flusher, times(1)).flush(journal, 3L);
+      assertThat(result).isCompleted();
+    }
+
+    @Test
+    void shouldFlushSyncViaFlusher() throws CheckedJournalException {
+      // given
+      final var journal = mock(Journal.class);
+      final var flusher = mock(RaftLogFlusher.class);
+      when(flusher.flush(journal, 3L)).thenReturn(CompletableFuture.completedFuture(null));
+      final var log = new RaftLog(journal, flusher);
+
+      // when
+      log.flushSync(3L);
+
+      // then
+      verify(flusher, times(1)).flush(journal, 3L);
+    }
+
+    @Test
+    void shouldThrowFlushExceptionWhenSyncFlushFails() {
+      // given
+      final var journal = mock(Journal.class);
+      final var flusher = mock(RaftLogFlusher.class);
+      final var failure = new FlushException(new IOException("failed to sync"));
+      when(flusher.flush(journal, 3L)).thenReturn(CompletableFuture.failedFuture(failure));
+      final var log = new RaftLog(journal, flusher);
+
+      // when - then
+      assertThatThrownBy(() -> log.flushSync(3L)).isSameAs(failure);
     }
 
     @Test
@@ -289,25 +322,27 @@ class RaftLogTest {
       when(journal.getLastIndex()).thenReturn(3L);
 
       // when
-      log.flush();
+      final var result = log.flush(3L);
 
       // then
       verify(journal, times(1)).flush();
+      assertThat(result).isCompleted();
     }
 
     @Test
-    void shouldDisableFlush() throws CheckedJournalException {
+    void shouldDisableFlush() {
       // given
       final var journal = mock(Journal.class);
       final var flusher = spy(new NoopFlusher());
       final var log = new RaftLog(journal, flusher);
 
       // when
-      log.flush();
+      final var result = log.flush(3L);
 
       // then
-      verify(flusher, times(1)).flush(journal);
-      verify(journal, never()).flush();
+      verify(flusher, times(1)).flush(journal, 3L);
+      verifyNoInteractions(journal);
+      assertThat(result).isCompleted();
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -315,6 +315,22 @@ class RaftLogTest {
     }
 
     @Test
+    void shouldFlushDirectlyOnDeleteAfterRegardlessOfFlusher() throws CheckedJournalException {
+      // given - a flusher which never flushes on its own
+      final var journal = mock(Journal.class);
+      final var flusher = spy(new NoopFlusher());
+      final var log = new RaftLog(journal, flusher);
+
+      // when
+      log.deleteAfter(2);
+
+      // then - the truncation is flushed directly, bypassing the flush strategy
+      verify(flusher, times(1)).onLogTruncation(2);
+      verify(journal, times(1)).deleteAfter(2);
+      verify(journal, times(1)).flush();
+    }
+
+    @Test
     void shouldFlushDirectly() throws CheckedJournalException {
       // given
       final var journal = mock(Journal.class);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -219,6 +219,76 @@ class RaftLogTest {
   }
 
   @Test
+  void shouldNotDeleteEntriesAnnouncedAsCommitted() {
+    // given
+    raftlog.append(new RaftLogEntry(1, firstApplicationEntry));
+    final ApplicationEntry secondApplicationEntry =
+        createApplicationEntryAfter(firstApplicationEntry);
+    final var deleteIndex = raftlog.append(new RaftLogEntry(1, secondApplicationEntry)).index();
+    final var announcedIndex =
+        raftlog
+            .append(new RaftLogEntry(1, createApplicationEntryAfter(secondApplicationEntry)))
+            .index();
+
+    // when - the leader announced the last entry as committed, but it is not durable yet, so the
+    // commit index does not cover it
+    raftlog.announceCommitIndex(announcedIndex);
+
+    // then
+    assertThat(raftlog.getCommitIndex()).isLessThan(announcedIndex);
+    assertThatThrownBy(() -> raftlog.deleteAfter(deleteIndex))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldNotResetBelowAnnouncedCommitIndex() {
+    // given
+    raftlog.append(new RaftLogEntry(1, firstApplicationEntry));
+    final ApplicationEntry secondApplicationEntry =
+        createApplicationEntryAfter(firstApplicationEntry);
+    final var resetIndex = raftlog.append(new RaftLogEntry(1, secondApplicationEntry)).index();
+    final var announcedIndex =
+        raftlog
+            .append(new RaftLogEntry(1, createApplicationEntryAfter(secondApplicationEntry)))
+            .index();
+
+    // when - the leader announced the last entry as committed, but it is not durable yet, so the
+    // commit index does not cover it
+    raftlog.announceCommitIndex(announcedIndex);
+
+    // then
+    assertThatThrownBy(() -> raftlog.reset(resetIndex)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldKeepHighestAnnouncedCommitIndex() {
+    // given
+    raftlog.announceCommitIndex(2);
+
+    // when - a lower commit index is announced afterwards, e.g. by an outdated request
+    raftlog.announceCommitIndex(1);
+
+    // then - the announced index never decreases, so it keeps protecting the entries
+    assertThat(raftlog.getAnnouncedCommitIndex()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldIncreaseTruncationGenerationOnEveryTruncation() throws CheckedJournalException {
+    // given
+    raftlog.append(new RaftLogEntry(1, firstApplicationEntry));
+    final var initialGeneration = raftlog.getTruncationGeneration();
+
+    // when
+    raftlog.deleteAfter(1);
+    final var generationAfterDelete = raftlog.getTruncationGeneration();
+    raftlog.reset(5);
+
+    // then - every truncation is detectable by operations which completed asynchronously
+    assertThat(generationAfterDelete).isGreaterThan(initialGeneration);
+    assertThat(raftlog.getTruncationGeneration()).isGreaterThan(generationAfterDelete);
+  }
+
+  @Test
   void shouldReset() {
     // given
     raftlog.append(new RaftLogEntry(1, firstApplicationEntry));

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,8 @@ import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
+import io.atomix.utils.concurrent.Scheduler;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
@@ -46,6 +49,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -403,10 +407,10 @@ class RaftLogTest {
     }
 
     @Test
-    void shouldFlushDirectlyOnDeleteAfterRegardlessOfFlusher() throws CheckedJournalException {
-      // given - a flusher which never flushes on its own
+    void shouldFlushTruncationImmediatelyWithDelayedFlusher() throws CheckedJournalException {
+      // given - a flusher which flushes eventually, but not when requested to
       final var journal = mock(Journal.class);
-      final var flusher = spy(new NoopFlusher());
+      final var flusher = spy(new DelayedFlusher(mock(Scheduler.class), Duration.ofSeconds(5)));
       final var log = new RaftLog(journal, flusher);
 
       // when
@@ -416,6 +420,42 @@ class RaftLogTest {
       verify(flusher, times(1)).onLogTruncation(2);
       verify(journal, times(1)).deleteAfter(2);
       verify(journal, times(1)).flush();
+    }
+
+    @Test
+    void shouldNotFlushTruncationWhenFlushingIsDisabled() throws CheckedJournalException {
+      // given - a flusher which never flushes, i.e. flushing is disabled
+      final var journal = mock(Journal.class);
+      final var flusher = spy(new NoopFlusher());
+      final var log = new RaftLog(journal, flusher);
+
+      // when
+      log.deleteAfter(2);
+
+      // then - no i/o is done on the write path, so a transient flush error cannot reject the
+      // truncation
+      verify(flusher, times(1)).onLogTruncation(2);
+      verify(journal, times(1)).deleteAfter(2);
+      verify(journal, never()).flush();
+    }
+
+    @Test
+    void shouldOnlyReportDirectFlushingForTheDirectFlusher() {
+      // given
+      final var journal = mock(Journal.class);
+
+      // when - then - only the direct flusher guarantees durability synchronously, so only for it
+      // callers may skip flushing, e.g. before taking a snapshot
+      assertThat(new RaftLog(journal, new DirectFlusher()).flushesDirectly()).isTrue();
+      assertThat(new RaftLog(journal, new NoopFlusher()).flushesDirectly()).isFalse();
+      assertThat(
+              new RaftLog(journal, new DelayedFlusher(mock(Scheduler.class), Duration.ofSeconds(5)))
+                  .flushesDirectly())
+          .isFalse();
+      assertThat(
+              new RaftLog(journal, new CoalescedFlusher(mock(ThreadContext.class)))
+                  .flushesDirectly())
+          .isFalse();
     }
 
     @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -297,6 +298,23 @@ class RaftLogTest {
       final var log = new RaftLog(journal, flusher);
 
       // when - then
+      assertThatThrownBy(() -> log.flushSync(3L)).isSameAs(failure);
+    }
+
+    @Test
+    void shouldFailFlushResultOnUnexpectedException() throws CheckedJournalException {
+      // given - a failure outside the expected journal exceptions, e.g. from the metastore
+      final var journal = mock(Journal.class);
+      final var log = new RaftLog(journal, new DirectFlusher());
+      final var failure = new IllegalStateException("unexpected");
+      doThrow(failure).when(journal).flush();
+
+      // when
+      final var result = log.flush(3L);
+
+      // then - the failure is reported through the result instead of thrown, so that callers
+      // reject the append or step down instead of crashing the raft thread
+      assertThat(result).isCompletedExceptionally();
       assertThatThrownBy(() -> log.flushSync(3L)).isSameAs(failure);
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -11,6 +11,7 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.partition.RaftStorageConfig;
+import io.atomix.raft.storage.log.CoalescedFlusher;
 import io.atomix.raft.storage.log.DelayedFlusher;
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.cluster.PartitionId;
@@ -134,7 +135,7 @@ public final class RaftPartitionFactory {
       final FlushConfig config, final ExperimentalCfg experimental) {
     // for backwards compatibility; remove this and flatten when this is removed
     if (experimental.isDisableExplicitRaftFlush()) {
-      return createFlusherFactory(new FlushConfig(false, Duration.ZERO));
+      return createFlusherFactory(new FlushConfig(false, Duration.ZERO, false));
     }
 
     return createFlusherFactory(config);
@@ -143,6 +144,18 @@ public final class RaftPartitionFactory {
   private RaftLogFlusher.Factory createFlusherFactory(final FlushConfig config) {
     if (config.enabled()) {
       final Duration delayTime = config.delayTime();
+      if (config.coalesced()) {
+        if (!delayTime.isZero()) {
+          throw new IllegalArgumentException(
+              ("Expected either a coalesced or a delayed Raft flush strategy, but both coalesced "
+                      + "flushing and a flush delay of %s are configured; configure only one of "
+                      + "them.")
+                  .formatted(delayTime));
+        }
+
+        return threadFactory -> new CoalescedFlusher(threadFactory.createContext());
+      }
+
       if (delayTime.isZero()) {
         return RaftLogFlusher.Factory::direct;
       }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -146,10 +146,11 @@ public final class RaftPartitionFactory {
       final Duration delayTime = config.delayTime();
       if (config.coalesced()) {
         if (!delayTime.isZero()) {
+          // this combination is already rejected when the configuration is read, see
+          // io.camunda.configuration.Raft; guards against a programmatically built config
           throw new IllegalArgumentException(
-              ("Expected either a coalesced or a delayed Raft flush strategy, but both coalesced "
-                      + "flushing and a flush delay of %s are configured; configure only one of "
-                      + "them.")
+              ("Expected either coalesced flushing or a flush delay, but both are configured "
+                      + "(flush delay: %s).")
                   .formatted(delayTime));
         }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -103,10 +103,8 @@ public final class RaftCfg implements ConfigurationEntry {
    *     without giving up durability; mutually exclusive with {@code delayTime}
    */
   public record FlushConfig(boolean enabled, Duration delayTime, boolean coalesced) {
-    public FlushConfig(final boolean enabled, final Duration delayTime, final boolean coalesced) {
-      this.enabled = enabled;
-      this.delayTime = delayTime == null ? Duration.ZERO : delayTime;
-      this.coalesced = coalesced;
+    public FlushConfig {
+      delayTime = delayTime == null ? Duration.ZERO : delayTime;
     }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -17,7 +17,8 @@ public final class RaftCfg implements ConfigurationEntry {
   public static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
   public static final int DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS = 3;
   public static final Duration DEFAULT_REBALANCE_LEADER_WAIT_TIMEOUT = Duration.ofMinutes(1);
-  private static final FlushConfig DEFAULT_FLUSH_CONFIG = new FlushConfig(true, Duration.ZERO);
+  private static final FlushConfig DEFAULT_FLUSH_CONFIG =
+      new FlushConfig(true, Duration.ZERO, false);
 
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
 
@@ -93,10 +94,19 @@ public final class RaftCfg implements ConfigurationEntry {
         + '}';
   }
 
-  public record FlushConfig(boolean enabled, Duration delayTime) {
-    public FlushConfig(final boolean enabled, final Duration delayTime) {
+  /**
+   * @param enabled if false, the raft log is only flushed before snapshots, trading durability for
+   *     performance
+   * @param delayTime if positive, flushes are delayed by at least the given period, trading
+   *     durability for performance; mutually exclusive with {@code coalesced}
+   * @param coalesced if true, redundant flushes are deduped and concurrent flushes are coalesced
+   *     without giving up durability; mutually exclusive with {@code delayTime}
+   */
+  public record FlushConfig(boolean enabled, Duration delayTime, boolean coalesced) {
+    public FlushConfig(final boolean enabled, final Duration delayTime, final boolean coalesced) {
       this.enabled = enabled;
       this.delayTime = delayTime == null ? Duration.ZERO : delayTime;
+      this.coalesced = coalesced;
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -8,13 +8,20 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.storage.log.CoalescedFlusher;
+import io.atomix.raft.storage.log.DelayedFlusher;
+import io.atomix.raft.storage.log.RaftLogFlusher.DirectFlusher;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -209,6 +216,64 @@ public final class RaftPartitionFactoryTest {
     // then
     assertThat(partition.getPartitionConfig().getPreferSnapshotReplicationThreshold())
         .isEqualTo(1000);
+  }
+
+  @Test
+  void shouldUseDirectFlushByDefault() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+
+    // when
+    final var partition = buildRaftPartition(brokerCfg);
+
+    // then
+    final var flusherFactory = partition.getPartitionConfig().getStorageConfig().flusherFactory();
+    assertThat(flusherFactory.createFlusher(() -> mock(ThreadContext.class)))
+        .isInstanceOf(DirectFlusher.class);
+  }
+
+  @Test
+  void shouldUseCoalescedFlusherWhenConfigured() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().getRaft().setFlush(new FlushConfig(true, Duration.ZERO, true));
+
+    // when
+    final var partition = buildRaftPartition(brokerCfg);
+
+    // then
+    final var flusherFactory = partition.getPartitionConfig().getStorageConfig().flusherFactory();
+    final var flusher = flusherFactory.createFlusher(() -> mock(ThreadContext.class));
+    assertThat(flusher).isInstanceOf(CoalescedFlusher.class);
+    flusher.close();
+  }
+
+  @Test
+  void shouldUseDelayedFlusherWhenDelayTimeConfigured() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().getRaft().setFlush(new FlushConfig(true, Duration.ofSeconds(1), false));
+
+    // when
+    final var partition = buildRaftPartition(brokerCfg);
+
+    // then
+    final var flusherFactory = partition.getPartitionConfig().getStorageConfig().flusherFactory();
+    final var flusher = flusherFactory.createFlusher(() -> mock(ThreadContext.class));
+    assertThat(flusher).isInstanceOf(DelayedFlusher.class);
+    flusher.close();
+  }
+
+  @Test
+  void shouldRejectCoalescedFlushCombinedWithFlushDelay() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().getRaft().setFlush(new FlushConfig(true, Duration.ofSeconds(1), true));
+
+    // when - then
+    assertThatThrownBy(() -> buildRaftPartition(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("coalesced");
   }
 
   @ParameterizedTest

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/CheckedJournalException.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/CheckedJournalException.java
@@ -20,5 +20,9 @@ public sealed class CheckedJournalException extends Exception {
     public FlushException(@Nullable final IOException cause) {
       super("Error when flushing", cause);
     }
+
+    public FlushException(final String message, @Nullable final Throwable cause) {
+      super(message, cause);
+    }
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -123,6 +123,19 @@ public interface Journal extends AutoCloseable {
   void flush() throws FlushException;
 
   /**
+   * Returns the index of the last record which is known to be flushed to persistent storage.
+   * Records up to and including this index are guaranteed to be durable. The returned index may lag
+   * behind the actual state on disk, e.g. while a flush is in progress, but it never leads it.
+   *
+   * <p>Note that the index is lowered when records are deleted, e.g. via {@link #deleteAfter(long)}
+   * or {@link #reset(long)}.
+   *
+   * @return the index of the last flushed record, or a value lower than {@link #getFirstIndex()} if
+   *     nothing is known to be flushed
+   */
+  long getLastFlushedIndex();
+
+  /**
    * Opens a new {@link JournalReader} for a consumer that reads on the same thread that writes to
    * this journal. Records it returns point directly into the journal, and stay valid until the next
    * call on the reader.

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -95,7 +95,8 @@ final class Segment implements AutoCloseable, FlushableSegment {
   }
 
   /**
-   * Returns the last index in the segment.
+   * Returns the last index in the segment. May be called concurrently with appends, e.g. by a
+   * flushing thread; see {@link SegmentWriter} for the visibility guarantees.
    *
    * @return The last index in the segment.
    */

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -52,7 +52,14 @@ final class SegmentWriter {
   private final long firstIndex;
   private final long firstAsqn;
   private long lastAsqn;
-  private @Nullable JournalRecord lastEntry;
+
+  // Volatile because flushing threads read it via Segment#lastIndex() to decide how far a flush
+  // reached, and that index is reported as durable afterwards. Publishing the record here, once all
+  // of its bytes were written to the mapped buffer, is the release which pairs with their acquiring
+  // read: a thread which sees this record is guaranteed to see all of its bytes, and therefore
+  // flushes them.
+  private volatile @Nullable JournalRecord lastEntry;
+
   private int lastEntryPosition;
   private final JournalRecordReaderUtil recordUtil;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
@@ -94,7 +101,8 @@ final class SegmentWriter {
   }
 
   long getLastIndex() {
-    return lastEntry != null ? lastEntry.index() : segment.index() - 1;
+    final var entry = lastEntry;
+    return entry != null ? entry.index() : segment.index() - 1;
   }
 
   int getLastEntryPosition() {
@@ -106,8 +114,9 @@ final class SegmentWriter {
   }
 
   long getNextIndex() {
-    if (lastEntry != null) {
-      return lastEntry.index() + 1;
+    final var entry = lastEntry;
+    if (entry != null) {
+      return entry.index() + 1;
     } else {
       return firstIndex;
     }
@@ -249,9 +258,12 @@ final class SegmentWriter {
     final int nextEntryOffset = startPosition + frameLength + metadataLength + recordLength;
     invalidateNextEntry(nextEntryOffset);
 
-    final var record =
-        updateLastWrittenEntry(startPosition, frameLength, metadataLength, recordLength);
+    final var record = readWrittenRecord(startPosition, frameLength, metadataLength, recordLength);
+    // the frame version is written last, so a record only becomes valid on recovery once all of its
+    // bytes are written
     FrameUtil.writeVersion(buffer, startPosition);
+    // publish the record only now that all of its bytes are in the buffer, see #lastEntry
+    updateLastWrittenEntry(record, startPosition);
 
     final int appendedBytes = frameLength + metadataLength + recordLength;
     buffer.position(startPosition + appendedBytes);
@@ -259,7 +271,12 @@ final class SegmentWriter {
     return record;
   }
 
-  private JournalRecord updateLastWrittenEntry(
+  /**
+   * Reads back the record just written to the buffer, verifying it creates no gap in the log.
+   *
+   * @return the record written at the given position
+   */
+  private JournalRecord readWrittenRecord(
       final int startPosition,
       final int frameLength,
       final int metadataLength,
@@ -268,17 +285,23 @@ final class SegmentWriter {
     final var data = serializer.readData(writeBuffer, startPosition + frameLength + metadataLength);
     verifyNoIndexGap(data.index(), getNextIndex());
 
-    lastEntry =
-        new PersistedJournalRecord(
-            metadata,
-            data,
-            new UnsafeBuffer(
-                writeBuffer, startPosition + frameLength + metadataLength, recordLength),
-            frameLength + metadataLength + recordLength);
-    updateLastAsqn(lastEntry.asqn());
-    index.index(lastEntry, startPosition);
+    return new PersistedJournalRecord(
+        metadata,
+        data,
+        new UnsafeBuffer(writeBuffer, startPosition + frameLength + metadataLength, recordLength),
+        frameLength + metadataLength + recordLength);
+  }
+
+  /**
+   * Publishes the given record as the last written entry and indexes it. Must only be called after
+   * all of the record's bytes were written to the buffer: publishing the record is what makes them
+   * visible to concurrently flushing threads.
+   */
+  private void updateLastWrittenEntry(final JournalRecord record, final int startPosition) {
+    lastEntry = record;
+    updateLastAsqn(record.asqn());
+    index.index(record, startPosition);
     lastEntryPosition = startPosition;
-    return lastEntry;
   }
 
   private void updateLastAsqn(final long asqn) {
@@ -364,10 +387,8 @@ final class SegmentWriter {
   private void advanceToNextEntry(final long nextIndex) {
     final int position = buffer.position();
     FrameUtil.readVersion(buffer);
-    lastEntry = recordUtil.read(buffer, nextIndex, FrameUtil.getLength());
-    updateLastAsqn(lastEntry.asqn());
-    lastEntryPosition = position;
-    index.index(lastEntry, position);
+    final var entry = recordUtil.read(buffer, nextIndex, FrameUtil.getLength());
+    updateLastWrittenEntry(entry, position);
     buffer.mark();
   }
 

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -176,13 +176,19 @@ public final class SegmentedJournal implements Journal {
       try {
         writer.flush();
       } finally {
+        // store the last flushed index while still holding the lock, so that the stored value can
+        // never overtake a concurrent truncation, which lowers the index under the write lock
+        if (writer.getLastFlushedIndex() > 0) {
+          metaStore.storeLastFlushedIndex(writer.getLastFlushedIndex());
+        }
         rwlock.unlockRead(stamp);
       }
-    } finally {
-      if (writer.getLastFlushedIndex() > 0) {
-        metaStore.storeLastFlushedIndex((writer.getLastFlushedIndex()));
-      }
     }
+  }
+
+  @Override
+  public long getLastFlushedIndex() {
+    return writer.getLastFlushedIndex();
   }
 
   @Override

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -174,13 +174,9 @@ public final class SegmentedJournal implements Journal {
       // sequentially anyway, meaning there is virtually no contention
       final var stamp = rwlock.readLock();
       try {
+        // the writer also updates the metastore's last flushed index while holding the read lock
         writer.flush();
       } finally {
-        // store the last flushed index while still holding the lock, so that the stored value can
-        // never overtake a concurrent truncation, which lowers the index under the write lock
-        if (writer.getLastFlushedIndex() > 0) {
-          metaStore.storeLastFlushedIndex(writer.getLastFlushedIndex());
-        }
         rwlock.unlockRead(stamp);
       }
     }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -209,6 +209,11 @@ final class SegmentedJournalWriter {
    * Stores whatever we managed to flush to avoid doing it again. Concurrent flushes may race here,
    * so the index is only ever advanced - truncation, which lowers it, is mutually exclusive with
    * flushing via the journal's write lock.
+   *
+   * <p>The metastore is updated together with the in-memory index, while holding this monitor and
+   * the journal's read lock: this keeps the stored index monotonic under concurrent flushes, and
+   * guarantees it never overtakes a concurrent truncation, which lowers it under the journal's
+   * write lock.
    */
   private synchronized void advanceLastFlushedIndex(
       final long flushedIndex, final int flushedSegments) {
@@ -219,6 +224,7 @@ final class SegmentedJournalWriter {
           lastFlushedIndex,
           flushedIndex);
       lastFlushedIndex = flushedIndex;
+      metaStore.storeLastFlushedIndex(flushedIndex);
     }
   }
 

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -54,6 +54,16 @@ final class SegmentedJournalWriter {
     lastFlushedIndex = metaStore.loadLastFlushedIndex();
     currentSegment = requireNonNull(segments.getLastSegment(), "journal not open");
     currentWriter = currentSegment.writer();
+
+    // An empty journal has no record left to flush, so everything below its first index is
+    // durable: those records are either covered by a snapshot the log was reset for, or were
+    // compacted. The stored index cannot tell us this, as resetting the segments nulls it (see
+    // SegmentsManager#resetSegments) and only the next flush stores it again - which never happens
+    // on an idle, empty journal.
+    final var firstSegment = segments.getFirstSegment();
+    if (firstSegment != null && currentWriter.getNextIndex() == firstSegment.index()) {
+      lastFlushedIndex = Math.max(lastFlushedIndex, firstSegment.index() - 1);
+    }
   }
 
   long getLastIndex() {
@@ -110,8 +120,11 @@ final class SegmentedJournalWriter {
   }
 
   void reset(final long index) {
+    // the log is empty afterwards, and everything below the reset index is covered by the snapshot
+    // this reset is for, so there is nothing left to flush below it. The stored index is
+    // deliberately not updated here: resetSegments nulls it to detect a crash in the middle of the
+    // reset, and it is derived again when opening an empty journal (see the constructor)
     lastFlushedIndex = index - 1;
-    metaStore.storeLastFlushedIndex(index - 1);
     currentSegment = segments.resetSegments(index);
     currentWriter = currentSegment.writer();
   }
@@ -128,10 +141,13 @@ final class SegmentedJournalWriter {
    *     that was overwritten while it was reading.
    */
   void deleteAfter(final long index, final boolean preserveDeletedRecords) {
-    // reset the last flushed index first to avoid corruption on restart in case of partial
-    // truncation (e.g. the node crashed while deleting segments)
-    lastFlushedIndex = index;
-    metaStore.storeLastFlushedIndex(index);
+    // lower the last flushed index first to avoid corruption on restart in case of partial
+    // truncation (e.g. the node crashed while deleting segments). It is only ever lowered here:
+    // deleting records flushes nothing, so truncating above the flushed index must not raise it,
+    // otherwise records which were never fsynced would be reported as durable
+    final long truncatedFlushedIndex = Math.min(lastFlushedIndex, index);
+    lastFlushedIndex = truncatedFlushedIndex;
+    metaStore.storeLastFlushedIndex(truncatedFlushedIndex);
 
     // Delete all segments with first indexes greater than the given index.
     while (index < currentSegment.index() && currentSegment != segments.getFirstSegment()) {
@@ -196,6 +212,9 @@ final class SegmentedJournalWriter {
 
     try {
       for (final var segment : dirtySegments) {
+        // read the last index before flushing, as records may be appended concurrently; reading it
+        // acquires everything the appending thread published with it (see SegmentWriter#lastEntry),
+        // so the flush below is guaranteed to cover all bytes of the records up to that index
         final long lastSegmentIndex = segment.lastIndex();
         segment.flush(); // throws FlushException
         flushedIndex = lastSegmentIndex;

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -35,7 +35,10 @@ final class SegmentedJournalWriter {
   private final SegmentsManager segments;
   private final JournalMetaStore metaStore;
   private final JournalMetrics journalMetrics;
-  private long lastFlushedIndex;
+
+  // may be read and advanced concurrently by multiple flushing threads (under the journal's read
+  // lock), while truncation lowers it exclusively under the journal's write lock
+  private volatile long lastFlushedIndex;
 
   private Segment currentSegment;
   private SegmentWriter currentWriter;
@@ -198,16 +201,24 @@ final class SegmentedJournalWriter {
         flushedIndex = lastSegmentIndex;
       }
     } finally {
-      // store whatever we managed to flush to avoid doing it again
-      if (flushedIndex > lastFlushedIndex) {
-        lastFlushedIndex = flushedIndex;
+      advanceLastFlushedIndex(flushedIndex, segmentsCount);
+    }
+  }
 
-        LOGGER.trace(
-            "Flushed {} segment(s), from index {} to index {}",
-            segmentsCount,
-            lastFlushedIndex,
-            flushedIndex);
-      }
+  /**
+   * Stores whatever we managed to flush to avoid doing it again. Concurrent flushes may race here,
+   * so the index is only ever advanced - truncation, which lowers it, is mutually exclusive with
+   * flushing via the journal's write lock.
+   */
+  private synchronized void advanceLastFlushedIndex(
+      final long flushedIndex, final int flushedSegments) {
+    if (flushedIndex > lastFlushedIndex) {
+      LOGGER.trace(
+          "Flushed {} segment(s), from index {} to index {}",
+          flushedSegments,
+          lastFlushedIndex,
+          flushedIndex);
+      lastFlushedIndex = flushedIndex;
     }
   }
 

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -244,7 +244,8 @@ final class JournalTest {
 
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
-    assertThat(metaStore.loadLastFlushedIndex()).isOne();
+    // nothing was ever flushed, so truncating must not claim that index 1 is durable
+    assertThat(metaStore.loadLastFlushedIndex()).isLessThan(1);
     assertThat(reader.hasNext()).isFalse();
   }
 

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.journal.file;
 
 import static io.camunda.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -1106,6 +1107,31 @@ class SegmentedJournalTest {
     journal.append(2, journalFactory.entry());
   }
 
+  @Test
+  void shouldReleaseFlushLockWhenMetaStoreWriteFails() {
+    // given - a journal whose metastore fails to store the last flushed index
+    journal = openJournal(2);
+    journal.append(1, journalFactory.entry());
+    journalFactory
+        .metaStore()
+        .setOnStoreFlushedIndex(
+            () -> {
+              throw new RuntimeException("failed to store last flushed index");
+            });
+
+    // when
+    assertThatThrownBy(journal::flush).isInstanceOf(RuntimeException.class);
+
+    // then - the read lock is released despite the failure, and write-exclusive operations as
+    // well as further flushes are still possible
+    assertThat(journal.rwlock().isReadLocked()).isFalse();
+    journalFactory.metaStore().setOnStoreFlushedIndex(null);
+    journal.deleteAfter(1);
+    journal.append(2, journalFactory.entry());
+    assertThatNoException().isThrownBy(journal::flush);
+    assertThat(journal.getLastFlushedIndex()).isEqualTo(2);
+  }
+
   // this test ensure that flushing is thread-safe w.r.t. write-exclusive methods such as
   // deleteUntil, deleteAfter, and reset
   @Test
@@ -1125,6 +1151,12 @@ class SegmentedJournalTest {
             SegmentedJournalWriter.class,
             Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
             (mock, context) -> {
+              // the construction mock bypasses the constructor, so inject the metastore field
+              // which the real flush methods update with the last flushed index
+              final var metaStoreField = SegmentedJournalWriter.class.getDeclaredField("metaStore");
+              metaStoreField.setAccessible(true);
+              metaStoreField.set(mock, journalFactory.metaStore());
+
               doAnswer(
                       (invocation) -> {
                         barrier.arriveAndAwaitAdvance();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.JournalException.InvalidAsqn;
 import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
 import io.camunda.zeebe.journal.JournalReader;
@@ -1130,6 +1131,71 @@ class SegmentedJournalTest {
     journal.append(2, journalFactory.entry());
     assertThatNoException().isThrownBy(journal::flush);
     assertThat(journal.getLastFlushedIndex()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldNotReportUnflushedRecordsAsFlushedAfterTruncate() throws FlushException {
+    // given - a journal with one flushed and one unflushed record
+    journal = openJournal(4);
+    journal.append(1, journalFactory.entry());
+    journal.flush();
+    journal.append(2, journalFactory.entry());
+
+    // when - truncating above the flushed index
+    journal.deleteAfter(2);
+
+    // then - the record which was never flushed is not reported as durable
+    assertThat(journal.getLastFlushedIndex()).isOne();
+    assertThat(journalFactory.metaStore().loadLastFlushedIndex()).isOne();
+  }
+
+  @Test
+  void shouldNotReportTruncatedRecordsAsFlushed() throws FlushException {
+    // given - a journal with two flushed records
+    journal = openJournal(4);
+    journal.append(1, journalFactory.entry());
+    journal.append(2, journalFactory.entry());
+    journal.flush();
+
+    // when - truncating below the flushed index
+    journal.deleteAfter(1);
+
+    // then - the deleted record is not reported as durable anymore
+    assertThat(journal.getLastFlushedIndex()).isOne();
+    assertThat(journalFactory.metaStore().loadLastFlushedIndex()).isOne();
+  }
+
+  @Test
+  void shouldReportRecordsBeforeResetIndexAsFlushed() {
+    // given
+    journal = openJournal(2);
+    journal.append(1, journalFactory.entry());
+
+    // when - resetting the log, e.g. after receiving a snapshot
+    journal.reset(10);
+
+    // then - nothing is left to flush below the reset index, as the log is empty and the records
+    // below it are covered by the snapshot the log was reset for
+    assertThat(journal.getLastFlushedIndex()).isEqualTo(9);
+    // the stored index is nulled while resetting, to detect a crash in the middle of the reset
+    assertThat(journalFactory.metaStore().hasLastFlushedIndex()).isFalse();
+  }
+
+  @Test
+  void shouldReportRecordsBeforeResetIndexAsFlushedAfterRestart() {
+    // given
+    journal = openJournal(2);
+    journal.append(1, journalFactory.entry());
+    journal.reset(10);
+
+    // when - reopening the journal with the same metastore, as it happens after a restart
+    journal.close();
+    journal = journalFactory.journal(journalFactory.segmentsManager(directory));
+    closeables.add(journal);
+
+    // then - the reset index is still reported as durable, even though nothing was appended and
+    // flushed since the reset, so a flush is never required for it
+    assertThat(journal.getLastFlushedIndex()).isEqualTo(9);
   }
 
   // this test ensure that flushing is thread-safe w.r.t. write-exclusive methods such as


### PR DESCRIPTION
## Description

Adds an opt-in **coalesced flush strategy** for the Raft log which dedupes redundant flushes and coalesces concurrent ones **without giving up durability** — unlike the existing `delayTime`/disabled options, appends are still only acknowledged and commits only advance once covered by an fsync.

**Motivation:** on disks with high flush latency (network-attached cloud disks, ~30ms per fsync), the default direct strategy makes flushing the dominant replication cost: the leader fsyncs on every commit advance (even when an earlier fsync already covers the committed index, since every fsync covers the whole appended tail), and followers fsync once per append request while the leader pipelines up to `maxAppendsPerFollower` requests.

With `coalesced` enabled:
- requests for already-durable indexes complete immediately (leader commit advances, re-transmitted appends);
- at most one fsync runs at a time on a dedicated thread; requests arriving during an in-flight fsync are all covered by the next one (group commit) — up to `maxAppendsPerFollower` follower acks per fsync;
- flush results complete only after a covering fsync succeeded; failures propagate so the Raft protocol drives retries exactly as today.

**Configuration** (default **off**; direct flushing remains byte-for-byte unchanged):

```yaml
camunda.cluster.raft.flush-coalesced: true       # unified
zeebe.broker.cluster.raft.flush.coalesced: true  # legacy
```

`flush-coalesced` and `flush-delay > 0` are mutually exclusive (rejected at startup).

**Groundwork / fixes along the way** (see individual commits):
- `refactor:` `RaftLogFlusher` is now an index-aware, completion-based API (`flush(journal, index)` → future, explicit `onLogTruncation`); the journal exposes its flush watermark and its bookkeeping is safe for flushing off the Raft thread. Behavior-preserving for all existing strategies.
- `fix:` truncation now always flushes directly instead of via the flush policy — with delayed/disabled flushing, a crash after truncation could silently resurrect or corrupt the truncated suffix.
- `fix:` the pre-snapshot `flushLog()` future now completes only when the fsync actually happened — previously it was fire-and-forget for the delayed strategy and a complete no-op with flushing disabled, so compaction could delete log below a non-durable tail.
- `fix:` the leader's match index no longer moves backwards on a late append response, which reordered acks made reachable.

**Out of scope / follow-ups:** flusher-level metrics (fsync rate/duration are already covered by the journal flush timers), revisiting `maxAppendsPerFollower` (caps the coalescing win), and removing the leader's residual synchronous wait on commit-critical fsyncs (would require feeding the leader's flushed index into the quorum computation).

This supersedes #58844, rebased onto current `main`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

- [x] This PR does not need a linked issue
