### PR TITLE
fix: bump Tasklist E2E workflow to Node 24 to unblock yarn install

### DIFF
--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install node dependencies
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite


### PR DESCRIPTION
## Summary
- The `test` job's "Install node dependencies" step (`yarn install` in `qa/c8-orchestration-cluster-e2e-test-suite`) fails on stable/8.6: `undici@8.10.2` now requires Node `>=22.19.0`, but the workflow pins Node `20`.
- That directory only ships an npm `package-lock.json`, not a `yarn.lock`, so `yarn install` re-resolves from scratch each run and picked up a newer `undici` release that raised its engine floor above Node 20.
- Bumps `Setup Node` to `24`, matching what main's replacement workflow (`c8-orchestration-cluster-reusable-e2e-tests.yml`) already uses for this same test suite. This legacy workflow only exists on stable branches (removed on main), so there's nothing to backport from.

Failing run: https://github.com/camunda/camunda/actions/runs/33882908662

## Related issues
- [x] This PR does not need a linked issue

## Test plan
- [ ] CI green on this PR (`Tasklist E2E Tests` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)