### PR TITLE
[Backport stable/8.8] fix: bound and retry the frontend SBOM Snyk scan

### DIFF
--- a/.github/actions/frontend-sbom-snyk/action.yml
+++ b/.github/actions/frontend-sbom-snyk/action.yml
@@ -88,7 +88,38 @@ runs:
       env:
         SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
       run: |
-        snyk sbom test \
+        # Bounds the `snyk` call so a single stuck/slow call to the Snyk API cannot consume the
+        # whole job's timeout (see INC-6630 for the same class of issue with unbounded external
+        # network calls in CI).
+        #
+        # snyk exit codes: 0 = no issues, 1 = vulnerabilities found (a valid result),
+        # 2 = error / re-run recommended, 3 = no supported projects. `timeout` returns 124 when
+        # it kills a stuck call. Only 2 and 124 are transient, so we retry those and pass every
+        # other code straight through - retrying a legitimate vuln finding (1) would needlessly
+        # double every scan that has findings and defeat the purpose of this bound.
+        function runSnykWithRetry() {
+          local maxAttempts=2
+          local perAttemptTimeoutSecs=120
+          local retryDelaySecs=10
+          local attempt=1
+
+          while true; do
+            local status=0
+            timeout "${perAttemptTimeoutSecs}s" snyk "$@" || status=$?
+            if [ "${status}" -ne 2 ] && [ "${status}" -ne 124 ]; then
+              return "${status}"
+            fi
+            if [ "${attempt}" -ge "${maxAttempts}" ]; then
+              echo "::error::snyk $* still failing after ${maxAttempts} attempts (exit ${status})"
+              return "${status}"
+            fi
+            echo "snyk $* transient failure (exit ${status}), retry ${attempt}/${maxAttempts} in ${retryDelaySecs}s..."
+            sleep "${retryDelaySecs}"
+            attempt=$((attempt + 1))
+          done
+        }
+
+        runSnykWithRetry sbom test \
           --file="${{ inputs.sbom-file }}" \
           --org="${{ inputs.snyk-org }}" \
           --severity-threshold="${{ inputs.severity-threshold }}"


### PR DESCRIPTION
⤵️ Completes the backport of #58559 → `stable/8.8`

## Context

INC-7759: the `identity-fe-sbom-snyk` nightly job on `stable/8.8` has failed 10 of the last 32 runs, always at the same step:

```
ERROR Client request cannot be processed (SNYK-0003)
unexpected response fetching test result for ID ...
Status: 504 Gateway Timeout
```

This is a transient Snyk API timeout on `snyk sbom test`. #58559 already fixed this exact class of failure (see INC-6630) by wrapping the call in a bounded retry, and it correctly landed on `main` and `stable/8.9` (#58609).

The `stable/8.8` backport (#58644) only carried the `zeebe-snyk.yml` half of that diff — the `.github/actions/frontend-sbom-snyk/action.yml` change was dropped, leaving `stable/8.8` as the only active branch still running the unprotected call. This PR ports the missing hunk verbatim from #58559, unchanged.

## Verification

- [ ] Confirm the workflow run on this branch passes the `Scan (stable/8.8) / Identity / Front End - Snyk SBOM` job
- [ ] Monitor the next few nightly runs for absence of SNYK-0003 failures on this leg

relates to INC-7759