### PR TITLE
feat: strip unused grpc-netty-shaded native libs from packaged c8run archive

### DIFF
--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -582,6 +582,109 @@ func stripConscryptNativeLibs(camundaVersion, osType, arch string) error {
 	return nil
 }
 
+// grpcNettyShadedNativeTokens returns the filename tokens used by
+// grpc-netty-shaded to identify native libs for the given platform: the
+// tcnative token (always present) and the epoll token (Linux-only — the
+// epoll transport JAR has no counterpart on darwin/windows).
+func grpcNettyShadedNativeTokens(osType, arch string) (tcnative string, epoll string, err error) {
+	switch osType {
+	case "linux":
+		switch arch {
+		case "x86_64":
+			return "_linux_x86_64.", "_epoll_x86_64.", nil
+		case "aarch64":
+			return "_linux_aarch_64.", "_epoll_aarch_64.", nil
+		}
+	case "darwin":
+		switch arch {
+		case "x86_64":
+			return "_osx_x86_64.", "", nil
+		case "aarch64":
+			return "_osx_aarch_64.", "", nil
+		}
+	case "windows":
+		switch arch {
+		case "x86_64":
+			return "_windows_x86_64.", "", nil
+		}
+	}
+	return "", "", fmt.Errorf("no grpc-netty-shaded native tokens for os=%s arch=%s", osType, arch)
+}
+
+func isGrpcNettyShadedNativeEntry(name string) bool {
+	return strings.HasPrefix(name, "META-INF/native/")
+}
+
+// stripGrpcNettyShadedNativeLibs removes grpc-netty-shaded native libs for
+// all platforms except the target one. Matching is done on filename tokens
+// (not a fixed prefix) because the Windows entry has no "lib" prefix and
+// grpc uses "aarch_64" (underscore) rather than "aarch64".
+func stripGrpcNettyShadedNativeLibs(camundaVersion, osType, arch string) error {
+	tcnativeToken, epollToken, err := grpcNettyShadedNativeTokens(osType, arch)
+	if err != nil {
+		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: %w", err)
+	}
+
+	pattern := filepath.Join("camunda-zeebe-"+camundaVersion, "lib", "grpc-netty-shaded-*.jar")
+	jars, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: failed to glob %s: %w", pattern, err)
+	}
+	if len(jars) == 0 {
+		log.Warn().Str("pattern", pattern).Msg("no grpc-netty-shaded jar found; skipping native lib stripping")
+		return nil
+	}
+	if len(jars) > 1 {
+		log.Warn().Strs("jars", jars).Msg("multiple grpc-netty-shaded jars found; stripping only the first")
+	}
+
+	keep := func(name string) bool {
+		if strings.Contains(name, tcnativeToken) {
+			return true
+		}
+		return epollToken != "" && strings.Contains(name, epollToken)
+	}
+
+	r, err := zip.OpenReader(jars[0])
+	if err != nil {
+		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: open %s: %w", jars[0], err)
+	}
+	var toDrop int
+	var keepFound bool
+	for _, f := range r.File {
+		if !isGrpcNettyShadedNativeEntry(f.Name) {
+			continue
+		}
+		if keep(f.Name) {
+			keepFound = true
+			continue
+		}
+		toDrop++
+	}
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: close %s: %w", jars[0], err)
+	}
+
+	if toDrop > 0 && !keepFound {
+		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: no entries matching tcnative token %q found in %s: verify grpcNettyShadedNativeTokens mapping", tcnativeToken, jars[0])
+	}
+
+	if toDrop == 0 {
+		log.Info().Str("jar", jars[0]).Str("keeping", tcnativeToken).Msg("no unused grpc-netty-shaded native libs to strip (already stripped?)")
+		return nil
+	}
+
+	log.Info().Str("jar", jars[0]).Str("keeping", tcnativeToken).Int("dropping", toDrop).Msg("stripping unused grpc-netty-shaded native libs")
+
+	shouldDrop := func(name string) bool {
+		return isGrpcNettyShadedNativeEntry(name) && !keep(name)
+	}
+	if _, err := rewriteJarDroppingEntries(jars[0], shouldDrop); err != nil {
+		return err
+	}
+	return nil
+}
+
 func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
@@ -1023,6 +1126,10 @@ func New(camundaVersion, connectorsVersion string) error {
 
 	if err := stripConscryptNativeLibs(camundaVersion, osType, architecture); err != nil {
 		return fmt.Errorf("package %s: failed to strip conscrypt native libs: %w", osType, err)
+	}
+
+	if err := stripGrpcNettyShadedNativeLibs(camundaVersion, osType, architecture); err != nil {
+		return fmt.Errorf("package %s: failed to strip grpc-netty-shaded native libs: %w", osType, err)
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -650,13 +650,17 @@ func stripGrpcNettyShadedNativeLibs(camundaVersion, osType, arch string) error {
 		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: open %s: %w", jars[0], err)
 	}
 	var toDrop int
-	var keepFound bool
+	var hasNativeEntries bool
+	var tcnativeFound bool
 	for _, f := range r.File {
 		if !isGrpcNettyShadedNativeEntry(f.Name) {
 			continue
 		}
+		hasNativeEntries = true
+		if strings.Contains(f.Name, tcnativeToken) {
+			tcnativeFound = true
+		}
 		if keep(f.Name) {
-			keepFound = true
 			continue
 		}
 		toDrop++
@@ -665,7 +669,7 @@ func stripGrpcNettyShadedNativeLibs(camundaVersion, osType, arch string) error {
 		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: close %s: %w", jars[0], err)
 	}
 
-	if toDrop > 0 && !keepFound {
+	if hasNativeEntries && !tcnativeFound {
 		return fmt.Errorf("stripGrpcNettyShadedNativeLibs: no entries matching tcnative token %q found in %s: verify grpcNettyShadedNativeTokens mapping", tcnativeToken, jars[0])
 	}
 

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -1247,6 +1247,243 @@ func TestStripConscryptNativeLibsSkipsWhenJarMissing(t *testing.T) {
 	}
 }
 
+func TestStripGrpcNettyShadedNativeLibsStripsJarLinux(t *testing.T) {
+	// given
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "grpc-netty-shaded-1.81.0.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/MANIFEST.MF",
+		"io/grpc/netty/shaded/io/grpc/netty/NettyServer.class",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_aarch_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_aarch_64.jnilib",
+		"META-INF/native/io_grpc_netty_shaded_netty_tcnative_windows_x86_64.dll",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_aarch_64.so",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 — keeps tcnative_linux_x86_64 + epoll_x86_64
+	err = stripGrpcNettyShadedNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripGrpcNettyShadedNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
+
+	kept := make(map[string]bool)
+	for _, entry := range r.File {
+		kept[entry.Name] = true
+	}
+
+	for _, mustKeep := range []string{
+		"META-INF/MANIFEST.MF",
+		"io/grpc/netty/shaded/io/grpc/netty/NettyServer.class",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so",
+	} {
+		if !kept[mustKeep] {
+			t.Fatalf("expected entry %q to be preserved, got entries: %v", mustKeep, kept)
+		}
+	}
+
+	for _, mustDrop := range []string{
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_aarch_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_aarch_64.jnilib",
+		"META-INF/native/io_grpc_netty_shaded_netty_tcnative_windows_x86_64.dll",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_aarch_64.so",
+	} {
+		if kept[mustDrop] {
+			t.Fatalf("expected entry %q to be dropped, but it was kept", mustDrop)
+		}
+	}
+}
+
+func TestStripGrpcNettyShadedNativeLibsDropsEpollOnDarwin(t *testing.T) {
+	// given: epoll transport is Linux-only — must be fully dropped on darwin targets.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "grpc-netty-shaded-1.81.0.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_aarch_64.so",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for darwin/x86_64 — epoll has no darwin variant, so both entries drop.
+	err = stripGrpcNettyShadedNativeLibs(version, "darwin", "x86_64")
+
+	// then
+	if err != nil {
+		t.Fatalf("stripGrpcNettyShadedNativeLibs returned error: %v", err)
+	}
+
+	r, err := zip.OpenReader(jarPath)
+	if err != nil {
+		t.Fatalf("failed to open stripped jar: %v", err)
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close stripped jar: %v", err)
+		}
+	}()
+
+	kept := make(map[string]bool)
+	for _, entry := range r.File {
+		kept[entry.Name] = true
+	}
+
+	if !kept["META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib"] {
+		t.Fatalf("expected osx tcnative entry to be preserved, got entries: %v", kept)
+	}
+	for _, mustDrop := range []string{
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_aarch_64.so",
+	} {
+		if kept[mustDrop] {
+			t.Fatalf("expected entry %q to be dropped on darwin, but it was kept", mustDrop)
+		}
+	}
+}
+
+func TestStripGrpcNettyShadedNativeLibsErrorsWhenKeepTokenAbsent(t *testing.T) {
+	// given: JAR contains only foreign-platform tcnative entries — target token absent.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "grpc-netty-shaded-1.81.0.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	fw, err := w.Create("META-INF/native/libio_grpc_netty_shaded_netty_tcnative_linux_aarch_64.so")
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte("binary")); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 — only aarch_64 tcnative entry exists, no x86_64 match.
+	err = stripGrpcNettyShadedNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err == nil {
+		t.Fatal("expected error when target token is absent in JAR, got nil")
+	}
+}
+
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()

--- a/c8run/internal/packages/package_test.go
+++ b/c8run/internal/packages/package_test.go
@@ -1484,6 +1484,63 @@ func TestStripGrpcNettyShadedNativeLibsErrorsWhenKeepTokenAbsent(t *testing.T) {
 	}
 }
 
+func TestStripGrpcNettyShadedNativeLibsErrorsWhenOnlyEpollMatches(t *testing.T) {
+	// given: JAR contains a matching Linux epoll entry but no matching tcnative entry —
+	// the epoll match must not be mistaken for proof that the required tcnative lib exists.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	version := "8.10.0-test"
+	libDir := filepath.Join("camunda-zeebe-"+version, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("failed to create lib dir: %v", err)
+	}
+	jarPath := filepath.Join(libDir, "grpc-netty-shaded-1.81.0.jar")
+	f, err := os.Create(jarPath)
+	if err != nil {
+		t.Fatalf("failed to create test jar: %v", err)
+	}
+	w := zip.NewWriter(f)
+	entries := []string{
+		"META-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so",
+		"META-INF/native/libio_grpc_netty_shaded_netty_tcnative_osx_x86_64.jnilib",
+	}
+	for _, name := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %s: %v", name, err)
+		}
+		if _, err := fw.Write([]byte("binary-" + name)); err != nil {
+			t.Fatalf("failed to write zip entry %s: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close jar file: %v", err)
+	}
+
+	// when: strip for linux/x86_64 — epoll_x86_64 matches, but no tcnative_linux_x86_64 entry exists.
+	err = stripGrpcNettyShadedNativeLibs(version, "linux", "x86_64")
+
+	// then
+	if err == nil {
+		t.Fatal("expected error when only epoll matches and tcnative entry is absent, got nil")
+	}
+}
+
 func TestVerifyClassFileVersionAcceptsJava21Class(t *testing.T) {
 	// given — minimal class file header with major version matching helperJavaRelease
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Strip unused platform native libs from `grpc-netty-shaded-*.jar` in the packaged c8run archive (~8MB saving), mirroring the existing stripping approach.
- Matches on filename tokens (not prefix/suffix) since the Windows entry lacks a `lib` prefix and grpc uses `aarch_64` with an underscore.
- Linux-only `epoll` transport entries are dropped entirely on darwin/windows targets.

## Related issues
relates to #54950

## Test plan
- [x] `go test ./internal/packages/... -v` passes
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [ ] Manual: build c8run archive for at least one platform and confirm `lib/grpc-netty-shaded-*.jar` no longer contains foreign-platform entries (`unzip -l`)