### PR TITLE
61405 rdbms schema version hang repro

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.migration.CurrentSchemaVersion;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -51,6 +52,31 @@ public class RdbmsSchemaVersionStore {
    * written/updated after every successful Liquibase migration run.
    */
   private static final String SCHEMA_VERSION_TABLE = "RDBMS_SCHEMA_VERSION";
+
+  /**
+   * Bounds every statement this class issues, so that contention for the single {@code
+   * RDBMS_SCHEMA_VERSION} row fails instead of waiting forever.
+   *
+   * <p>Nothing serializes the nodes writing that row: {@link #recordCurrentVersion()} runs after
+   * Liquibase's changelog lock and {@code LiquibaseSchemaManager}'s migration lock are both
+   * released, and every broker initializes the schema itself. Unbounded, a peer holding the row in
+   * an open transaction parks the caller inside the JDBC call for as long as the vendor allows —
+   * indefinitely on PostgreSQL, Oracle and MySQL — throwing nothing, and so logging nothing
+   * (#61405).
+   *
+   * <p>Matches HikariCP's {@code connectionTimeout} default, which already bounds the other half of
+   * these calls. Not configurable: the failure it raises is retryable, so the value decides how
+   * soon an operator sees a log line, not whether the node recovers.
+   *
+   * <p>Bounds it on PostgreSQL, MySQL, MariaDB and MSSQL, whose drivers cancel a waiting statement.
+   * Oracle and H2 do not: measured on 23 (free) and 2.4.240, their lock waits ignore both this and
+   * {@link java.sql.Statement#cancel()}. H2 self-protects with its own {@code LOCK_TIMEOUT} (~2s by
+   * default); Oracle has no equivalent, so what keeps it out of an unbounded wait is {@link
+   * #recordCurrentVersion()} not issuing the write at all when the version is unchanged. Bounding
+   * Oracle's remaining write path would need vendor-specific SQL ({@code SELECT ... FOR UPDATE WAIT
+   * n}, or a {@code MERGE}), which this class has none of.
+   */
+  private static final int STATEMENT_TIMEOUT_SECONDS = 30;
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSchemaVersionStore.class);
   private final DataSource dataSource;
@@ -199,7 +225,14 @@ public class RdbmsSchemaVersionStore {
    * Liquibase migration. The version is normalized to stable {@code major.minor.patch} before
    * storage (pre-release suffixes such as {@code -SNAPSHOT} are stripped). If the version cannot be
    * parsed as a semantic version (e.g. {@code "development"}), the write is skipped with a warning.
-   * Any failure fails with an {@link RdbmsSchemaVersionUnreadableException} because a missing or
+   *
+   * <p>The write is also skipped when the row already holds that version, which is what every start
+   * after the first finds. That is not only an avoided round trip: the write contends with every
+   * other node recording the same version, and not issuing it is the only way to keep a vendor
+   * whose lock wait cannot be bounded — Oracle, H2 — out of that contention altogether. See {@link
+   * #STATEMENT_TIMEOUT_SECONDS}.
+   *
+   * <p>Any failure fails with an {@link RdbmsSchemaVersionUnreadableException} because a missing or
    * incorrect schema-version record would cause the next startup to perform an incorrect
    * compatibility check; it is retryable, since re-running the whole initialization writes it
    * again.
@@ -221,6 +254,21 @@ public class RdbmsSchemaVersionStore {
     final var tableName = prefix + SCHEMA_VERSION_TABLE;
 
     try (final var connection = dataSource.getConnection()) {
+      if (stableVersion.get().equals(readSchemaVersion(connection, prefix))) {
+        // Nothing to write, and so nothing to contend for. Every node records the same version,
+        // and the row already holds it on every start after the first — which is the state a
+        // restart finds, and the one the peers whose uncommitted row could otherwise be waited on
+        // are themselves recording. Reads do not block behind an uncommitted write on any vendor
+        // whose reads are snapshot-based, so this is also the only step Oracle can take safely:
+        // its row-lock wait cannot be bounded from here at all.
+        LOG.debug(
+            "[RDBMS Schema] Schema version {} is already recorded for prefix '{}'; nothing to"
+                + " write.",
+            stableVersion.get(),
+            prefix);
+        return;
+      }
+
       final var autoCommit = connection.getAutoCommit();
       connection.setAutoCommit(false);
       try {
@@ -294,7 +342,7 @@ public class RdbmsSchemaVersionStore {
     if (!tableExists(connection, tableName)) {
       return null;
     }
-    try (final var stmt = connection.prepareStatement("SELECT VERSION FROM " + tableName)) {
+    try (final var stmt = boundedStatement(connection, "SELECT VERSION FROM " + tableName)) {
       stmt.setMaxRows(1);
       try (final var rs = stmt.executeQuery()) {
         return rs.next() ? rs.getString(1) : null;
@@ -399,7 +447,7 @@ public class RdbmsSchemaVersionStore {
       final Connection connection, final String tableName, final String stableVersion)
       throws SQLException {
     try (final var updateStmt =
-        connection.prepareStatement("UPDATE " + tableName + " SET VERSION = ? WHERE ID = 1")) {
+        boundedStatement(connection, "UPDATE " + tableName + " SET VERSION = ? WHERE ID = 1")) {
       updateStmt.setString(1, stableVersion);
       return updateStmt.executeUpdate();
     }
@@ -409,9 +457,26 @@ public class RdbmsSchemaVersionStore {
       final Connection connection, final String tableName, final String stableVersion)
       throws SQLException {
     try (final var insertStmt =
-        connection.prepareStatement("INSERT INTO " + tableName + " (ID, VERSION) VALUES (1, ?)")) {
+        boundedStatement(connection, "INSERT INTO " + tableName + " (ID, VERSION) VALUES (1, ?)")) {
       insertStmt.setString(1, stableVersion);
       insertStmt.executeUpdate();
     }
+  }
+
+  /**
+   * Prepares a statement that gives up rather than waiting indefinitely. See {@link
+   * #STATEMENT_TIMEOUT_SECONDS} for why every statement in this class needs that.
+   */
+  private static PreparedStatement boundedStatement(final Connection connection, final String sql)
+      throws SQLException {
+    final var statement = connection.prepareStatement(sql);
+    try {
+      statement.setQueryTimeout(STATEMENT_TIMEOUT_SECONDS);
+    } catch (final SQLException cannotBeBounded) {
+      // an unbounded statement is what this exists to prevent, so it is not run instead
+      statement.close();
+      throw cannotBeBounded;
+    }
+    return statement;
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionRowContentionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionRowContentionIT.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.camunda.application.commons.rdbms.RdbmsDataSources;
+import io.camunda.application.commons.rdbms.RdbmsSchemaInitializer;
+import io.camunda.db.rdbms.PerTenantSchemaConfig;
+import io.camunda.db.rdbms.RdbmsSchemaManager;
+import io.camunda.db.rdbms.RdbmsSchemaManagers;
+import io.camunda.db.rdbms.exception.RdbmsSchemaVersionUnreadableException;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.zeebe.util.VersionUtil;
+import java.sql.Connection;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies on every supported vendor that a node initializing its schema against a {@code
+ * RDBMS_SCHEMA_VERSION} row another session holds uncommitted reaches an outcome, rather than
+ * hanging forever with nothing logged (#61405). The running test application plays the first node,
+ * a connection borrowed from its pool plays the peer, and a second {@code RdbmsSchemaInitializer}
+ * plays the node that starts into the contention.
+ *
+ * <p>One case per half of the fix. A <b>restart</b> finds the version it would record already
+ * recorded, so no write is issued and there is nothing to contend for. A <b>version change</b> has
+ * to write, so the statement timeout is what has to end the wait.
+ *
+ * <p>This belongs on the matrix rather than on one database because the mechanism varies in every
+ * respect: how long an unbounded wait lasts, whether a statement timeout can end it, and whether a
+ * read has to wait behind an uncommitted write at all. An earlier version ran against PostgreSQL
+ * alone and passed; running it here is what turned up Oracle. So each case is written against the
+ * outcome, with the vendors that reach it differently named where they diverge.
+ *
+ * <p>Both cases use a single {@code default} tenant, which is every deployment that has not
+ * configured physical tenants, and is also the shape with the least between the database call and
+ * the operator: {@code RdbmsSchemaInitializer} forks on the tenant count, and with one tenant it
+ * applies the schema on the calling thread, so a failure travels out into Spring's own context
+ * refresh. What the gate does when a node has a tenant to spare is {@code
+ * RdbmsSchemaVersionRowContentionMultiTenantIT}.
+ */
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+final class RdbmsSchemaVersionRowContentionIT {
+
+  /**
+   * Vendors whose row-lock wait no application-level bound can reach: measured on Oracle 23 (free),
+   * neither a statement timeout nor {@link java.sql.Statement#cancel()} interrupts it. H2 ignores
+   * both as well but is absent from this set deliberately — its own {@code LOCK_TIMEOUT} gives up
+   * after ~2s, so the wait ends there regardless. Emptying this set is the goal; doing it needs
+   * vendor-specific SQL ({@code SELECT ... FOR UPDATE WAIT n}, or a {@code MERGE}) in a class that
+   * has none.
+   */
+  private static final Set<String> UNBOUNDED_WRITE_WAIT = Set.of("oracle");
+
+  /** What the node that starts into the contention runs, and so has to record. */
+  private static final String APPLICATION_VERSION = "8.10.0";
+
+  /**
+   * Seeded as already recorded to force the write: one minor behind, so the upgrade path is legal
+   * and the version genuinely has to change. Fixed rather than derived from the running version, so
+   * that what this test forces does not move with the release.
+   */
+  private static final String PREVIOUS_VERSION = "8.9.0";
+
+  /**
+   * An upper bound on "bounded", deliberately well above the store's own statement timeout rather
+   * than equal to it: what is asserted is that startup settles at all, and pinning the exact value
+   * would make tuning it a test change.
+   */
+  private static final Duration BOUNDED = Duration.ofMinutes(2);
+
+  /**
+   * How long a vendor in {@link #UNBOUNDED_WRITE_WAIT} is watched before the wait is called
+   * unbounded. Comfortably longer than the store's statement timeout, so that "still waiting" means
+   * the timeout had its chance and could not take it.
+   */
+  private static final Duration PAST_THE_STATEMENT_TIMEOUT = Duration.ofSeconds(45);
+
+  @TestTemplate
+  void shouldSettleARestartWithoutContendingAtAll(final CamundaRdbmsTestApplication testApplication)
+      throws Exception {
+    // given - the schema is migrated and its version recorded, which is the state every restart
+    // after the first finds
+    final var dataSources = testApplication.bean(RdbmsDataSources.class);
+    final var dataSource = dataSources.dataSourceFor(DEFAULT_PHYSICAL_TENANT_ID);
+    final var initializer = initializerFor(dataSources, VersionUtil.getVersion());
+
+    // and - a peer session has written that row and not committed. Borrowed from the application's
+    // own pool so that this needs no vendor-specific connection details; the row is only ever
+    // rolled back, so the version the application recorded is what every later test still reads.
+    try (final var peer = dataSource.getConnection()) {
+      peer.setAutoCommit(false);
+      holdRow(peer, "0.0.1");
+
+      try {
+        // when - the node restarts against the same schema
+        final var startedAt = System.nanoTime();
+        final var outcome = catchThrowable(initializer::afterPropertiesSet);
+        final var settledIn = Duration.ofNanos(System.nanoTime() - startedAt);
+
+        // then - it reached an outcome at all, which is the whole regression: this call used to
+        // stay inside the JDBC driver for as long as the peer held the row, throwing nothing and
+        // so logging nothing
+        assertThat(settledIn)
+            .as("startup settled rather than waiting for as long as the peer held the row")
+            .isLessThan(BOUNDED);
+
+        // and - which outcome is the vendor's to decide, because it decides whether a read has to
+        // wait behind an uncommitted write
+        if (outcome == null) {
+          // Snapshot reads (PostgreSQL, Oracle, MySQL, MariaDB, H2): the recorded version is read
+          // straight past the peer's uncommitted row, matches what this node would write, and so
+          // no contending write is issued at all. This is the case that matters most, being every
+          // restart of an already-initialized deployment - and it is the only thing that saves
+          // Oracle, whose lock wait no application-level timeout can bound.
+          assertThat(initializer.isInitialized(DEFAULT_PHYSICAL_TENANT_ID)).isTrue();
+        } else {
+          // MSSQL's locking READ COMMITTED makes even that read wait, so there the statement
+          // timeout is what ends it: a typed, retryable failure, carried out of the synchronous
+          // single-tenant path, which on a plain deployment is Spring's own context refresh.
+          assertThat(outcome)
+              .isInstanceOf(RdbmsSchemaVersionUnreadableException.class)
+              .hasMessageContaining("[RDBMS Schema]")
+              .hasStackTraceContaining("RdbmsSchemaVersionStore")
+              .hasStackTraceContaining("SingleTenantSchemaInitialization.start")
+              .hasStackTraceContaining("RdbmsSchemaInitializer.afterPropertiesSet");
+          assertThat(initializer.isInitialized(DEFAULT_PHYSICAL_TENANT_ID)).isFalse();
+        }
+      } finally {
+        initializer.destroy();
+        peer.rollback();
+      }
+    }
+  }
+
+  @TestTemplate
+  void shouldBoundAContendedWriteWhereTheVendorAllowsItToBeBounded(
+      final CamundaRdbmsTestApplication testApplication) throws Exception {
+    final var dataSources = testApplication.bean(RdbmsDataSources.class);
+    final var dataSource = dataSources.dataSourceFor(DEFAULT_PHYSICAL_TENANT_ID);
+    final var databaseId = dataSources.vendorPropertiesFor(DEFAULT_PHYSICAL_TENANT_ID).databaseId();
+
+    // given - an older version recorded, so this node has to replace it and the skip does not
+    // apply. Restored afterwards, since the application this borrows is shared with later tests.
+    final var recordedByTheApplication = readRecordedVersion(dataSource);
+    writeRecordedVersion(dataSource, PREVIOUS_VERSION);
+    try {
+      // and - a peer session holding that row uncommitted, so the write has to wait for it
+      try (final var peer = dataSource.getConnection()) {
+        peer.setAutoCommit(false);
+        holdRow(peer, PREVIOUS_VERSION);
+
+        // when - the node starts, on its own thread because on some vendors it will not return
+        final var initializer = initializerFor(dataSources, APPLICATION_VERSION);
+        final var startupSettled = new CountDownLatch(1);
+        final var startupThread =
+            Thread.ofPlatform()
+                .name("context-refresh")
+                .start(
+                    () -> {
+                      try {
+                        initializer.afterPropertiesSet();
+                      } catch (final Throwable expectedOnSomeVendors) {
+                        // whether it settled at all is the assertion, not how
+                      } finally {
+                        startupSettled.countDown();
+                      }
+                    });
+        try {
+          if (UNBOUNDED_WRITE_WAIT.contains(databaseId)) {
+            // then - the known gap, asserted rather than hidden: this vendor's lock wait ignores
+            // the statement timeout, so startup is still inside the JDBC call after the timeout
+            // has had every chance to fire. A restart never reaches this path, because the write
+            // is skipped; a first start against a fresh database, or a real version change, does.
+            // When this vendor gains a bound, this assertion fails and the vendor comes off
+            // UNBOUNDED_WRITE_WAIT.
+            assertThat(
+                    startupSettled.await(PAST_THE_STATEMENT_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+                .as("'%s' has no bound for a contended write yet", databaseId)
+                .isFalse();
+          } else {
+            // then - the statement timeout ends the wait, whether the driver cancels the statement
+            // (PostgreSQL, MySQL, MariaDB, MSSQL) or the vendor's own lock timeout gets there
+            // first (H2)
+            assertThat(startupSettled.await(BOUNDED.toSeconds(), TimeUnit.SECONDS))
+                .as("'%s' bounds a contended write", databaseId)
+                .isTrue();
+            assertThat(initializer.isInitialized(DEFAULT_PHYSICAL_TENANT_ID)).isFalse();
+          }
+        } finally {
+          // releasing the row lets an unbounded wait finish too, so no thread is left parked
+          peer.rollback();
+        }
+
+        assertThat(startupSettled.await(BOUNDED.toSeconds(), TimeUnit.SECONDS))
+            .as("startup settles once the peer releases the row")
+            .isTrue();
+        startupThread.join(BOUNDED.toMillis());
+        initializer.destroy();
+      }
+    } finally {
+      writeRecordedVersion(dataSource, recordedByTheApplication);
+    }
+  }
+
+  // ---- helpers ----
+
+  /** Writes the row without committing, leaving it locked by an open transaction. */
+  private static void holdRow(final Connection peer, final String version) throws Exception {
+    try (final var statement = peer.createStatement()) {
+      statement.executeUpdate(
+          "UPDATE RDBMS_SCHEMA_VERSION SET VERSION = '" + version + "' WHERE ID = 1");
+    }
+  }
+
+  private static @Nullable String readRecordedVersion(final DataSource dataSource)
+      throws Exception {
+    try (final var connection = dataSource.getConnection();
+        final var statement = connection.createStatement();
+        final var result = statement.executeQuery("SELECT VERSION FROM RDBMS_SCHEMA_VERSION")) {
+      return result.next() ? result.getString(1) : null;
+    }
+  }
+
+  private static void writeRecordedVersion(
+      final DataSource dataSource, final @Nullable String version) throws Exception {
+    if (version == null) {
+      return;
+    }
+    try (final var connection = dataSource.getConnection()) {
+      try (final var statement = connection.createStatement()) {
+        statement.executeUpdate(
+            "UPDATE RDBMS_SCHEMA_VERSION SET VERSION = '" + version + "' WHERE ID = 1");
+      }
+      // the application's pool runs with autoCommit disabled, so returning the connection without
+      // this rolls the write back
+      connection.commit();
+    }
+  }
+
+  /**
+   * Another node's initializer against the same schema as the running application: same data
+   * source, same (empty) prefix, and single-tenant, so it takes the synchronous shape.
+   */
+  private static RdbmsSchemaInitializer initializerFor(
+      final RdbmsDataSources dataSources, final String applicationVersion) {
+    final Map<String, RdbmsSchemaManager> schemaManagers =
+        RdbmsSchemaManagers.fromConfigs(
+            Map.of(
+                DEFAULT_PHYSICAL_TENANT_ID,
+                new PerTenantSchemaConfig(
+                    dataSources.dataSourceFor(DEFAULT_PHYSICAL_TENANT_ID),
+                    dataSources.vendorPropertiesFor(DEFAULT_PHYSICAL_TENANT_ID),
+                    "",
+                    /* autoDdl= */ true,
+                    Duration.ofMinutes(15))),
+            applicationVersion);
+    return new RdbmsSchemaInitializer(schemaManagers);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionRowContentionMultiTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionRowContentionMultiTenantIT.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.application.commons.rdbms.RdbmsSchemaInitializer;
+import io.camunda.db.rdbms.PerTenantSchemaConfig;
+import io.camunda.db.rdbms.RdbmsSchemaManager;
+import io.camunda.db.rdbms.RdbmsSchemaManagers;
+import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Covers what only a node with a tenant to spare can show: {@code PerTenantSchemaInitialization}'s
+ * gate cannot open until every tenant has settled, so a tenant that never produced an outcome used
+ * to hold the whole node's startup shut while its siblings sat migrated and ready — the signature
+ * #61405 reports. The node must now come up, degrade the contended tenant alone, and recover it in
+ * the background once the peer releases the row.
+ *
+ * <p>One tenant records an older version, so its start genuinely has to write and contends with a
+ * peer holding that row; the other is left alone, and is what the gate opens on.
+ *
+ * <p>One database rather than the vendor matrix, because what this asserts is the gate — Java that
+ * behaves identically on every vendor. Whether a contended write can be bounded at all <em>is</em>
+ * vendor-dependent, and is asserted per vendor in {@code RdbmsSchemaVersionRowContentionIT}. Two
+ * tenants also means migrating two independently prefixed schemas from scratch, which a throwaway
+ * PostgreSQL absorbs and the shared per-vendor test applications would be left holding — so it
+ * brings its own container, the way {@code RdbmsExporterPositionRecoveryIT} does.
+ */
+@Tag("rdbms")
+@Timeout(180)
+class RdbmsSchemaVersionRowContentionMultiTenantIT {
+
+  /** What the restarting node runs, and so what it has to record. */
+  private static final String APPLICATION_VERSION = "8.10.0";
+
+  /**
+   * What the first node recorded: one minor behind, so the restart is a legal upgrade that must
+   * actually write the row. Recording the same version would make {@code recordCurrentVersion()}
+   * skip the write, which is the point of the sibling cross-vendor test rather than this one.
+   */
+  private static final String PREVIOUS_VERSION = "8.9.0";
+
+  private static final String HEALTHY_TENANT = "healthy";
+  private static final String STUCK_TENANT = "stuck";
+  private static final String HEALTHY_PREFIX = "H_";
+  private static final String STUCK_PREFIX = "S_";
+  private static final String DATABASE_NAME = "camunda";
+  private static final String DATABASE_USER = "camunda";
+  private static final String DATABASE_PASSWORD = "camunda";
+
+  /**
+   * An upper bound on "bounded", deliberately far above the store's own statement timeout rather
+   * than equal to it: what this test is about is that the wait ends at all, and pinning the exact
+   * value here would make tuning it a test change.
+   */
+  private static final Duration BOUNDED = Duration.ofMinutes(2);
+
+  @SuppressWarnings("resource")
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName(DATABASE_NAME)
+          .withUsername(DATABASE_USER)
+          .withPassword(DATABASE_PASSWORD)
+          .withStartupTimeout(Duration.ofMinutes(5));
+
+  @BeforeAll
+  static void startPostgres() {
+    POSTGRES.start();
+  }
+
+  @AfterAll
+  static void stopPostgres() {
+    POSTGRES.stop();
+  }
+
+  @Test
+  void shouldComeUpAndDegradeOnlyTheContendedTenant() throws Exception {
+    // given - both tenants have migrated once, sharing one PostgreSQL the way physical tenants
+    // really do, distinguished only by table prefix: the state every restart after the first
+    // finds, where RDBMS_SCHEMA_VERSION already has its row
+    final var tenants = Map.of(HEALTHY_TENANT, HEALTHY_PREFIX, STUCK_TENANT, STUCK_PREFIX);
+    runToCompletionOnce(tenants, PREVIOUS_VERSION);
+
+    // and - a peer session has updated the stuck tenant's schema-version row and not committed:
+    // from this node's side, indistinguishable from a session that never will
+    try (final var peer = peerHolding(STUCK_PREFIX)) {
+      // when - the node starts, as it does on every restart
+      final var initializer = initializerFor(tenants, APPLICATION_VERSION);
+      try {
+        final var startedAt = System.nanoTime();
+        initializer.afterPropertiesSet();
+        final var heldFor = Duration.ofNanos(System.nanoTime() - startedAt);
+
+        // then - startup got past the gate, which it could only do because the contended tenant
+        // produced an outcome instead of none; the node serves the tenant it can and degrades the
+        // one it cannot, rather than serving nobody
+        assertThat(heldFor)
+            .as("startup was held only until the contended statement timed out, not indefinitely")
+            .isLessThan(BOUNDED);
+        assertThat(initializer.isInitialized(HEALTHY_TENANT)).isTrue();
+        assertThat(initializer.isInitialized(STUCK_TENANT)).isFalse();
+
+        // when - the peer finally does what every other session is assumed to do promptly
+        peer.rollback();
+
+        // then - the retry that the bounded failure made possible carries the tenant the rest of
+        // the way: no restart, no operator
+        await("the contended tenant recovers on a later attempt")
+            .atMost(Duration.ofSeconds(60))
+            .untilAsserted(() -> assertThat(initializer.isInitialized(STUCK_TENANT)).isTrue());
+      } finally {
+        initializer.destroy();
+      }
+    }
+  }
+
+  // ---- helpers ----
+
+  /**
+   * A session standing in for any other node's own {@code recordCurrentVersion()} that has written
+   * the row and not yet committed.
+   */
+  private static Connection peerHolding(final String prefix) throws Exception {
+    final var peer =
+        DriverManager.getConnection(POSTGRES.getJdbcUrl(), DATABASE_USER, DATABASE_PASSWORD);
+    peer.setAutoCommit(false);
+    try (final var statement = peer.createStatement()) {
+      // rewrites the row with what it already holds, so that the only thing this peer changes is
+      // that the row is now locked by an open transaction
+      statement.executeUpdate(
+          "UPDATE "
+              + prefix
+              + "RDBMS_SCHEMA_VERSION SET VERSION = '"
+              + PREVIOUS_VERSION
+              + "' WHERE ID = 1");
+    }
+    return peer;
+  }
+
+  private static void runToCompletionOnce(
+      final Map<String, String> prefixesByTenant, final String applicationVersion)
+      throws Exception {
+    final var initializer = initializerFor(prefixesByTenant, applicationVersion);
+    try {
+      initializer.afterPropertiesSet();
+      assertThat(prefixesByTenant.keySet()).allMatch(initializer::isInitialized);
+    } finally {
+      initializer.destroy();
+    }
+  }
+
+  private static RdbmsSchemaInitializer initializerFor(
+      final Map<String, String> prefixesByTenant, final String applicationVersion)
+      throws Exception {
+    final var configs = new LinkedHashMap<String, PerTenantSchemaConfig>();
+    for (final var tenant : prefixesByTenant.entrySet()) {
+      configs.put(tenant.getKey(), schemaConfig(dataSource(), tenant.getValue()));
+    }
+    final Map<String, RdbmsSchemaManager> schemaManagers =
+        RdbmsSchemaManagers.fromConfigs(configs, applicationVersion);
+    return new RdbmsSchemaInitializer(schemaManagers);
+  }
+
+  private static PerTenantSchemaConfig schemaConfig(
+      final PGSimpleDataSource dataSource, final String prefix) throws Exception {
+    return new PerTenantSchemaConfig(
+        dataSource,
+        VendorDatabasePropertiesLoader.load("postgresql"),
+        prefix,
+        /* autoDdl= */ true,
+        Duration.ofMinutes(15));
+  }
+
+  private static PGSimpleDataSource dataSource() {
+    final var dataSource = new PGSimpleDataSource();
+    dataSource.setUrl(POSTGRES.getJdbcUrl());
+    dataSource.setUser(DATABASE_USER);
+    dataSource.setPassword(DATABASE_PASSWORD);
+    return dataSource;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

