### PR TITLE
feat: expose operation name and retry count in retry statergy logs

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableDelayedRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableDelayedRetryStrategy.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.RetryDelayStrategy;
 import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ public final class AbortableDelayedRetryStrategy implements RetryStrategy {
 
   private final ActorControl actor;
   private final RetryDelayStrategy delayStrategy;
-  private final String operationName;
+  private final @Nullable String operationName;
 
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier currentTerminateCondition;
@@ -38,11 +39,13 @@ public final class AbortableDelayedRetryStrategy implements RetryStrategy {
 
   public AbortableDelayedRetryStrategy(
       final ActorControl actor, final RetryDelayStrategy delayStrategy) {
-    this(actor, delayStrategy, DEFAULT_OPERATION_NAME);
+    this(actor, delayStrategy, null);
   }
 
   public AbortableDelayedRetryStrategy(
-      final ActorControl actor, final RetryDelayStrategy delayStrategy, final String operationName) {
+      final ActorControl actor,
+      final RetryDelayStrategy delayStrategy,
+      final @Nullable String operationName) {
     this.actor = actor;
     this.delayStrategy = delayStrategy;
     this.operationName = operationName;
@@ -74,8 +77,10 @@ public final class AbortableDelayedRetryStrategy implements RetryStrategy {
       } else if (currentTerminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else {
-        LOG.trace(
-            "Operation '{}' did not complete, scheduling retry {}", operationName, ++retryCount);
+        if (operationName != null) {
+          LOG.trace(
+              "Operation '{}' did not complete, scheduling retry {}", operationName, ++retryCount);
+        }
         backOff();
       }
     } catch (final Exception exception) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableDelayedRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableDelayedRetryStrategy.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.RetryDelayStrategy;
 import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Retries an operation with delays between attempts. The first attempt runs immediately; retries
@@ -23,17 +25,27 @@ import java.util.function.BooleanSupplier;
  */
 public final class AbortableDelayedRetryStrategy implements RetryStrategy {
 
+  private static final Logger LOG = LoggerFactory.getLogger(AbortableDelayedRetryStrategy.class);
+
   private final ActorControl actor;
   private final RetryDelayStrategy delayStrategy;
+  private final String operationName;
 
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier currentTerminateCondition;
   private OperationToRetry currentCallable;
+  private int retryCount;
 
   public AbortableDelayedRetryStrategy(
       final ActorControl actor, final RetryDelayStrategy delayStrategy) {
+    this(actor, delayStrategy, DEFAULT_OPERATION_NAME);
+  }
+
+  public AbortableDelayedRetryStrategy(
+      final ActorControl actor, final RetryDelayStrategy delayStrategy, final String operationName) {
     this.actor = actor;
     this.delayStrategy = delayStrategy;
+    this.operationName = operationName;
   }
 
   @Override
@@ -47,6 +59,7 @@ public final class AbortableDelayedRetryStrategy implements RetryStrategy {
     currentFuture = new CompletableActorFuture<>();
     currentTerminateCondition = terminateCondition;
     currentCallable = callable;
+    retryCount = 0;
     delayStrategy.reset();
 
     actor.run(this::run);
@@ -61,6 +74,8 @@ public final class AbortableDelayedRetryStrategy implements RetryStrategy {
       } else if (currentTerminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else {
+        LOG.trace(
+            "Operation '{}' did not complete, scheduling retry {}", operationName, ++retryCount);
         backOff();
       }
     } catch (final Exception exception) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -87,7 +87,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       } else if (!retryLimitExceeded(++retryCount, maxRetries, exception, LOG, currentFuture)) {
         throttledLog.warn(
             "Operation '{}' caught recoverable exception (retry {}/{}), will retry: {}",
-            operationName != null ? operationName : "unknown",
+            operationName != null ? operationName : DEFAULT_OPERATION_NAME,
             retryCount,
             maxRetries,
             exception.getMessage(),

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.Control;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +25,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
-  private final String operationName;
+  private final @Nullable String operationName;
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
@@ -35,11 +36,11 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   }
 
   public EndlessRetryStrategy(final ActorControl actor, final int maxRetries) {
-    this(actor, maxRetries, DEFAULT_OPERATION_NAME);
+    this(actor, maxRetries, null);
   }
 
   public EndlessRetryStrategy(
-      final ActorControl actor, final int maxRetries, final String operationName) {
+      final ActorControl actor, final int maxRetries, final @Nullable String operationName) {
     this.actor = actor;
     this.maxRetries = maxRetries;
     this.operationName = operationName;
@@ -69,11 +70,13 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         if (!retryLimitExceeded(++retryCount, maxRetries, null, LOG, currentFuture)) {
-          LOG.trace(
-              "Operation '{}' did not complete, scheduling retry {}/{}",
-              operationName,
-              retryCount,
-              maxRetries);
+          if (operationName != null) {
+            LOG.trace(
+                "Operation '{}' did not complete, scheduling retry {}/{}",
+                operationName,
+                retryCount,
+                maxRetries);
+          }
           actor.run(this::run);
           actor.yieldThread();
         }
@@ -84,7 +87,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       } else if (!retryLimitExceeded(++retryCount, maxRetries, exception, LOG, currentFuture)) {
         throttledLog.warn(
             "Operation '{}' caught recoverable exception (retry {}/{}), will retry: {}",
-            operationName,
+            operationName != null ? operationName : "unknown",
             retryCount,
             maxRetries,
             exception.getMessage(),

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -24,6 +24,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
+  private final String operationName;
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
@@ -34,8 +35,14 @@ public final class EndlessRetryStrategy implements RetryStrategy {
   }
 
   public EndlessRetryStrategy(final ActorControl actor, final int maxRetries) {
+    this(actor, maxRetries, DEFAULT_OPERATION_NAME);
+  }
+
+  public EndlessRetryStrategy(
+      final ActorControl actor, final int maxRetries, final String operationName) {
     this.actor = actor;
     this.maxRetries = maxRetries;
+    this.operationName = operationName;
     retryMechanism = new ActorRetryMechanism();
   }
 
@@ -62,6 +69,11 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         if (!retryLimitExceeded(++retryCount, maxRetries, null, LOG, currentFuture)) {
+          LOG.trace(
+              "Operation '{}' did not complete, scheduling retry {}/{}",
+              operationName,
+              retryCount,
+              maxRetries);
           actor.run(this::run);
           actor.yieldThread();
         }
@@ -71,7 +83,8 @@ public final class EndlessRetryStrategy implements RetryStrategy {
         currentFuture.complete(false);
       } else if (!retryLimitExceeded(++retryCount, maxRetries, exception, LOG, currentFuture)) {
         throttledLog.warn(
-            "Caught recoverable exception (retry {}/{}), will retry: {}",
+            "Operation '{}' caught recoverable exception (retry {}/{}), will retry: {}",
+            operationName,
             retryCount,
             maxRetries,
             exception.getMessage(),

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
-  private final String operationName;
+  private final @Nullable String operationName;
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
@@ -36,11 +37,11 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
   }
 
   public RecoverableRetryStrategy(final ActorControl actor, final int maxRetries) {
-    this(actor, maxRetries, DEFAULT_OPERATION_NAME);
+    this(actor, maxRetries, null);
   }
 
   public RecoverableRetryStrategy(
-      final ActorControl actor, final int maxRetries, final String operationName) {
+      final ActorControl actor, final int maxRetries, final @Nullable String operationName) {
     this.actor = actor;
     this.maxRetries = maxRetries;
     this.operationName = operationName;
@@ -70,11 +71,13 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         if (!retryLimitExceeded(++retryCount, maxRetries, null, LOG, currentFuture)) {
-          LOG.trace(
-              "Operation '{}' did not complete, scheduling retry {}/{}",
-              operationName,
-              retryCount,
-              maxRetries);
+          if (operationName != null) {
+            LOG.trace(
+                "Operation '{}' did not complete, scheduling retry {}/{}",
+                operationName,
+                retryCount,
+                maxRetries);
+          }
           actor.run(this::run);
           actor.yieldThread();
         }
@@ -84,7 +87,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
         if (!retryLimitExceeded(++retryCount, maxRetries, ex, LOG, currentFuture)) {
           throttledLog.warn(
               "Operation '{}' caught recoverable exception (retry {}/{}), will retry: {}",
-              operationName,
+              operationName != null ? operationName : "unknown",
               retryCount,
               maxRetries,
               ex.getMessage(),

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -87,7 +87,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
         if (!retryLimitExceeded(++retryCount, maxRetries, ex, LOG, currentFuture)) {
           throttledLog.warn(
               "Operation '{}' caught recoverable exception (retry {}/{}), will retry: {}",
-              operationName != null ? operationName : "unknown",
+              operationName != null ? operationName : DEFAULT_OPERATION_NAME,
               retryCount,
               maxRetries,
               ex.getMessage(),

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -25,6 +25,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
   private final int maxRetries;
+  private final String operationName;
   private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
@@ -35,8 +36,14 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
   }
 
   public RecoverableRetryStrategy(final ActorControl actor, final int maxRetries) {
+    this(actor, maxRetries, DEFAULT_OPERATION_NAME);
+  }
+
+  public RecoverableRetryStrategy(
+      final ActorControl actor, final int maxRetries, final String operationName) {
     this.actor = actor;
     this.maxRetries = maxRetries;
+    this.operationName = operationName;
     retryMechanism = new ActorRetryMechanism();
   }
 
@@ -63,6 +70,11 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         if (!retryLimitExceeded(++retryCount, maxRetries, null, LOG, currentFuture)) {
+          LOG.trace(
+              "Operation '{}' did not complete, scheduling retry {}/{}",
+              operationName,
+              retryCount,
+              maxRetries);
           actor.run(this::run);
           actor.yieldThread();
         }
@@ -71,7 +83,8 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       if (!terminateCondition.getAsBoolean()) {
         if (!retryLimitExceeded(++retryCount, maxRetries, ex, LOG, currentFuture)) {
           throttledLog.warn(
-              "Caught recoverable exception (retry {}/{}), will retry: {}",
+              "Operation '{}' caught recoverable exception (retry {}/{}), will retry: {}",
+              operationName,
               retryCount,
               maxRetries,
               ex.getMessage(),

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RetryStrategy.java
@@ -14,6 +14,8 @@ import org.slf4j.Logger;
 
 public interface RetryStrategy {
 
+  String DEFAULT_OPERATION_NAME = "unknown";
+
   /**
    * Runs the given runnable with the defined retry strategy.
    *

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RetryStrategy.java
@@ -14,8 +14,6 @@ import org.slf4j.Logger;
 
 public interface RetryStrategy {
 
-  String DEFAULT_OPERATION_NAME = "unknown";
-
   /**
    * Runs the given runnable with the defined retry strategy.
    *

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -128,6 +128,8 @@ public final class ProcessingStateMachine implements CloseableSilently {
   private static final double WRITE_RETRY_BACKOFF_FACTOR = 1.2;
   private static final String ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED =
       "Expected to process command '{} {}' successfully on stream processor, but caught unexpected exception. Failed to handle the exception gracefully.";
+  private static final String RETRY_OPERATION_WRITE = "writeRetry";
+  private static final String RETRY_OPERATION_UPDATE_STATE = "updateStateRetry";
   private final RecordMetadataBlock recordTypeDecoder = new RecordMetadataBlock();
   private final EventFilter processingFilter;
   private final EventFilter isEventOrRejection =
@@ -207,9 +209,11 @@ public final class ProcessingStateMachine implements CloseableSilently {
             new ExponentialBackoffRetryDelay(
                 WRITE_RETRY_BACKOFF_MAX_DELAY,
                 WRITE_RETRY_BACKOFF_MIN_DELAY,
-                WRITE_RETRY_BACKOFF_FACTOR));
+                WRITE_RETRY_BACKOFF_FACTOR),
+            RETRY_OPERATION_WRITE);
     updateStateRetryStrategy =
-        new RecoverableRetryStrategy(actor, context.getMaxRecoverableRetries());
+        new RecoverableRetryStrategy(
+            actor, context.getMaxRecoverableRetries(), RETRY_OPERATION_UPDATE_STATE);
     this.shouldProcessNext = shouldProcessNext;
 
     final int partitionId = context.getLogStream().getPartitionId();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -52,6 +52,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter, CloseableSile
       "Expected that position '%d' of current event is higher then position '%d' of last event, but was not. Inconsistent log detected!";
   private static final String ERROR_MSG_EXPECTED_TO_READ_METADATA =
       "Expected to read the metadata for the record '%s', but an exception was thrown.";
+  private static final String RETRY_OPERATION_REPLAY = "replayRetry";
 
   private final RecordMetadata metadata = new RecordMetadata();
   private final KeyGeneratorControls keyGeneratorControls;
@@ -109,7 +110,9 @@ public final class ReplayStateMachine implements LogRecordAwaiter, CloseableSile
     lastProcessedPositionState = context.getLastProcessedPositionState();
 
     typedEvent = new TypedRecordImpl(context.getLogStream().getPartitionId());
-    replayStrategy = new RecoverableRetryStrategy(actor, context.getMaxRecoverableRetries());
+    replayStrategy =
+        new RecoverableRetryStrategy(
+            actor, context.getMaxRecoverableRetries(), RETRY_OPERATION_REPLAY);
     streamProcessorMode = context.getProcessorMode();
     logStream = context.getLogStream();
     logStreamBatchReader = new LogStreamBatchReaderImpl(context.getLogStreamReader());


### PR DESCRIPTION
## Description

  When a retry strategy was actively retrying, logs contained no context                                                                                                                                                                                                                                                                                                
  about which phase triggered it or how many times it had retried —
  making it very hard to diagnose production incidents.                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                        
  This PR adds an `operationName` parameter to `RecoverableRetryStrategy`,
  `EndlessRetryStrategy`, and `AbortableDelayedRetryStrategy`:                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                      
  - **DEBUG** log per attempt: `"Operation 'writeRetry' did not complete, scheduling retry 3/2147483647"`                                                                                                                                                                                                                                                               
  - **WARN** (throttled) log on recoverable exception: `"Operation 'updateStateRetry' caught recoverable exception (retry 1/...), will retry: ..."`
                                                                                                                                                                                                                                                                                                                                                                        
  The default name (`"unknown"`) is defined once on `RetryStrategy` and                                                                                                                                                                                                                                                                                               
  inherited by all implementations.                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                        
  Descriptive names are wired at the call sites:
  - `ProcessingStateMachine`: `"writeRetry"` and `"updateStateRetry"`                                                                                                                                                                                                                                                                                                   
  - `ReplayStateMachine`: `"replayRetry"`                                                                                                                                                                                                                                                                                                                             

  The actor name is already present in MDC via `ActorThread` (key:                                                                                                                                                                                                                                                                                                      
  `actor-name`), so retry log lines automatically carry it without
  additional changes.                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                      
  ## Checklist

  - [ ] Enable backports when necessary                                                                                                                                                                                                                                   
  ## Related issues                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                      
  closes #50991