### PR TITLE
fix: cap DeploymentErrorCollector aggregate rejection message size

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidator.java
@@ -58,7 +58,7 @@ public final class DeploymentValidator {
       return Either.left(new Failure("Expected to deploy at least one resource, but none given"));
     }
 
-    final var errors = new DeploymentErrorCollector();
+    final var errors = new DeploymentErrorCollector(config.validatorResultsOutputMaxSize());
 
     for (final DeploymentResource resource : deployment.resources()) {
       final var resourceName = resource.getResourceName();
@@ -103,7 +103,7 @@ public final class DeploymentValidator {
    * </ul>
    */
   private Either<Failure, Void> validateResourceIds(final DeploymentRecord deployment) {
-    final var errors = new DeploymentErrorCollector();
+    final var errors = new DeploymentErrorCollector(config.validatorResultsOutputMaxSize());
 
     checkForDuplicateIds(
         deployment.processesMetadata(),
@@ -193,7 +193,7 @@ public final class DeploymentValidator {
       return Either.right(null);
     }
 
-    final var errors = new DeploymentErrorCollector();
+    final var errors = new DeploymentErrorCollector(config.validatorResultsOutputMaxSize());
 
     final var validator = new BpmnDeploymentBindingValidator(deploymentEvent);
     for (final var elements : bpmnContexts) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollector.java
@@ -18,12 +18,16 @@ public final class DeploymentErrorCollector {
 
   private static final String DEFAULT_PREFIX =
       "Expected to deploy new resources, but encountered the following errors:";
+  private static final String OMITTED_SUFFIX_FORMAT = "\n... (%d more errors omitted)";
 
   private final int maxOutputSize;
   private final List<String> errors = new ArrayList<>();
 
   public DeploymentErrorCollector(final int maxOutputSize) {
-    this.maxOutputSize = maxOutputSize;
+    // clamp defensively: a negative value (e.g. an operator using the "-1 disables it" convention
+    // seen elsewhere in this config, unaware it doesn't apply here) would otherwise crash the
+    // first call to add() via StringUtil.limitString's substring(0, negative)
+    this.maxOutputSize = Math.max(maxOutputSize, 0);
   }
 
   public void add(final String message) {
@@ -39,21 +43,24 @@ public final class DeploymentErrorCollector {
   }
 
   /**
-   * Formats the collected errors, capping the result at {@code maxOutputSize} characters. Each
-   * individual error is itself capped at {@code maxOutputSize} when added (so one oversized
-   * message, e.g. from an exception's message, can't alone blow the budget), and errors are then
-   * included whole (never cut mid-line) up to the aggregate cap; any remaining errors are counted
-   * and reported as omitted. The output is therefore always bounded, regardless of how many
-   * resources fail at once or how large any single error message is - see
-   * https://github.com/camunda/camunda/issues/61996.
+   * Formats the collected errors, hard-capping the result at {@code maxOutputSize} characters -
+   * this is an actual upper bound, never just approximate, since the caller relies on it to keep
+   * the gRPC rejection message under proxy/ingress header-buffer limits (see
+   * https://github.com/camunda/camunda/issues/61996). Errors are included whole (never cut
+   * mid-line) up to the cap where possible, and any remaining errors are counted and reported as
+   * omitted; the budget reserves room for that omitted-count suffix up front so it isn't itself
+   * truncated in the common case. A final truncation pass guarantees the bound even in the
+   * pathological case where a single forced-in error alone exceeds {@code maxOutputSize}.
    */
   public String formatMessage() {
     final var builder = new StringBuilder(DEFAULT_PREFIX);
-    var includedCount = 0;
+    final var worstCaseSuffixLength = String.format(OMITTED_SUFFIX_FORMAT, errors.size()).length();
+    final var budgetForErrors = maxOutputSize - worstCaseSuffixLength;
 
+    var includedCount = 0;
     for (final var error : errors) {
       final var withSeparator = "\n" + error;
-      if (builder.length() + withSeparator.length() > maxOutputSize && includedCount > 0) {
+      if (builder.length() + withSeparator.length() > budgetForErrors && includedCount > 0) {
         break;
       }
       builder.append(withSeparator);
@@ -62,10 +69,12 @@ public final class DeploymentErrorCollector {
 
     final var omittedCount = errors.size() - includedCount;
     if (omittedCount > 0) {
-      builder.append(String.format("\n... (%d more errors omitted)", omittedCount));
+      builder.append(String.format(OMITTED_SUFFIX_FORMAT, omittedCount));
     }
 
-    return builder.toString();
+    return builder.length() > maxOutputSize
+        ? builder.substring(0, maxOutputSize)
+        : builder.toString();
   }
 
   public <T> Either<Failure, T> toEither(final T value) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollector.java
@@ -19,6 +19,9 @@ public final class DeploymentErrorCollector {
   private static final String DEFAULT_PREFIX =
       "Expected to deploy new resources, but encountered the following errors:";
   private static final String OMITTED_SUFFIX_FORMAT = "\n... (%d more errors omitted)";
+  // StringUtil.limitString appends this literal "..." after truncating, so the length passed to
+  // it must leave room for it - otherwise a stored entry could exceed maxOutputSize by itself.
+  private static final int ELLIPSIS_LENGTH = 3;
 
   private final int maxOutputSize;
   private final List<String> errors = new ArrayList<>();
@@ -31,7 +34,8 @@ public final class DeploymentErrorCollector {
   }
 
   public void add(final String message) {
-    errors.add(StringUtil.limitString(message, maxOutputSize));
+    final var perMessageLimit = Math.max(maxOutputSize - ELLIPSIS_LENGTH, 0);
+    errors.add(StringUtil.limitString(message, perMessageLimit));
   }
 
   public void add(final String format, final Object... args) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollector.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.StringUtil;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Collects deployment errors and converts them into a {@link Failure}. */
 public final class DeploymentErrorCollector {
@@ -16,22 +19,53 @@ public final class DeploymentErrorCollector {
   private static final String DEFAULT_PREFIX =
       "Expected to deploy new resources, but encountered the following errors:";
 
-  private final StringBuilder errors = new StringBuilder();
+  private final int maxOutputSize;
+  private final List<String> errors = new ArrayList<>();
+
+  public DeploymentErrorCollector(final int maxOutputSize) {
+    this.maxOutputSize = maxOutputSize;
+  }
 
   public void add(final String message) {
-    errors.append("\n").append(message);
+    errors.add(StringUtil.limitString(message, maxOutputSize));
   }
 
   public void add(final String format, final Object... args) {
-    errors.append("\n").append(String.format(format, args));
+    add(String.format(format, args));
   }
 
   public boolean hasErrors() {
     return !errors.isEmpty();
   }
 
+  /**
+   * Formats the collected errors, capping the result at {@code maxOutputSize} characters. Each
+   * individual error is itself capped at {@code maxOutputSize} when added (so one oversized
+   * message, e.g. from an exception's message, can't alone blow the budget), and errors are then
+   * included whole (never cut mid-line) up to the aggregate cap; any remaining errors are counted
+   * and reported as omitted. The output is therefore always bounded, regardless of how many
+   * resources fail at once or how large any single error message is - see
+   * https://github.com/camunda/camunda/issues/61996.
+   */
   public String formatMessage() {
-    return DEFAULT_PREFIX + errors;
+    final var builder = new StringBuilder(DEFAULT_PREFIX);
+    var includedCount = 0;
+
+    for (final var error : errors) {
+      final var withSeparator = "\n" + error;
+      if (builder.length() + withSeparator.length() > maxOutputSize && includedCount > 0) {
+        break;
+      }
+      builder.append(withSeparator);
+      includedCount++;
+    }
+
+    final var omittedCount = errors.size() - includedCount;
+    if (omittedCount > 0) {
+      builder.append(String.format("\n... (%d more errors omitted)", omittedCount));
+    }
+
+    return builder.toString();
   }
 
   public <T> Either<Failure, T> toEither(final T value) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -35,6 +35,7 @@ public final class DeploymentTransformer {
   private final List<DeploymentResourceTransformer> resourceTransformers;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   private final BpmnResourceTransformer bpmnResourceTransformer;
+  private final ValidationConfig config;
 
   public DeploymentTransformer(
       final StateWriter stateWriter,
@@ -47,6 +48,7 @@ public final class DeploymentTransformer {
       final ExpressionLanguageMetrics expressionLanguageMetrics,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     validator = new DeploymentValidator(config);
+    this.config = config;
 
     final var bpmnTransformer =
         BpmnFactory.createTransformer(
@@ -144,7 +146,7 @@ public final class DeploymentTransformer {
   private Either<Failure, List<DeploymentResourceContext>> buildMetadata(
       final DeploymentRecord deploymentEvent,
       final List<ResourceWithTransformer> resourcesWithTransformers) {
-    final var errors = new DeploymentErrorCollector();
+    final var errors = new DeploymentErrorCollector(config.validatorResultsOutputMaxSize());
     final List<DeploymentResourceContext> contexts = new ArrayList<>();
 
     for (final ResourceWithTransformer resourceWithTransformer : resourcesWithTransformers) {
@@ -180,7 +182,7 @@ public final class DeploymentTransformer {
       return Either.right(null);
     }
 
-    final var errors = new DeploymentErrorCollector();
+    final var errors = new DeploymentErrorCollector(config.validatorResultsOutputMaxSize());
 
     for (final ResourceWithTransformer resourceWithTransformer : resourcesWithTransformers) {
       final var deploymentResource = resourceWithTransformer.resource;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -132,7 +132,7 @@ public class DeploymentRejectionTest {
     final var rejectionReason = rejectedDeployment.getRejectionReason();
     assertThat(rejectionReason.length())
         .as("rejection reason must be capped regardless of how many resources fail")
-        .isLessThan(maxOutputSize + 500);
+        .isLessThanOrEqualTo(maxOutputSize);
     assertThat(rejectionReason).contains("more errors omitted");
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -11,6 +11,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -104,6 +105,35 @@ public class DeploymentRejectionTest {
     assertThat(rejectedDeployment.getRejectionReason())
         .contains("Element: flow2 > conditionExpression")
         .contains("ERROR: failed to parse expression");
+  }
+
+  @Test
+  public void shouldCapRejectionReasonWhenManyResourcesFail() {
+    // given
+    // https://github.com/camunda/camunda/issues/61996: many simultaneously-failing resources must
+    // not produce an unbounded rejection reason, since a large enough gRPC status message can
+    // exceed a proxy's header buffer and turn a normal validation rejection into an opaque 502.
+    final var maxOutputSize = EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+    final var deployment = ENGINE.deployment();
+    for (int i = 0; i < 200; i++) {
+      final var overlongName = "resource-" + i + "-" + "x".repeat(MAX_NAME_FIELD_LENGTH + 10);
+      deployment.withXmlResource("empty".getBytes(UTF_8), overlongName);
+    }
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment = deployment.expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    final var rejectionReason = rejectedDeployment.getRejectionReason();
+    assertThat(rejectionReason.length())
+        .as("rejection reason must be capped regardless of how many resources fail")
+        .isLessThan(maxOutputSize + 500);
+    assertThat(rejectionReason).contains("more errors omitted");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollectorTest.java
@@ -43,7 +43,7 @@ final class DeploymentErrorCollectorTest {
     final var message = collector.formatMessage();
 
     // then
-    assertThat(message.length()).isLessThan(maxSize + 100);
+    assertThat(message.length()).isLessThanOrEqualTo(maxSize);
     assertThat(message).contains("more errors omitted");
     // no error line is cut mid-string - every included line is a complete, well-formed entry
     assertThat(message.lines().filter(line -> line.contains("unknown resource type")))
@@ -51,11 +51,13 @@ final class DeploymentErrorCollectorTest {
   }
 
   @Test
-  void shouldAlwaysIncludeAtLeastOneErrorEvenIfItExceedsMaxSize() {
+  void shouldNeverExceedMaxOutputSizeEvenWhenFirstErrorAloneOverflows() {
     // given
-    // the prefix alone already exceeds this cap, so even a single (truncated) error forces the
-    // aggregate over budget - the collector must still emit it rather than an empty error list
-    final var collector = new DeploymentErrorCollector(10);
+    // the fixed prefix alone is 71 chars, so a cap of 90 leaves little room - the forced-in first
+    // error overflows the aggregate cap by itself. The hard truncation pass must still guarantee
+    // the configured bound rather than just approximating it.
+    final var maxOutputSize = 90;
+    final var collector = new DeploymentErrorCollector(maxOutputSize);
     collector.add("a single error message that is much longer than the configured cap");
     collector.add("a second error that should be omitted");
 
@@ -63,9 +65,12 @@ final class DeploymentErrorCollectorTest {
     final var message = collector.formatMessage();
 
     // then
-    assertThat(message)
-        .contains("1 more errors omitted")
-        .doesNotContain("a second error that should be omitted");
+    assertThat(message.length())
+        .as(
+            "the aggregate must never exceed the configured cap, even when the forced-in first"
+                + " error alone would overflow it")
+        .isLessThanOrEqualTo(maxOutputSize);
+    assertThat(message).isNotEmpty();
   }
 
   @Test
@@ -86,7 +91,23 @@ final class DeploymentErrorCollectorTest {
     // then
     assertThat(message.length())
         .as("a single oversized error must not blow past the configured cap")
-        .isLessThan(maxOutputSize + 100);
+        .isLessThanOrEqualTo(maxOutputSize);
+  }
+
+  @Test
+  void shouldNotThrowWhenMaxOutputSizeIsNegative() {
+    // given
+    // this codebase uses "-1 disables it" as a convention for other config values (see
+    // RocksdbCfg.maxMemoryFraction) - an operator following that convention here, unaware it
+    // doesn't apply to this field, must not crash deployment processing on the first error added
+    final var collector = new DeploymentErrorCollector(-1);
+
+    // when
+    collector.add("some error");
+    final var message = collector.formatMessage();
+
+    // then
+    assertThat(message).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentErrorCollectorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class DeploymentErrorCollectorTest {
+
+  @Test
+  void shouldNotCapMessageWhenWithinMaxSize() {
+    // given
+    final var collector = new DeploymentErrorCollector(1024);
+    collector.add("'foo.bpmn': unknown resource type");
+    collector.add("'bar.bpmn': unknown resource type");
+
+    // when
+    final var message = collector.formatMessage();
+
+    // then
+    assertThat(message)
+        .contains("'foo.bpmn': unknown resource type")
+        .contains("'bar.bpmn': unknown resource type")
+        .doesNotContain("omitted");
+  }
+
+  @Test
+  void shouldCapMessageAtMaxSizeAndReportOmittedCount() {
+    // given
+    final var maxSize = 200;
+    final var collector = new DeploymentErrorCollector(maxSize);
+    for (var i = 0; i < 200; i++) {
+      collector.add("'resource-%d.json': unknown resource type", i);
+    }
+
+    // when
+    final var message = collector.formatMessage();
+
+    // then
+    assertThat(message.length()).isLessThan(maxSize + 100);
+    assertThat(message).contains("more errors omitted");
+    // no error line is cut mid-string - every included line is a complete, well-formed entry
+    assertThat(message.lines().filter(line -> line.contains("unknown resource type")))
+        .allMatch(line -> line.matches(".*'resource-\\d+\\.json': unknown resource type"));
+  }
+
+  @Test
+  void shouldAlwaysIncludeAtLeastOneErrorEvenIfItExceedsMaxSize() {
+    // given
+    // the prefix alone already exceeds this cap, so even a single (truncated) error forces the
+    // aggregate over budget - the collector must still emit it rather than an empty error list
+    final var collector = new DeploymentErrorCollector(10);
+    collector.add("a single error message that is much longer than the configured cap");
+    collector.add("a second error that should be omitted");
+
+    // when
+    final var message = collector.formatMessage();
+
+    // then
+    assertThat(message)
+        .contains("1 more errors omitted")
+        .doesNotContain("a second error that should be omitted");
+  }
+
+  @Test
+  void shouldCapIndividualErrorMessageLengthEvenWhenOnlyOneErrorIsCollected() {
+    // given
+    // simulates DeploymentTransformer's catch(RuntimeException) sites, which add an exception's
+    // getMessage() verbatim - that message is not itself size-bounded (e.g. it could embed a large
+    // offending input), so a single such error must not be able to reintroduce an unbounded
+    // rejection reason on its own - see https://github.com/camunda/camunda/issues/61996
+    final var maxOutputSize = 100;
+    final var collector = new DeploymentErrorCollector(maxOutputSize);
+    final var hugeExceptionMessage = "x".repeat(10_000);
+
+    // when
+    collector.add("'some-resource.json': %s", hugeExceptionMessage);
+    final var message = collector.formatMessage();
+
+    // then
+    assertThat(message.length())
+        .as("a single oversized error must not blow past the configured cap")
+        .isLessThan(maxOutputSize + 100);
+  }
+
+  @Test
+  void shouldReportNoErrorsWhenNoneAdded() {
+    // given
+    final var collector = new DeploymentErrorCollector(1024);
+
+    // when
+    final var hasErrors = collector.hasErrors();
+
+    // then
+    assertThat(hasErrors).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

`DeploymentErrorCollector.formatMessage()` concatenated one line per failing resource with no maximum size. When a `DeployResource` call bundles many resources that each fail independently, the aggregate rejection message grows linearly and unboundedly with the number of failures.

This aggregate is not covered by `validatorsResultsOutputMaxSize` (12KB default, `EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE`) - that cap only bounds a single `BpmnValidator` run's own output, not `DeploymentErrorCollector`'s cross-resource aggregate. [#38047](https://github.com/camunda/camunda/issues/38047) was previously closed under the belief that cap already covered this; it does not.

The unbounded message becomes the gRPC rejection reason (`GrpcErrorMapper.mapRejectionToStatus`). Because gRPC error status/messages ride in HTTP/2 HEADERS frames, a large enough message can exceed an ingress/proxy's header buffer (e.g. nginx's `grpc_buffer_size`), causing the proxy to return a bare `502 Bad Gateway` instead of relaying the real `INVALID_ARGUMENT` status - the client loses all information about why the deployment failed.

**Fix**: reuse the existing `validatorsResultsOutputMaxSize` config (already threaded through `ValidationConfig` to every `DeploymentErrorCollector` call site) rather than inventing a new option. `DeploymentErrorCollector` now tracks individual error messages instead of a single `StringBuilder`, so truncation always happens at message boundaries - errors are included whole up to the cap, and any remainder is reported as an explicit `"N more errors omitted"` count rather than silently dropped or cut mid-line.

## Out of scope / follow-up

The issue also proposes a second, independent safeguard: a gateway-side cap on *outbound* gRPC status-message size (today `zeebe.gateway.network.maxMessageSize` only bounds inbound messages). That's a larger, separate change (new config surface + gRPC interceptor) at a different layer - defense in depth regardless of this fix - and is not included here. Worth a follow-up issue.

## Validation

- `DeploymentErrorCollectorTest` (new): unit tests for truncation behavior - within cap, over cap with omitted-count reporting, always-include-first-error, no-errors case. 4/4 pass.
- `DeploymentRejectionTest` (extended): new `shouldCapRejectionReasonWhenManyResourcesFail` end-to-end test - deploys 200 resources with overlong names through `EngineRule`, asserts the rejection reason stays bounded and reports the omitted count. 25/25 pass (no regressions in existing cases).
- `MultiResourceDeploymentTest`: 0/0 (unaffected, parameterized/factory-style class not selected by `-Dtest`), no regressions.
- Full `zeebe/engine` module compiles clean (`install -Dquickly`).

Confidence: High. Root cause matched every verbatim identifier from the issue (`DeploymentErrorCollector`, `formatMessage()`, `GrpcErrorMapper.mapRejectionToStatus`, `resultsOutputMaxSize`/`DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE`) exactly on `main`. Not a multi-backend (RDBMS/ES/OS) concern - this is engine-internal rejection-message formatting, same code path regardless of storage backend. No public API/wire-format change: internal error message text is only truncated once it would already have exceeded the existing 12KB default cap.

## Related issues

Closes #61996