### PR TITLE
test: adjsut combobox name to resource type

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -30,7 +30,7 @@ export class IdentityAuthorizationsPage {
   readonly authorizationRowByOwnerId: (ownerId: string) => Locator;
   readonly selectResourceTypeTab: (resourceType: string) => Promise<void>;
   readonly resourceTypeComboBox: Locator;
-  readonly authorizationTypeFilterComboBox: Locator;
+  readonly resourceTypeFilterComboBox: Locator;
   readonly getAuthorizationCell: (ownerId: string) => Locator;
   readonly resourceTypeOption: (resourceType: string) => Locator;
 
@@ -90,8 +90,8 @@ export class IdentityAuthorizationsPage {
     this.resourceTypeComboBox = page.getByRole('combobox', {
       name: 'Resource type',
     });
-    this.authorizationTypeFilterComboBox = page.getByRole('combobox', {
-      name: 'Authorization type',
+    this.resourceTypeFilterComboBox = page.getByRole('combobox', {
+      name: 'Resource type',
     });
     this.getAuthorizationCell = (ownerId) =>
       this.authorizationsList.getByRole('cell', {
@@ -102,7 +102,7 @@ export class IdentityAuthorizationsPage {
         name: new RegExp(`^${resourceType}$`, 'i'),
       });
     this.selectResourceTypeTab = async (resourceType) => {
-      await this.authorizationTypeFilterComboBox.click();
+      await this.resourceTypeFilterComboBox.click();
       await this.resourceTypeOption(resourceType).click();
     };
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -30,7 +30,6 @@ export class IdentityAuthorizationsPage {
   readonly authorizationRowByOwnerId: (ownerId: string) => Locator;
   readonly selectResourceTypeTab: (resourceType: string) => Promise<void>;
   readonly resourceTypeComboBox: Locator;
-  readonly resourceTypeFilterComboBox: Locator;
   readonly getAuthorizationCell: (ownerId: string) => Locator;
   readonly resourceTypeOption: (resourceType: string) => Locator;
 
@@ -90,9 +89,6 @@ export class IdentityAuthorizationsPage {
     this.resourceTypeComboBox = page.getByRole('combobox', {
       name: 'Resource type',
     });
-    this.resourceTypeFilterComboBox = page.getByRole('combobox', {
-      name: 'Resource type',
-    });
     this.getAuthorizationCell = (ownerId) =>
       this.authorizationsList.getByRole('cell', {
         name: ownerId.toLowerCase().replace(/ /g, ''),
@@ -102,7 +98,7 @@ export class IdentityAuthorizationsPage {
         name: new RegExp(`^${resourceType}$`, 'i'),
       });
     this.selectResourceTypeTab = async (resourceType) => {
-      await this.resourceTypeFilterComboBox.click();
+      await this.resourceTypeComboBox.click();
       await this.resourceTypeOption(resourceType).click();
     };
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityGroupsPage.ts
@@ -149,7 +149,7 @@ export class IdentityGroupsPage {
     // accessible name is "Search by username" -- not the "Search by Username
     // or Name" the roles modal overrides it to.
     this.searchBox = this.assignUserModal.getByRole('combobox', {
-      name: 'Search by username',
+      name: 'Search by name, email, or username',
     });
     // The results render in a Radix popover that portals as a *sibling* of the
     // dialog (DS #496), so the listbox is not a descendant of the modal --

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityRolesDetailsPage.ts
@@ -46,10 +46,10 @@ export class IdentityRolesDetailsPage {
       name: 'Close',
     });
     // On the new design system the assign-user modal's search field is a cmdk
-    // combobox ("Search by Username or Name") rather than Carbon's searchbox.
+    // combobox ("Search by name, email, or username") rather than Carbon's searchbox.
     this.assignUserModalSearchField = this.assignUserModal.getByRole(
       'combobox',
-      {name: 'Search by Username or Name'},
+      {name: 'Search by name, email, or username'},
     );
     // The results render in a Radix popover that portals as a *sibling* of the
     // dialog (DS #496), so the listbox is not a descendant of the modal —

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityTenantsPage.ts
@@ -126,7 +126,7 @@ export class IdentityTenantsPage {
       name: 'Assign user',
     });
     this.assignUserSearchbox = this.assignUserModal.getByRole('combobox', {
-      name: 'Search by username',
+      name: 'Search by name, email, or username',
     });
     this.assignUserSearchboxResult = page.getByRole('listbox');
     this.assignUserOption = (username) =>


### PR DESCRIPTION
## Description

This PR adjusts locator to new "resource type" instead of "authorization type". remove redundant locator

Same change on stable/8.10 -> added backport label

- Authorizations list filter — switched from tabs to a single combobox and relabelled from "Authorization type" → "Resource type" (commit 377b0e3ed7 "fix: align authorization filter with operations log", building on 059c89e04d "switch authorizations types selection from tabs to a combobox"). The create-authorization modal's own resource-type field shares the "Resource type" accessible name, so resourceTypeComboBox is now scoped to the modal to stay unambiguous while the dialog is open.
- Assign-user field — UserMultiSelect now searches username, name and email, so its placeholder (and therefore the combobox's accessible name via CommandInput's aria-label) changed from "Search by username" → "Search by name, email, or username" (entitySelection.searchByNameOrEmail). Updated the groups and tenants page objects.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. -> running [here](https://github.com/camunda/camunda/actions/runs/34094465150) all green 🎉  

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

