### PR TITLE
fix: prevent broker startup hang under many physical tenants

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/pt/PerTenantSchemaInitialization.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PerTenantSchemaInitialization.java
@@ -104,10 +104,13 @@ public final class PerTenantSchemaInitialization implements SchemaInitialization
   public void start() {
     tenants.forEach(
         (tenantId, state) -> {
-          // virtual: a tenant's task is a storage call and a sleep, and a tenant that stays
-          // degraded holds its thread for as long as it keeps retrying
+          // platform, not virtual. The virtual-thread scheduler's parallelism defaults to the
+          // CPU count, so a handful of tenants first-touching a class at once can pin every
+          // carrier (JEP-491 removed most pinning cases, but not class initialization) and
+          // starve the whole scheduler, hanging the node (see #61405)
           final var worker =
-              Thread.ofVirtual()
+              Thread.ofPlatform()
+                  .daemon()
                   .name("schema-init-" + tenantId)
                   .unstarted(() -> initializeTenant(tenantId, state));
           // registered before it runs, so that a close() racing this loop still interrupts it

--- a/dist/src/test/java/io/camunda/application/commons/pt/PerTenantSchemaInitializationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/PerTenantSchemaInitializationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import java.time.Duration;
 import java.util.LinkedHashSet;
@@ -45,6 +46,13 @@ final class PerTenantSchemaInitializationTest {
 
   private static final String TENANT_A = "tenanta";
   private static final String TENANT_B = "tenantb";
+
+  /**
+   * Read by {@link PinsItsCarrier}'s static initializer. Lives on this already-initialized class
+   * rather than on {@link PinsItsCarrier} itself, so releasing it in a test's {@code finally} never
+   * has to touch - and therefore wait to initialize - {@link PinsItsCarrier}.
+   */
+  private static volatile CountDownLatch pinnedCarrierRelease;
 
   @Test
   void shouldHoldTheGateWhileTheOnlyTenantKeepsFailing() throws Exception {
@@ -634,6 +642,57 @@ final class PerTenantSchemaInitializationTest {
   }
 
   @Test
+  @RegressionTest("https://github.com/camunda/camunda/issues/61405")
+  void shouldOpenTheGateForAHealthyTenantWhenOtherTenantsPinEveryCarrier() throws Exception {
+    // given - more pinning tenants than the virtual-thread scheduler has carriers (default
+    // parallelism is availableProcessors()), plus one healthy tenant. This mirrors production:
+    // 16 tenants against 3 CPUs
+    final int pinnerCount = Runtime.getRuntime().availableProcessors() + 1;
+    pinnedCarrierRelease = new CountDownLatch(1);
+    final var pinnerIds = new LinkedHashSet<String>();
+    for (int i = 0; i < pinnerCount; i++) {
+      pinnerIds.add("pinner-" + i);
+    }
+    final var tenantIds = new LinkedHashSet<>(pinnerIds);
+    tenantIds.add(TENANT_A);
+
+    final var initialization =
+        initialization(
+            tenantIds,
+            tenantId -> {
+              // each pinning tenant's attempt blocks inside PinsItsCarrier's class initializer,
+              // which JEP 491 still pins even though the thread running it is virtual
+              if (pinnerIds.contains(tenantId)) {
+                PinsItsCarrier.touch();
+              }
+            });
+    try {
+      final var gateOpened = startInBackground(initialization);
+
+      // when / then - the healthy tenant is scheduled and settles on its own, even though every
+      // carrier ends up pinned by the other tenants' class-init blocking and none of them has
+      // settled yet (the gate itself cannot open until every tenant has, so it cannot be the
+      // signal here). Before the fix this never happens: no carrier is ever freed for the healthy
+      // tenant's virtual thread to run on, so it is never even scheduled
+      Awaitility.await("the healthy tenant is initialized despite every other tenant being stuck")
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(() -> assertThat(initialization.isInitialized(TENANT_A)).isTrue());
+
+      // when - the pinning tenants are released too
+      pinnedCarrierRelease.countDown();
+
+      // then - every tenant can now settle, so the gate opens fully
+      assertThat(gateOpened.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      // releases PinsItsCarrier's <clinit>, freeing every pinned carrier - from this platform
+      // thread, so the release itself never depends on a virtual thread being schedulable. A
+      // no-op if the try block above already released it
+      pinnedCarrierRelease.countDown();
+      initialization.close();
+    }
+  }
+
+  @Test
   void shouldTolerateNoTenants() {
     // given - a deployment with no search-engine tenant must not hold startup: every tenant has
     // settled vacuously, and none is trying
@@ -737,6 +796,25 @@ final class PerTenantSchemaInitializationTest {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  /**
+   * A class whose static initializer blocks - one of the two residual pinning cases JEP 491 leaves
+   * for virtual threads: the thread that runs this initializer pins its carrier on the blocking
+   * call, and every other thread that touches this class pins its own carrier waiting on the
+   * class-initialization monitor. A class initializes at most once per classloader, so this must
+   * not be shared with another test method.
+   */
+  private static final class PinsItsCarrier {
+    static {
+      try {
+        pinnedCarrierRelease.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    static void touch() {}
   }
 
   /** A failure the orchestrator is told retrying cannot repair. */


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Broker startup could hang permanently when running with many physical tenants ( > 3): each tenant's schema-init task ran on a virtual thread, whose scheduler caps real "carrier" threads at the CPU count (example 3). If enough tenants raced to first-touch a not-yet-loaded class at once,  every carrier could get pinned simultaneously, starving the whole scheduler and leaving the node silently not-ready forever.

Switches the per-tenant schema-init workers from virtual to platform threads, which can never be pinned. Thread count is bounded by the physical tenant count.

## Evidence

Thread dump:  broker stuck at startup 

```
"Mounted virtual thread #61"
  at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:92)
  - waiting on the Class initialization monitor for com.zaxxer.hikari.util.ConcurrentBag
  at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111)
  - locked <0x0000000083a807a8> (a com.zaxxer.hikari.HikariDataSource)
  at io.camunda.db.rdbms.LiquibaseSchemaManager.releaseStaleLockIfPresent(LiquibaseSchemaManager.java:304)
  at io.camunda.db.rdbms.LiquibaseSchemaManager.initialize(LiquibaseSchemaManager.java:159)
  at io.camunda.application.commons.rdbms.RdbmsSchemaInitializer.initializeTenant(RdbmsSchemaInitializer.java:174)
  at io.camunda.application.commons.pt.PerTenantSchemaInitialization.initializeTenant(PerTenantSchemaInitialization.java:241)
  at io.camunda.application.commons.pt.PerTenantSchemaInitialization.lambda$start$1(PerTenantSchemaInitialization.java:112)
```

the thread that actually won the race to run ConcurrentBag's class initializer, now stuck one level deeper, inside log4j2 itself:
```
  at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:472)
  at com.zaxxer.hikari.util.ConcurrentBag.<clinit>(ConcurrentBag.java:66)
  at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:92)
  at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:111)
  - locked <0x0000000083983c30> (a com.zaxxer.hikari.HikariDataSource)
  at io.camunda.db.rdbms.LiquibaseSchemaManager.releaseStaleLockIfPresent(LiquibaseSchemaManager.java:304)
  at java.util.concurrent.locks.ReentrantReadWriteLock$ReadLock.lock(...)
  at org.apache.logging.log4j.core.util.internal.InternalLoggerRegistry.getLogger(InternalLoggerRegistry.java:113)
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes https://github.com/camunda/camunda/issues/61405

- [ ] This PR does not need a linked issue

