### PR TITLE
test: reduce redistribution interval to 1s in IT tests

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -547,6 +547,14 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     unifiedConfig.getProcessing().setEnablePreconditionsCheck(true);
     unifiedConfig.getProcessing().setEnableForeignKeyChecks(true);
 
+    // Default delay is 10s, which can make some tests
+    // waiting for deployment flaky
+    unifiedConfig
+        .getProcessing()
+        .getEngine()
+        .getDistribution()
+        .setRedistributionInterval(Duration.ofSeconds(1));
+
     // Set dynamic ports via properties (these aren't in unified config yet)
     unifiedConfig
         .getCluster()


### PR DESCRIPTION


## Description

Default value of 10s was introducing flaky failures when waiting for a deployment to be done in all partitions when the timeout was not large enough (for example in ExporterDisableTest).
This might reduce the time it takes to run some IT as well.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

