### PR TITLE
fix: resolve host.testcontainers.internal in Operate backup-restore ITs

### DIFF
--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -364,7 +364,7 @@ public class TestContainerUtil {
         new GenericContainer<>(String.format("%s:%s", dockerImageName, version))
             .withExposedPorts(8080)
             .withNetwork(testContext.getNetwork())
-            .withExtraHost("host.testcontainer.internal", "host-gateway")
+            .withExtraHost("host.testcontainers.internal", "host-gateway")
             .withCopyFileToContainer(
                 MountableFile.forHostPath(createConfigurationFile(testContext), 0775),
                 "/usr/local/operate/config/application.properties")


### PR DESCRIPTION
Fixes a typo in the Operate container's Testcontainers extra-host that caused intermittent `UnknownHostException` failures.

Fixes INC-7777