### PR TITLE
ci: stop paging on-call for the 8.11 preview-env smoke test until its tests exist

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -172,7 +172,15 @@ jobs:
 
   deploy-8-11:
     name: Deploy 8.11 Preview Environment
-    if: contains(fromJSON('["all", "8.11", ""]'), inputs.version) && inputs.existing-host == ''
+    # Temporary: 8.11 only runs when someone starts this workflow by hand and
+    # picks version 8.11. We keep it out of the weekly Monday run because the
+    # 8.11 smoke tests (tests/SM-8.11/smoke-tests.spec.ts) don't exist yet in
+    # camunda/c8-cross-component-e2e-tests. With them missing, the scheduled run
+    # failed every Monday with "No tests found" and paged the on-call medic for
+    # nothing they could fix. The team agreed to stick with the 8.10 tests until
+    # 8.11 is released, so we don't add a new version here until its tests exist.
+    # Once QA ships tests/SM-8.11, put "all" and "" back to run it on schedule.
+    if: contains(fromJSON('["8.11"]'), inputs.version) && inputs.existing-host == ''
     uses: ./.github/workflows/preview-env-build-and-deploy.yml
     secrets: inherit
     with:

--- a/docs/monorepo-docs/ci-runbooks.md
+++ b/docs/monorepo-docs/ci-runbooks.md
@@ -367,6 +367,18 @@ runs weekly on Mondays to verify that preview environment deployments are workin
 failure indicates a potential issue with the preview environment infrastructure that could affect
 developers using the `deploy-preview` label on their PRs.
 
+> **Note — a job for an unreleased version is skipped on purpose:** The `deploy-<version>` job for a
+> minor that hasn't been released yet is set up to run only when someone starts the workflow by hand.
+> This is because its smoke tests often don't exist yet in
+> [`camunda/c8-cross-component-e2e-tests`](https://github.com/camunda/c8-cross-component-e2e-tests).
+> If that job did run on schedule, it would fail every Monday with `No tests found` and page
+> `monorepo-ci-medic` for something no one can fix.
+>
+> **So:** don't turn on a version's job (or move the smoke tests to a new version) until that minor is
+> released and its tests exist — see the [minor-release checklist](release/release-monorepo.md). If the
+> Monday run fails only on a version that isn't released yet, that's expected. Skip that job instead of
+> treating it as a real infra failure.
+
 #### Troubleshooting
 
 1. Check the failed workflow run linked in the Slack notification:

--- a/docs/monorepo-docs/release/release-monorepo.md
+++ b/docs/monorepo-docs/release/release-monorepo.md
@@ -364,6 +364,7 @@ Ownership model:
 #### 8. Wire release workflows (branch must exist)
 
 - [ ] Merge the dry-run and preview/smoke-test PRs (drafted earlier). Every job resolves `uses: ...@stable/<minor>` and checks out the branch, so they only pass once it exists. **Quote every version literal** — unquoted, `8.10` parses as `8.1`.
+- [ ] ⚠️ **Preview-env smoke test:** wait until this minor is released and its smoke tests exist in `camunda/c8-cross-component-e2e-tests` before turning on its `deploy-<minor>` job in [`preview-env-smoke-test.yml`](../../../.github/workflows/preview-env-smoke-test.yml). Until then, keep the job set to run by hand only (its `if:` should match just its own version, not `all` or `""`). If you turn it on too early, the Monday run fails with `No tests found` and pages `monorepo-ci-medic`. See the [Preview Environment Smoke Test Failure runbook](../ci-runbooks.md#preview-environment-smoke-test-failure).
 - [ ] Verify the release BPMN uses `stable/<minor>` as the source branch, and that the code freeze date and start date are correct when starting the minor instance.
 - [ ] Confirm the scheduled `stable/<minor>` release dry-run is green before starting the minor.
 


### PR DESCRIPTION
## What this does

The weekly **Preview Environment Smoke Test** has failed every Monday on the `deploy-8-11` job and paged the `monorepo-ci-medic` on-call for something they can't fix.

The 8.11 smoke tests (`tests/SM-8.11/smoke-tests.spec.ts`) don't exist yet in [`camunda/c8-cross-component-e2e-tests`](https://github.com/camunda/c8-cross-component-e2e-tests) — QA is still building that suite (blocked on their own dependency chain, expected around end of next week). So the job dies with `No tests found`: a known, already-tracked, non-actionable failure.

## Change

- `deploy-8-11` now only runs when someone starts the workflow **by hand** and picks version `8.11`. Its `if:` matches only `"8.11"` — no longer `"all"` or `""` — so it's skipped on the weekly schedule.
- The downstream `test` and `notify-failure` jobs stop on their own: a skipped job's result is `skipped`, not `success`/`failure`/`cancelled`, so nothing else needed to change.

This matches the team decision to keep running the **8.10** tests in front of the release and not move the smoke tests to a new version until that minor is released.

**This is temporary.** Once QA ships `tests/SM-8.11`, restore `"all"` and `""` so 8.11 runs on schedule again.

## Docs

To stop this being rediscovered the hard way, I also documented the rule:
- `docs/monorepo-docs/ci-runbooks.md` — a note that a job for a not-yet-released version is skipped on purpose, and a Monday failure on such a version is expected (not an infra problem).
- `docs/monorepo-docs/release/release-monorepo.md` — a minor-release checklist reminder to only turn a version's job on after that minor is released and its tests exist.

## Related issues

- [x] This PR does not need a linked issue

## Review

The workflow is owned by `@camunda/engineering-operations` (per its `# owner:` header) — flagging for review. No backport needed; this only affects the scheduled workflow on `main`.