### PR TITLE
deps: bump jackson on stable/optimize-8.7 to align with other release lines

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -46,7 +46,7 @@
     <awssdk.version>2.28.13</awssdk.version>
 
     <jetty.version>12.0.36</jetty.version>
-    <jackson.version>2.21.5</jackson.version>
+    <jackson.version>2.21.6</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.6.4</apache.http5-client.version>
     <apache.http5-core.version>5.4.3</apache.http5-core.version>


### PR DESCRIPTION
## Description

optimize/pom.xml pinned jackson.version to 2.21.5, one patch behind the 2.21.6 already shipped on the other active release lines (8.7, 8.8, 8.9, 8.10). Bump it here too so this branch tracks the same jackson-databind patch level as the rest of the supported lines.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

