### PR TITLE
feat: strip unused aws-crt native libs from packaged c8run archive

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -689,6 +689,109 @@ func stripGrpcNettyShadedNativeLibs(camundaVersion, osType, arch string) error {
 	return nil
 }
 
+// awsCrtNativePrefix returns the 3-level directory prefix used by aws-crt to
+// store native libs for the given platform: "<os>/<arch>/<libc>/". Linux
+// targets keep glibc only — c8run targets standard distros, not Alpine/musl.
+func awsCrtNativePrefix(osType, arch string) (string, error) {
+	switch osType {
+	case "linux":
+		switch arch {
+		case "x86_64":
+			return "linux/x86_64/glibc/", nil
+		case "aarch64":
+			return "linux/armv8/glibc/", nil
+		}
+	case "darwin":
+		switch arch {
+		case "x86_64":
+			return "osx/x86_64/cruntime/", nil
+		case "aarch64":
+			return "osx/armv8/cruntime/", nil
+		}
+	case "windows":
+		switch arch {
+		case "x86_64":
+			return "windows/x86_64/cruntime/", nil
+		}
+	}
+	return "", fmt.Errorf("no aws-crt native prefix for os=%s arch=%s", osType, arch)
+}
+
+// awsCrtNativeOsPrefixes lists all top-level OS directory prefixes used by
+// aws-crt to store native libs, across all platforms it ships.
+var awsCrtNativeOsPrefixes = []string{
+	"linux/", "osx/", "windows/",
+}
+
+func isAwsCrtNativeEntry(name string) bool {
+	for _, prefix := range awsCrtNativeOsPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripAwsCrtNativeLibs removes aws-crt native libs for all platforms except
+// the target one. Like stripZstdJniNativeLibs, it globs
+// camunda-zeebe-<version>/lib/aws-crt-*.jar relative to CWD.
+func stripAwsCrtNativeLibs(camundaVersion, osType, arch string) error {
+	keepPrefix, err := awsCrtNativePrefix(osType, arch)
+	if err != nil {
+		return fmt.Errorf("stripAwsCrtNativeLibs: %w", err)
+	}
+
+	pattern := filepath.Join("camunda-zeebe-"+camundaVersion, "lib", "aws-crt-*.jar")
+	jars, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("stripAwsCrtNativeLibs: failed to glob %s: %w", pattern, err)
+	}
+	if len(jars) == 0 {
+		log.Warn().Str("pattern", pattern).Msg("no aws-crt jar found; skipping native lib stripping")
+		return nil
+	}
+	if len(jars) > 1 {
+		log.Warn().Strs("jars", jars).Msg("multiple aws-crt jars found; stripping only the first")
+	}
+
+	r, err := zip.OpenReader(jars[0])
+	if err != nil {
+		return fmt.Errorf("stripAwsCrtNativeLibs: open %s: %w", jars[0], err)
+	}
+	var toDrop int
+	var keepFound bool
+	for _, f := range r.File {
+		if strings.HasPrefix(f.Name, keepPrefix) {
+			keepFound = true
+		}
+		if isAwsCrtNativeEntry(f.Name) && !strings.HasPrefix(f.Name, keepPrefix) {
+			toDrop++
+		}
+	}
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("stripAwsCrtNativeLibs: close %s: %w", jars[0], err)
+	}
+
+	if toDrop > 0 && !keepFound {
+		return fmt.Errorf("stripAwsCrtNativeLibs: no entries matching prefix %q found in %s: verify awsCrtNativePrefix mapping", keepPrefix, jars[0])
+	}
+
+	if toDrop == 0 {
+		log.Info().Str("jar", jars[0]).Str("keeping", keepPrefix).Msg("no unused aws-crt native libs to strip (already stripped?)")
+		return nil
+	}
+
+	log.Info().Str("jar", jars[0]).Str("keeping", keepPrefix).Int("dropping", toDrop).Msg("stripping unused aws-crt native libs")
+
+	shouldDrop := func(name string) bool {
+		return isAwsCrtNativeEntry(name) && !strings.HasPrefix(name, keepPrefix)
+	}
+	if _, err := rewriteJarDroppingEntries(jars[0], shouldDrop); err != nil {
+		return err
+	}
+	return nil
+}
+
 func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
@@ -1134,6 +1237,10 @@ func New(camundaVersion, connectorsVersion string) error {
 
 	if err := stripGrpcNettyShadedNativeLibs(camundaVersion, osType, architecture); err != nil {
 		return fmt.Errorf("package %s: failed to strip grpc-netty-shaded native libs: %w", osType, err)
+	}
+
+	if err := stripAwsCrtNativeLibs(camundaVersion, osType, architecture); err != nil {
+		return fmt.Errorf("package %s: failed to strip aws-crt native libs: %w", osType, err)
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -1541,6 +1541,159 @@ func TestStripGrpcNettyShadedNativeLibsErrorsWhenOnlyEpollMatches(t *testing.T) 
 	}
 }
 
+func TestStripAwsCrtNativeLibsStripsJar(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "aws-crt-0.45.1.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/MANIFEST.MF",
+		"software/amazon/awssdk/crt/CRT.class",
+		"linux/x86_64/glibc/libaws-crt-jni.so",
+		"linux/x86_64/musl/libaws-crt-jni.so",
+		"linux/armv8/glibc/libaws-crt-jni.so",
+		"linux/armv8/musl/libaws-crt-jni.so",
+		"osx/x86_64/cruntime/libaws-crt-jni.dylib",
+		"osx/armv8/cruntime/libaws-crt-jni.dylib",
+		"windows/x86_64/cruntime/aws-crt-jni.dll",
+		"windows/x86_32/cruntime/aws-crt-jni.dll",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 (keeps linux/x86_64/glibc/ only, not musl)
+	err = stripAwsCrtNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripAwsCrtNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
+
+	kept := make(map[string]bool)
+	for _, entry := range r.File {
+		kept[entry.Name] = true
+	}
+
+	for _, mustKeep := range []string{
+		"META-INF/MANIFEST.MF",
+		"software/amazon/awssdk/crt/CRT.class",
+		"linux/x86_64/glibc/libaws-crt-jni.so",
+	} {
+		if !kept[mustKeep] {
+			t.Fatalf("expected entry %q to be preserved, got entries: %v", mustKeep, kept)
+		}
+	}
+
+	for _, mustDrop := range []string{
+		"linux/x86_64/musl/libaws-crt-jni.so",
+		"linux/armv8/glibc/libaws-crt-jni.so",
+		"linux/armv8/musl/libaws-crt-jni.so",
+		"osx/x86_64/cruntime/libaws-crt-jni.dylib",
+		"osx/armv8/cruntime/libaws-crt-jni.dylib",
+		"windows/x86_64/cruntime/aws-crt-jni.dll",
+		"windows/x86_32/cruntime/aws-crt-jni.dll",
+	} {
+		if kept[mustDrop] {
+			t.Fatalf("expected entry %q to be dropped, but it was kept", mustDrop)
+		}
+	}
+}
+
+func TestStripAwsCrtNativeLibsErrorsWhenKeepPrefixAbsent(t *testing.T) {
+	// given: JAR contains only foreign-platform native libs — target prefix is absent.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "aws-crt-0.45.1.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	fw, err := w.Create("linux/armv8/glibc/libaws-crt-jni.so")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte("binary")); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 — keepPrefix "linux/x86_64/glibc/" is absent.
+	err = stripAwsCrtNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err == nil {
+		t.Fatal("expected error when target prefix is absent in JAR, got nil")
+	}
+}
+
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Strip unused platform native libs from `aws-crt-*.jar` in the packaged c8run archive (~17MB saving), mirroring the existing zstd-jni/conscrypt stripping.
- Linux targets keep glibc only (not musl) — c8run targets standard distros, not Alpine.

## Related issues
relates to #54950

## Test plan
- [x] `go test ./internal/packages/... -v` passes
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [ ] Manual: build c8run archive for at least one platform and confirm `lib/aws-crt-*.jar` no longer contains foreign-platform entries (`unzip -l`)