### PR TITLE
test: extend Operate e2e waits for slow-runner import lag

### DIFF
--- a/operate/client/e2e-playwright/tests/decisionInstances.spec.ts
+++ b/operate/client/e2e-playwright/tests/decisionInstances.spec.ts
@@ -8,7 +8,7 @@
 
 import {setup} from './decisionInstances.mocks';
 import {test} from '../test-fixtures';
-import {SETUP_WAITING_TIME} from './constants';
+import {SETUP_WAITING_TIME, SETUP_WAITING_TIME_LONG} from './constants';
 import {expect} from '@playwright/test';
 import {config} from '../config';
 
@@ -40,6 +40,7 @@ test.describe('Decision Instances', () => {
   });
 
   test('Switch between Decision versions', async ({decisionsPage}) => {
+    test.setTimeout(SETUP_WAITING_TIME_LONG);
     const {decisions} = initialData;
     const [
       decision1Version1,
@@ -76,7 +77,7 @@ test.describe('Decision Instances', () => {
     await decisionsPage.selectDecision('Decision 2');
     await expect(
       decisionsPage.decisionViewer.getByText('Decision 2'),
-    ).toBeVisible();
+    ).toBeVisible({timeout: SETUP_WAITING_TIME});
 
     await decisionsPage.selectVersion(decision2Version1!.version);
     await expect(

--- a/operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts
@@ -9,7 +9,7 @@
 import {setup} from './processInstanceMigration.mocks';
 import {test} from '../test-fixtures';
 import {expect} from '@playwright/test';
-import {SETUP_WAITING_TIME} from './constants';
+import {SETUP_WAITING_TIME, SETUP_WAITING_TIME_LONG} from './constants';
 import {config} from '../config';
 import {zeebeGrpcApi} from '../api/zeebe-grpc';
 
@@ -35,7 +35,7 @@ test.beforeAll(async ({request}) => {
 
         return await response.json();
       },
-      {timeout: SETUP_WAITING_TIME},
+      {timeout: SETUP_WAITING_TIME_LONG},
     )
     .toHaveProperty('total', 10);
 
@@ -67,7 +67,7 @@ test.beforeAll(async ({request}) => {
 
         return await response.json();
       },
-      {timeout: SETUP_WAITING_TIME},
+      {timeout: SETUP_WAITING_TIME_LONG},
     )
     .toHaveProperty('total', 10);
 
@@ -92,7 +92,7 @@ test.beforeAll(async ({request}) => {
 
         return await response.json();
       },
-      {timeout: SETUP_WAITING_TIME},
+      {timeout: SETUP_WAITING_TIME_LONG},
     )
     .toHaveProperty('total', 10);
 
@@ -116,7 +116,7 @@ test.beforeAll(async ({request}) => {
 
         return await response.json();
       },
-      {timeout: SETUP_WAITING_TIME},
+      {timeout: SETUP_WAITING_TIME_LONG},
     )
     .toHaveProperty('total', 10);
 
@@ -140,7 +140,7 @@ test.beforeAll(async ({request}) => {
 
         return await response.json();
       },
-      {timeout: SETUP_WAITING_TIME},
+      {timeout: SETUP_WAITING_TIME_LONG},
     )
     .toHaveProperty('total', 10);
 });


### PR DESCRIPTION
## Description

Two Operate Playwright specs fail intermittently on `stable/8.6` after the GitHub-hosted runner image refresh, which slowed the Zeebe → exporter → Elasticsearch → Operate import path and frontend rendering. Both are **timing flakes, not product defects** — the data does become consistent and the viewer does render, just past the existing wait budgets. No product code is changed.

**`processInstanceMigration.spec.ts` (`beforeAll`, `total: 9` of `10`)**
`setup()` awaits `Promise.all` of 10 `createSingleInstance` calls, so all 10 instances exist at the broker — a genuinely dropped creation would throw *before* the poll runs. The observed `total: 9` is therefore pure import lag, not a lost instance. The five setup readiness polls now use `SETUP_WAITING_TIME_LONG` (40s) instead of `SETUP_WAITING_TIME` (20s). The poll-until-consistent pattern is unchanged; only the ceiling grows.

**`decisionInstances.spec.ts:79` (viewer not showing "Decision 2")**
Switching to "Decision 2" refetches and re-renders the DMN viewer, so asserting the title on the default 15s `expect` timeout races the reload. The post-switch assertion now waits `SETUP_WAITING_TIME`, and the test gets `SETUP_WAITING_TIME_LONG` of overall headroom for its many sequential viewer reloads.

These are legitimate readiness/eventual-consistency waits, not blind `sleep`/retry masking — the poll and auto-retrying assertions still fail fast if the condition never holds.

## Related issues

relates to #61938
