### PR TITLE
feat: Enrich warning message for differences in the mapping resolvers

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMapping.java
@@ -18,4 +18,15 @@ import org.jspecify.annotations.NullMarked;
  * target shadows a same-named variable from a higher scope only for the keys it defines.
  */
 @NullMarked
-public record InputMapping(Expression source, List<String> targetPath) {}
+public record InputMapping(Expression source, List<String> targetPath) {
+
+  @Override
+  public String toString() {
+    return "InputMapping{"
+        + "source='"
+        + source.getExpression()
+        + "', targetPath="
+        + targetPath
+        + '}';
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
@@ -33,4 +33,10 @@ public record InputMappings(
     List<InputMapping> mappings,
     Expression combinedExpression,
     Map<String, Set<SecretReference>> secretReferences,
-    Map<String, Set<ClusterVariableReference>> clusterVariableReferences) {}
+    Map<String, Set<ClusterVariableReference>> clusterVariableReferences) {
+
+  @Override
+  public String toString() {
+    return "InputMappings{" + "mappings=" + mappings + '}';
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMapping.java
@@ -19,4 +19,15 @@ import org.jspecify.annotations.NullMarked;
  * OutputMappingResultBuilder}).
  */
 @NullMarked
-public record OutputMapping(Expression source, List<String> targetPath) {}
+public record OutputMapping(Expression source, List<String> targetPath) {
+
+  @Override
+  public String toString() {
+    return "OutputMapping{"
+        + "source='"
+        + source.getExpression()
+        + "', targetPath="
+        + targetPath
+        + '}';
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/OutputMappings.java
@@ -22,4 +22,10 @@ import org.jspecify.annotations.NullMarked;
  * exists the field is always a valid expression.
  */
 @NullMarked
-public record OutputMappings(Expression combinedExpression, List<OutputMapping> mappings) {}
+public record OutputMappings(Expression combinedExpression, List<OutputMapping> mappings) {
+
+  @Override
+  public String toString() {
+    return "OutputMappings{" + "mappings=" + mappings + '}';
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
@@ -57,16 +57,18 @@ public final class ComparingMappingResolver<M> implements MappingResolver<M> {
 
       if (!equivalent(snapshot, comparisonResult)) {
         LOG.warn(
-            "Mapping results differ between {} and {} resolvers [{}].",
+            "Mapping results differ between {} and {} resolvers [{}, {}].",
             primary.getClass().getSimpleName(),
             comparison.getClass().getSimpleName(),
-            processor.getMappingContext());
+            processor.getMappingContext(),
+            mappings);
       }
     } catch (final Exception e) {
       LOG.warn(
-          "Comparison resolver {} threw unexpectedly [{}]; primary {} result is applied.",
+          "Comparison resolver {} threw unexpectedly [{}, {}]; primary {} result is applied.",
           comparison.getClass().getSimpleName(),
           processor.getMappingContext(),
+          mappings,
           primaryResult.isRight() ? "success" : "failure",
           e);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolver.java
@@ -11,8 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import io.camunda.zeebe.util.logging.ThrottledLogger;
-import java.time.Duration;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NullMarked;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
@@ -34,9 +32,6 @@ public final class ComparingMappingResolver<M> implements MappingResolver<M> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ComparingMappingResolver.class);
   private static final ObjectMapper MSGPACK_MAPPER = new ObjectMapper(new MessagePackFactory());
-
-  // 1/s throttle per instance; one engine instance → one resolver → effective global rate limit
-  private final Logger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(1));
 
   private final MappingResolver<M> primary;
   private final MappingResolver<M> comparison;
@@ -61,7 +56,7 @@ public final class ComparingMappingResolver<M> implements MappingResolver<M> {
       final var comparisonResult = comparison.resolve(mappings, processor);
 
       if (!equivalent(snapshot, comparisonResult)) {
-        throttledLog.warn(
+        LOG.warn(
             "Mapping results differ between {} and {} resolvers [{}].",
             primary.getClass().getSimpleName(),
             comparison.getClass().getSimpleName(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -268,4 +268,17 @@ final class ComparingMappingResolverTest {
               assertThat(e.getMessage().getFormattedMessage()).contains("threw unexpectedly");
             });
   }
+
+  @Test
+  void shouldLogWarnForEachDivergence() {
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
+
+    resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
+    resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(recorder.getAppendedEvents()).hasSize(2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -281,4 +281,26 @@ final class ComparingMappingResolverTest {
 
     assertThat(recorder.getAppendedEvents()).hasSize(2);
   }
+
+  @Test
+  void shouldIncludeMappingContextInWarnMessage() {
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
+
+    final var result = resolver.resolve(INPUT_MAPPINGS, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            e -> {
+              final String formattedMessage = e.getMessage().getFormattedMessage();
+              assertThat(formattedMessage)
+                  .contains(
+                      "MappingContext[elementId=element-1, scopeKey=100, processInstanceKey=200, processDefinitionKey=300, tenantId=default]");
+            });
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ComparingMappingResolverTest.java
@@ -11,13 +11,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMapping;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMapping;
+import io.camunda.zeebe.engine.processing.deployment.model.element.OutputMappings;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.logging.RecordingAppender;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collections;
+import java.util.List;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.apache.logging.log4j.Level;
@@ -301,6 +307,70 @@ final class ComparingMappingResolverTest {
               assertThat(formattedMessage)
                   .contains(
                       "MappingContext[elementId=element-1, scopeKey=100, processInstanceKey=200, processDefinitionKey=300, tenantId=default]");
+            });
+  }
+
+  @Test
+  void shouldIncludeInputMappingsInWarnMessage() {
+    final MappingResolver<InputMappings> primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
+    final MappingResolver<InputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
+
+    final Expression sourceExpression = mock(Expression.class);
+    when(sourceExpression.getExpression()).thenReturn("=1");
+
+    final Expression combinedExpression = mock(Expression.class);
+
+    final InputMappings inputMappings =
+        new InputMappings(
+            List.of(new InputMapping(sourceExpression, List.of("a"))),
+            combinedExpression,
+            Collections.emptyMap(),
+            Collections.emptyMap());
+
+    final var result = resolver.resolve(inputMappings, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            e -> {
+              final String formattedMessage = e.getMessage().getFormattedMessage();
+              assertThat(formattedMessage)
+                  .contains("InputMappings{mappings=[InputMapping{source='=1', targetPath=[a]}]}");
+            });
+  }
+
+  @Test
+  void shouldIncludeOutputMappingsInWarnMessage() {
+    final MappingResolver<OutputMappings> primary = (m, p) -> Either.right(msgPackOf("{\"a\":1}"));
+    final MappingResolver<OutputMappings> comparison =
+        (m, p) -> Either.right(msgPackOf("{\"a\":2}"));
+    final var resolver = new ComparingMappingResolver<>(primary, comparison);
+
+    final Expression sourceExpression = mock(Expression.class);
+    when(sourceExpression.getExpression()).thenReturn("=1");
+
+    final Expression combinedExpression = mock(Expression.class);
+
+    final OutputMappings outputMappings =
+        new OutputMappings(
+            combinedExpression, List.of(new OutputMapping(sourceExpression, List.of("a"))));
+
+    final var result = resolver.resolve(outputMappings, PROCESSOR);
+
+    assertThat(result.isRight()).isTrue();
+    assertThat(recorder.getAppendedEvents())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            e -> {
+              final String formattedMessage = e.getMessage().getFormattedMessage();
+              assertThat(formattedMessage)
+                  .contains(
+                      "OutputMappings{mappings=[OutputMapping{source='=1', targetPath=[a]}]}");
             });
   }
 }


### PR DESCRIPTION
## Description

Adjust the logging message of the `ComparingMappingResolver` that prints a warning if the mapping resolvers produce a different result. 

- Include the raw input/output mappings in the message to avoid collecting them from the BPMN
- Remove the log throttling to detect all differences 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

related to https://github.com/camunda/camunda/issues/60556