### PR TITLE
test: explore deep-nesting limits for AgentHistoryRecord (#57230)

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
@@ -57,33 +57,45 @@ import org.junit.jupiter.params.provider.MethodSource;
  * flagged) rather than asserted into a fixed pass/fail, since the whole point is to find where the
  * current, unguarded behavior breaks down.
  *
- * <p><b>Observed finding — three distinct boundaries, identical for both content kinds:</b>
+ * <p><b>Observed finding — run against each locally-runnable {@code DatabaseType} via {@code
+ * -Dtest.integration.camunda.database.type=<ES|OS|RDBMS_H2>}, identical for both content kinds:</b>
  *
  * <ul>
- *   <li><b>depth &le; 990</b> — succeeds end-to-end: UPDATE accepted, committed, and confirmed
- *       searchable via secondary storage.
- *   <li><b>depth 995</b> — UPDATE <em>succeeds</em> (the item is written), but the subsequent
- *       search read fails with a {@code 500 Internal Server Error}: Elasticsearch's own client
- *       library ({@code co.elastic.clients}) deserializes the search hit's {@code _source} via a
- *       separate Jackson {@code ObjectMapper} that keeps Jackson's <em>unrelaxed default</em>
- *       {@code StreamReadConstraints} (max depth 1000, exceeded at depth 1001 through the {@code
- *       AgentHistoryEntity["content"]->...->["object"]} reference chain). The item is written but
- *       becomes permanently unreadable via the search API — this is a real, reproduced instance of
- *       the same write-succeeds-read-fails asymmetry that made #54335 dangerous for {@code
- *       VariableRecord}, now confirmed for {@code AgentHistoryRecord} via real secondary storage.
- *   <li><b>depth 996</b> — rejected at the gateway itself, before it ever reaches the engine:
- *       Spring's Jackson HTTP message converter hits its own default {@code StreamReadConstraints}
- *       (max depth 1000) parsing the incoming request body, surfacing as a clean {@code 400 Bad
- *       Request}.
- *   <li><b>depth &ge; 997</b> — rejected by the Java client itself, before any network call: the
- *       client's own {@code ObjectMapper} hits Jackson's default {@code StreamWriteConstraints}
- *       (max depth 1000) while serializing the request body.
+ *   <li><b>depth &le; 993</b> — the last depth that fully succeeds end-to-end on every backend:
+ *       UPDATE accepted, committed, and confirmed searchable via secondary storage.
+ *   <li><b>depth 994–995</b> — <b>Elasticsearch and OpenSearch only:</b> UPDATE <em>succeeds</em>
+ *       (the item is written), but the subsequent search read fails with a {@code 500 Internal
+ *       Server Error}. Both clients' search-response JSON mapper ({@code
+ *       co.elastic.clients.json.jackson}/{@code org.opensearch.client.json.jackson}) deserializes
+ *       the search hit via a separate Jackson {@code ObjectMapper} that keeps Jackson's
+ *       <em>unrelaxed default</em> {@code StreamReadConstraints} (max depth 1000, exceeded at depth
+ *       1001 through the {@code AgentHistoryEntity["content"]->...->["object"]} reference chain —
+ *       identical exception on both). The item is written but becomes permanently unreadable via
+ *       the search API — a real, reproduced instance of the same write-succeeds-read-fails
+ *       asymmetry that made #54335 dangerous for {@code VariableRecord}, now confirmed for {@code
+ *       AgentHistoryRecord} via real secondary storage.
+ *       <p><b>RDBMS (H2) does not reproduce this</b> — depths 994 and 995 round-trip successfully.
+ *       {@code AgentHistoryDbModel}'s reader ({@code
+ *       db/rdbms/.../write/domain/AgentHistoryDbModel.java}) deserializes just the raw JSON {@code
+ *       content} column via a plain, unguarded {@code ObjectMapper}, without the extra
+ *       response-envelope nesting ({@code hits.hits[]._source...}) that the ES/OS client libraries
+ *       add on top of the stored document when parsing the whole search hit. That extra envelope
+ *       depth is exactly what pushes ES/OS over the 1000-depth ceiling two levels earlier than the
+ *       write-side gate below.
+ *   <li><b>depth 996</b> — rejected at the gateway itself, before it ever reaches the engine, on
+ *       every backend: Spring's Jackson HTTP message converter hits its own default {@code
+ *       StreamReadConstraints} (max depth 1000) parsing the incoming request body, surfacing as a
+ *       clean {@code 400 Bad Request}.
+ *   <li><b>depth &ge; 997</b> — rejected by the Java client itself, before any network call, on
+ *       every backend: the client's own {@code ObjectMapper} hits Jackson's default {@code
+ *       StreamWriteConstraints} (max depth 1000) while serializing the request body.
  * </ul>
  *
  * <p>Note the asymmetry with {@code AgentInstanceDeepNestingTest} (zeebe/qa/integration-tests):
- * that test's {@code Record#toJson()} exporter simulation does <em>not</em> reproduce the depth-995
- * failure above, because it never round-trips through Elasticsearch's own deserialization — the
- * real bug only surfaces with an actual secondary-storage read, which only this test exercises.
+ * that test's {@code Record#toJson()} exporter simulation does <em>not</em> reproduce the
+ * depth-994/995 ES/OS failure above, because it never round-trips through a real search client's
+ * deserialization — the real bug only surfaces with an actual secondary-storage read, which only
+ * this test exercises.
  */
 @MultiDbTest
 @CompatibilityTest

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
@@ -30,9 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Exploratory test for https://github.com/camunda/camunda/issues/57230.
@@ -56,13 +57,33 @@ import org.junit.jupiter.params.provider.ValueSource;
  * flagged) rather than asserted into a fixed pass/fail, since the whole point is to find where the
  * current, unguarded behavior breaks down.
  *
- * <p><b>Observed finding:</b> both content kinds succeed end-to-end — UPDATE accepted, committed,
- * and confirmed searchable via secondary storage — up to depth ~900, and are rejected at the CLIENT
- * layer from depth ~999 onward, before the request is even sent: the Java client's own {@code
- * ObjectMapper} hits Jackson's unconfigured default {@code StreamWriteConstraints} (max depth 1000)
- * while serializing the request body. No depth in the tested range was ever accepted by UPDATE but
- * then missing from secondary storage — the client-side guard consistently rejects deep payloads
- * before they can reach that failure mode.
+ * <p><b>Observed finding — three distinct boundaries, identical for both content kinds:</b>
+ *
+ * <ul>
+ *   <li><b>depth &le; 990</b> — succeeds end-to-end: UPDATE accepted, committed, and confirmed
+ *       searchable via secondary storage.
+ *   <li><b>depth 995</b> — UPDATE <em>succeeds</em> (the item is written), but the subsequent
+ *       search read fails with a {@code 500 Internal Server Error}: Elasticsearch's own client
+ *       library ({@code co.elastic.clients}) deserializes the search hit's {@code _source} via a
+ *       separate Jackson {@code ObjectMapper} that keeps Jackson's <em>unrelaxed default</em>
+ *       {@code StreamReadConstraints} (max depth 1000, exceeded at depth 1001 through the {@code
+ *       AgentHistoryEntity["content"]->...->["object"]} reference chain). The item is written but
+ *       becomes permanently unreadable via the search API — this is a real, reproduced instance of
+ *       the same write-succeeds-read-fails asymmetry that made #54335 dangerous for {@code
+ *       VariableRecord}, now confirmed for {@code AgentHistoryRecord} via real secondary storage.
+ *   <li><b>depth 996</b> — rejected at the gateway itself, before it ever reaches the engine:
+ *       Spring's Jackson HTTP message converter hits its own default {@code StreamReadConstraints}
+ *       (max depth 1000) parsing the incoming request body, surfacing as a clean {@code 400 Bad
+ *       Request}.
+ *   <li><b>depth &ge; 997</b> — rejected by the Java client itself, before any network call: the
+ *       client's own {@code ObjectMapper} hits Jackson's default {@code StreamWriteConstraints}
+ *       (max depth 1000) while serializing the request body.
+ * </ul>
+ *
+ * <p>Note the asymmetry with {@code AgentInstanceDeepNestingTest} (zeebe/qa/integration-tests):
+ * that test's {@code Record#toJson()} exporter simulation does <em>not</em> reproduce the depth-995
+ * failure above, because it never round-trips through Elasticsearch's own deserialization — the
+ * real bug only surfaces with an actual secondary-storage read, which only this test exercises.
  */
 @MultiDbTest
 @CompatibilityTest
@@ -72,14 +93,23 @@ public class AgentInstanceDeepNestingIT {
 
   private static CamundaClient camundaClient;
 
+  /**
+   * Nesting depths probed by both parameterized tests below, from safely shallow to well past the
+   * client-side rejection boundary, with fine-grained steps between 900 and 999 to pinpoint the
+   * exact depth at which the Java client starts rejecting the request.
+   */
+  private static IntStream nestingDepths() {
+    return IntStream.of(10, 500, 900, 950, 990, 993, 994, 995, 996, 997, 998, 999, 1_000, 1_500);
+  }
+
   @ParameterizedTest(name = "objectContentNestingDepth={0}")
-  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  @MethodSource("nestingDepths")
   void shouldFlagIfDeeplyNestedObjectContentIsUnavailableViaSecondaryStorage(final int depth) {
     exploreNestingDepth(depth, "nested-object-" + depth, this::assistantItemWithObjectContent);
   }
 
   @ParameterizedTest(name = "toolCallArgumentsNestingDepth={0}")
-  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  @MethodSource("nestingDepths")
   void shouldFlagIfDeeplyNestedToolCallArgumentsAreUnavailableViaSecondaryStorage(final int depth) {
     exploreNestingDepth(depth, "nested-args-" + depth, this::assistantItemWithToolCallArguments);
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryItem;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Exploratory test for https://github.com/camunda/camunda/issues/57230.
+ *
+ * <p>Unlike {@code AgentInstanceDeepNestingTest} (zeebe/qa/integration-tests, which only checks the
+ * command layer against a bare broker), this test exercises the realistic path: an ASSISTANT-role
+ * history item with deeply nested {@code object} content or tool-call {@code arguments} is
+ * submitted via {@code UPDATE} — the way real agent output actually reaches `AgentHistoryRecord` —
+ * is committed by completing the job, and is then read back through the real {@code CamundaClient}
+ * search API, backed by a real secondary storage (Elasticsearch / OpenSearch / RDBMS, whichever
+ * {@code @MultiDbTest} is running against).
+ *
+ * <p>{@code AgentHistoryMessageContent#object} and {@code AgentHistoryEmbeddedToolCall#arguments}
+ * round-trip through {@code MsgPackConverter}'s {@code MESSSAGE_PACK_OBJECT_MAPPER}, which disables
+ * Jackson's read-side nesting depth guard entirely. The exporter re-serializes every record to JSON
+ * for indexing — calling exactly those getters — so if a payload survives UPDATE but blows up
+ * during export, the history item (or the whole agent instance) never becomes queryable, i.e. it is
+ * silently lost to the API consumer with no rejection at write time.
+ *
+ * <p>This is investigation only, not a fix: each depth is reported (and any inaccessibility
+ * flagged) rather than asserted into a fixed pass/fail, since the whole point is to find where the
+ * current, unguarded behavior breaks down.
+ *
+ * <p><b>Observed finding:</b> both content kinds succeed end-to-end — UPDATE accepted, committed,
+ * and confirmed searchable via secondary storage — up to depth ~900, and are rejected at the CLIENT
+ * layer from depth ~999 onward, before the request is even sent: the Java client's own {@code
+ * ObjectMapper} hits Jackson's unconfigured default {@code StreamWriteConstraints} (max depth 1000)
+ * while serializing the request body. No depth in the tested range was ever accepted by UPDATE but
+ * then missing from secondary storage — the client-side guard consistently rejects deep payloads
+ * before they can reach that failure mode.
+ */
+@MultiDbTest
+@CompatibilityTest
+public class AgentInstanceDeepNestingIT {
+
+  private static final String SERVICE_TASK_ID = "agentTask";
+
+  private static CamundaClient camundaClient;
+
+  @ParameterizedTest(name = "objectContentNestingDepth={0}")
+  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  void shouldFlagIfDeeplyNestedObjectContentIsUnavailableViaSecondaryStorage(final int depth) {
+    exploreNestingDepth(depth, "nested-object-" + depth, this::assistantItemWithObjectContent);
+  }
+
+  @ParameterizedTest(name = "toolCallArgumentsNestingDepth={0}")
+  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  void shouldFlagIfDeeplyNestedToolCallArgumentsAreUnavailableViaSecondaryStorage(final int depth) {
+    exploreNestingDepth(depth, "nested-args-" + depth, this::assistantItemWithToolCallArguments);
+  }
+
+  private void exploreNestingDepth(
+      final int depth,
+      final String suffix,
+      final Function<Map<String, Object>, AgentInstanceHistoryItem> itemBuilder) {
+    // given — a fresh process/agent instance, with a real job activation backing the UPDATE, the
+    // way the AI-agent feature itself submits history: after CREATE, via UPDATE on job completion.
+    final long processInstanceKey = deployAndStartProcessInstance(suffix);
+    final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey, suffix);
+    final ActivatedJob job = activateAgenticJob(suffix);
+    final AgentInstanceHistoryItem deepItem = itemBuilder.apply(nestedMap(depth));
+
+    // when
+    final Throwable updateFailure =
+        attemptUpdate(agentInstanceKey, elementInstanceKey, job, deepItem);
+    if (updateFailure != null) {
+      System.out.println(
+          "[57230]["
+              + suffix
+              + "] depth="
+              + depth
+              + " -> UPDATE FAILED at CLIENT/REST layer "
+              + classify(updateFailure)
+              + ": "
+              + rootCauseMessage(updateFailure));
+      return;
+    }
+
+    // committing the PENDING item is what makes it visible via the default search filter
+    camundaClient.newCompleteCommand(job).send().join();
+
+    // then — must become visible via secondary storage within a bounded time; flag if not
+    try {
+      Awaitility.await(
+              "agent instance history item for depth " + depth + " indexed in secondary storage")
+          .atMost(Duration.ofSeconds(30))
+          .pollInterval(Duration.ofMillis(500))
+          .untilAsserted(
+              () -> {
+                final var items =
+                    camundaClient
+                        .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                        .filter(f -> f.role(AgentInstanceHistoryRole.ASSISTANT))
+                        .execute()
+                        .items();
+                assertThat(items).as("history item must be searchable").isNotEmpty();
+              });
+      System.out.println(
+          "[57230]["
+              + suffix
+              + "] depth="
+              + depth
+              + " -> SUCCEEDED: accessible via secondary storage (history search)");
+    } catch (final Throwable t) {
+      System.out.println(
+          "[57230]["
+              + suffix
+              + "] depth="
+              + depth
+              + " -> FLAGGED: NOT accessible via secondary storage after UPDATE succeeded ("
+              + t.getClass().getName()
+              + "): "
+              + rootCauseMessage(t));
+    }
+  }
+
+  private Throwable attemptUpdate(
+      final long agentInstanceKey,
+      final long elementInstanceKey,
+      final ActivatedJob job,
+      final AgentInstanceHistoryItem item) {
+    try {
+      camundaClient
+          .newUpdateAgentInstanceCommand(agentInstanceKey)
+          .elementInstanceKey(elementInstanceKey)
+          .jobKey(job.getKey())
+          .jobLease(job.getLeaseToken())
+          .history(List.of(item))
+          .send()
+          .join();
+      return null;
+    } catch (final Throwable t) {
+      return t;
+    }
+  }
+
+  private String classify(final Throwable failure) {
+    if (failure instanceof final ProblemException problemException) {
+      return "REST ("
+          + problemException.details().getStatus()
+          + " "
+          + problemException.details().getTitle()
+          + ")";
+    }
+    return "CLIENT/CONNECTION (" + failure.getClass().getName() + ")";
+  }
+
+  private static String rootCauseMessage(final Throwable failure) {
+    Throwable current = failure;
+    while (current.getCause() != null) {
+      current = current.getCause();
+    }
+    return current.getMessage();
+  }
+
+  private long deployAndStartProcessInstance(final String suffix) {
+    final var processModel =
+        Bpmn.createExecutableProcess("nesting-process-" + suffix)
+            .startEvent()
+            .serviceTask(
+                SERVICE_TASK_ID, t -> t.zeebeJobType(jobType(suffix)).zeebeAiAgentTaskDefinition())
+            .endEvent()
+            .done();
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "agent-nesting-" + suffix + ".bpmn");
+    final var pi = startProcessInstance(camundaClient, process.getBpmnProcessId());
+    final long processInstanceKey = pi.getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient, f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey), 1);
+    return processInstanceKey;
+  }
+
+  private long getServiceTaskElementInstanceKey(final long processInstanceKey) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey))
+        .execute()
+        .items()
+        .getFirst()
+        .getElementInstanceKey();
+  }
+
+  private long createAgentInstance(final long elementInstanceKey, final String suffix) {
+    // CREATE requires a jobKey backed by an actual activation of the agentic job; fail it straight
+    // back (no backoff) so activateAgenticJob() below can pick it up again for the real UPDATE.
+    final var activatedJob = activateAgenticJob(suffix);
+    final long agentInstanceKey =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(activatedJob.getKey())
+            .jobLease(activatedJob.getLeaseToken())
+            .history(
+                List.of(
+                    new AgentInstanceHistoryItem()
+                        .historyItemId(UUID.randomUUID().toString())
+                        .loopIteration(1)
+                        .role(AgentInstanceHistoryRole.CONFIGURATION)
+                        .content(List.of(AgentInstanceHistoryContent.text("configuration")))
+                        .producedAt(OffsetDateTime.now())
+                        .model("test-model")
+                        .provider("test-provider")
+                        .systemPrompt(
+                            List.of(
+                                AgentInstanceHistoryContent.text("You are a helpful assistant.")))))
+            .send()
+            .join()
+            .getAgentInstanceKey();
+    camundaClient.newFailCommand(activatedJob).retries(1).execute();
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+    return agentInstanceKey;
+  }
+
+  private ActivatedJob activateAgenticJob(final String suffix) {
+    final var activatedJobs =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(jobType(suffix))
+            .maxJobsToActivate(1)
+            .withLease(true)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    assertThat(activatedJobs).as("expected to activate one agent job for %s", suffix).isNotEmpty();
+    return activatedJobs.getFirst();
+  }
+
+  private static String jobType(final String suffix) {
+    return "agent-task-" + suffix;
+  }
+
+  private AgentInstanceHistoryItem assistantItemWithObjectContent(
+      final Map<String, Object> nested) {
+    return new AgentInstanceHistoryItem()
+        .historyItemId(UUID.randomUUID().toString())
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.ASSISTANT)
+        .content(List.of(AgentInstanceHistoryContent.object(nested)))
+        .producedAt(OffsetDateTime.now());
+  }
+
+  private AgentInstanceHistoryItem assistantItemWithToolCallArguments(
+      final Map<String, Object> nestedArguments) {
+    return new AgentInstanceHistoryItem()
+        .historyItemId(UUID.randomUUID().toString())
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.ASSISTANT)
+        .content(List.of(AgentInstanceHistoryContent.text("calling a tool")))
+        .producedAt(OffsetDateTime.now())
+        .toolCalls(
+            List.of(
+                new AgentInstanceHistoryToolCall()
+                    .toolCallId(UUID.randomUUID().toString())
+                    .toolName("test-tool")
+                    .elementId(SERVICE_TASK_ID)
+                    .arguments(nestedArguments)));
+  }
+
+  /**
+   * Builds a chain of {@code depth} single-key nested maps: {@code {"nested": {"nested": ...}}}.
+   */
+  private static Map<String, Object> nestedMap(final int depth) {
+    Map<String, Object> current = new HashMap<>();
+    current.put("leaf", true);
+    for (int i = 0; i < depth - 1; i++) {
+      final Map<String, Object> next = new HashMap<>();
+      next.put("nested", current);
+      current = next;
+    }
+    return current;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceDeepNestingIT.java
@@ -58,7 +58,8 @@ import org.junit.jupiter.params.provider.MethodSource;
  * current, unguarded behavior breaks down.
  *
  * <p><b>Observed finding — run against each locally-runnable {@code DatabaseType} via {@code
- * -Dtest.integration.camunda.database.type=<ES|OS|RDBMS_H2>}, identical for both content kinds:</b>
+ * -Dtest.integration.camunda.database.type=<ES|OS|RDBMS_H2|RDBMS_MYSQL>} (MySQL via {@code docker
+ * compose -f db/docker-compose.yml up -d mysql}), identical for both content kinds:</b>
  *
  * <ul>
  *   <li><b>depth &le; 993</b> — the last depth that fully succeeds end-to-end on every backend:
@@ -74,8 +75,9 @@ import org.junit.jupiter.params.provider.MethodSource;
  *       the search API — a real, reproduced instance of the same write-succeeds-read-fails
  *       asymmetry that made #54335 dangerous for {@code VariableRecord}, now confirmed for {@code
  *       AgentHistoryRecord} via real secondary storage.
- *       <p><b>RDBMS (H2) does not reproduce this</b> — depths 994 and 995 round-trip successfully.
- *       {@code AgentHistoryDbModel}'s reader ({@code
+ *       <p><b>RDBMS does not reproduce this</b> — depths 994 and 995 round-trip successfully,
+ *       confirmed on both H2 and MySQL (same {@code AgentHistoryDbModel} read path, dialect makes
+ *       no difference here). {@code AgentHistoryDbModel}'s reader ({@code
  *       db/rdbms/.../write/domain/AgentHistoryDbModel.java}) deserializes just the raw JSON {@code
  *       content} column via a plain, unguarded {@code ObjectMapper}, without the extra
  *       response-envelope nesting ({@code hits.hits[]._source...}) that the ES/OS client libraries

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.engine.client.command;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryItem;
+import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Exploratory test for https://github.com/camunda/camunda/issues/57230.
+ *
+ * <p>{@code AgentHistoryMessageContent#object} and {@code AgentHistoryEmbeddedToolCall#arguments}
+ * round-trip through {@code MsgPackConverter}'s {@code MESSSAGE_PACK_OBJECT_MAPPER}, which disables
+ * Jackson's read-side nesting depth guard entirely. This drives a deeply nested payload through the
+ * real, client-reachable path — {@code CamundaClient} -&gt; {@code POST /v2/agent-instances} -&gt;
+ * {@code AgentInstanceMapper} -&gt; {@code AgentInstanceCreateProcessor} — to find out,
+ * empirically, at which nesting depth creation starts failing and at which layer:
+ *
+ * <ul>
+ *   <li><b>CLIENT/CONNECTION</b> — the failure never produced a structured REST response (e.g. the
+ *       client's own request serialization blew up, or the server-side handling thread died before
+ *       it could reply).
+ *   <li><b>REST</b> — the gateway replied with a structured problem (HTTP status + title).
+ *   <li><b>EXPORTER</b> — the command was accepted and the {@code AGENT_HISTORY.CREATED} event was
+ *       appended to the log (broker/engine layer is fine), but re-serializing that record to JSON —
+ *       exactly what a real exporter (camunda-exporter/rdbms-exporter, via {@code
+ *       getObject()}/{@code getArguments()}) does before indexing it — fails. This is simulated
+ *       directly via {@link Record#toJson()} on the recorded event instead of standing up a real
+ *       Elasticsearch/OpenSearch/RDBMS exporter, since the failure mode lives entirely in the
+ *       shared {@code MsgPackConverter} read path, not in any exporter-specific code.
+ * </ul>
+ *
+ * <p>This is investigation only, not a fix: the assertions document the currently-observed behavior
+ * so a future change (e.g. an explicit depth guard) is caught as an intentional behavior change
+ * rather than silently.
+ *
+ * <p><b>Observed finding:</b> both content kinds succeed end-to-end (broker/engine and the
+ * exporter-style re-serialization) up to depth ~900, and are rejected at the CLIENT layer from
+ * depth ~999 onward — the Java client's own {@code ObjectMapper} hits Jackson's unconfigured
+ * default {@code StreamWriteConstraints} (max depth 1000) while serializing the request, before any
+ * network call. No depth in the tested range ever reaches a broker/engine or exporter-layer
+ * failure, because the client-side guard rejects it first.
+ */
+@ZeebeIntegration
+final class AgentInstanceDeepNestingTest {
+
+  @TestZeebe
+  private static final TestStandaloneBroker ZEEBE =
+      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+
+  @AutoClose CamundaClient client;
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  void init() {
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(30)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @ParameterizedTest(name = "objectContentNestingDepth={0}")
+  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  void shouldRevealFailureLayerForDeeplyNestedObjectContent(final int depth) {
+    // given
+    final var target = createAgentServiceTaskInstance("nested-object-job-" + depth);
+    final List<AgentInstanceHistoryItem> history =
+        List.of(configurationHistoryItem(), assistantItemWithObjectContent(nestedMap(depth)));
+
+    // when
+    final Throwable createFailure = attemptCreate(target, history);
+    final Throwable exportFailure =
+        createFailure == null ? attemptExporterStyleReserialization(target, history.size()) : null;
+
+    // then
+    report("OBJECT content", depth, createFailure, exportFailure);
+  }
+
+  @ParameterizedTest(name = "toolCallArgumentsNestingDepth={0}")
+  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  void shouldRevealFailureLayerForDeeplyNestedToolCallArguments(final int depth) {
+    // given
+    final var target = createAgentServiceTaskInstance("nested-args-job-" + depth);
+    final List<AgentInstanceHistoryItem> history =
+        List.of(configurationHistoryItem(), assistantItemWithToolCallArguments(nestedMap(depth)));
+
+    // when
+    final Throwable createFailure = attemptCreate(target, history);
+    final Throwable exportFailure =
+        createFailure == null ? attemptExporterStyleReserialization(target, history.size()) : null;
+
+    // then
+    report("tool call arguments", depth, createFailure, exportFailure);
+  }
+
+  private Throwable attemptCreate(
+      final ElementInstanceAndJob target, final List<AgentInstanceHistoryItem> history) {
+    try {
+      client
+          .newCreateAgentInstanceCommand()
+          .elementInstanceKey(target.elementInstanceKey())
+          .jobKey(target.jobKey())
+          .jobLease("test-job-lease")
+          .history(history)
+          .execute();
+      return null;
+    } catch (final Throwable t) {
+      return t;
+    }
+  }
+
+  /**
+   * Simulates the exporter layer: fetches the {@code AGENT_HISTORY.CREATED} events just appended
+   * for this element instance, and re-serializes each to JSON via {@link Record#toJson()} — the
+   * same call a real exporter makes, which recurses into {@code getObject()}/{@code getArguments()}
+   * for any content/tool-call fields.
+   */
+  private Throwable attemptExporterStyleReserialization(
+      final ElementInstanceAndJob target, final int expectedRecordCount) {
+    final List<Record<AgentHistoryRecordValue>> createdRecords =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.CREATED)
+            .withElementInstanceKey(target.elementInstanceKey())
+            .limit(expectedRecordCount)
+            .toList();
+
+    for (final Record<AgentHistoryRecordValue> record : createdRecords) {
+      try {
+        record.toJson();
+      } catch (final Throwable t) {
+        return t;
+      }
+    }
+    return null;
+  }
+
+  private void report(
+      final String field,
+      final int depth,
+      final Throwable createFailure,
+      final Throwable exportFailure) {
+    if (createFailure != null) {
+      System.out.println(
+          "[57230]["
+              + field
+              + "] depth="
+              + depth
+              + " -> FAILED at CLIENT/REST layer "
+              + classify(createFailure)
+              + ": "
+              + rootCauseMessage(createFailure));
+      return;
+    }
+    if (exportFailure == null) {
+      System.out.println(
+          "[57230]["
+              + field
+              + "] depth="
+              + depth
+              + " -> SUCCEEDED through broker/engine AND exporter-style re-serialization");
+      return;
+    }
+    System.out.println(
+        "[57230]["
+            + field
+            + "] depth="
+            + depth
+            + " -> broker/engine layer OK, but FAILED at EXPORTER layer ("
+            + exportFailure.getClass().getName()
+            + "): "
+            + rootCauseMessage(exportFailure));
+  }
+
+  /**
+   * Classifies where a create-time failure surfaced: {@code REST} if the gateway responded with a
+   * structured problem (an HTTP status + title), or {@code CLIENT/CONNECTION} if the channel broke
+   * before a structured response came back (e.g. the server-side handling thread died mid-request).
+   */
+  private String classify(final Throwable failure) {
+    if (failure instanceof final ProblemException problemException) {
+      return "REST ("
+          + problemException.details().getStatus()
+          + " "
+          + problemException.details().getTitle()
+          + ")";
+    }
+    return "CLIENT/CONNECTION (" + failure.getClass().getName() + ")";
+  }
+
+  private static String rootCauseMessage(final Throwable failure) {
+    Throwable current = failure;
+    while (current.getCause() != null) {
+      current = current.getCause();
+    }
+    return current.getMessage();
+  }
+
+  private ElementInstanceAndJob createAgentServiceTaskInstance(final String jobType) {
+    final long processDefinitionKey =
+        resourcesHelper.deployProcess(
+            Bpmn.createExecutableProcess("nesting-test-" + jobType)
+                .startEvent()
+                .serviceTask(
+                    "service-task", t -> t.zeebeJobType(jobType).zeebeAiAgentTaskDefinition())
+                .endEvent()
+                .done());
+    resourcesHelper.createProcessInstance(processDefinitionKey);
+    final long elementInstanceKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withType(jobType)
+            .getFirst()
+            .getValue()
+            .getElementInstanceKey();
+    final long jobKey =
+        client
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    return new ElementInstanceAndJob(elementInstanceKey, jobKey);
+  }
+
+  private AgentInstanceHistoryItem configurationHistoryItem() {
+    return new AgentInstanceHistoryItem()
+        .historyItemId(UUID.randomUUID().toString())
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.CONFIGURATION)
+        .content(List.of(AgentInstanceHistoryContent.text("configuration")))
+        .producedAt(OffsetDateTime.now())
+        .model("test-model")
+        .provider("test-provider")
+        .systemPrompt(List.of(AgentInstanceHistoryContent.text("You are a helpful assistant.")));
+  }
+
+  private AgentInstanceHistoryItem assistantItemWithObjectContent(final Object nested) {
+    return new AgentInstanceHistoryItem()
+        .historyItemId(UUID.randomUUID().toString())
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.ASSISTANT)
+        .content(List.of(AgentInstanceHistoryContent.object(nested)))
+        .producedAt(OffsetDateTime.now());
+  }
+
+  private AgentInstanceHistoryItem assistantItemWithToolCallArguments(
+      final Map<String, Object> nestedArguments) {
+    return new AgentInstanceHistoryItem()
+        .historyItemId(UUID.randomUUID().toString())
+        .loopIteration(1)
+        .role(AgentInstanceHistoryRole.ASSISTANT)
+        .content(List.of(AgentInstanceHistoryContent.text("calling a tool")))
+        .producedAt(OffsetDateTime.now())
+        .toolCalls(
+            List.of(
+                new AgentInstanceHistoryToolCall()
+                    .toolCallId(UUID.randomUUID().toString())
+                    .toolName("test-tool")
+                    .elementId("service-task")
+                    .arguments(nestedArguments)));
+  }
+
+  /**
+   * Builds a chain of {@code depth} single-key nested maps: {@code {"nested": {"nested": ...}}}.
+   */
+  private static Map<String, Object> nestedMap(final int depth) {
+    Map<String, Object> current = new HashMap<>();
+    current.put("leaf", true);
+    for (int i = 0; i < depth - 1; i++) {
+      final Map<String, Object> next = new HashMap<>();
+      next.put("nested", current);
+      current = next;
+    }
+    return current;
+  }
+
+  private record ElementInstanceAndJob(long elementInstanceKey, long jobKey) {}
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
@@ -70,13 +70,17 @@ import org.junit.jupiter.params.provider.MethodSource;
  * call. (Depth 996 instead gets a clean {@code 400 Bad Request} from the gateway's own Jackson
  * request-body parsing hitting the same default limit.)
  *
- * <p><b>Important caveat:</b> the {@link Record#toJson()} exporter simulation here reports depth
- * 995 as succeeding, but {@code AgentInstanceDeepNestingIT} (qa/acceptance-tests) — which reads the
- * item back through a real Elasticsearch-backed search API instead of simulating it — shows that
- * depth 995 actually breaks on read: Elasticsearch's own client library deserializes the search hit
- * via a separate Jackson {@code ObjectMapper} with the same unrelaxed default depth limit, so the
- * item is written but never becomes readable again ({@code 500 Internal Server Error}). This test's
- * simulated exporter check is too permissive to catch that; see the other test for the confirmed
+ * <p><b>Important caveat:</b> the {@link Record#toJson()} exporter simulation here reports depths
+ * up to 995 as succeeding, but {@code AgentInstanceDeepNestingIT} (qa/acceptance-tests) — run
+ * against each locally-runnable secondary storage backend — shows a more nuanced picture: depth 993
+ * is the last depth that works on <em>every</em> backend. From depth 994 the write still succeeds,
+ * but on Elasticsearch and OpenSearch specifically the read breaks: their search-client libraries
+ * deserialize the search hit via a separate Jackson {@code ObjectMapper} with the same unrelaxed
+ * default depth limit, so the item is written but never becomes readable again ({@code 500 Internal
+ * Server Error}). RDBMS (H2) does not reproduce this — its reader parses the stored JSON directly,
+ * without the extra response-envelope nesting the ES/OS clients add, so it keeps working through
+ * depth 995 same as this simulation reports. This test's simulated exporter check is too permissive
+ * to catch the ES/OS-specific failure; see the other test for the confirmed, backend-dependent
  * write-succeeds-read-fails finding.
  */
 @ZeebeIntegration

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
@@ -29,10 +29,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Exploratory test for https://github.com/camunda/camunda/issues/57230.
@@ -63,11 +64,20 @@ import org.junit.jupiter.params.provider.ValueSource;
  * rather than silently.
  *
  * <p><b>Observed finding:</b> both content kinds succeed end-to-end (broker/engine and the
- * exporter-style re-serialization) up to depth ~900, and are rejected at the CLIENT layer from
- * depth ~999 onward — the Java client's own {@code ObjectMapper} hits Jackson's unconfigured
- * default {@code StreamWriteConstraints} (max depth 1000) while serializing the request, before any
- * network call. No depth in the tested range ever reaches a broker/engine or exporter-layer
- * failure, because the client-side guard rejects it first.
+ * exporter-style re-serialization) up to depth 995, and are rejected at the CLIENT layer from depth
+ * 997 onward — the Java client's own {@code ObjectMapper} hits Jackson's unconfigured default
+ * {@code StreamWriteConstraints} (max depth 1000) while serializing the request, before any network
+ * call. (Depth 996 instead gets a clean {@code 400 Bad Request} from the gateway's own Jackson
+ * request-body parsing hitting the same default limit.)
+ *
+ * <p><b>Important caveat:</b> the {@link Record#toJson()} exporter simulation here reports depth
+ * 995 as succeeding, but {@code AgentInstanceDeepNestingIT} (qa/acceptance-tests) — which reads the
+ * item back through a real Elasticsearch-backed search API instead of simulating it — shows that
+ * depth 995 actually breaks on read: Elasticsearch's own client library deserializes the search hit
+ * via a separate Jackson {@code ObjectMapper} with the same unrelaxed default depth limit, so the
+ * item is written but never becomes readable again ({@code 500 Internal Server Error}). This test's
+ * simulated exporter check is too permissive to catch that; see the other test for the confirmed
+ * write-succeeds-read-fails finding.
  */
 @ZeebeIntegration
 final class AgentInstanceDeepNestingTest {
@@ -85,8 +95,18 @@ final class AgentInstanceDeepNestingTest {
     resourcesHelper = new ZeebeResourcesHelper(client);
   }
 
+  /**
+   * Nesting depths probed by both parameterized tests below, from safely shallow to well past the
+   * client-side rejection boundary, with fine-grained steps between 900 and 999 to pinpoint the
+   * exact depth at which the Java client starts rejecting the request.
+   */
+  private static IntStream nestingDepths() {
+    return IntStream.of(
+        10, 500, 900, 950, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999, 1_000, 1_500);
+  }
+
   @ParameterizedTest(name = "objectContentNestingDepth={0}")
-  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  @MethodSource("nestingDepths")
   void shouldRevealFailureLayerForDeeplyNestedObjectContent(final int depth) {
     // given
     final var target = createAgentServiceTaskInstance("nested-object-job-" + depth);
@@ -103,7 +123,7 @@ final class AgentInstanceDeepNestingTest {
   }
 
   @ParameterizedTest(name = "toolCallArgumentsNestingDepth={0}")
-  @ValueSource(ints = {10, 500, 900, 999, 1_000, 1_500})
+  @MethodSource("nestingDepths")
   void shouldRevealFailureLayerForDeeplyNestedToolCallArguments(final int depth) {
     // given
     final var target = createAgentServiceTaskInstance("nested-args-job-" + depth);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/AgentInstanceDeepNestingTest.java
@@ -77,11 +77,11 @@ import org.junit.jupiter.params.provider.MethodSource;
  * but on Elasticsearch and OpenSearch specifically the read breaks: their search-client libraries
  * deserialize the search hit via a separate Jackson {@code ObjectMapper} with the same unrelaxed
  * default depth limit, so the item is written but never becomes readable again ({@code 500 Internal
- * Server Error}). RDBMS (H2) does not reproduce this — its reader parses the stored JSON directly,
- * without the extra response-envelope nesting the ES/OS clients add, so it keeps working through
- * depth 995 same as this simulation reports. This test's simulated exporter check is too permissive
- * to catch the ES/OS-specific failure; see the other test for the confirmed, backend-dependent
- * write-succeeds-read-fails finding.
+ * Server Error}). RDBMS does not reproduce this, on either H2 or MySQL — its reader parses the
+ * stored JSON directly, without the extra response-envelope nesting the ES/OS clients add, so it
+ * keeps working through depth 995 same as this simulation reports. This test's simulated exporter
+ * check is too permissive to catch the ES/OS-specific failure; see the other test for the
+ * confirmed, backend-dependent write-succeeds-read-fails finding.
  */
 @ZeebeIntegration
 final class AgentInstanceDeepNestingTest {


### PR DESCRIPTION
## Summary

This is an **exploration-only PR — not intended to be merged.** It contains no production code changes, only two new test classes that empirically answer the question raised in #57230 (a follow-up to #54335): *is `AgentHistoryRecord` exposed to the same deep-nesting stack-overflow risk that made #54335 dangerous for `VariableRecord`, and if a payload gets through, what actually happens?*

Rather than reasoning about this from code alone, these tests drive deeply nested `object` content and tool-call `arguments` through the real, client-reachable path (`CamundaClient` → REST → engine → secondary storage) across a range of nesting depths, and report — per depth — where and how it fails. The plan is to close this PR with a short comment pointing back to the underlying issue once the findings are captured there; the branch/PR stays around as a citable, reproducible record of the investigation.

## What's included

- **`zeebe/qa/integration-tests/.../command/AgentInstanceDeepNestingTest.java`** — bare-broker test via `CreateAgentInstance`. Classifies each depth's outcome as failing at the CLIENT/CONNECTION layer, the REST/gateway layer, or the (simulated) exporter layer, using `Record#toJson()` as a stand-in for real exporter re-serialization.
- **`qa/acceptance-tests/.../client/AgentInstanceDeepNestingIT.java`** — the realistic path via `UpdateAgentInstance` (how ASSISTANT content/tool-call arguments actually arrive in production), against **real** secondary storage (`@MultiDbTest`), reading the result back through the actual `CamundaClient` search API. Run manually against every locally-runnable backend: Elasticsearch, OpenSearch, RDBMS/H2, and RDBMS/MySQL.

Both tests probe the same depth range (10 up to 1500, with fine-grained steps between 990–999) for two content shapes: `AgentHistoryMessageContent#object` and `AgentHistoryEmbeddedToolCall#arguments`.

## Findings

Identical for both content shapes. Four distinct outcomes depending on nesting depth — three identical across every backend, one that's backend-dependent:

| Depth | Outcome | ES | OS | RDBMS (H2) | RDBMS (MySQL) |
|---|---|---|---|---|---|
| ≤ 993 | Succeeds fully — written and searchable. **Last depth that works for both write and read, on every backend.** | ✅ | ✅ | ✅ | ✅ |
| **994–995** | **UPDATE succeeds (item is written), but the search read-back fails** with `500 Internal Server Error`. | ❌ ES client's own Jackson mapper hits default depth 1000 deserializing the search hit | ❌ same, via OpenSearch's client-side Jackson mapper | ✅ plain unguarded `ObjectMapper` on the raw JSON column, no envelope overhead | ✅ same as H2 — dialect doesn't affect the Java read path |
| 996 | Rejected at the **gateway** — clean `400 Bad Request`. | ❌ Spring's Jackson HTTP converter hits default depth 1000 parsing the request body | ❌ same | ❌ same | ❌ same |
| ≥ 997 | Rejected by the **Java client itself**, before any network call. | ❌ client's own `ObjectMapper` hits default `StreamWriteConstraints` (1000) | ❌ same | ❌ same | ❌ same |

### The important part: depth 994–995 is a real, reproduced write-succeeds/read-fails bug — but only on Elasticsearch/OpenSearch

```
co.elastic.clients.transport.TransportException: ... Failed to decode response
Caused by: co.elastic.clients.json.JsonpMappingException: Error deserializing ...Hit: ...
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Document nesting depth (1001)
  exceeds the maximum allowed (1000, from `StreamReadConstraints.getMaxNestingDepth()`)
  (through reference chain: ...AgentHistoryEntity["content"]->ArrayList[0]->AgentHistoryContentValue["object"])
Caused by: com.fasterxml.jackson.core.exc.StreamConstraintsException: Document nesting depth (1001)
  exceeds the maximum allowed (1000, from `StreamReadConstraints.getMaxNestingDepth()`)
```

OpenSearch produces the byte-for-byte identical exception chain via `org.opensearch.client.json.jackson.JacksonUtils`. Both search clients deserialize the search hit's `_source` via a **separate** Jackson `ObjectMapper` that keeps Jackson's **unrelaxed default** `StreamReadConstraints` (max depth 1000) — unlike `MsgPackConverter`'s own mapper (`MESSSAGE_PACK_OBJECT_MAPPER`), which has this explicitly disabled. So on ES/OS: the item is accepted and durably written, but every subsequent read via the search API fails with 500, permanently — the item is silently lost to any API consumer. This is a real, reproduced instance of the same write-succeeds-read-fails asymmetry that made #54335 dangerous for `VariableRecord`.

**RDBMS does not reproduce this**, confirmed on both H2 and MySQL: `AgentHistoryDbModel`'s reader deserializes the raw JSON `content` column directly via a plain, unguarded `ObjectMapper`, without the extra response-envelope nesting (`hits.hits[]._source...`) the ES/OS client libraries add when parsing a whole search hit — that extra envelope depth is exactly what pushes ES/OS over the 1000-depth ceiling two levels earlier than the write-side gate.

Notably, the broker-only test's `Record#toJson()` exporter *simulation* does **not** catch the ES/OS failure (it reports success through depth 995), since it never round-trips through a real search client's deserialization — only the real secondary-storage test reveals it.

### Can deeply nested content block a partition by failing during export, like #54335?

**No — not observed at any tested depth, on any backend.** This is the core mechanism behind #54335's severity, so it's worth walking through explicitly:

- In #54335, the dangerous sequence was: a deeply nested `VariableRecord` gets *accepted onto the log* (no upfront validation existed yet), then the **exporter itself** throws an uncaught exception while serializing that specific record to JSON for the ES bulk request. Since the exporter's retry loop (`BackOffRetryStrategy`) has no way to skip or discard a poisoned record, it retries the *same* failing record forever. The exporter's position can never advance past it, which stalls that partition's exporting — and, transitively, its processing — indefinitely. That's what made a single bad variable capable of taking down a whole partition (and potentially the cluster) with no workaround.
- For `AgentHistoryRecord`, across every tested depth (10 up to 1500) and every backend (ES, OS, RDBMS/H2, RDBMS/MySQL), the exporter itself **never threw and never got stuck**:
  - At depth ≥ 996, the payload never even reaches the log stream — it's rejected upstream (client or gateway), so the exporter never sees it at all.
  - At depth ≤ 995, on every backend, the record is written *and* successfully exported/indexed — export itself never fails, regardless of backend.
  - The depth-994/995 ES/OS failure happens strictly *after* successful export, in a completely different, independent code path: `GET /v2/agent-instances/{key}/history/search`, a **query/read** endpoint. The fact that this endpoint returns a `JsonMappingException` while deserializing an existing search *hit* is itself proof the document was already durably indexed — if export had failed or blocked, there would be no hit to fail on. A failed search request just returns a `500` to whichever caller issued that specific query; it doesn't retry indefinitely, doesn't touch the exporter's position, and has no effect on partition processing.
- So the qualitative difference from #54335 is real: there, the failure was a **write-time, exporter-loop** problem with no bounded blast radius. Here, the worst observed outcome is a **read-time, per-request** problem (a permanently-500-ing search call for that one item) — annoying and worth fixing, but it cannot stall a partition the way #54335 did.

### Answering the rest of the original question

- **Is the impact "simply rejecting the request"?** On RDBMS, yes. On Elasticsearch/OpenSearch, no — for the depth-994/995 window the request is silently accepted and stored but becomes permanently unreadable via search, which is a real (if narrow) backend-dependent correctness/availability bug, distinct from both "rejected outright" and from #54335's partition-blocking failure mode.

### Residual risk (unchanged from the issue's original framing)

All of the above only covers the **client-reachable surface**. Any internal engine code path that could construct `AgentHistoryMessageContent`/`AgentHistoryEmbeddedToolCall` directly — bypassing `setObject()`/`setArguments()`'s own (accidental, Jackson-default-bounded) write guard — would still hit the **fully unguarded** read path (`getObject()`/`getArguments()`, `maxNestingDepth = Integer.MAX_VALUE`) with no protection at all. That was not (and likely cannot be, from the outside) exercised by these client-driven tests.

## Try it yourself

<details>
<summary>Broker-only test (no secondary storage needed)</summary>

```bash
./mvnw verify -pl zeebe/qa/integration-tests \
  -Dit.test=AgentInstanceDeepNestingTest \
  -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=0
```
</details>

<details>
<summary>Acceptance test against Elasticsearch (default)</summary>

```bash
./mvnw verify -pl qa/acceptance-tests -Pmulti-db-test \
  -Dit.test=AgentInstanceDeepNestingIT \
  -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=0
```
</details>

<details>
<summary>Acceptance test against OpenSearch</summary>

```bash
./mvnw verify -pl qa/acceptance-tests -Pmulti-db-test \
  -Dit.test=AgentInstanceDeepNestingIT \
  -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=0 \
  -D test.integration.camunda.database.type=OS
```
</details>

<details>
<summary>Acceptance test against RDBMS / H2 (no Docker needed)</summary>

```bash
./mvnw verify -pl qa/acceptance-tests -Pmulti-db-test \
  -Dit.test=AgentInstanceDeepNestingIT \
  -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=0 \
  -D test.integration.camunda.database.type=RDBMS_H2
```
</details>

<details>
<summary>Acceptance test against RDBMS / MySQL (requires Docker)</summary>

```bash
# start MySQL and wait for it to accept connections
docker compose -f db/docker-compose.yml --project-name db up -d mysql
until docker exec db-mysql-1 mysqladmin ping -h 127.0.0.1 -u camunda -pcamunda --silent; do
  sleep 2
done

./mvnw verify -pl qa/acceptance-tests -Pmulti-db-test \
  -Dit.test=AgentInstanceDeepNestingIT \
  -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=0 \
  -D test.integration.camunda.database.type=RDBMS_MYSQL

# tear it down afterwards
docker compose -f db/docker-compose.yml --project-name db down
```
</details>

Each run prints a `[57230][...]` line per depth to stdout (captured in the failsafe report's `<system-out>`), e.g.:

```
[57230][nested-object-994] depth=994 -> FLAGGED: NOT accessible via secondary storage after UPDATE succeeded (io.camunda.client.api.command.ProblemException): Failed with code 500: ...
```

## Test plan

- [x] No production code touched — test-only change.
- [x] Both test classes build and pass locally (`./mvnw license:format spotless:apply` + module-scoped `verify` runs against ES, OS, RDBMS/H2, RDBMS/MySQL).
- [x] Full repo compiles (`./mvnw install -Dquickly -T1C`).
- [x] This PR does not need a linked issue — N/A, tracked issue linked above as `relates to`, not `closes` (exploration only).

## Related issues

relates to #57230