### PR TITLE
feat: migrate functionality of auto-select to new design system

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/shadcn/_auth/tasklist/_tasks/route.tsx
@@ -8,8 +8,16 @@
 
 import {useCallback, useMemo} from 'react';
 import {useSuspenseInfiniteQuery, useSuspenseQuery} from '@tanstack/react-query';
-import {createFileRoute, notFound, retainSearchParams, stripSearchParams, useRouterState} from '@tanstack/react-router';
+import {
+	createFileRoute,
+	notFound,
+	redirect,
+	retainSearchParams,
+	stripSearchParams,
+	useRouterState,
+} from '@tanstack/react-router';
 import {queries} from '#/shared/http/queries';
+import {getStateLocally} from '#/shared/browser-storage/local-storage';
 import {getTasksRequestBody} from '#/tasklist/modules/available-tasks/getTasksRequestBody';
 import {TasksLayoutPage} from '#/tasklist/pages/shadcn.components/TasksLayoutPage';
 import {
@@ -32,10 +40,23 @@ export const Route = createFileRoute('/shadcn/_auth/tasklist/_tasks')({
 	notFoundComponent: () => {
 		throw notFound({routeId: '/shadcn/_auth/tasklist'});
 	},
-	beforeLoad: async ({context: {queryClient}, search}) => {
+	beforeLoad: async ({context: {queryClient}, search, location}) => {
+		const isAutoSelectNextTaskEnabled = getStateLocally('tasklist.autoSelectNextTask') === true;
+		const isFromTaskCompletion = location.state.tasklistAutoSelectSource === 'task-completion';
+		const shouldAutoSelectNextTask = isAutoSelectNextTaskEnabled && isFromTaskCompletion;
 		const currentUser = await queryClient.query(queries.getCurrentUser());
 		const queryOptions = queries.queryUserTasks(getTasksRequestBody(search, {currentUsername: currentUser.username}));
-		await queryClient.infiniteQuery(queryOptions);
+		const {pages} = await queryClient.infiniteQuery(queryOptions);
+		const nextOpenTask = pages.flatMap((page) => page.items).find(({state}) => state === 'CREATED');
+
+		if (shouldAutoSelectNextTask && nextOpenTask !== undefined) {
+			throw redirect({
+				to: '/shadcn/tasklist/$userTaskKey',
+				params: {userTaskKey: nextOpenTask.userTaskKey},
+				search,
+				replace: true,
+			});
+		}
 	},
 	component: function TasksLayoutRoute() {
 		const search = Route.useSearch();

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/task-completion.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/task-completion.test.ts
@@ -83,6 +83,68 @@ test.describe('Task completion', () => {
 		await expect(page).toHaveURL(/\/shadcn\/tasklist$/);
 	});
 
+	test('should navigate to the next open task when auto-select is enabled', async ({
+		network,
+		shadcnTaskDetailPage,
+		page,
+	}) => {
+		const assigningTask = createUserTask({
+			userTaskKey: '2251799813685283',
+			name: 'Assigning purchase request after auto-select',
+			processName: 'Purchase process',
+			assignee: currentUser.username,
+			state: 'ASSIGNING',
+		});
+		const nextTask = createUserTask({
+			userTaskKey: '2251799813685282',
+			name: 'Review purchase request after auto-select',
+			processName: 'Purchase process',
+			assignee: currentUser.username,
+			state: 'CREATED',
+		});
+
+		network.use(
+			mockCompleteTaskEndpoint({
+				successResponse: new HttpResponse(null, {status: 200}),
+			}),
+		);
+
+		await shadcnTaskDetailPage.goto('2251799813685281', '?filter=assigned-to-me&sortBy=priority');
+		await expect(shadcnTaskDetailPage.detailsInfo.getByText('Review invoice before auto-select')).toBeVisible();
+		await shadcnTaskDetailPage.autoSelectNextTaskSwitch.click({force: true});
+
+		network.use(
+			mockQueryUserTasksEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryUserTasksResponse({
+						items: [completedTask, assigningTask, nextTask],
+					}),
+				),
+			}),
+		);
+
+		await shadcnTaskDetailPage.completeTaskButton.click();
+
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(completedTask),
+			}),
+		);
+
+		await expect(shadcnTaskDetailPage.header.notifications.getByNotificationTitle('Task completed')).toBeVisible();
+
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(nextTask),
+			}),
+		);
+
+		await expect(page).toHaveURL(/\/shadcn\/tasklist\/2251799813685282\?/);
+		expect(new URL(page.url()).searchParams.get('filter')).toBe('assigned-to-me');
+		expect(new URL(page.url()).searchParams.get('sortBy')).toBe('priority');
+		await expect(shadcnTaskDetailPage.detailsInfo.getByText('Review purchase request after auto-select')).toBeVisible();
+	});
+
 	test('should show a failed state when completion is forbidden', async ({network, shadcnTaskDetailPage, page}) => {
 		network.use(
 			mockCompleteTaskEndpoint({

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/tasklist-filters.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/tasklist-filters.test.ts
@@ -150,6 +150,41 @@ test.describe('Filter request bodies', () => {
 			await expect(shadcnTasklistIndexPage.sortOption('Completion date')).toBeVisible();
 		});
 	});
+
+	test('should not auto-select completed tasks when auto-select is enabled', async ({
+		network,
+		page,
+		shadcnTasklistIndexPage,
+	}) => {
+		await page.addInitScript(`localStorage.setItem('tasklist.autoSelectNextTask', JSON.stringify(true))`);
+		network.use(
+			mockQueryUserTasksEndpoint({
+				schema: createUserTasksRequestSchema({
+					filter: z.object({
+						state: z.literal('COMPLETED'),
+					}),
+					sortField: 'completionDate',
+				}),
+				successResponse: HttpResponse.json(
+					createQueryUserTasksResponse({
+						items: [createUserTask({userTaskKey: '1', name: 'Completed task', state: 'COMPLETED'})],
+					}),
+				),
+				failureResponse: new HttpResponse(null, {status: 400}),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createUserTask({userTaskKey: '1', name: 'Completed task', state: 'COMPLETED'}),
+				),
+			}),
+		);
+
+		await page.goto('/shadcn/tasklist?filter=completed&sortBy=completion');
+
+		await expect(page).toHaveURL(/\/shadcn\/tasklist\?filter=completed&sortBy=completion$/);
+		await expect(shadcnTasklistIndexPage.taskItem('Completed task')).toBeVisible();
+		await expect(shadcnTasklistIndexPage.taskItem('Completed task')).toBeVisible();
+	});
 });
 
 test.describe('Sorting', () => {

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/tasklist-navigation.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/shadcn/tasklist-navigation.test.ts
@@ -117,6 +117,28 @@ test.describe('Tasks panel', () => {
 		await expect(shadcnTasklistIndexPage.taskItem('Review contract')).toBeVisible();
 	});
 
+	test('should not auto-select a task on direct navigation when auto-select is enabled', async ({
+		network,
+		page,
+		shadcnTasklistIndexPage,
+	}) => {
+		await page.addInitScript(`localStorage.setItem('tasklist.autoSelectNextTask', JSON.stringify(true))`);
+		network.use(
+			mockQueryUserTasksEndpoint({
+				successResponse: HttpResponse.json(
+					createQueryUserTasksResponse({
+						items: [createUserTask({userTaskKey: '2251799813685281', name: 'Approve purchase order'})],
+					}),
+				),
+			}),
+		);
+
+		await shadcnTasklistIndexPage.goto();
+
+		await expect(page).toHaveURL('/shadcn/tasklist');
+		await expect(shadcnTasklistIndexPage.taskItem('Approve purchase order')).toBeVisible();
+	});
+
 	test('should show the empty state', async ({shadcnTasklistIndexPage}) => {
 		await shadcnTasklistIndexPage.goto();
 

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/ShadcnTaskDetail.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/ShadcnTaskDetail.page.ts
@@ -204,6 +204,10 @@ class ShadcnTaskDetailPage extends BasePage {
 		await this.jsonEditorInput('Edit Variable').pressSequentially(value);
 	}
 
+	get autoSelectNextTaskSwitch() {
+		return this.page.getByRole('switch', {name: 'Auto-select first available task'});
+	}
+
 	get assignee() {
 		return this.detailsHeader.getByTestId('assignee');
 	}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The auto-select toggle was migrated before but the functionality wasn't there yet. This PR fixes the functionality

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

relates https://github.com/camunda/camunda/issues/59208

- [x] This PR does not need a linked issue

