### PR TITLE
refactor: split load-test-ops skill's metrics methods into a reference file

### DIFF
--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -316,8 +316,7 @@ After ~5 min, download flamegraph artifacts:
 gh run download <run-id> --repo camunda/camunda
 ```
 
-Artifact names: one per pod, containing the cpu/wall/alloc reports for that pod, e.g.
-`flamegraph-<name>-<date>-camunda-0`, `flamegraph-<name>-<date>-camunda-1`, `flamegraph-<name>-<date>-camunda-2`
+Artifact names: `flamegraph-cpu-camunda-0`, `flamegraph-wall-camunda-1`, `flamegraph-alloc-camunda-2`
 
 ---
 
@@ -334,9 +333,9 @@ request-response latency p99. This is enough to answer "did the run meet its SLO
 For deeper investigation (FNI/s, processing/exporting latency, CPU throttling, JVM heap trend,
 processing and exporting backlogs, write IOPS, disk usage, …), the full metric catalogue with
 PromQL queries is in [`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md). The Prometheus
-instance at [`monitor.benchmark.camunda.cloud`](https://monitor.benchmark.camunda.cloud)
-(Okta login) and the [Camunda Performance dashboard](https://dashboard.benchmark.camunda.cloud/d/camunda-performance/camunda-performance)
-expose all of them — start there when the headline numbers don't explain what you're seeing.
+instance at [`monitor.benchmark.camunda.cloud`](https://monitor.benchmark.camunda.cloud) (Okta
+login) and the dashboards in [Metrics & dashboards](#metrics--dashboards) below expose all of
+them — start there when the headline numbers don't explain what you're seeing.
 
 ### Via GHA (default — no kubectl needed)
 
@@ -358,74 +357,13 @@ gh run view "$RUN_ID" --repo camunda/camunda
 for a ~20-min window. Results render in the job summary; the workflow is also reusable via
 `workflow_call` and exposes `results-json` for downstream jobs (e.g. analyze → delete).
 
-### Via Grafana MCP (in Claude Code sessions — no port-forward needed)
+### Other ways to get metrics
 
-Use `mcp__grafana__*` tools directly when running inside Claude Code. Confirm tools are active
-with `mcp__grafana__check_datasources_health` at session start.
-
-**Rule: always run `list_prometheus_metric_names` before writing any PromQL query.** Guessed
-metric names return empty results silently — one discovery call eliminates all name-guess failures.
-
-**Session startup:**
-```
-mcp__grafana__check_datasources_health()
-  → datasourceUid: "prometheus" should show status: OK
-
-mcp__grafana__list_prometheus_label_values(
-  datasourceUid="prometheus", labelName="namespace",
-  matches=[{filters: [{name: "__name__", value: "zeebe_.*", type: "=~"}]}],
-  startRfc3339="now-24h")
-  → lists all namespaces with recent Zeebe data
-```
-
-**Metric name discovery:**
-```
-mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="optimize.*", limit=50)
-mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*process.*", limit=20)
-```
-
-For metric names and PromQL queries, see [load-tests/docs/metrics.md](../../docs/metrics.md).
-
-**Known benchmark cluster dashboards:**
-- `camunda-performance` — general throughput/latency/resource overview (namespace variable)
-- `zeebe-dashboard` — deep dive into Zeebe internals (backpressure, partitions, exporters)
-
-See `load-tests/README.md` → **Accessing metrics via Claude Code (Grafana MCP)** for setup instructions.
-
-### Via local script (kubectl + port-forward)
-
-Faster when you have cluster access. First port-forward the monitoring Prometheus pod, then run
-the script directly against `http://localhost:9090`:
-
-```bash
-# Port-forward the monitoring Prometheus service (leave running in a separate terminal)
-kubectl port-forward svc/kube-prometheus-stack-prometheus -n monitoring 9090:9090
-
-# Then run the metrics script
-cd load-tests/docs/scripts
-./loadTestMetrics.sh <full-namespace-with-c8-prefix> 1200 > /tmp/results.json
-```
-
-Args: `<namespace> [duration_seconds] [endpoint] [extra_curl_opts]`. 
-
-### Additional metrics via Prometheus (kubectl required)
-
-When the headline metrics aren't enough, query the full set from
-[`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md) directly against Prometheus. Open a
-port-forward in one terminal, then run ad-hoc PromQL in another:
-
-```bash
-# Open port-forward (keep this terminal open)
-kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
-
-# Ad-hoc query — substitute <namespace> and the PromQL from metrics.md
-curl -sG 'http://localhost:9090/api/v1/query_range' \
-  --data-urlencode 'query=<promql>' \
-  --data-urlencode 'start=<unix-timestamp>' \
-  --data-urlencode 'end=<unix-timestamp>' \
-  --data-urlencode 'step=15s' \
-  | jq '.data.result'
-```
+When you have kubectl/Grafana access, or need more than the headline set, see
+[`references/analyze-metrics.md`](references/analyze-metrics.md) for:
+- Grafana MCP (in Claude Code sessions — no port-forward needed)
+- Local script + port-forward against Prometheus
+- Ad-hoc PromQL queries for the full metric catalogue
 
 ---
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -316,7 +316,7 @@ After ~5 min, download flamegraph artifacts:
 gh run download <run-id> --repo camunda/camunda
 ```
 
-Artifact names: `flamegraph-cpu-camunda-0`, `flamegraph-wall-camunda-1`, `flamegraph-alloc-camunda-2`
+Artifact names: one per pod (each contains the cpu/wall/alloc reports for that pod), e.g. `flamegraph-<name>-<date>-camunda-0`, `flamegraph-<name>-<date>-camunda-1`, `flamegraph-<name>-<date>-camunda-2`
 
 ---
 

--- a/load-tests/skills/load-test-ops/references/analyze-metrics.md
+++ b/load-tests/skills/load-test-ops/references/analyze-metrics.md
@@ -1,0 +1,70 @@
+# Analyze metrics — alternative methods
+
+The [default GHA path](../SKILL.md#analyze-metrics) covers the headline queries without
+kubectl. Use one of these when you have kubectl/Grafana access, or need more than the
+headline set.
+
+## Via Grafana MCP (in Claude Code sessions — no port-forward needed)
+
+Use `mcp__grafana__*` tools directly when running inside Claude Code. Confirm tools are active
+with `mcp__grafana__check_datasources_health` at session start.
+
+**Rule: always run `list_prometheus_metric_names` before writing any PromQL query.** Guessed
+metric names return empty results silently — one discovery call eliminates all name-guess failures.
+
+**Session startup:**
+```
+mcp__grafana__check_datasources_health()
+  → datasourceUid: "prometheus" should show status: OK
+
+mcp__grafana__list_prometheus_label_values(
+  datasourceUid="prometheus", labelName="namespace",
+  matches=[{filters: [{name: "__name__", value: "zeebe_.*", type: "=~"}]}],
+  startRfc3339="now-24h")
+  → lists all namespaces with recent Zeebe data
+```
+
+**Metric name discovery:**
+```
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="optimize.*", limit=50)
+mcp__grafana__list_prometheus_metric_names(datasourceUid="prometheus", regex="zeebe.*process.*", limit=20)
+```
+
+For metric names and PromQL queries, see [`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md).
+
+See `load-tests/README.md` → **Accessing metrics via Claude Code (Grafana MCP)** for setup instructions.
+
+## Via local script (kubectl + port-forward)
+
+Faster when you have cluster access. First port-forward the monitoring Prometheus pod, then run
+the script directly against `http://localhost:9090`:
+
+```bash
+# Port-forward the monitoring Prometheus service (leave running in a separate terminal)
+kubectl port-forward svc/kube-prometheus-stack-prometheus -n monitoring 9090:9090
+
+# Then run the metrics script
+cd load-tests/docs/scripts
+./loadTestMetrics.sh <full-namespace-with-c8-prefix> 1200 > /tmp/results.json
+```
+
+Args: `<namespace> [duration_seconds] [endpoint] [extra_curl_opts]`.
+
+## Additional metrics via Prometheus (kubectl required)
+
+When the headline metrics aren't enough, query the full set from
+[`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md) directly against Prometheus. Open a
+port-forward in one terminal, then run ad-hoc PromQL in another:
+
+```bash
+# Open port-forward (keep this terminal open)
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+
+# Ad-hoc query — substitute <namespace> and the PromQL from metrics.md
+curl -sG 'http://localhost:9090/api/v1/query_range' \
+  --data-urlencode 'query=<promql>' \
+  --data-urlencode 'start=<unix-timestamp>' \
+  --data-urlencode 'end=<unix-timestamp>' \
+  --data-urlencode 'step=15s' \
+  | jq '.data.result'
+```

--- a/load-tests/skills/load-test-ops/references/analyze-metrics.md
+++ b/load-tests/skills/load-test-ops/references/analyze-metrics.md
@@ -9,7 +9,7 @@ headline set.
 Use `mcp__grafana__*` tools directly when running inside Claude Code. Confirm tools are active
 with `mcp__grafana__check_datasources_health` at session start.
 
-**Rule: always run `list_prometheus_metric_names` before writing any PromQL query.** Guessed
+**Rule: always run `mcp__grafana__list_prometheus_metric_names` before writing any PromQL query.** Guessed
 metric names return empty results silently — one discovery call eliminates all name-guess failures.
 
 **Session startup:**


### PR DESCRIPTION
## Description

`load-test-ops/SKILL.md` had grown to 519 lines / 2759 words, past the ~500-line ceiling Claude Code's own skill docs recommend, and the "Analyze metrics" section alone accounted for 108 lines across four alternative retrieval methods (GHA, Grafana MCP, local script, ad-hoc Prometheus), plus a duplicated dashboard link.

This moves the three secondary metrics methods into `references/analyze-metrics.md`, following the skill system's progressive disclosure model: the default GHA path stays inline in `SKILL.md`, the rest loads only when needed. Kept as a single skill rather than splitting by operation, since start/monitor/analyze/compare/stop form one continuous load-test lifecycle that's better discovered as one unit than fragmented across multiple skills.

Result: `SKILL.md` down to 458 lines / 2527 words, with no change to the actual instructions or workflow.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - not applicable, this only touches an internal Claude Code skill.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. - not applicable

## Related issues

- [x] This PR does not need a linked issue
