### PR TITLE
fix: buffer due timer triggers while a process instance is suspended

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -236,6 +236,8 @@ jobs:
         uses: ./.github/actions/analyze-test-runs
         with:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+          # workaround to avoid https://github.com/camunda/camunda/issues/16604
+          skipSummary: true
       - name: Summarize test results
         if: always()
         run: |

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeTimerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeTimerIT.java
@@ -7,18 +7,13 @@
  */
 package io.camunda.it.client;
 
-import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
-import static io.camunda.it.util.TestHelper.startProcessInstance;
-import static io.camunda.it.util.TestHelper.waitForElementInstances;
-import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
-import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
-import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static io.camunda.it.util.TestHelper.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.ElementInstanceState;
-import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.enums.WaitStateType;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -44,7 +39,7 @@ public class ProcessInstanceSuspendResumeTimerIT {
   private static CamundaClient camundaClient;
 
   @Test
-  void shouldFireTimerThatCameDueWhileSuspendedOnlyAfterResume() {
+  void shouldFireTimerTriggeredDuringSuspensionAfterResume() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
     deployProcessAndWaitForIt(
@@ -72,33 +67,9 @@ public class ProcessInstanceSuspendResumeTimerIT {
     // when - the due-date checker would fire if the timer were still indexed
     addTime(Duration.ofSeconds(10));
 
-    // then - trigger is buffered; the catch event does not complete while suspended
-    await()
-        .pollDelay(Duration.ofSeconds(2))
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              assertThat(
-                      camundaClient
-                          .newProcessInstanceGetRequest(processInstanceKey)
-                          .send()
-                          .join()
-                          .getState())
-                  .isEqualTo(ProcessInstanceState.SUSPENDED);
-              assertThat(
-                      camundaClient
-                          .newElementInstanceSearchRequest()
-                          .filter(
-                              f ->
-                                  f.processInstanceKey(processInstanceKey)
-                                      .elementId("timer")
-                                      .state(ElementInstanceState.ACTIVE))
-                          .send()
-                          .join()
-                          .items())
-                  .hasSize(1);
-            });
+    // trigger is buffered: the catch event stays active and the timer wait-state is not
+    // removed (TRIGGERED would drop it)
+    assertTimerWaitStatePresent(processInstanceKey);
 
     // when
     camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
@@ -106,6 +77,7 @@ public class ProcessInstanceSuspendResumeTimerIT {
     // then
     waitForProcessInstancesToBeCompleted(
         camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    assertNumberOfCompletedTimers(processInstanceKey, "timer", 1);
   }
 
   @Test
@@ -136,40 +108,32 @@ public class ProcessInstanceSuspendResumeTimerIT {
 
     // when - resume before the timer is due, then let the checker fire normally
     camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
-    await()
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
-        .ignoreExceptions()
-        .untilAsserted(
-            () ->
-                assertThat(
-                        camundaClient
-                            .newProcessInstanceGetRequest(processInstanceKey)
-                            .send()
-                            .join()
-                            .getState())
-                    .isEqualTo(ProcessInstanceState.ACTIVE));
-    assertThat(
-            camundaClient
-                .newElementInstanceSearchRequest()
-                .filter(
-                    f ->
-                        f.processInstanceKey(processInstanceKey)
-                            .elementId("timer")
-                            .state(ElementInstanceState.ACTIVE))
-                .send()
-                .join()
-                .items())
-        .hasSize(1);
+    waitForProcessInstancesToStart(camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("timer")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+    // the catch event is active again, but the timer must not fire until it is due
+    assertTimerWaitStatePresent(processInstanceKey);
 
     addTime(Duration.ofSeconds(10));
 
     // then
     waitForProcessInstancesToBeCompleted(
         camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+    assertNumberOfCompletedTimers(processInstanceKey, "timer", 1);
   }
 
+  /**
+   * When a cycling timer triggers during a suspension, we expect only a single trigger to be
+   * buffered. Following this, upon resumption, if next due date of the timer is in the past, the
+   * timer will be rescheduled again to now(), causing a second trigger.
+   */
   @Test
-  void shouldFireRepeatingTimerTwiceAfterResumeWhenSeveralCyclesWereDue() {
+  void shouldFireCyclingTimerTwiceAfterResumeWhenSeveralCyclesWereDue() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
     final var jobType = Strings.newRandomValidBpmnId();
@@ -200,46 +164,17 @@ public class ProcessInstanceSuspendResumeTimerIT {
 
     // when - ten one-minute dues pass while suspended; the checker must not catch up yet
     addTime(Duration.ofMinutes(10));
-    await()
-        .pollDelay(Duration.ofSeconds(2))
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              assertThat(
-                      camundaClient
-                          .newProcessInstanceGetRequest(processInstanceKey)
-                          .send()
-                          .join()
-                          .getState())
-                  .isEqualTo(ProcessInstanceState.SUSPENDED);
-              assertThat(
-                      camundaClient
-                          .newElementInstanceSearchRequest()
-                          .filter(
-                              f ->
-                                  f.processInstanceKey(processInstanceKey)
-                                      .elementId("timerEnd")
-                                      .state(ElementInstanceState.COMPLETED))
-                          .send()
-                          .join()
-                          .items())
-                  .isEmpty();
-            });
-
-    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
-
-    // then - buffered trigger plus one overdue reschedule snapped to now; not ten catch-up fires
     waitForElementInstances(
         camundaClient,
         f ->
             f.processInstanceKey(processInstanceKey)
-                .elementId("timerEnd")
-                .state(ElementInstanceState.COMPLETED),
-        2);
+                .elementId("task")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+    // boundary timers are not wait-states; assert the catch-up path did not complete timerEnd
     await()
         .pollDelay(Duration.ofSeconds(2))
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .atMost(Duration.ofSeconds(30))
         .ignoreExceptions()
         .untilAsserted(
             () ->
@@ -254,10 +189,61 @@ public class ProcessInstanceSuspendResumeTimerIT {
                             .send()
                             .join()
                             .items())
-                    .hasSize(2));
-    completeJob(jobType);
-    waitForProcessInstancesToBeCompleted(
-        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+                    .isEmpty());
+
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then - buffered trigger plus one overdue reschedule snapped to now; not ten catch-up fires
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("timerEnd")
+                .state(ElementInstanceState.COMPLETED),
+        2);
+    assertNumberOfCompletedTimers(processInstanceKey, "timerEnd", 2);
+  }
+
+  private static void assertNumberOfCompletedTimers(
+      final long processInstanceKey, final String elementId, final int numberOfCompletedTimers) {
+    await()
+        .pollDelay(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(elementId)
+                                        .state(ElementInstanceState.COMPLETED))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(numberOfCompletedTimers));
+  }
+
+  private static void assertTimerWaitStatePresent(final long processInstanceKey) {
+    await()
+        .pollDelay(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .waitStateType(WaitStateType.TIMER))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
   }
 
   private static void addTime(final Duration duration) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeTimerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSuspendResumeTimerIT.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeSuspended;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage of timer due-date checks against a live broker while an instance is
+ * suspended. EngineRule tests drive time in-process; this class lets {@code
+ * DueDateTimerCheckScheduler} race the suspend/resume path on a real cluster clock.
+ */
+@MultiDbTest
+public class ProcessInstanceSuspendResumeTimerIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withProperty("zeebe.clock.controlled", "true");
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldFireTimerThatCameDueWhileSuspendedOnlyAfterResume() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    deployProcessAndWaitForIt(
+        camundaClient,
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent("timer", e -> e.timerWithDuration("PT5S"))
+            .endEvent()
+            .done(),
+        processId + ".bpmn");
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("timer")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when - the due-date checker would fire if the timer were still indexed
+    addTime(Duration.ofSeconds(10));
+
+    // then - trigger is buffered; the catch event does not complete while suspended
+    await()
+        .pollDelay(Duration.ofSeconds(2))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newProcessInstanceGetRequest(processInstanceKey)
+                          .send()
+                          .join()
+                          .getState())
+                  .isEqualTo(ProcessInstanceState.SUSPENDED);
+              assertThat(
+                      camundaClient
+                          .newElementInstanceSearchRequest()
+                          .filter(
+                              f ->
+                                  f.processInstanceKey(processInstanceKey)
+                                      .elementId("timer")
+                                      .state(ElementInstanceState.ACTIVE))
+                          .send()
+                          .join()
+                          .items())
+                  .hasSize(1);
+            });
+
+    // when
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+  }
+
+  @Test
+  void shouldFireTimerThatBecomesDueAfterResume() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    deployProcessAndWaitForIt(
+        camundaClient,
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent("timer", e -> e.timerWithDuration("PT5S"))
+            .endEvent()
+            .done(),
+        processId + ".bpmn");
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("timer")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when - resume before the timer is due, then let the checker fire normally
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceGetRequest(processInstanceKey)
+                            .send()
+                            .join()
+                            .getState())
+                    .isEqualTo(ProcessInstanceState.ACTIVE));
+    assertThat(
+            camundaClient
+                .newElementInstanceSearchRequest()
+                .filter(
+                    f ->
+                        f.processInstanceKey(processInstanceKey)
+                            .elementId("timer")
+                            .state(ElementInstanceState.ACTIVE))
+                .send()
+                .join()
+                .items())
+        .hasSize(1);
+
+    addTime(Duration.ofSeconds(10));
+
+    // then
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+  }
+
+  @Test
+  void shouldFireRepeatingTimerTwiceAfterResumeWhenSeveralCyclesWereDue() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var jobType = Strings.newRandomValidBpmnId();
+    deployProcessAndWaitForIt(
+        camundaClient,
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .boundaryEvent("timer", b -> b.cancelActivity(false).timerWithCycle("R/PT1M"))
+            .endEvent("timerEnd")
+            .moveToActivity("task")
+            .endEvent("taskEnd")
+            .done(),
+        processId + ".bpmn");
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, processId).getProcessInstanceKey();
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("task")
+                .state(ElementInstanceState.ACTIVE),
+        1);
+
+    camundaClient.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+    waitForProcessInstancesToBeSuspended(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+
+    // when - ten one-minute dues pass while suspended; the checker must not catch up yet
+    addTime(Duration.ofMinutes(10));
+    await()
+        .pollDelay(Duration.ofSeconds(2))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      camundaClient
+                          .newProcessInstanceGetRequest(processInstanceKey)
+                          .send()
+                          .join()
+                          .getState())
+                  .isEqualTo(ProcessInstanceState.SUSPENDED);
+              assertThat(
+                      camundaClient
+                          .newElementInstanceSearchRequest()
+                          .filter(
+                              f ->
+                                  f.processInstanceKey(processInstanceKey)
+                                      .elementId("timerEnd")
+                                      .state(ElementInstanceState.COMPLETED))
+                          .send()
+                          .join()
+                          .items())
+                  .isEmpty();
+            });
+
+    camundaClient.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then - buffered trigger plus one overdue reschedule snapped to now; not ten catch-up fires
+    waitForElementInstances(
+        camundaClient,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .elementId("timerEnd")
+                .state(ElementInstanceState.COMPLETED),
+        2);
+    await()
+        .pollDelay(Duration.ofSeconds(2))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId("timerEnd")
+                                        .state(ElementInstanceState.COMPLETED))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(2));
+    completeJob(jobType);
+    waitForProcessInstancesToBeCompleted(
+        camundaClient, f -> f.processInstanceKey(processInstanceKey), 1);
+  }
+
+  private static void addTime(final Duration duration) {
+    ActorClockActuator.of(BROKER.actuatorUri("clock").toString())
+        .addTime(new AddTimeRequest(duration.toMillis()));
+  }
+
+  private static void completeJob(final String jobType) {
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var activated =
+                  camundaClient
+                      .newActivateJobsCommand()
+                      .jobType(jobType)
+                      .maxJobsToActivate(1)
+                      .workerName("test")
+                      .timeout(Duration.ofSeconds(10))
+                      .send()
+                      .join()
+                      .getJobs();
+              assertThat(activated).hasSize(1);
+              camundaClient.newCompleteCommand(activated.getFirst().getKey()).send().join();
+            });
+  }
+}

--- a/zeebe/docs/adr/0009-810-suspended-timer-buffering.md
+++ b/zeebe/docs/adr/0009-810-suspended-timer-buffering.md
@@ -1,0 +1,157 @@
+# Suspended timers: buffer the due trigger instead of rejecting it
+
+**DRI**: Ambrose Tan
+
+**Status**: Accepted (8.10)
+
+**Purpose**: Defines how a timer that comes due while its process instance is suspended is held and
+later fired — the `Timer.SUSPENDED`/`Timer.RESUMED` events, the due-date index removal, and the
+`onSuspended`/`onResuming` shape of the suspension gate this required.
+
+**Audience**: Zeebe engineers working on timers, the due-date checker, or process instance
+suspension, and AI agents reasoning about the suspension gate.
+
+## Context
+
+Firing a timer advances the token, so `Timer.TRIGGER` could not simply be processed while the
+instance is suspended. The first implementation rejected it. Rejection is a dead end for timers:
+
+- **The command comes back.** A rejection leaves the timer's due-date index row
+  (`TIMER_DUE_DATES`) in place, so `DueDateTimerCheckScheduler` rewrites the same `TRIGGER` on
+  every check for as long as the instance stays suspended. The log fills with rejections that
+  change nothing.
+- **Resume had to re-arm the checker, and that reordered.** To make a missed timer fire at all,
+  `COMPLETE_RESUMING` nudged the checker with a `scheduleTimer(-1)` side effect. A side effect runs
+  after the batch, so the resulting `TRIGGER` landed *after* the buffered commands drained — a
+  timer that came due before a buffered internal command could fire after it, reordering the
+  instance's own history relative to how it would have run unsuspended.
+
+The gate itself also could not express what timers needed. `SuspensionAware.suspensionBehavior`
+returned a classification, and the events that had to accompany buffering were written elsewhere
+(`onBuffer`), while resume ran a separate `void onResume` hook after the gate had already flipped
+`BUFFER` to `PROCESS`. Writing `Timer.SUSPENDED` at buffer time was easy to miss, and the resume
+hook fired for commands that had never been buffered.
+
+## Decision
+
+**D1. A due `Timer.TRIGGER` on a suspended instance is buffered, not rejected, and
+`Timer.SUSPENDED` drops the timer from the due-date index.** `TimerTriggerProcessor.onSuspended`
+appends `Timer.SUSPENDED` and returns `BUFFER`. `TimerSuspendedApplier` removes only the due-date
+index row and keeps the timer instance, so `Timer.CANCEL` and the eventual fire still find the
+timer. The checker no longer sees the timer, so it stops rewriting the command; the original
+`TRIGGER` waits in the buffer and drains during `RESUMING`, in the same position it would have had.
+
+Consequences of dropping the index rather than the instance:
+
+- `remove()` deletes the due-date row with `deleteIfExists`, so a suspended timer takes the normal
+  removal path. The `TRIGGERED`/`CANCELED` v2 appliers that were added to tolerate a missing
+  due-date row were deleted again — the v1 appliers already work with or without it.
+- `hasDueDateEntry(elementInstanceKey, timerKey)` encapsulates the "is this timer suspended"
+  check on the state interface, reading the stored due date rather than making callers pass one.
+
+**D2. `RESUMING` no longer schedules the due-date checker.** The drained `TRIGGER` fires inside
+the drain chain in order, removing the side-effect-ordering hazard described in Context.
+`Timer.RESUMED` restores the due-date index immediately before `Timer.TRIGGERED` removes the timer
+in the same processing transaction. No committed intermediate state exposes the restored overdue
+timer to the checker, while replay follows the complete timer lifecycle.
+
+**D3. `Timer.RESUMED` is written for every `TRIGGER` the gate lets through while `RESUMING`, not
+only for previously buffered ones.** An earlier revision checked if a due-date index was missing so
+that a timer that triggered *during* `RESUMING` did not get an unpaired `RESUMED`. That guard was
+dropped: distinguishing the two cases costs a state read on every pass-through and buys only strict
+event pairing, which nothing consumes (D5). The resumed applier upserts the due-date entry when the
+timer still exists, so an already indexed fresh trigger is unchanged and a duplicate trigger cannot
+recreate an index entry after the timer was removed. `shouldEmitResumedForFreshTriggerWhileResuming`
+tests the chosen behavior.
+
+**D4. The gate exposes two classification callbacks, `onSuspended` and `onResuming`, both returning
+`SuspensionAction`.** The gate switches on the marker and calls `onSuspended` while `SUSPENDED`,
+`onResuming` while `RESUMING`. Events that accompany buffering belong in `onSuspended`; events that
+accompany resume belong in `onResuming`. This replaces the split between a classifier and a
+separate `onBuffer`/`onResume` pair, and is what makes the timer's two writes sit next to the
+decision that causes them.
+
+- A processor that rejects while `SUSPENDED` must also return `REJECT` from `onResuming`.
+  Rejected commands were never buffered, so they have no work that needs to drain. Returning
+  `PROCESS` would admit external job, user-task, migration, or repeated-suspend commands while
+  buffered commands and suspended jobs are still being restored. Depending on how far resume had
+  progressed, the same command could then be accepted or rejected by downstream state checks.
+  Keeping it at `REJECT` makes the instance unavailable for those operations until the suspension
+  marker is removed.
+- A mixed processor such as `BpmnStreamProcessor` still rejects only externally issued commands
+  and passes internal ones through.
+- Renames that follow: `SuspensionCheck` → `SuspensionBehavior` (the gate),
+  `SuspensionAware.SuspensionBehavior` → `SuspensionAction` (the enum).
+- `Engine` now applies the outcome with an exhaustive switch that names `PROCESS`, so a new
+  `SuspensionAction` fails to compile until it is handled, replacing the `IllegalStateException`
+  fallback.
+
+**D5. Both events drive engine state through their appliers, but change nothing in secondary
+storage.** They are added to `TimerIntent` as events (values 6 and 7), and they are handled at two
+distinct stages:
+
+- **Engine state (applied).** `TimerSuspendedApplier` removes the due-date index row (D1);
+  `TimerResumedApplier` restores it before the drained trigger removes the timer (D2). Both are
+  registered in `EventAppliers`, so replay reconstructs the same state.
+- **Secondary storage (not written).** `TimerBasedWaitStateTransformer` decides what a timer record
+  does to the wait-state index from `WaitStateConfigs.TIMER_CONFIG`, whose intent lists are
+  `CREATED` (add), `MIGRATED` (update), and `TRIGGERED`/`CANCELED` (remove). `SUSPENDED` and
+  `RESUMED` are in none of them, so a suspended timer keeps its existing wait-state entry rather
+  than being removed and re-added around the suspension.
+
+This is the same position [ADR-0008](0008-810-suspended-job-state.md) D4 takes for
+`Job.SUSPENDED`/`Job.RESUMED`: suspension stays visible at process instance level only.
+
+**D6. Start-event timers are unchanged.** They have no process instance, so the gate never resolves
+a suspension marker for them.
+
+## Alternatives considered
+
+- **Keep rejecting `TRIGGER` and re-arm the checker on resume.** The shipped-then-replaced
+  behavior. Rejected on the three failures in Context: repeated rejections while suspended, a
+  post-drain fire that reorders against buffered commands, and a catch-up count that depends on
+  checker passes.
+- **Restore the due-date index on `Timer.RESUMED` and let the checker fire the timer again.**
+  Rejected because deferring the fire to the checker puts it outside the drain chain and
+  reintroduces exactly the ordering problem D2 removes. The chosen approach restores the index and
+  processes the drained `TRIGGER` in the same transaction instead.
+- **Remove the whole timer instance on suspend and recreate it on resume.** Rejected: `Timer.CANCEL`
+  and element termination need to keep finding the timer while the instance is suspended, and
+  recreating it would have to reconstruct the record from the buffered command.
+- **Guard `Timer.RESUMED` on a missing due-date index** (see D3). Rejected as a state read per
+  pass-through for pairing no consumer needs.
+- **Derive `onResuming` from `onSuspended`.** Rejected because `onSuspended` is not a pure
+  classification: it may write events such as `Timer.SUSPENDED`, and returning `BUFFER` during
+  `RESUMING` would re-buffer drained commands and prevent resume from completing.
+
+## Consequences
+
+- A repeating timer that missed several cycles while suspended fires **twice** after resume: the
+  buffered trigger, plus one overdue reschedule snapped to now — not once per missed cycle. This is
+  the user-visible catch-up contract and is asserted on a live broker.
+- A duplicate `TRIGGER` that arrives while suspended is also buffered; drain rejects the extra as
+  `NOT_FOUND`. Suspension is not deduplicating.
+- A timer that becomes due after resume is neither suspended nor resumed — the normal path.
+- `hasDueDateEntry` is currently exercised only by tests, since D3 removed its production caller.
+  It stays on the state interface as the sanctioned way to ask the question.
+- Every processor implementing `SuspensionAware` must explicitly classify commands for both
+  `SUSPENDED` and `RESUMING`. The compiler prevents omissions, while the classifications still need
+  to be reviewed together for consistency.
+- No downgrade once a timer is suspended: older brokers do not know `TimerIntent` values 6 and 7.
+
+## Testing
+
+`EngineRule` drives time in-process and cannot race `DueDateTimerCheckScheduler` against a cluster
+clock, so the due-date behavior is covered by a MultiDb IT
+(`ProcessInstanceSuspendResumeTimerIT`) with a controlled actor clock, asserting the user-visible
+outcomes: a timer due while suspended does not fire until resume, a timer due after resume fires
+normally, and the repeating-timer catch-up above. Unit coverage sits in `TimerSuspensionGateTest`,
+`TimerSuspendedApplierTest`, `TimerInstanceStateTest`, and `SuspensionBehaviorTest`.
+
+## Source
+
+- [#61750](https://github.com/camunda/camunda/issues/61750) — overhaul timer suspension.
+- [#62241](https://github.com/camunda/camunda/pull/62241) — implementation summarized by this ADR.
+- [ADR-0008](0008-810-suspended-job-state.md) — suspended job state; the export position (D5) and
+  the suspend/resume gate this ADR extends.
+

--- a/zeebe/docs/adr/0009-810-suspended-timer-buffering.md
+++ b/zeebe/docs/adr/0009-810-suspended-timer-buffering.md
@@ -11,115 +11,42 @@ later fired — the `Timer.SUSPENDED`/`Timer.RESUMED` events, the due-date index
 **Audience**: Zeebe engineers working on timers, the due-date checker, or process instance
 suspension, and AI agents reasoning about the suspension gate.
 
-## Context
-
-Firing a timer advances the token, so `Timer.TRIGGER` could not simply be processed while the
-instance is suspended. The first implementation rejected it. Rejection is a dead end for timers:
-
-- **The command comes back.** A rejection leaves the timer's due-date index row
-  (`TIMER_DUE_DATES`) in place, so `DueDateTimerCheckScheduler` rewrites the same `TRIGGER` on
-  every check for as long as the instance stays suspended. The log fills with rejections that
-  change nothing.
-- **Resume had to re-arm the checker, and that reordered.** To make a missed timer fire at all,
-  `COMPLETE_RESUMING` nudged the checker with a `scheduleTimer(-1)` side effect. A side effect runs
-  after the batch, so the resulting `TRIGGER` landed *after* the buffered commands drained — a
-  timer that came due before a buffered internal command could fire after it, reordering the
-  instance's own history relative to how it would have run unsuspended.
-
-The gate itself also could not express what timers needed. `SuspensionAware.suspensionBehavior`
-returned a classification, and the events that had to accompany buffering were written elsewhere
-(`onBuffer`), while resume ran a separate `void onResume` hook after the gate had already flipped
-`BUFFER` to `PROCESS`. Writing `Timer.SUSPENDED` at buffer time was easy to miss, and the resume
-hook fired for commands that had never been buffered.
-
 ## Decision
 
-**D1. A due `Timer.TRIGGER` on a suspended instance is buffered, not rejected, and
-`Timer.SUSPENDED` drops the timer from the due-date index.** `TimerTriggerProcessor.onSuspended`
+**D1. A due `Timer.TRIGGER` on a suspended instance is buffered and `Timer.SUSPENDED` drops the
+timer from the due-date index.** `TimerTriggerProcessor.onSuspended`
 appends `Timer.SUSPENDED` and returns `BUFFER`. `TimerSuspendedApplier` removes only the due-date
 index row and keeps the timer instance, so `Timer.CANCEL` and the eventual fire still find the
 timer. The checker no longer sees the timer, so it stops rewriting the command; the original
-`TRIGGER` waits in the buffer and drains during `RESUMING`, in the same position it would have had.
+`TRIGGER` waits in the buffer and drains during `RESUMING` in order.
 
 Consequences of dropping the index rather than the instance:
 
-- `remove()` deletes the due-date row with `deleteIfExists`, so a suspended timer takes the normal
-  removal path. The `TRIGGERED`/`CANCELED` v2 appliers that were added to tolerate a missing
-  due-date row were deleted again — the v1 appliers already work with or without it.
-- `hasDueDateEntry(elementInstanceKey, timerKey)` encapsulates the "is this timer suspended"
-  check on the state interface, reading the stored due date rather than making callers pass one.
+- `remove()` must now delete the due-date row with `deleteIfExists`, so a suspended timer without
+  a due-date row can take the normal removal path.
 
-**D2. `RESUMING` no longer schedules the due-date checker.** The drained `TRIGGER` fires inside
-the drain chain in order, removing the side-effect-ordering hazard described in Context.
-`Timer.RESUMED` restores the due-date index immediately before `Timer.TRIGGERED` removes the timer
-in the same processing transaction. No committed intermediate state exposes the restored overdue
-timer to the checker, while replay follows the complete timer lifecycle.
-
-**D3. `Timer.RESUMED` is written for every `TRIGGER` the gate lets through while `RESUMING`, not
-only for previously buffered ones.** An earlier revision checked if a due-date index was missing so
-that a timer that triggered *during* `RESUMING` did not get an unpaired `RESUMED`. That guard was
-dropped: distinguishing the two cases costs a state read on every pass-through and buys only strict
-event pairing, which nothing consumes (D5). The resumed applier upserts the due-date entry when the
+**D2. `Timer.RESUMED` is written for every `TRIGGER` the gate lets through while `RESUMING`, not
+only for previously buffered ones.** The resumed applier upserts the due-date entry when the
 timer still exists, so an already indexed fresh trigger is unchanged and a duplicate trigger cannot
-recreate an index entry after the timer was removed. `shouldEmitResumedForFreshTriggerWhileResuming`
-tests the chosen behavior.
+recreate an index entry after the timer was removed. This side-effect is currently accepted.
 
-**D4. The gate exposes two classification callbacks, `onSuspended` and `onResuming`, both returning
-`SuspensionAction`.** The gate switches on the marker and calls `onSuspended` while `SUSPENDED`,
+**D3. The gate exposes two classification callbacks, `onSuspended` and `onResuming`, both returning
+`SuspensionAction`.** The gate checks the marker and calls `onSuspended` while `SUSPENDED` and
 `onResuming` while `RESUMING`. Events that accompany buffering belong in `onSuspended`; events that
-accompany resume belong in `onResuming`. This replaces the split between a classifier and a
-separate `onBuffer`/`onResume` pair, and is what makes the timer's two writes sit next to the
-decision that causes them.
+accompany resume belong in `onResuming`.
 
-- A processor that rejects while `SUSPENDED` must also return `REJECT` from `onResuming`.
-  Rejected commands were never buffered, so they have no work that needs to drain. Returning
-  `PROCESS` would admit external job, user-task, migration, or repeated-suspend commands while
-  buffered commands and suspended jobs are still being restored. Depending on how far resume had
-  progressed, the same command could then be accepted or rejected by downstream state checks.
-  Keeping it at `REJECT` makes the instance unavailable for those operations until the suspension
-  marker is removed.
-- A mixed processor such as `BpmnStreamProcessor` still rejects only externally issued commands
-  and passes internal ones through.
-- Renames that follow: `SuspensionCheck` → `SuspensionBehavior` (the gate),
-  `SuspensionAware.SuspensionBehavior` → `SuspensionAction` (the enum).
-- `Engine` now applies the outcome with an exhaustive switch that names `PROCESS`, so a new
-  `SuspensionAction` fails to compile until it is handled, replacing the `IllegalStateException`
-  fallback.
+- Processors must ensure that the commands returned are compatible between `onSuspended` and
+  `onResuming`. For instance, a command that always gets processed on suspend should always get
+  processed when resuming.
 
-**D5. Both events drive engine state through their appliers, but change nothing in secondary
-storage.** They are added to `TimerIntent` as events (values 6 and 7), and they are handled at two
-distinct stages:
-
-- **Engine state (applied).** `TimerSuspendedApplier` removes the due-date index row (D1);
-  `TimerResumedApplier` restores it before the drained trigger removes the timer (D2). Both are
-  registered in `EventAppliers`, so replay reconstructs the same state.
-- **Secondary storage (not written).** `TimerBasedWaitStateTransformer` decides what a timer record
-  does to the wait-state index from `WaitStateConfigs.TIMER_CONFIG`, whose intent lists are
-  `CREATED` (add), `MIGRATED` (update), and `TRIGGERED`/`CANCELED` (remove). `SUSPENDED` and
-  `RESUMED` are in none of them, so a suspended timer keeps its existing wait-state entry rather
-  than being removed and re-added around the suspension.
-
-This is the same position [ADR-0008](0008-810-suspended-job-state.md) D4 takes for
-`Job.SUSPENDED`/`Job.RESUMED`: suspension stays visible at process instance level only.
-
-**D6. Start-event timers are unchanged.** They have no process instance, so the gate never resolves
+**D4. Start-event timers are unchanged.** They have no process instance, so the gate never resolves
 a suspension marker for them.
 
 ## Alternatives considered
 
-- **Keep rejecting `TRIGGER` and re-arm the checker on resume.** The shipped-then-replaced
-  behavior. Rejected on the three failures in Context: repeated rejections while suspended, a
-  post-drain fire that reorders against buffered commands, and a catch-up count that depends on
-  checker passes.
-- **Restore the due-date index on `Timer.RESUMED` and let the checker fire the timer again.**
-  Rejected because deferring the fire to the checker puts it outside the drain chain and
-  reintroduces exactly the ordering problem D2 removes. The chosen approach restores the index and
-  processes the drained `TRIGGER` in the same transaction instead.
-- **Remove the whole timer instance on suspend and recreate it on resume.** Rejected: `Timer.CANCEL`
-  and element termination need to keep finding the timer while the instance is suspended, and
-  recreating it would have to reconstruct the record from the buffered command.
-- **Guard `Timer.RESUMED` on a missing due-date index** (see D3). Rejected as a state read per
-  pass-through for pairing no consumer needs.
+- **Keep rejecting `TRIGGER` and re-arm the checker on resume.** Rejected due to two failure
+  points: repeated rejections while a timer was suspended, and an out of order timer trigger since
+  rescheduling the timer only happens after draining.
 - **Derive `onResuming` from `onSuspended`.** Rejected because `onSuspended` is not a pure
   classification: it may write events such as `Timer.SUSPENDED`, and returning `BUFFER` during
   `RESUMING` would re-buffer drained commands and prevent resume from completing.
@@ -128,12 +55,48 @@ a suspension marker for them.
 
 - A repeating timer that missed several cycles while suspended fires **twice** after resume: the
   buffered trigger, plus one overdue reschedule snapped to now — not once per missed cycle. This is
-  the user-visible catch-up contract and is asserted on a live broker.
+  the user-visible catch-up contract and is asserted on a live broker. This is illustrated by the
+  sequence diagram below.
+
+  ```mermaid
+  sequenceDiagram
+    autonumber
+    participant Clock
+    participant DueDateChecker
+    participant Processor as TimerTriggerProcessor
+    participant Interval as Interval.toEpochMilli
+    participant Catch as CatchEventBehavior
+    participant State as Timer state
+
+    Note over Clock,State: Cycle R/PT1H. Timer CREATED due at t=1h.
+    Clock->>Clock: Instance suspended
+    Processor->>State: TIMER.SUSPENDED (BUFFER the TRIGGER)
+    Clock->>Clock: Time jumps 1h → 4.5h<br/>(slots 2h, 3h, 4h never scheduled)
+
+    Clock->>Processor: Resume
+    Processor->>State: TIMER.RESUMED (restore due-date index)
+    Note over Processor: PROCESS buffered TRIGGER (due=1h)
+
+    Processor->>State: TIMER.TRIGGERED (fire 1)
+    Processor->>Processor: refreshTimer: start = 1h + 1h = 2h
+    Processor->>Catch: subscribeToTimerEvent(refreshed)
+    Catch->>Interval: getDueDate(now=4.5h)
+    Interval-->>Catch: max(2h, 4.5h) = 4.5h  (snap)
+    Catch->>State: TIMER.CREATED due=4.5h
+    Catch->>DueDateChecker: scheduleTimer(4.5h)
+
+    DueDateChecker->>Processor: TIMER.TRIGGER (already due)
+    Processor->>State: TIMER.TRIGGERED (fire 2, catch-up)
+    Processor->>Processor: refreshTimer: start = 4.5h + 1h = 5.5h
+    Processor->>Catch: subscribeToTimerEvent(refreshed)
+    Catch->>Interval: getDueDate(now≈4.5h)
+    Interval-->>Catch: max(5.5h, 4.5h) = 5.5h
+    Catch->>State: TIMER.CREATED due=5.5h
+    Note over Clock,State: Missed 2h/3h/4h are not replayed.<br/>Next fire is at 5.5h.
+  ```
 - A duplicate `TRIGGER` that arrives while suspended is also buffered; drain rejects the extra as
   `NOT_FOUND`. Suspension is not deduplicating.
 - A timer that becomes due after resume is neither suspended nor resumed — the normal path.
-- `hasDueDateEntry` is currently exercised only by tests, since D3 removed its production caller.
-  It stays on the state interface as the sanctioned way to ask the question.
 - Every processor implementing `SuspensionAware` must explicitly classify commands for both
   `SUSPENDED` and `RESUMING`. The compiler prevents omissions, while the classifications still need
   to be reviewed together for consistency.
@@ -141,17 +104,14 @@ a suspension marker for them.
 
 ## Testing
 
-`EngineRule` drives time in-process and cannot race `DueDateTimerCheckScheduler` against a cluster
-clock, so the due-date behavior is covered by a MultiDb IT
-(`ProcessInstanceSuspendResumeTimerIT`) with a controlled actor clock, asserting the user-visible
-outcomes: a timer due while suspended does not fire until resume, a timer due after resume fires
-normally, and the repeating-timer catch-up above. Unit coverage sits in `TimerSuspensionGateTest`,
-`TimerSuspendedApplierTest`, `TimerInstanceStateTest`, and `SuspensionBehaviorTest`.
+The due-date behavior is covered by a MultiDb IT (`ProcessInstanceSuspendResumeTimerIT`)
+with a controlled actor clock, asserting the user-visible outcomes: a timer due while suspended does
+not fire until resume, a timer due after resume fires normally, and the repeating-timer catch-up
+above. Unit test coverage sits in `TimerSuspensionGateTest`, `TimerSuspendedApplierTest`,
+`TimerInstanceStateTest`, and `SuspensionBehaviorTest`.
 
 ## Source
 
 - [#61750](https://github.com/camunda/camunda/issues/61750) — overhaul timer suspension.
 - [#62241](https://github.com/camunda/camunda/pull/62241) — implementation summarized by this ADR.
-- [ADR-0008](0008-810-suspended-job-state.md) — suspended job state; the export position (D5) and
-  the suspend/resume gate this ADR extends.
 

--- a/zeebe/docs/adr/README.md
+++ b/zeebe/docs/adr/README.md
@@ -18,4 +18,5 @@ process-execution data path). These are module-scoped decisions; see the
 | [0006](0006-810-late-business-id-assignment.md)                     | Late Business ID assignment: one irreversible forward-only assignment on a running instance (uniqueness off)  |
 | [0007](0007-810-job-waiting-for-secret-resolution-state.md)         | Persisted `WAITING_FOR_SECRET_RESOLUTION` job state for jobs parked while their secret references resolve     |
 | [0008](0008-810-suspended-job-state.md)                             | Persisted `SUSPENDED` job state that withholds the jobs of a suspended process instance from hand-out         |
+| [0009](0009-810-suspended-timer-buffering.md)                       | Buffer a due timer trigger while suspended, drop its due-date index, fire it in the drain chain               |
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -196,20 +196,14 @@ public class Engine implements RecordProcessor {
       }
 
       final var suspension = suspensionBehavior.process(typedCommand, currentProcessor);
-      final boolean shouldProcess =
-          switch (suspension.outcome()) {
-            case REJECT -> {
-              rejectSuspendedInstanceCommand(typedCommand, suspension.processInstanceKey());
-              yield false;
-            }
-            case BUFFER -> {
-              bufferingBehavior.bufferCommand(typedCommand, suspension.processInstanceKey());
-              yield false;
-            }
-            case PROCESS -> true;
-          };
-      if (shouldProcess) {
-        currentProcessor.processRecord(record, processingResultBuilder);
+      switch (suspension.outcome()) {
+        case REJECT -> {
+          rejectSuspendedInstanceCommand(typedCommand, suspension.processInstanceKey());
+        }
+        case BUFFER -> {
+          bufferingBehavior.bufferCommand(typedCommand, suspension.processInstanceKey());
+        }
+        default -> currentProcessor.processRecord(record, processingResultBuilder);
       }
     }
     return processingResultBuilder.build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -10,8 +10,7 @@ package io.camunda.zeebe.engine;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.processinstance.CommandBufferingBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorContextImpl;
@@ -58,8 +57,6 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
   private static final String DEBUG_MESSAGE_PI_KEY_NOT_FOUND =
       "Expected to reject command for banned process instance, but could not extract process instance key from record '{}'. Skipping rejection response.";
-  private static final String ERROR_MESSAGE_UNEXPECTED_SUSPENSION_DECISION =
-      "Expected to handle a known suspension decision, but got '%s'. Please report this as a bug.";
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
       EnumSet.range(ValueType.JOB, ValueType.SCALE);
 
@@ -67,7 +64,7 @@ public class Engine implements RecordProcessor {
   private RecordProcessorMap recordProcessorMap;
   private MutableProcessingState processingState;
   private CommandBufferingBehavior bufferingBehavior;
-  private SuspensionCheck suspensionCheck;
+  private SuspensionBehavior suspensionBehavior;
 
   private final ErrorRecord errorRecord = new ErrorRecord();
 
@@ -137,7 +134,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext, writers, config, securityConfig);
     processingState = typedProcessorContext.getProcessingState();
     writers.setKeyValidator(processingState.getKeyGenerator());
-    suspensionCheck = new SuspensionCheck(processingState);
+    suspensionBehavior = new SuspensionBehavior(processingState);
     final var suspensionMetrics = typedProcessorContext.getSuspensionMetrics();
 
     ((EventAppliers) eventApplier).registerEventAppliers(processingState);
@@ -192,18 +189,28 @@ public class Engine implements RecordProcessor {
         rejectBannedInstanceCommand(typedCommand);
         return processingResultBuilder.build();
       }
-      final var suspension = suspensionCheck.resolve(typedCommand, currentProcessor);
-      if (suspension.outcome() != SuspensionBehavior.PROCESS) {
-        // Reject or buffer commands for suspended process instances
-        handleSuspensionOutcome(typedCommand, suspension);
-        return processingResultBuilder.build();
-      }
 
       // regular case handling
       if (currentProcessor.shouldProcessResultsInSeparateBatches()) {
         processingResultBuilder.withProcessInASeparateBatch();
       }
-      currentProcessor.processRecord(record, processingResultBuilder);
+
+      final var suspension = suspensionBehavior.process(typedCommand, currentProcessor);
+      final boolean shouldProcess =
+          switch (suspension.outcome()) {
+            case REJECT -> {
+              rejectSuspendedInstanceCommand(typedCommand, suspension.processInstanceKey());
+              yield false;
+            }
+            case BUFFER -> {
+              bufferingBehavior.bufferCommand(typedCommand, suspension.processInstanceKey());
+              yield false;
+            }
+            case PROCESS -> true;
+          };
+      if (shouldProcess) {
+        currentProcessor.processRecord(record, processingResultBuilder);
+      }
     }
     return processingResultBuilder.build();
   }
@@ -285,19 +292,6 @@ public class Engine implements RecordProcessor {
       final TypedRecord<?> typedCommand, final long processInstanceKey) {
     rejectInstanceCommand(
         typedCommand, String.format(ERROR_MESSAGE_SUSPENDED_PI, processInstanceKey));
-  }
-
-  private void handleSuspensionOutcome(
-      final TypedRecord<?> typedCommand, final SuspensionCheck.SuspensionResult suspension) {
-    final var outcome = suspension.outcome();
-    if (outcome == SuspensionBehavior.REJECT) {
-      rejectSuspendedInstanceCommand(typedCommand, suspension.processInstanceKey());
-    } else if (outcome == SuspensionBehavior.BUFFER) {
-      bufferingBehavior.bufferCommand(typedCommand, suspension.processInstanceKey());
-    } else {
-      throw new IllegalStateException(
-          String.format(ERROR_MESSAGE_UNEXPECTED_SUSPENSION_DECISION, outcome));
-    }
   }
 
   private void rejectInstanceCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -101,7 +101,6 @@ public final class BpmnProcessors {
         processingState,
         asyncRequestBehavior,
         cslCheck,
-        timerChecker,
         bpmnBehaviors.jobActivationBehavior(),
         subscriptionCommandSender,
         transientProcessMessageSubscriptionState,
@@ -189,7 +188,6 @@ public final class BpmnProcessors {
       final ProcessingState processingState,
       final AsyncRequestBehavior asyncRequestBehavior,
       final CslAuthorizationCheck cslCheck,
-      final DueDateTimerCheckScheduler timerChecker,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
@@ -216,7 +214,6 @@ public final class BpmnProcessors {
             processingState.getElementInstanceState(),
             processingState.getSuspensionState(),
             writers,
-            timerChecker,
             suspensionMetrics));
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdH
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -183,11 +182,15 @@ public class AdHocSubProcessInstructionActivateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
     // external commands are rejected, not buffered: buffering intercepts before authorize() runs,
     // so a queued external command would replay as internal on drain and skip authorization
-    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 
   private void writeRejectionError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -185,12 +185,12 @@ public class AdHocSubProcessInstructionActivateProcessor
   public SuspensionAction onSuspended(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
     // external commands are rejected, not buffered: buffering intercepts before authorize() runs,
     // so a queued external command would replay as internal on drain and skip authorization
-    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    return SuspensionAware.bufferInternalOnly(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+    return SuspensionAware.processInternalOnly(record);
   }
 
   private void writeRejectionError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
@@ -72,12 +72,12 @@ public class AdHocSubProcessInstructionCompleteProcessor
 
   @Override
   public SuspensionAction onSuspended(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    return SuspensionAware.bufferInternalOnly(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+    return SuspensionAware.processInternalOnly(record);
   }
 
   private BpmnElementContext createBpmnElementContext(final ElementInstance elementInstance) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionCompleteProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnAdHocSubProcessBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -72,9 +71,13 @@ public class AdHocSubProcessInstructionCompleteProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<AdHocSubProcessInstructionRecord> record) {
-    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AdHocSubProcessInstructionRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 
   private BpmnElementContext createBpmnElementContext(final ElementInstance elementInstance) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.agentinstance.AgentHistoryBatchBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -110,7 +109,12 @@ public final class AgentHistoryCommitProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -55,7 +54,12 @@ public final class AgentHistoryDiscardProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AgentHistoryRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistorybatch/AgentHistoryBatchCleanUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistorybatch/AgentHistoryBatchCleanUpProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.agenthistorybatch;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -95,6 +94,11 @@ public final class AgentHistoryBatchCleanUpProcessor
     }
   }
 
+  @Override
+  public boolean shouldProcessResultsInSeparateBatches() {
+    return true;
+  }
+
   private boolean collectUpToChunkSize(
       final HashSet<String> idsToDelete, final AtomicBoolean hasMore, final String id) {
     // An id already collected from the other column family doesn't need a new budget slot: check
@@ -116,12 +120,12 @@ public final class AgentHistoryBatchCleanUpProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentHistoryBatchRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<AgentHistoryBatchRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   @Override
-  public boolean shouldProcessResultsInSeparateBatches() {
-    return true;
+  public SuspensionAction onResuming(final TypedRecord<AgentHistoryBatchRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCompleteProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -85,7 +84,12 @@ public final class AgentInstanceCompleteProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<AgentInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AgentInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -361,11 +361,11 @@ public final class AgentInstanceCreateProcessor
 
   @Override
   public SuspensionAction onSuspended(final TypedRecord<AgentInstanceRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    return SuspensionAware.bufferInternalOnly(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<AgentInstanceRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+    return SuspensionAware.processInternalOnly(record);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -360,7 +360,12 @@ public final class AgentInstanceCreateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
-    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<AgentInstanceRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AgentInstanceRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -367,11 +367,11 @@ public final class AgentInstanceUpdateProcessor
 
   @Override
   public SuspensionAction onSuspended(final TypedRecord<AgentInstanceRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    return SuspensionAware.bufferInternalOnly(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<AgentInstanceRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+    return SuspensionAware.processInternalOnly(record);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -366,7 +366,12 @@ public final class AgentInstanceUpdateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<AgentInstanceRecord> record) {
-    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<AgentInstanceRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<AgentInstanceRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -178,7 +178,7 @@ public final class BpmnStreamProcessor
     // is rejected; internal forward-progress element events are buffered instead.
     return switch ((ProcessInstanceIntent) record.getIntent()) {
       case TERMINATE_ELEMENT, CONTINUE_TERMINATING_ELEMENT -> SuspensionAction.PROCESS;
-      default -> record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+      default -> SuspensionAware.bufferInternalOnly(record);
     };
   }
 
@@ -186,7 +186,7 @@ public final class BpmnStreamProcessor
   public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
     return switch ((ProcessInstanceIntent) record.getIntent()) {
       case TERMINATE_ELEMENT, CONTINUE_TERMINATING_ELEMENT -> SuspensionAction.PROCESS;
-      default -> record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+      default -> SuspensionAware.processInternalOnly(record);
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -173,12 +173,20 @@ public final class BpmnStreamProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceRecord> record) {
     // Termination must complete even on a suspended instance. Any other externally issued command
     // is rejected; internal forward-progress element events are buffered instead.
     return switch ((ProcessInstanceIntent) record.getIntent()) {
-      case TERMINATE_ELEMENT, CONTINUE_TERMINATING_ELEMENT -> SuspensionBehavior.PROCESS;
-      default -> record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+      case TERMINATE_ELEMENT, CONTINUE_TERMINATING_ELEMENT -> SuspensionAction.PROCESS;
+      default -> record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    };
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
+    return switch ((ProcessInstanceIntent) record.getIntent()) {
+      case TERMINATE_ELEMENT, CONTINUE_TERMINATING_ELEMENT -> SuspensionAction.PROCESS;
+      default -> record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalSubscriptionTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalSubscriptionTriggerProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -113,8 +112,12 @@ public class ConditionalSubscriptionTriggerProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ConditionalSubscriptionRecord> record) {
-    return SuspensionBehavior.BUFFER;
+  public SuspensionAction onSuspended(final TypedRecord<ConditionalSubscriptionRecord> record) {
+    return SuspensionAction.BUFFER;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ConditionalSubscriptionRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -313,11 +313,11 @@ public final class IncidentResolveProcessor
 
   @Override
   public SuspensionAction onSuspended(final TypedRecord<IncidentRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    return SuspensionAware.bufferInternalOnly(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<IncidentRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+    return SuspensionAware.processInternalOnly(record);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -95,8 +94,7 @@ public final class IncidentResolveProcessor
     this.cslCheck = cslCheck;
     this.tenantCheck = tenantCheck;
     this.incidentMetrics = incidentMetrics;
-    this.bannedInstanceCheck =
-        new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
+    bannedInstanceCheck = new BannedInstanceCommandCheck(processingState.getBannedInstanceState());
   }
 
   @Override
@@ -314,7 +312,12 @@ public final class IncidentResolveProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<IncidentRecord> record) {
-    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<IncidentRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<IncidentRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.AgentDefinitionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -79,8 +78,13 @@ public final class JobCancelProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
     // cancellation should still work during suspension
-    return SuspensionBehavior.PROCESS;
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizatio
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignmentBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -632,7 +631,12 @@ public final class JobCompleteProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -236,7 +235,12 @@ public final class JobFailProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurAfterBackoffProcessor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -94,7 +93,12 @@ public class JobRecurAfterBackoffProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.BUFFER;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.BUFFER;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -282,7 +281,12 @@ public class JobThrowErrorProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -102,9 +101,14 @@ public final class JobTimeOutProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
     // Process while suspended: an activated job must leave ACTIVATED on time-out so it can be
     // parked (Job.SUSPENDED) instead of looping on rejected TIME_OUT commands forever.
-    return SuspensionBehavior.PROCESS;
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -93,7 +92,12 @@ public class JobUpdateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -64,7 +63,12 @@ public final class JobUpdateRetriesProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -64,7 +63,12 @@ public class JobUpdateTimeoutProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -67,10 +66,15 @@ public final class JobYieldProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<JobRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<JobRecord> record) {
     // YIELD is an internal command (written by the job-stream error handler when a client is
     // blocked); buffer it while suspended so the yield is applied once the instance resumes instead
     // of being lost to a rejection.
-    return SuspensionBehavior.BUFFER;
+    return SuspensionAction.BUFFER;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<JobRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior.MessageData;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -305,7 +304,12 @@ public final class MessageCorrelationCorrelateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<MessageCorrelationRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<MessageCorrelationRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<MessageCorrelationRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -143,7 +142,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       // Race window: SUSPEND already deleted the message-side subscription, but this CORRELATE
       // was already in flight. Reject to release the message-side lock — another active
       // subscriber can then correlate, or the message returns 404. Gated on exact SUSPENDED, not
-      // isSuspended(); see suspensionBehavior() below for why RESUMING must fall through instead.
+      // isSuspended(); see onSuspended() below for why RESUMING must fall through instead.
       // Checked last so a stale or duplicate correlate goes through those paths instead, without
       // releasing a live replacement's correlation lock.
       rejectCommand(command, RejectionType.INVALID_STATE, SUSPENDED_PI_MESSAGE);
@@ -273,13 +272,17 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ProcessMessageSubscriptionRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<ProcessMessageSubscriptionRecord> record) {
     // Process unconditionally — buffering would keep the message-partition lock held
     // indefinitely while the instance is suspended or resuming. The exact-SUSPENDED check
     // inside processRecord rejects a CORRELATE that arrives during the narrow suspend/close
     // race window. During RESUMING it must fall through instead: an early reopened subscription
     // can correlate a still-buffered message while later REOPEN commands are still draining.
-    return SuspensionBehavior.PROCESS;
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessMessageSubscriptionRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BufferedCommandDrainProcessor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -38,7 +37,7 @@ import org.jspecify.annotations.NullMarked;
  * current, since event appliers run synchronously — to decide the next step: another {@code DRAIN}
  * if more remains, or {@code RESUME_JOBS} to hand off to {@link
  * ProcessInstanceResumeJobsProcessor}, which un-parks jobs and appends {@code COMPLETE_RESUMING}
- * itself. {@link SuspensionBehavior#PROCESS} is unconditional: gating a {@code DRAIN} would strand
+ * itself. {@link SuspensionAction#PROCESS} is unconditional: gating a {@code DRAIN} would strand
  * the instance in {@code RESUMING} forever.
  *
  * <p>A cycle that fails to write (e.g. batch size exceeded) halts rather than drops the command:
@@ -162,9 +161,14 @@ public final class BufferedCommandDrainProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<BufferedCommandRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<BufferedCommandRecord> record) {
     // DRAIN is what ends the suspension: gating it would strand the instance in RESUMING
-    return SuspensionBehavior.PROCESS;
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<BufferedCommandRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   private void appendBufferedCommand(final BufferedCommand buffered) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -135,8 +134,12 @@ public final class ProcessInstanceBatchActivateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ProcessInstanceBatchRecord> record) {
-    return SuspensionBehavior.BUFFER;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceBatchRecord> record) {
+    return SuspensionAction.BUFFER;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceBatchRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchTerminateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchTerminateProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -67,9 +66,13 @@ public final class ProcessInstanceBatchTerminateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ProcessInstanceBatchRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceBatchRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceBatchRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   private List<ElementInstance> getChildInstances(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -163,8 +162,12 @@ public class ProcessInstanceBusinessIdAssignProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ProcessInstanceBusinessIdRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceBusinessIdRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceBusinessIdRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -93,8 +92,13 @@ public final class ProcessInstanceCancelProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   private boolean validateCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessor.java
@@ -10,13 +10,10 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -35,7 +32,7 @@ import org.jspecify.annotations.NullMarked;
  * than silently skipped, so a concurrent drain chain restarted via {@code RESUME} (see {@link
  * ProcessInstanceResumeProcessor}) cannot write {@code RESUMED} twice.
  *
- * <p>{@link SuspensionBehavior#PROCESS} is unconditional: the marker is still {@code RESUMING} at
+ * <p>{@link SuspensionAction#PROCESS} is unconditional: the marker is still {@code RESUMING} at
  * this point, and gating would strand the instance there forever.
  */
 @ExcludeAuthorizationCheck
@@ -54,25 +51,20 @@ public final class ProcessInstanceCompleteResumingProcessor
           + "by the ending lifecycle.";
 
   private final StateWriter stateWriter;
-  private final SideEffectWriter sideEffectWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final ElementInstanceState elementInstanceState;
   private final SuspensionState suspensionState;
-  private final DueDateTimerCheckScheduler timerChecker;
   private final SuspensionMetrics suspensionMetrics;
 
   public ProcessInstanceCompleteResumingProcessor(
       final ElementInstanceState elementInstanceState,
       final SuspensionState suspensionState,
       final Writers writers,
-      final DueDateTimerCheckScheduler timerChecker,
       final SuspensionMetrics suspensionMetrics) {
     stateWriter = writers.state();
-    sideEffectWriter = writers.sideEffect();
     rejectionWriter = writers.rejection();
     this.elementInstanceState = elementInstanceState;
     this.suspensionState = suspensionState;
-    this.timerChecker = timerChecker;
     this.suspensionMetrics = suspensionMetrics;
   }
 
@@ -99,20 +91,19 @@ public final class ProcessInstanceCompleteResumingProcessor
 
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceIntent.RESUMED, elementInstance.getValue());
-    // the instance is fully resumed now (the RESUMED applier clears the suspension marker), so
-    // any timer that came due and was rejected while suspended can finally fire; nudge the
-    // due-date checker rather than waiting for an unrelated future timer to wake it
-    sideEffectWriter.appendSideEffect(
-        () -> {
-          timerChecker.scheduleTimer(-1);
-        });
+
     suspensionMetrics.stopResumeDuration(processInstanceKey);
     suspensionMetrics.instanceResumed();
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   private void reject(final TypedRecord<ProcessInstanceRecord> command, final String reason) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -721,10 +720,14 @@ public class ProcessInstanceMigrationMigrateProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ProcessInstanceMigrationRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceMigrationRecord> record) {
     // migration restructures a running instance, which is unsafe while suspended; reject.
-    return SuspensionBehavior.REJECT;
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceMigrationRecord> record) {
+    return SuspensionAction.REJECT;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -1525,9 +1524,13 @@ public final class ProcessInstanceModificationModifyProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(
-      final TypedRecord<ProcessInstanceModificationRecord> record) {
-    return record.isInternalCommand() ? SuspensionBehavior.BUFFER : SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceModificationRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceModificationRecord> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -1525,12 +1525,12 @@ public final class ProcessInstanceModificationModifyProcessor
 
   @Override
   public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceModificationRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+    return SuspensionAware.bufferInternalOnly(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<ProcessInstanceModificationRecord> record) {
-    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+    return SuspensionAware.processInternalOnly(record);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeJobsProcessor.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -60,7 +59,7 @@ import org.jspecify.annotations.NullMarked;
  * is ending ({@code ELEMENT_TERMINATING}/{@code ELEMENT_COMPLETING}): resuming and publishing a job
  * in any of those cases would act on a resume this cycle no longer owns.
  *
- * <p>{@link SuspensionBehavior#PROCESS} is unconditional: the marker is still {@code RESUMING} at
+ * <p>{@link SuspensionAction#PROCESS} is unconditional: the marker is still {@code RESUMING} at
  * this point, and gating would strand the instance there forever.
  */
 @ExcludeAuthorizationCheck
@@ -142,6 +141,21 @@ public final class ProcessInstanceResumeJobsProcessor
   }
 
   /**
+   * A cycle's own writes are small on their own — one {@code Job.RESUMED}, at most one {@code
+   * JobBatch.ACTIVATED}, one follow-up command — but without this override the stream processor
+   * keeps reusing the same result builder across consecutive {@code RESUME_JOBS} cycles instead of
+   * starting a fresh one per command, so an instance with many suspended jobs would still
+   * accumulate every cycle's hand-out into that one shared batch until it exceeds the log's maximum
+   * fragment size — the same reasoning {@code SecretReferenceBatchReactivateJobsProcessor} gives
+   * for its own override. Isolating each cycle keeps the batch bounded by one job's hand-out,
+   * matching what already holds for that job at creation time.
+   */
+  @Override
+  public boolean shouldProcessResultsInSeparateBatches() {
+    return true;
+  }
+
+  /**
    * Resumes and hands out the first still-suspended job found from {@code startAfterJobKey};
    * returns its key, or {@code -1} if none was found. Stops the walk after that one job: one per
    * cycle, see class javadoc.
@@ -160,24 +174,14 @@ public final class ProcessInstanceResumeJobsProcessor
     return resumedJobKey.get();
   }
 
-  /**
-   * A cycle's own writes are small on their own — one {@code Job.RESUMED}, at most one {@code
-   * JobBatch.ACTIVATED}, one follow-up command — but without this override the stream processor
-   * keeps reusing the same result builder across consecutive {@code RESUME_JOBS} cycles instead of
-   * starting a fresh one per command, so an instance with many suspended jobs would still
-   * accumulate every cycle's hand-out into that one shared batch until it exceeds the log's maximum
-   * fragment size — the same reasoning {@code SecretReferenceBatchReactivateJobsProcessor} gives
-   * for its own override. Isolating each cycle keeps the batch bounded by one job's hand-out,
-   * matching what already holds for that job at creation time.
-   */
   @Override
-  public boolean shouldProcessResultsInSeparateBatches() {
-    return true;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   private void reject(final TypedRecord<ProcessInstanceRecord> command, final String reason) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -94,8 +93,13 @@ public final class ProcessInstanceResumeProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 
   private Either<Rejection, ElementInstance> validateNotFound(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -186,9 +185,14 @@ public final class ProcessInstanceSuspendProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<ProcessInstanceRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<ProcessInstanceRecord> record) {
     // reject: a repeated suspend while a marker is present must fail like the processor's own
     // "already suspended" rejection; buffering would silently swallow it.
-    return SuspensionBehavior.REJECT;
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<ProcessInstanceRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAware.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAware.java
@@ -11,32 +11,50 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 /**
- * Implemented by {@link TypedRecordProcessor}s whose commands are related to a process instance, in
- * order to classify how the primary suspension gate (see {@code Engine#process}) should treat the
- * command while the target process instance carries a suspension marker ({@code SUSPENDED} or
- * {@code RESUMING}).
+ * Opt-in hook for {@link TypedRecordProcessor}s whose commands target a process instance.
+ *
+ * <p>When the target instance is {@code SUSPENDED} or {@code RESUMING}, the primary gate (see
+ * {@code Engine#process}) calls {@link #onSuspended} or {@link #onResuming} instead of {@link
+ * TypedRecordProcessor#processRecord}. Each hook can write follow-up events that belong to that
+ * state, then returns a {@link SuspensionAction} telling the gate whether to process, reject, or
+ * buffer the command.
  *
  * @param <T> the record value type processed by the implementing {@link TypedRecordProcessor}
  */
 public interface SuspensionAware<T extends UnifiedRecordValue> {
 
   /**
-   * Classifies how the suspension gate should treat the given command while its target is
-   * suspended.
+   * Handles the command while the target instance is {@code SUSPENDED}, instead of processing it.
+   * Write any events that must accompany this outcome (for example {@code Timer.SUSPENDED} when
+   * dropping a due-date index), then return how the gate should treat the command.
    *
-   * @param record the command record being classified
-   * @return the {@link SuspensionBehavior} to apply; never {@code null}
+   * @param record the command being handled
+   * @return the {@link SuspensionAction} the gate should apply; never {@code null}
    */
-  SuspensionBehavior suspensionBehavior(final TypedRecord<T> record);
+  SuspensionAction onSuspended(final TypedRecord<T> record);
 
-  enum SuspensionBehavior {
+  /**
+   * Handles the command while the target instance is {@code RESUMING}, instead of processing it.
+   * Write any events that must accompany this outcome (for example {@code Timer.RESUMED} before a
+   * drained trigger runs), then return how the gate should treat the command.
+   *
+   * <p>The returned action should match {@link #onSuspended} for command execution, except {@link
+   * SuspensionAction#BUFFER} is not allowed: buffered commands must drain, not re-buffer.
+   *
+   * @param record the command being handled
+   * @return {@link SuspensionAction#PROCESS} or {@link SuspensionAction#REJECT}; never {@code null}
+   *     or {@link SuspensionAction#BUFFER}
+   */
+  SuspensionAction onResuming(final TypedRecord<T> record);
+
+  enum SuspensionAction {
     /** Process the command immediately, regardless of the suspension marker. */
     PROCESS,
     /** Reject the command while any suspension marker (SUSPENDED or RESUMING) is present. */
     REJECT,
     /**
-     * Buffer the command while {@code SUSPENDED}; pass it through while {@code RESUMING} so that
-     * commands drained during resume can actually execute.
+     * Buffer the command while {@code SUSPENDED}. Must not be returned from {@link #onResuming};
+     * the gate throws {@link IllegalStateException} if it is.
      */
     BUFFER
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAware.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionAware.java
@@ -34,12 +34,12 @@ public interface SuspensionAware<T extends UnifiedRecordValue> {
   SuspensionAction onSuspended(final TypedRecord<T> record);
 
   /**
-   * Handles the command while the target instance is {@code RESUMING}, instead of processing it.
+   * Handles the command when the target instance is {@code RESUMING}, instead of processing it.
    * Write any events that must accompany this outcome (for example {@code Timer.RESUMED} before a
    * drained trigger runs), then return how the gate should treat the command.
    *
-   * <p>The returned action should match {@link #onSuspended} for command execution, except {@link
-   * SuspensionAction#BUFFER} is not allowed: buffered commands must drain, not re-buffer.
+   * <p>The returned action be compatible {@link #onSuspended} for command execution. {@link
+   * SuspensionAction#BUFFER} is not allowed: buffered commands must drain.
    *
    * @param record the command being handled
    * @return {@link SuspensionAction#PROCESS} or {@link SuspensionAction#REJECT}; never {@code null}
@@ -47,15 +47,20 @@ public interface SuspensionAware<T extends UnifiedRecordValue> {
    */
   SuspensionAction onResuming(final TypedRecord<T> record);
 
+  static SuspensionAction bufferInternalOnly(final TypedRecord<?> record) {
+    return record.isInternalCommand() ? SuspensionAction.BUFFER : SuspensionAction.REJECT;
+  }
+
+  static SuspensionAction processInternalOnly(final TypedRecord<?> record) {
+    return record.isInternalCommand() ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
+  }
+
   enum SuspensionAction {
     /** Process the command immediately, regardless of the suspension marker. */
     PROCESS,
     /** Reject the command while any suspension marker (SUSPENDED or RESUMING) is present. */
     REJECT,
-    /**
-     * Buffer the command while {@code SUSPENDED}. Must not be returned from {@link #onResuming};
-     * the gate throws {@link IllegalStateException} if it is.
-     */
+    /** Buffer the command while {@code SUSPENDED}. Must not be returned by {@link #onResuming}. */
     BUFFER
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehavior.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.Loggers;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionAction;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -27,17 +27,18 @@ import org.slf4j.Logger;
  * instance carries a suspension marker.
  *
  * <p>Only processors that implement {@link SuspensionAware} are gated; every other command is
- * processed normally. An implementing processor's {@link SuspensionAware#suspensionBehavior}
- * classifies the command as {@code PROCESS}, {@code REJECT}, or {@code BUFFER}.
+ * processed normally. An implementing processor's {@link SuspensionAware#onSuspended} classifies
+ * the command as {@code PROCESS}, {@code REJECT}, or {@code BUFFER} while {@code SUSPENDED}. While
+ * {@code RESUMING}, {@link SuspensionAware#onResuming} classifies instead.
  */
 @NullMarked
-public final class SuspensionCheck {
+public final class SuspensionBehavior {
 
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
 
   private final ProcessingState processingState;
 
-  public SuspensionCheck(final ProcessingState processingState) {
+  public SuspensionBehavior(final ProcessingState processingState) {
     this.processingState = processingState;
   }
 
@@ -48,46 +49,49 @@ public final class SuspensionCheck {
    * {@code JOB}/{@code INCIDENT}/{@code USER_TASK}/{@code AD_HOC_SUB_PROCESS_INSTRUCTION} commands
    * don't carry it on the wire).
    */
-  public SuspensionResult resolve(
+  public SuspensionResult process(
       final TypedRecord<?> command, final TypedRecordProcessor<?> processor) {
     if (!(processor instanceof final SuspensionAware<?> suspensionAware)) {
       // processors that don't opt in via SuspensionAware are never gated; checked before resolving
       // the process instance key to keep the state lookups off the hot path for unrelated commands
-      return new SuspensionResult(SuspensionBehavior.PROCESS, -1);
+      return passThrough(-1);
     }
 
     final long processInstanceKey = resolveProcessInstanceKey(command);
     if (processInstanceKey <= 0) {
-      return new SuspensionResult(SuspensionBehavior.PROCESS, processInstanceKey);
+      return passThrough(processInstanceKey);
     }
 
     final State marker =
         processingState.getSuspensionState().getSuspensionState(processInstanceKey);
-    if (marker == null) {
-      return new SuspensionResult(SuspensionBehavior.PROCESS, processInstanceKey);
-    }
 
-    final SuspensionBehavior behavior = suspensionBehavior(suspensionAware, command);
-    if (behavior == null) {
+    final SuspensionAction action =
+        switch (marker) {
+          case SUSPENDED -> onSuspended(suspensionAware, command);
+          case RESUMING -> onResuming(suspensionAware, command);
+          case null -> SuspensionAction.PROCESS;
+        };
+
+    if (action == null) {
       LOG.error(
           "Processor '{}' implements SuspensionAware but returned a null suspension behavior for"
               + " command '{}'; processing it normally. Please report this as a bug.",
           processor.getClass().getName(),
           command.getValueType());
-      return new SuspensionResult(SuspensionBehavior.PROCESS, processInstanceKey);
+      return passThrough(processInstanceKey);
     }
 
-    final SuspensionBehavior decision =
-        switch (behavior) {
-          case PROCESS -> SuspensionBehavior.PROCESS;
-          case REJECT -> SuspensionBehavior.REJECT;
-          case BUFFER ->
-              marker == State.SUSPENDED
-                  ? SuspensionBehavior.BUFFER
-                  // RESUMING: pass through so drained commands can execute.
-                  : SuspensionBehavior.PROCESS;
-        };
-    return new SuspensionResult(decision, processInstanceKey);
+    if (marker == State.RESUMING && action == SuspensionAction.BUFFER) {
+      throw new IllegalStateException(
+          "Expected PROCESS or REJECT from onResuming, but got BUFFER from processor '%s' for command '%s'."
+              .formatted(processor.getClass().getName(), command.getValueType()));
+    }
+
+    return new SuspensionResult(action, processInstanceKey);
+  }
+
+  private static SuspensionResult passThrough(final long processInstanceKey) {
+    return new SuspensionResult(SuspensionAction.PROCESS, processInstanceKey);
   }
 
   /**
@@ -165,11 +169,22 @@ public final class SuspensionCheck {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  private static @Nullable SuspensionBehavior suspensionBehavior(
+  private static SuspensionAware.@Nullable SuspensionAction onSuspended(
       final SuspensionAware<?> suspensionAware, final TypedRecord<?> command) {
-    return ((SuspensionAware) suspensionAware).suspensionBehavior(command);
+    return ((SuspensionAware) suspensionAware).onSuspended(command);
   }
 
-  /** The gate outcome for a command, with the resolved target process instance key. */
-  public record SuspensionResult(SuspensionBehavior outcome, long processInstanceKey) {}
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static SuspensionAware.@Nullable SuspensionAction onResuming(
+      final SuspensionAware<?> suspensionAware, final TypedRecord<?> command) {
+    return ((SuspensionAware) suspensionAware).onResuming(command);
+  }
+
+  /**
+   * The gate outcome for a command, with the resolved target process instance key.
+   *
+   * @param outcome the gate action to take
+   * @param processInstanceKey the resolved target instance, or {@code -1}
+   */
+  public record SuspensionResult(SuspensionAction outcome, long processInstanceKey) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehavior.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
@@ -69,9 +68,10 @@ public final class SuspensionBehavior {
         switch (marker) {
           case SUSPENDED -> onSuspended(suspensionAware, command);
           case RESUMING -> onResuming(suspensionAware, command);
-          case null -> SuspensionAction.PROCESS;
+          case null -> null;
         };
 
+    // captures onSuspended and onResuming null return values along with null markers
     if (action == null) {
       LOG.error(
           "Processor '{}' implements SuspensionAware but returned a null suspension behavior for"
@@ -79,12 +79,6 @@ public final class SuspensionBehavior {
           processor.getClass().getName(),
           command.getValueType());
       return passThrough(processInstanceKey);
-    }
-
-    if (marker == State.RESUMING && action == SuspensionAction.BUFFER) {
-      throw new IllegalStateException(
-          "Expected PROCESS or REJECT from onResuming, but got BUFFER from processor '%s' for command '%s'."
-              .formatted(processor.getClass().getName(), command.getValueType()));
     }
 
     return new SuspensionResult(action, processInstanceKey);
@@ -169,15 +163,21 @@ public final class SuspensionBehavior {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  private static SuspensionAware.@Nullable SuspensionAction onSuspended(
+  private static SuspensionAware.SuspensionAction onSuspended(
       final SuspensionAware<?> suspensionAware, final TypedRecord<?> command) {
     return ((SuspensionAware) suspensionAware).onSuspended(command);
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  private static SuspensionAware.@Nullable SuspensionAction onResuming(
+  private static SuspensionAware.SuspensionAction onResuming(
       final SuspensionAware<?> suspensionAware, final TypedRecord<?> command) {
-    return ((SuspensionAware) suspensionAware).onResuming(command);
+    final SuspensionAction action = ((SuspensionAware) suspensionAware).onResuming(command);
+    if (action == SuspensionAction.BUFFER) {
+      throw new IllegalStateException(
+          "Expected PROCESS or REJECT from onResuming, but got BUFFER from processor '%s' for command '%s'."
+              .formatted(suspensionAware.getClass().getName(), command.getValueType()));
+    }
+    return action;
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerCancelProcessor.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.timer;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -54,7 +53,12 @@ public final class TimerCancelProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<TimerRecord> record) {
-    return SuspensionBehavior.PROCESS;
+  public SuspensionAction onSuspended(final TypedRecord<TimerRecord> record) {
+    return SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<TimerRecord> record) {
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -15,15 +15,15 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionAction;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
 import io.camunda.zeebe.model.bpmn.util.time.RepeatingInterval;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
@@ -53,7 +53,7 @@ public final class TimerTriggerProcessor
   private final CatchEventBehavior catchEventBehavior;
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
-  private final MutableTimerInstanceState timerInstanceState;
+  private final TimerInstanceState timerInstanceState;
   private final ExpressionProcessor expressionProcessor;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -204,9 +204,17 @@ public final class TimerTriggerProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<TimerRecord> record) {
-    // firing a timer advances the token, so reject while suspended. Rejecting does not remove the
-    // due timer, so it may strand or re-trigger until firing is suppressed and re-armed on resume.
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<TimerRecord> record) {
+    stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.SUSPENDED, record.getValue());
+    return SuspensionAction.BUFFER;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<TimerRecord> record) {
+    final long timerKey = record.getKey();
+    final var timer = record.getValue();
+    // RESUMED restores a missing due-date entry before the drained TRIGGER removes the timer.
+    stateWriter.appendFollowUpEvent(timerKey, TimerIntent.RESUMED, timer);
+    return SuspensionAction.PROCESS;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionAction;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizatio
 import io.camunda.zeebe.engine.processing.identity.authorization.CslTenantCheck;
 import io.camunda.zeebe.engine.processing.incident.RetryTypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -417,7 +416,12 @@ public class UserTaskProcessor
   }
 
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<UserTaskRecord> record) {
-    return SuspensionBehavior.REJECT;
+  public SuspensionAction onSuspended(final TypedRecord<UserTaskRecord> record) {
+    return SuspensionAction.REJECT;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<UserTaskRecord> record) {
+    return SuspensionAction.REJECT;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -268,21 +268,25 @@ public final class VariableDocumentUpdateProcessor
         .writeAcceptedResponseOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
   }
 
-  /**
-   * Allow variable updates while suspended for recovery. Reject only Camunda user-task scopes: that
-   * path can start an {@code UPDATING} task listener, which cannot complete while suspended.
-   */
   @Override
   public SuspensionAction onSuspended(final TypedRecord<VariableDocumentRecord> record) {
-    final var scope = elementInstanceState.getInstance(record.getValue().getScopeKey());
-    return scope != null && isCamundaUserTask(scope)
-        ? SuspensionAction.REJECT
-        : SuspensionAction.PROCESS;
+    return getActionForSuspension(record);
   }
 
   @Override
   public SuspensionAction onResuming(final TypedRecord<VariableDocumentRecord> record) {
-    return onSuspended(record);
+    return getActionForSuspension(record);
+  }
+
+  /**
+   * Allow variable updates while suspended for recovery. Reject only Camunda user-task scopes: that
+   * path can start an {@code UPDATING} task listener, which cannot complete while suspended.
+   */
+  private SuspensionAction getActionForSuspension(
+      final TypedRecord<VariableDocumentRecord> record) {
+    final var scope = elementInstanceState.getInstance(record.getValue().getScopeKey());
+    final boolean canBeProcessedWhileSuspended = scope == null || !isCamundaUserTask(scope);
+    return canBeProcessedWhileSuspended ? SuspensionAction.PROCESS : SuspensionAction.REJECT;
   }
 
   public static void mergeVariables(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUse
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -274,11 +273,16 @@ public final class VariableDocumentUpdateProcessor
    * path can start an {@code UPDATING} task listener, which cannot complete while suspended.
    */
   @Override
-  public SuspensionBehavior suspensionBehavior(final TypedRecord<VariableDocumentRecord> record) {
+  public SuspensionAction onSuspended(final TypedRecord<VariableDocumentRecord> record) {
     final var scope = elementInstanceState.getInstance(record.getValue().getScopeKey());
     return scope != null && isCamundaUserTask(scope)
-        ? SuspensionBehavior.REJECT
-        : SuspensionBehavior.PROCESS;
+        ? SuspensionAction.REJECT
+        : SuspensionAction.PROCESS;
+  }
+
+  @Override
+  public SuspensionAction onResuming(final TypedRecord<VariableDocumentRecord> record) {
+    return onSuspended(record);
   }
 
   public static void mergeVariables(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -305,6 +305,8 @@ public final class EventAppliers implements EventApplier {
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
     register(TimerIntent.MIGRATED, new TimerInstanceMigratedApplier(state.getTimerState()));
+    register(TimerIntent.SUSPENDED, new TimerSuspendedApplier(state.getTimerState()));
+    register(TimerIntent.RESUMED, new TimerResumedApplier(state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerResumedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerResumedApplier.java
@@ -22,6 +22,6 @@ final class TimerResumedApplier implements TypedEventApplier<TimerIntent, TimerR
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    timerInstanceState.restoreDueDate(value.getElementInstanceKey(), key, value.getDueDate());
+    timerInstanceState.resume(value.getElementInstanceKey(), key, value.getDueDate());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerResumedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerResumedApplier.java
@@ -8,13 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 
 final class TimerResumedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
+  private final MutableTimerInstanceState timerInstanceState;
+
+  TimerResumedApplier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    // Resume does not restore the due-date index. Firing is the drained TRIGGER command.
+    timerInstanceState.restoreDueDate(value.getElementInstanceKey(), key, value.getDueDate());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerResumedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerResumedApplier.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+final class TimerResumedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    // Resume does not restore the due-date index. Firing is the drained TRIGGER command.
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+final class TimerSuspendedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private final MutableTimerInstanceState timerInstanceState;
+
+  TimerSuspendedApplier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    timerInstanceState.removeDueDate(value.getElementInstanceKey(), key, value.getDueDate());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplier.java
@@ -22,6 +22,6 @@ final class TimerSuspendedApplier implements TypedEventApplier<TimerIntent, Time
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    timerInstanceState.removeDueDate(value.getElementInstanceKey(), key, value.getDueDate());
+    timerInstanceState.suspend(value.getElementInstanceKey(), key, value.getDueDate());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
@@ -27,8 +27,6 @@ public interface TimerInstanceState {
 
   TimerInstance get(long elementInstanceKey, long timerKey);
 
-  boolean hasDueDateEntry(long elementInstanceKey, long timerKey);
-
   @FunctionalInterface
   interface TimerVisitor {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
@@ -27,7 +27,7 @@ public interface TimerInstanceState {
 
   TimerInstance get(long elementInstanceKey, long timerKey);
 
-  boolean hasDueDate(long elementInstanceKey, long timerKey, long dueDate);
+  boolean hasDueDateEntry(long elementInstanceKey, long timerKey);
 
   @FunctionalInterface
   interface TimerVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
@@ -27,6 +27,8 @@ public interface TimerInstanceState {
 
   TimerInstance get(long elementInstanceKey, long timerKey);
 
+  boolean hasDueDate(long elementInstanceKey, long timerKey, long dueDate);
+
   @FunctionalInterface
   interface TimerVisitor {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -23,7 +23,6 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
 
   private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbLong>, TimerInstance>
       timerInstanceColumnFamily;
-  private final TimerInstance timerInstance;
   private final DbLong timerKey;
   private final DbForeignKey<DbLong> elementInstanceKey;
   private final DbCompositeKey<DbForeignKey<DbLong>, DbLong> elementAndTimerKey;
@@ -39,7 +38,7 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
 
   public DbTimerInstanceState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
-    timerInstance = new TimerInstance();
+    final TimerInstance timerInstance = new TimerInstance();
     timerKey = new DbLong();
     elementInstanceKey =
         new DbForeignKey<>(
@@ -80,7 +79,7 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
     timerInstanceColumnFamily.deleteExisting(elementAndTimerKey);
 
     dueDate.wrapLong(timer.getDueDate());
-    dueDateColumnFamily.deleteExisting(dueDateCompositeKey);
+    dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
   }
 
   @Override
@@ -91,27 +90,19 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   }
 
   @Override
+  public void restoreDueDate(
+      final long elementInstanceKey, final long timerKey, final long dueDate) {
+    if (get(elementInstanceKey, timerKey) != null) {
+      wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
+      dueDateColumnFamily.upsert(dueDateCompositeKey, DbNil.INSTANCE);
+    }
+  }
+
+  @Override
   public void removeDueDate(
       final long elementInstanceKey, final long timerKey, final long dueDate) {
     wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
     dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
-  }
-
-  @Override
-  public void removeIgnoringMissingDueDate(final TimerInstance timer) {
-    elementInstanceKey.inner().wrapLong(timer.getElementInstanceKey());
-    timerKey.wrapLong(timer.getKey());
-    timerInstanceColumnFamily.deleteExisting(elementAndTimerKey);
-
-    dueDate.wrapLong(timer.getDueDate());
-    dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
-  }
-
-  @Override
-  public boolean hasDueDate(
-      final long elementInstanceKey, final long timerKey, final long dueDate) {
-    wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
-    return dueDateColumnFamily.exists(dueDateCompositeKey);
   }
 
   private void wrapDueDateKey(
@@ -171,5 +162,15 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
     this.timerKey.wrapLong(timerKey);
 
     return timerInstanceColumnFamily.get(elementAndTimerKey);
+  }
+
+  @Override
+  public boolean hasDueDateEntry(final long elementInstanceKey, final long timerKey) {
+    final TimerInstance timerInstance = get(elementInstanceKey, timerKey);
+    if (timerInstance == null) {
+      return false;
+    }
+    wrapDueDateKey(elementInstanceKey, timerKey, timerInstance.getDueDate());
+    return dueDateColumnFamily.exists(dueDateCompositeKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -90,19 +90,17 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   }
 
   @Override
-  public void restoreDueDate(
-      final long elementInstanceKey, final long timerKey, final long dueDate) {
+  public void suspend(final long elementInstanceKey, final long timerKey, final long dueDate) {
+    wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
+    dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
+  }
+
+  @Override
+  public void resume(final long elementInstanceKey, final long timerKey, final long dueDate) {
     if (get(elementInstanceKey, timerKey) != null) {
       wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
       dueDateColumnFamily.upsert(dueDateCompositeKey, DbNil.INSTANCE);
     }
-  }
-
-  @Override
-  public void removeDueDate(
-      final long elementInstanceKey, final long timerKey, final long dueDate) {
-    wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
-    dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
   }
 
   private void wrapDueDateKey(
@@ -162,15 +160,5 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
     this.timerKey.wrapLong(timerKey);
 
     return timerInstanceColumnFamily.get(elementAndTimerKey);
-  }
-
-  @Override
-  public boolean hasDueDateEntry(final long elementInstanceKey, final long timerKey) {
-    final TimerInstance timerInstance = get(elementInstanceKey, timerKey);
-    if (timerInstance == null) {
-      return false;
-    }
-    wrapDueDateKey(elementInstanceKey, timerKey, timerInstance.getDueDate());
-    return dueDateColumnFamily.exists(dueDateCompositeKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -91,6 +91,37 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   }
 
   @Override
+  public void removeDueDate(
+      final long elementInstanceKey, final long timerKey, final long dueDate) {
+    wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
+    dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
+  }
+
+  @Override
+  public void removeIgnoringMissingDueDate(final TimerInstance timer) {
+    elementInstanceKey.inner().wrapLong(timer.getElementInstanceKey());
+    timerKey.wrapLong(timer.getKey());
+    timerInstanceColumnFamily.deleteExisting(elementAndTimerKey);
+
+    dueDate.wrapLong(timer.getDueDate());
+    dueDateColumnFamily.deleteIfExists(dueDateCompositeKey);
+  }
+
+  @Override
+  public boolean hasDueDate(
+      final long elementInstanceKey, final long timerKey, final long dueDate) {
+    wrapDueDateKey(elementInstanceKey, timerKey, dueDate);
+    return dueDateColumnFamily.exists(dueDateCompositeKey);
+  }
+
+  private void wrapDueDateKey(
+      final long elementInstanceKey, final long timerKey, final long dueDate) {
+    this.elementInstanceKey.inner().wrapLong(elementInstanceKey);
+    this.timerKey.wrapLong(timerKey);
+    this.dueDate.wrapLong(dueDate);
+  }
+
+  @Override
   public long processTimersWithDueDateBefore(final long timestamp, final TimerVisitor consumer) {
     nextDueDate = -1L;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
@@ -17,4 +17,8 @@ public interface MutableTimerInstanceState extends TimerInstanceState {
   void remove(TimerInstance timer);
 
   void update(TimerInstance timer);
+
+  void removeDueDate(long elementInstanceKey, long timerKey, long dueDate);
+
+  void removeIgnoringMissingDueDate(TimerInstance timer);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
@@ -18,7 +18,7 @@ public interface MutableTimerInstanceState extends TimerInstanceState {
 
   void update(TimerInstance timer);
 
-  void removeDueDate(long elementInstanceKey, long timerKey, long dueDate);
+  void restoreDueDate(long elementInstanceKey, long timerKey, long dueDate);
 
-  void removeIgnoringMissingDueDate(TimerInstance timer);
+  void removeDueDate(long elementInstanceKey, long timerKey, long dueDate);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
@@ -18,7 +18,7 @@ public interface MutableTimerInstanceState extends TimerInstanceState {
 
   void update(TimerInstance timer);
 
-  void restoreDueDate(long elementInstanceKey, long timerKey, long dueDate);
+  void suspend(long elementInstanceKey, long timerKey, long dueDate);
 
-  void removeDueDate(long elementInstanceKey, long timerKey, long dueDate);
+  void resume(long elementInstanceKey, long timerKey, long dueDate);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionBehavior;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistorySuspensionGateTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionBehavior;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceSuspensionGateTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.agentinstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionBehavior;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -47,11 +48,10 @@ import org.junit.Test;
  * <p>COMPLETE is classified {@code PROCESS} so that teardown bookkeeping is not orphaned when a
  * suspended instance is cancelled.
  *
- * <p>{@link io.camunda.zeebe.engine.processing.streamprocessor.SuspensionCheck} resolves the
- * process instance key for CREATE by looking up the target element instance ({@code
- * elementInstanceKey}), and for UPDATE by looking up the agent instance identified by the command
- * key — both are populated by real clients, so the gate fires for genuine external/internal
- * commands without any test scaffolding.
+ * <p>{@link SuspensionBehavior} resolves the process instance key for CREATE by looking up the
+ * target element instance ({@code elementInstanceKey}), and for UPDATE by looking up the agent
+ * instance identified by the command key — both are populated by real clients, so the gate fires
+ * for genuine external/internal commands without any test scaffolding.
  */
 public class AgentInstanceSuspensionGateTest {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCompleteResumingProcessorTest.java
@@ -17,11 +17,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.metrics.SuspensionMetrics;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
@@ -30,7 +28,6 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.stream.api.SideEffectProducer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -42,9 +39,7 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
   private ElementInstanceState elementInstanceState;
   private SuspensionState suspensionState;
   private StateWriter stateWriter;
-  private SideEffectWriter sideEffectWriter;
   private TypedRejectionWriter rejectionWriter;
-  private DueDateTimerCheckScheduler timerChecker;
   private SuspensionMetrics suspensionMetrics;
   private ProcessInstanceCompleteResumingProcessor processor;
 
@@ -53,19 +48,16 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
     elementInstanceState = mock(ElementInstanceState.class);
     suspensionState = mock(SuspensionState.class);
     stateWriter = mock(StateWriter.class);
-    sideEffectWriter = mock(SideEffectWriter.class);
     rejectionWriter = mock(TypedRejectionWriter.class);
-    timerChecker = mock(DueDateTimerCheckScheduler.class);
     suspensionMetrics = mock(SuspensionMetrics.class);
 
     final var writers = mock(Writers.class);
     when(writers.state()).thenReturn(stateWriter);
-    when(writers.sideEffect()).thenReturn(sideEffectWriter);
     when(writers.rejection()).thenReturn(rejectionWriter);
 
     processor =
         new ProcessInstanceCompleteResumingProcessor(
-            elementInstanceState, suspensionState, writers, timerChecker, suspensionMetrics);
+            elementInstanceState, suspensionState, writers, suspensionMetrics);
 
     // default: the common case of an active instance still marked RESUMING
     when(suspensionState.getSuspensionState(PROCESS_INSTANCE_KEY))
@@ -86,23 +78,6 @@ public final class ProcessInstanceCompleteResumingProcessorTest {
         .appendFollowUpEvent(
             eq(PROCESS_INSTANCE_KEY), eq(ProcessInstanceIntent.RESUMED), eq(record));
     verify(rejectionWriter, never()).appendRejection(any(), any(), any());
-  }
-
-  @Test
-  void shouldNudgeDueDateTimerCheckerWhenResumeCompletes() {
-    // given - resume must nudge the checker so a timer stranded during suspension fires promptly
-    // instead of waiting for the next unrelated timer
-    seedActiveInstance(new ProcessInstanceRecord().setProcessInstanceKey(PROCESS_INSTANCE_KEY));
-
-    // when
-    processor.processRecord(continueResumingCommand());
-
-    // then
-    final var sideEffectCaptor = ArgumentCaptor.forClass(SideEffectProducer.class);
-    verify(sideEffectWriter).appendSideEffect(sideEffectCaptor.capture());
-    sideEffectCaptor.getValue().flush();
-
-    verify(timerChecker).scheduleTimer(-1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendResumeEquivalenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendResumeEquivalenceTest.java
@@ -74,13 +74,9 @@ public final class SuspendResumeEquivalenceTest {
     RecordingExporter.timerRecords(TimerIntent.CREATED).withProcessInstanceKey(testKey).await();
     ENGINE.processInstance().withInstanceKey(testKey).suspend();
 
-    // when - await the checker's rejected TRIGGER so resume deterministically exercises the
-    // stranded-timer rescan, not a race with the checker's own regular polling
+    // when - await the buffered TRIGGER so resume drains it instead of racing the checker
     ENGINE.increaseTime(Duration.ofSeconds(2));
-    RecordingExporter.timerRecords(TimerIntent.TRIGGER)
-        .onlyCommandRejections()
-        .withProcessInstanceKey(testKey)
-        .await();
+    RecordingExporter.timerRecords(TimerIntent.SUSPENDED).withProcessInstanceKey(testKey).await();
     ENGINE.processInstance().withInstanceKey(testKey).resume();
     ENGINE.job().withType(jobType).ofInstance(testKey).complete();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehaviorTest.java
@@ -138,6 +138,19 @@ final class SuspensionBehaviorTest {
   }
 
   @Test
+  void shouldResumeWhenProcessorIsNotSuspensionAware() {
+    // given - a suspended instance and a processor that does not opt into suspension handling
+    markerIs(State.RESUMING);
+
+    // when
+    final var result = suspensionBehavior.process(command(), plainProcessor());
+
+    // then - non-aware processors are never gated, and the key is not even resolved
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
+    assertThat(result.processInstanceKey()).isEqualTo(-1);
+  }
+
+  @Test
   void shouldFlipBufferToProcessWhileResuming() {
     // given
     markerIs(State.RESUMING);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SuspensionBehaviorTest.java
@@ -8,12 +8,16 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.SuspensionAware.SuspensionAction;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -33,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-final class SuspensionCheckTest {
+final class SuspensionBehaviorTest {
 
   private static final long PROCESS_INSTANCE_KEY = 42L;
   private static final long JOB_KEY = 7L;
@@ -41,14 +45,14 @@ final class SuspensionCheckTest {
 
   private ProcessingState processingState;
   private SuspensionState suspensionState;
-  private SuspensionCheck suspensionCheck;
+  private SuspensionBehavior suspensionBehavior;
 
   @BeforeEach
   void setUp() {
     processingState = mock(ProcessingState.class);
     suspensionState = mock(SuspensionState.class);
     when(processingState.getSuspensionState()).thenReturn(suspensionState);
-    suspensionCheck = new SuspensionCheck(processingState);
+    suspensionBehavior = new SuspensionBehavior(processingState);
   }
 
   @Test
@@ -57,10 +61,10 @@ final class SuspensionCheckTest {
     markerIs(State.SUSPENDED);
 
     // when
-    final var result = suspensionCheck.resolve(command(), plainProcessor());
+    final var result = suspensionBehavior.process(command(), plainProcessor());
 
     // then - non-aware processors are never gated, and the key is not even resolved
-    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.PROCESS);
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
     assertThat(result.processInstanceKey()).isEqualTo(-1);
   }
 
@@ -68,94 +72,128 @@ final class SuspensionCheckTest {
   void shouldProcessWhenNoSuspensionMarker() {
     // given - no marker, but a processor that would otherwise reject
     markerIs(null);
+    final var command = command();
+    final var processor = overridingProcessor(SuspensionAction.REJECT);
 
-    // when / then
-    assertThat(
-            suspensionCheck
-                .resolve(command(), overridingProcessor(SuspensionBehavior.REJECT))
-                .outcome())
-        .isEqualTo(SuspensionBehavior.PROCESS);
+    // when
+    final var result = suspensionBehavior.process(command, processor);
+
+    // then - no marker means the processor is not consulted
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
+    verifyNoClassification(processor);
   }
 
   @ParameterizedTest
   @EnumSource(
-      value = SuspensionBehavior.class,
+      value = SuspensionAction.class,
       names = {"PROCESS", "REJECT"})
-  void shouldApplyProcessorClassificationWhileSuspended(final SuspensionBehavior behavior) {
+  void shouldApplyProcessorClassificationWhileSuspended(final SuspensionAction behavior) {
     // given
     markerIs(State.SUSPENDED);
-    final SuspensionBehavior expected =
+    final var command = command();
+    final var processor = overridingProcessor(behavior);
+    final SuspensionAction expected =
         switch (behavior) {
-          case PROCESS -> SuspensionBehavior.PROCESS;
-          case REJECT -> SuspensionBehavior.REJECT;
+          case PROCESS -> SuspensionAction.PROCESS;
+          case REJECT -> SuspensionAction.REJECT;
           case BUFFER -> throw new IllegalStateException("unreachable");
         };
 
-    // when / then
-    assertThat(suspensionCheck.resolve(command(), overridingProcessor(behavior)).outcome())
-        .isEqualTo(expected);
+    // when
+    final var result = suspensionBehavior.process(command, processor);
+
+    // then
+    assertThat(result.outcome()).isEqualTo(expected);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
   void shouldBufferWhenProcessorClassifiesBufferWhileSuspended() {
     // given
     markerIs(State.SUSPENDED);
+    final var command = command();
+    final var processor = overridingProcessor(SuspensionAction.BUFFER);
 
     // when
-    final var result =
-        suspensionCheck.resolve(command(), overridingProcessor(SuspensionBehavior.BUFFER));
+    final var result = suspensionBehavior.process(command, processor);
 
     // then
-    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.BUFFER);
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.BUFFER);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
   void shouldProcessWhenAwareProcessorReturnsNull() {
     // given
     markerIs(State.SUSPENDED);
+    final var command = command();
+    final var processor = overridingProcessor(null);
 
-    // when / then - a contract-violating null classification is logged and processed (fail-open)
-    assertThat(suspensionCheck.resolve(command(), overridingProcessor(null)).outcome())
-        .isEqualTo(SuspensionBehavior.PROCESS);
+    // when
+    final var result = suspensionBehavior.process(command, processor);
+
+    // then - a contract-violating null classification is logged and processed (fail-open)
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
   void shouldFlipBufferToProcessWhileResuming() {
     // given
     markerIs(State.RESUMING);
+    final var command = command();
+    final var processor = overridingProcessor(SuspensionAction.PROCESS);
 
-    // when / then - buffered commands drain (pass through) while resuming
-    assertThat(
-            suspensionCheck
-                .resolve(command(), overridingProcessor(SuspensionBehavior.BUFFER))
-                .outcome())
-        .isEqualTo(SuspensionBehavior.PROCESS);
+    // when
+    final var result = suspensionBehavior.process(command, processor);
+
+    // then - buffered commands drain (pass through) while resuming
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
+    verifyOnResuming(processor, command);
   }
 
   @Test
   void shouldStillRejectWhileResuming() {
     // given
     markerIs(State.RESUMING);
+    final var command = command();
+    final var processor = overridingProcessor(SuspensionAction.REJECT);
 
-    // when / then - rejected commands stay rejected until draining clears the marker
-    assertThat(
-            suspensionCheck
-                .resolve(command(), overridingProcessor(SuspensionBehavior.REJECT))
-                .outcome())
-        .isEqualTo(SuspensionBehavior.REJECT);
+    // when
+    final var result = suspensionBehavior.process(command, processor);
+
+    // then - rejected commands stay rejected until draining clears the marker
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.REJECT);
+    verifyOnResuming(processor, command);
+  }
+
+  @Test
+  void shouldThrowWhenOnResumingReturnsBuffer() {
+    // given
+    markerIs(State.RESUMING);
+    final var command = command();
+    final var processor = overridingProcessor(SuspensionAction.BUFFER);
+
+    // when / then - BUFFER is only valid while SUSPENDED; re-buffering while draining is a bug
+    assertThatThrownBy(() -> suspensionBehavior.process(command, processor))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Expected PROCESS or REJECT from onResuming, but got BUFFER");
+    verifyOnResuming(processor, command);
   }
 
   @Test
   void shouldReturnProcessInstanceKeyResolvedFromCommandValue() {
     // given
     markerIs(State.SUSPENDED);
+    final var command = command();
+    final var processor = overridingProcessor(SuspensionAction.REJECT);
 
     // when
-    final var result =
-        suspensionCheck.resolve(command(), overridingProcessor(SuspensionBehavior.REJECT));
+    final var result = suspensionBehavior.process(command, processor);
 
     // then - callers reuse the resolved key instead of re-deriving it
     assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
@@ -170,14 +208,15 @@ final class SuspensionCheckTest {
     when(command.getValue()).thenReturn(new JobRecord());
     when(command.getKey()).thenReturn(JOB_KEY);
     when(command.getValueType()).thenReturn(ValueType.JOB);
+    final var processor = overridingProcessor(SuspensionAction.REJECT);
 
     // when
-    final var result =
-        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.REJECT));
+    final var result = suspensionBehavior.process(command, processor);
 
     // then - the real process instance key is resolved via job state and returned to the caller
-    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.REJECT);
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.REJECT);
     assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
@@ -194,14 +233,15 @@ final class SuspensionCheckTest {
     final var command = mock(TypedRecord.class);
     when(command.getValue()).thenReturn(new VariableDocumentRecord().setScopeKey(scopeKey));
     when(command.getValueType()).thenReturn(ValueType.VARIABLE_DOCUMENT);
+    final var processor = overridingProcessor(SuspensionAction.PROCESS);
 
     // when
-    final var result =
-        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.PROCESS));
+    final var result = suspensionBehavior.process(command, processor);
 
     // then
-    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.PROCESS);
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
     assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
@@ -224,15 +264,16 @@ final class SuspensionCheckTest {
             new AdHocSubProcessInstructionRecord()
                 .setAdHocSubProcessInstanceKey(AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY));
     when(command.getValueType()).thenReturn(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION);
+    final var processor = overridingProcessor(SuspensionAction.BUFFER);
 
     // when
-    final var result =
-        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.BUFFER));
+    final var result = suspensionBehavior.process(command, processor);
 
     // then - the real process instance key is resolved via the element instance state and returned
     // to the caller
-    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.BUFFER);
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.BUFFER);
     assertThat(result.processInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+    verifyOnSuspended(processor, command);
   }
 
   @Test
@@ -248,14 +289,15 @@ final class SuspensionCheckTest {
             new AdHocSubProcessInstructionRecord()
                 .setAdHocSubProcessInstanceKey(AD_HOC_SUB_PROCESS_ELEMENT_INSTANCE_KEY));
     when(command.getValueType()).thenReturn(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION);
+    final var processor = overridingProcessor(SuspensionAction.BUFFER);
 
     // when
-    final var result =
-        suspensionCheck.resolve(command, overridingProcessor(SuspensionBehavior.BUFFER));
+    final var result = suspensionBehavior.process(command, processor);
 
     // then - the key can't be resolved (-1), so the command is processed rather than gated
-    assertThat(result.outcome()).isEqualTo(SuspensionBehavior.PROCESS);
+    assertThat(result.outcome()).isEqualTo(SuspensionAction.PROCESS);
     assertThat(result.processInstanceKey()).isEqualTo(-1);
+    verifyNoClassification(processor);
   }
 
   private void markerIs(final @Nullable State state) {
@@ -275,10 +317,32 @@ final class SuspensionCheckTest {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   private static TypedRecordProcessor<?> overridingProcessor(
-      final @Nullable SuspensionBehavior behavior) {
+      final SuspensionAware.@Nullable SuspensionAction behavior) {
     final var processor =
         mock(TypedRecordProcessor.class, withSettings().extraInterfaces(SuspensionAware.class));
-    when(((SuspensionAware) processor).suspensionBehavior(any())).thenReturn(behavior);
+    // doReturn avoids counting stubbing as an invocation, so verify() only sees production calls
+    doReturn(behavior).when((SuspensionAware) processor).onSuspended(any());
+    doReturn(behavior).when((SuspensionAware) processor).onResuming(any());
     return processor;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static void verifyOnSuspended(
+      final TypedRecordProcessor<?> processor, final TypedRecord<?> command) {
+    verify((SuspensionAware) processor).onSuspended(command);
+    verify((SuspensionAware) processor, never()).onResuming(any());
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static void verifyOnResuming(
+      final TypedRecordProcessor<?> processor, final TypedRecord<?> command) {
+    verify((SuspensionAware) processor).onResuming(command);
+    verify((SuspensionAware) processor, never()).onSuspended(any());
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static void verifyNoClassification(final TypedRecordProcessor<?> processor) {
+    verify((SuspensionAware) processor, never()).onSuspended(any());
+    verify((SuspensionAware) processor, never()).onResuming(any());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
@@ -238,5 +238,11 @@ class DueDateTimerCheckSchedulerTest {
     public TimerInstance get(final long elementInstanceKey, final long timerKey) {
       return null;
     }
+
+    @Override
+    public boolean hasDueDate(
+        final long elementInstanceKey, final long timerKey, final long dueDate) {
+      return false;
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
@@ -240,8 +240,7 @@ class DueDateTimerCheckSchedulerTest {
     }
 
     @Override
-    public boolean hasDueDate(
-        final long elementInstanceKey, final long timerKey, final long dueDate) {
+    public boolean hasDueDateEntry(final long elementInstanceKey, final long timerKey) {
       return false;
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckSchedulerTest.java
@@ -238,10 +238,5 @@ class DueDateTimerCheckSchedulerTest {
     public TimerInstance get(final long elementInstanceKey, final long timerKey) {
       return null;
     }
-
-    @Override
-    public boolean hasDueDateEntry(final long elementInstanceKey, final long timerKey) {
-      return false;
-    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerSuspensionGateTest.java
@@ -132,52 +132,6 @@ public final class TimerSuspensionGateTest {
   }
 
   @Test
-  public void shouldEmitResumedForFreshTriggerWhileResuming() {
-    // given - suspend before the timer is due so the due-date index is still present
-    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
-    final var created =
-        RecordingExporter.timerRecords(TimerIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-    final var process =
-        RecordingExporter.processInstanceRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.PROCESS)
-            .getFirst();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
-
-    // when - RESUME then a fresh TRIGGER while the instance is still RESUMING
-    ENGINE.writeRecords(
-        RecordToWrite.command()
-            .processInstance(ProcessInstanceIntent.RESUME, process.getValue())
-            .key(processInstanceKey),
-        RecordToWrite.command()
-            .timer(TimerIntent.TRIGGER, created.getValue())
-            .key(created.getKey()));
-
-    // then
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.PROCESS)
-        .await();
-    assertThat(
-            RecordingExporter.records()
-                .limitToProcessInstance(processInstanceKey)
-                .timerRecords()
-                .withIntent(TimerIntent.RESUMED)
-                .count())
-        .isEqualTo(1);
-    assertThat(
-            RecordingExporter.records()
-                .limitToProcessInstance(processInstanceKey)
-                .timerRecords()
-                .withIntent(TimerIntent.TRIGGERED)
-                .filter(r -> r.getValue().getProcessInstanceKey() == processInstanceKey)
-                .count())
-        .isEqualTo(1);
-  }
-
-  @Test
   public void shouldFireTimerThatBecomesDueAfterResume() {
     // given
     final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerSuspensionGateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerSuspensionGateTest.java
@@ -10,11 +10,16 @@ package io.camunda.zeebe.engine.processing.timer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -30,52 +35,276 @@ public final class TimerSuspensionGateTest {
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldTriggerStrandedTimerAfterResume() {
-    // given - an instance with a timer that came due while suspended; the due-date checker's
-    // resulting TRIGGER is rejected instead of firing, because the instance is suspended
+  public void shouldBufferDueTimerAndFireOnResume() {
+    // given
     final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
     RecordingExporter.timerRecords(TimerIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .await();
     ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
     ENGINE.increaseTime(Duration.ofSeconds(1));
-    final var rejection =
-        RecordingExporter.timerRecords(TimerIntent.TRIGGER)
-            .onlyCommandRejections()
+
+    // then
+    RecordingExporter.timerRecords(TimerIntent.SUSPENDED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    final var timerResumed =
+        RecordingExporter.timerRecords(TimerIntent.RESUMED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
-    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
-
-    // when - the instance resumes; no clock advance follows, so a TRIGGERED event can only come
-    // from the resume-triggered rescan, not from the checker's regular polling
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
-
-    // then - the stranded timer fires
-    assertThat(
-            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
-                .withProcessInstanceKey(processInstanceKey)
-                .exists())
-        .isTrue();
-  }
-
-  @Test
-  public void shouldFireTimerThatBecomesDueAfterResume() {
-    // given - an instance suspended and resumed before its timer is due
-    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
-    RecordingExporter.timerRecords(TimerIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .await();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
-
-    // when - the timer becomes due after resume
-    ENGINE.increaseTime(Duration.ofSeconds(1));
-
-    // then - it fires through the normal path and the process completes
+    final var triggered =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    final var resumed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(timerResumed.getPosition()).isLessThan(triggered.getPosition());
+    assertThat(triggered.getPosition()).isLessThan(resumed.getPosition());
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
         .withProcessInstanceKey(processInstanceKey)
         .withElementType(BpmnElementType.PROCESS)
         .await();
+    assertThat(bufferedTimerTriggerCount(processInstanceKey)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotFireTwiceWhenDuplicateTriggerIsBufferedWhileSuspended() {
+    // given
+    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
+    final var created =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.increaseTime(Duration.ofSeconds(1));
+    RecordingExporter.timerRecords(TimerIntent.SUSPENDED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when - a second TRIGGER is also buffered; the due-date index is already gone
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, created.getValue())
+            .key(created.getKey()));
+    RecordingExporter.records()
+        .filter(
+            r ->
+                r.getValueType() == ValueType.BUFFERED_COMMAND
+                    && r.getIntent() == BufferedCommandIntent.BUFFERED
+                    && ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                        == processInstanceKey
+                    && ((BufferedCommandRecordValue) r.getValue()).getIntent()
+                        == TimerIntent.TRIGGER)
+        .skip(1)
+        .await();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then - only the first drained TRIGGER fires; the duplicate is NOT_FOUND
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.TRIGGERED)
+                .filter(r -> r.getValue().getProcessInstanceKey() == processInstanceKey)
+                .count())
+        .isEqualTo(1);
+    final var duplicateRejection =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(duplicateRejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldEmitResumedForFreshTriggerWhileResuming() {
+    // given - suspend before the timer is due so the due-date index is still present
+    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
+    final var created =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    final var process =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when - RESUME then a fresh TRIGGER while the instance is still RESUMING
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.RESUME, process.getValue())
+            .key(processInstanceKey),
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, created.getValue())
+            .key(created.getKey()));
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.RESUMED)
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.TRIGGERED)
+                .filter(r -> r.getValue().getProcessInstanceKey() == processInstanceKey)
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldFireTimerThatBecomesDueAfterResume() {
+    // given
+    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // when
+    ENGINE.increaseTime(Duration.ofSeconds(1));
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.SUSPENDED)
+                .count())
+        .isZero();
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.RESUMED)
+                .count())
+        .isZero();
+  }
+
+  @Test
+  public void shouldCancelSuspendedTimer() {
+    // given
+    final long processInstanceKey = deployAndStartProcessWithTimer(Strings.newRandomValidBpmnId());
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.increaseTime(Duration.ofSeconds(1));
+    RecordingExporter.timerRecords(TimerIntent.SUSPENDED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    RecordingExporter.timerRecords(TimerIntent.CANCELED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+  }
+
+  @Test
+  public void shouldBufferRepeatingTimerOnceWhileSuspended() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(processId))
+                .boundaryEvent("timer", b -> b.cancelActivity(false).timerWithCycle("R/PT1S"))
+                .endEvent()
+                .moveToActivity("task")
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+    ENGINE.increaseTime(Duration.ofSeconds(5));
+    RecordingExporter.timerRecords(TimerIntent.SUSPENDED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // then - no fire before the first due trigger is buffered
+    assertThat(
+            RecordingExporter.records()
+                .limit(
+                    r ->
+                        r.getValueType() == ValueType.TIMER
+                            && r.getIntent() == TimerIntent.SUSPENDED
+                            && ((TimerRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.TRIGGERED)
+                .filter(r -> r.getValue().getProcessInstanceKey() == processInstanceKey)
+                .count())
+        .isZero();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).resume();
+    RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    ENGINE.job().ofInstance(processInstanceKey).withType(processId).complete();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then - later cycles are not buffered while suspended
+    assertThat(bufferedTimerTriggerCount(processInstanceKey)).isEqualTo(1);
+  }
+
+  private long bufferedTimerTriggerCount(final long processInstanceKey) {
+    return RecordingExporter.records()
+        .limitToProcessInstance(processInstanceKey)
+        .filter(
+            r ->
+                r.getValueType() == ValueType.BUFFERED_COMMAND
+                    && r.getIntent() == BufferedCommandIntent.BUFFERED
+                    && ((BufferedCommandRecordValue) r.getValue()).getProcessInstanceKey()
+                        == processInstanceKey
+                    && ((BufferedCommandRecordValue) r.getValue()).getIntent()
+                        == TimerIntent.TRIGGER)
+        .count();
   }
 
   private long deployAndStartProcessWithTimer(final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplierTest.java
@@ -36,7 +36,7 @@ public class TimerSuspendedApplierTest {
 
   private MutableTimerInstanceState timerState;
   private TimerSuspendedApplier suspendedApplier;
-  private TimerTriggeredV2Applier triggeredV2Applier;
+  private TimerTriggeredApplier triggeredApplier;
   private TimerCancelledApplier cancelledApplier;
   private TimerResumedApplier resumedApplier;
 
@@ -44,9 +44,9 @@ public class TimerSuspendedApplierTest {
   void setUp() {
     timerState = processingState.getTimerState();
     suspendedApplier = new TimerSuspendedApplier(timerState);
-    triggeredV2Applier = new TimerTriggeredV2Applier(timerState);
+    triggeredApplier = new TimerTriggeredApplier(timerState);
     cancelledApplier = new TimerCancelledApplier(timerState);
-    resumedApplier = new TimerResumedApplier();
+    resumedApplier = new TimerResumedApplier(timerState);
   }
 
   @Test
@@ -59,7 +59,7 @@ public class TimerSuspendedApplierTest {
 
     // then
     assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNotNull();
-    assertThat(timerState.hasDueDate(ELEMENT_INSTANCE_KEY, TIMER_KEY, DUE_DATE)).isFalse();
+    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isFalse();
     assertThat(dueTimers()).isEmpty();
   }
 
@@ -70,7 +70,7 @@ public class TimerSuspendedApplierTest {
     suspendedApplier.applyState(TIMER_KEY, timerRecord());
 
     // when
-    triggeredV2Applier.applyState(TIMER_KEY, timerRecord());
+    triggeredApplier.applyState(TIMER_KEY, timerRecord());
 
     // then
     assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNull();
@@ -90,7 +90,7 @@ public class TimerSuspendedApplierTest {
   }
 
   @Test
-  void shouldNotRestoreDueDateOnResume() {
+  void shouldRestoreDueDateOnResume() {
     // given
     storeTimer();
     suspendedApplier.applyState(TIMER_KEY, timerRecord());
@@ -100,7 +100,36 @@ public class TimerSuspendedApplierTest {
 
     // then
     assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNotNull();
-    assertThat(timerState.hasDueDate(ELEMENT_INSTANCE_KEY, TIMER_KEY, DUE_DATE)).isFalse();
+    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isTrue();
+    assertThat(dueTimers()).extracting(TimerInstance::getKey).containsExactly(TIMER_KEY);
+  }
+
+  @Test
+  void shouldKeepExistingDueDateOnResume() {
+    // given
+    storeTimer();
+
+    // when
+    resumedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // then
+    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isTrue();
+    assertThat(dueTimers()).extracting(TimerInstance::getKey).containsExactly(TIMER_KEY);
+  }
+
+  @Test
+  void shouldNotRestoreDueDateWhenTimerNoLongerExists() {
+    // given
+    storeTimer();
+    suspendedApplier.applyState(TIMER_KEY, timerRecord());
+    triggeredApplier.applyState(TIMER_KEY, timerRecord());
+
+    // when
+    resumedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // then
+    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isFalse();
+    assertThat(dueTimers()).isEmpty();
   }
 
   private void storeTimer() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplierTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class TimerSuspendedApplierTest {
+
+  private static final long ELEMENT_INSTANCE_KEY = 1L;
+  private static final long TIMER_KEY = 2L;
+  private static final long DUE_DATE = 1000L;
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableTimerInstanceState timerState;
+  private TimerSuspendedApplier suspendedApplier;
+  private TimerTriggeredV2Applier triggeredV2Applier;
+  private TimerCancelledApplier cancelledApplier;
+  private TimerResumedApplier resumedApplier;
+
+  @BeforeEach
+  void setUp() {
+    timerState = processingState.getTimerState();
+    suspendedApplier = new TimerSuspendedApplier(timerState);
+    triggeredV2Applier = new TimerTriggeredV2Applier(timerState);
+    cancelledApplier = new TimerCancelledApplier(timerState);
+    resumedApplier = new TimerResumedApplier();
+  }
+
+  @Test
+  void shouldDropDueDateAndKeepTimer() {
+    // given
+    storeTimer();
+
+    // when
+    suspendedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // then
+    assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNotNull();
+    assertThat(timerState.hasDueDate(ELEMENT_INSTANCE_KEY, TIMER_KEY, DUE_DATE)).isFalse();
+    assertThat(dueTimers()).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveTimerOnTriggeredAfterSuspend() {
+    // given
+    storeTimer();
+    suspendedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // when
+    triggeredV2Applier.applyState(TIMER_KEY, timerRecord());
+
+    // then
+    assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNull();
+  }
+
+  @Test
+  void shouldRemoveTimerOnCanceledAfterSuspend() {
+    // given
+    storeTimer();
+    suspendedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // when
+    cancelledApplier.applyState(TIMER_KEY, timerRecord());
+
+    // then
+    assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNull();
+  }
+
+  @Test
+  void shouldNotRestoreDueDateOnResume() {
+    // given
+    storeTimer();
+    suspendedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // when
+    resumedApplier.applyState(TIMER_KEY, timerRecord());
+
+    // then
+    assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNotNull();
+    assertThat(timerState.hasDueDate(ELEMENT_INSTANCE_KEY, TIMER_KEY, DUE_DATE)).isFalse();
+  }
+
+  private void storeTimer() {
+    processingState
+        .getElementInstanceState()
+        .createInstance(
+            new ElementInstance(
+                ELEMENT_INSTANCE_KEY,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                new ProcessInstanceRecord()));
+    final TimerInstance timer = new TimerInstance();
+    timer.setElementInstanceKey(ELEMENT_INSTANCE_KEY);
+    timer.setKey(TIMER_KEY);
+    timer.setDueDate(DUE_DATE);
+    timerState.store(timer);
+  }
+
+  private TimerRecord timerRecord() {
+    return new TimerRecord()
+        .setElementInstanceKey(ELEMENT_INSTANCE_KEY)
+        .setDueDate(DUE_DATE)
+        .setTargetElementId(BufferUtil.wrapString("timer"))
+        .setRepetitions(0)
+        .setProcessDefinitionKey(1)
+        .setProcessInstanceKey(ELEMENT_INSTANCE_KEY);
+  }
+
+  private List<TimerInstance> dueTimers() {
+    final List<TimerInstance> timers = new ArrayList<>();
+    timerState.processTimersWithDueDateBefore(DUE_DATE, timers::add);
+    return timers;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TimerSuspendedApplierTest.java
@@ -59,7 +59,8 @@ public class TimerSuspendedApplierTest {
 
     // then
     assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNotNull();
-    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isFalse();
+    assertThat(timerState.processTimersWithDueDateBefore(ELEMENT_INSTANCE_KEY, t -> true))
+        .isEqualTo(-1L);
     assertThat(dueTimers()).isEmpty();
   }
 
@@ -100,7 +101,8 @@ public class TimerSuspendedApplierTest {
 
     // then
     assertThat(timerState.get(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isNotNull();
-    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isTrue();
+    assertThat(timerState.processTimersWithDueDateBefore(ELEMENT_INSTANCE_KEY, t -> true))
+        .isEqualTo(DUE_DATE);
     assertThat(dueTimers()).extracting(TimerInstance::getKey).containsExactly(TIMER_KEY);
   }
 
@@ -113,7 +115,8 @@ public class TimerSuspendedApplierTest {
     resumedApplier.applyState(TIMER_KEY, timerRecord());
 
     // then
-    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isTrue();
+    assertThat(timerState.processTimersWithDueDateBefore(ELEMENT_INSTANCE_KEY, t -> true))
+        .isEqualTo(DUE_DATE);
     assertThat(dueTimers()).extracting(TimerInstance::getKey).containsExactly(TIMER_KEY);
   }
 
@@ -128,7 +131,8 @@ public class TimerSuspendedApplierTest {
     resumedApplier.applyState(TIMER_KEY, timerRecord());
 
     // then
-    assertThat(timerState.hasDueDateEntry(ELEMENT_INSTANCE_KEY, TIMER_KEY)).isFalse();
+    assertThat(timerState.processTimersWithDueDateBefore(ELEMENT_INSTANCE_KEY, t -> true))
+        .isEqualTo(-1L);
     assertThat(dueTimers()).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -180,7 +180,7 @@ public final class TimerInstanceStateTest {
 
     // then
     assertThat(state.get(1L, 2L)).isNotNull();
-    assertThat(state.hasDueDate(1L, 2L, 1000L)).isFalse();
+    assertThat(state.hasDueDateEntry(1L, 2L)).isFalse();
     final List<TimerInstance> timers = new ArrayList<>();
     state.processTimersWithDueDateBefore(1000L, timers::add);
     assertThat(timers).isEmpty();
@@ -193,7 +193,7 @@ public final class TimerInstanceStateTest {
     state.removeDueDate(1L, 2L, 1000L);
 
     // when
-    state.removeIgnoringMissingDueDate(timer);
+    state.remove(timer);
 
     // then
     assertThat(state.get(1L, 2L)).isNull();
@@ -205,8 +205,8 @@ public final class TimerInstanceStateTest {
     createTimerInstance(1, 2, 1000L);
 
     // then
-    assertThat(state.hasDueDate(1L, 2L, 1000L)).isTrue();
-    assertThat(state.hasDueDate(1L, 2L, 2000L)).isFalse();
+    assertThat(state.hasDueDateEntry(1L, 2L)).isTrue();
+    assertThat(state.hasDueDateEntry(2L, 2L)).isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -176,11 +176,11 @@ public final class TimerInstanceStateTest {
     createTimerInstance(1, 2, 1000L);
 
     // when
-    state.removeDueDate(1L, 2L, 1000L);
+    state.suspend(1L, 2L, 1000L);
 
     // then
     assertThat(state.get(1L, 2L)).isNotNull();
-    assertThat(state.hasDueDateEntry(1L, 2L)).isFalse();
+    assertThat(state.processTimersWithDueDateBefore(1000L, t -> true)).isEqualTo(-1L);
     final List<TimerInstance> timers = new ArrayList<>();
     state.processTimersWithDueDateBefore(1000L, timers::add);
     assertThat(timers).isEmpty();
@@ -190,23 +190,13 @@ public final class TimerInstanceStateTest {
   public void shouldRemoveTimerWhenDueDateAlreadyGone() {
     // given
     final TimerInstance timer = createTimerInstance(1, 2, 1000L);
-    state.removeDueDate(1L, 2L, 1000L);
+    state.suspend(1L, 2L, 1000L);
 
     // when
     state.remove(timer);
 
     // then
     assertThat(state.get(1L, 2L)).isNull();
-  }
-
-  @Test
-  public void shouldReportWhetherDueDateExists() {
-    // given
-    createTimerInstance(1, 2, 1000L);
-
-    // then
-    assertThat(state.hasDueDateEntry(1L, 2L)).isTrue();
-    assertThat(state.hasDueDateEntry(2L, 2L)).isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -171,6 +171,45 @@ public final class TimerInstanceStateTest {
   }
 
   @Test
+  public void shouldRemoveDueDateWithoutRemovingTimer() {
+    // given
+    createTimerInstance(1, 2, 1000L);
+
+    // when
+    state.removeDueDate(1L, 2L, 1000L);
+
+    // then
+    assertThat(state.get(1L, 2L)).isNotNull();
+    assertThat(state.hasDueDate(1L, 2L, 1000L)).isFalse();
+    final List<TimerInstance> timers = new ArrayList<>();
+    state.processTimersWithDueDateBefore(1000L, timers::add);
+    assertThat(timers).isEmpty();
+  }
+
+  @Test
+  public void shouldRemoveTimerWhenDueDateAlreadyGone() {
+    // given
+    final TimerInstance timer = createTimerInstance(1, 2, 1000L);
+    state.removeDueDate(1L, 2L, 1000L);
+
+    // when
+    state.removeIgnoringMissingDueDate(timer);
+
+    // then
+    assertThat(state.get(1L, 2L)).isNull();
+  }
+
+  @Test
+  public void shouldReportWhetherDueDateExists() {
+    // given
+    createTimerInstance(1, 2, 1000L);
+
+    // then
+    assertThat(state.hasDueDate(1L, 2L, 1000L)).isTrue();
+    assertThat(state.hasDueDate(1L, 2L, 2000L)).isFalse();
+  }
+
+  @Test
   public void shouldListAllTimersByElementInstanceKey() {
     // given
     createElementInstance(1);

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_RESUMED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_RESUMED_v1.golden
@@ -8,13 +8,24 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 
 final class TimerResumedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
+  private final MutableTimerInstanceState timerInstanceState;
+
+  TimerResumedApplier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    // Resume does not restore the due-date index. Firing is the drained TRIGGER command.
+    // A duplicate buffered trigger can resume after the first trigger removed the timer.
+    // Do not recreate a due-date entry for a timer that no longer exists.
+    if (timerInstanceState.get(value.getElementInstanceKey(), key) != null) {
+      timerInstanceState.restoreDueDate(value.getElementInstanceKey(), key, value.getDueDate());
+    }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_RESUMED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_RESUMED_v1.golden
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+final class TimerResumedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    // Resume does not restore the due-date index. Firing is the drained TRIGGER command.
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_RESUMED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_RESUMED_v1.golden
@@ -22,10 +22,6 @@ final class TimerResumedApplier implements TypedEventApplier<TimerIntent, TimerR
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    // A duplicate buffered trigger can resume after the first trigger removed the timer.
-    // Do not recreate a due-date entry for a timer that no longer exists.
-    if (timerInstanceState.get(value.getElementInstanceKey(), key) != null) {
-      timerInstanceState.restoreDueDate(value.getElementInstanceKey(), key, value.getDueDate());
-    }
+    timerInstanceState.resume(value.getElementInstanceKey(), key, value.getDueDate());
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_SUSPENDED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_SUSPENDED_v1.golden
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+final class TimerSuspendedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private final MutableTimerInstanceState timerInstanceState;
+
+  TimerSuspendedApplier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    timerInstanceState.removeDueDate(value.getElementInstanceKey(), key, value.getDueDate());
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Timer_SUSPENDED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Timer_SUSPENDED_v1.golden
@@ -22,6 +22,6 @@ final class TimerSuspendedApplier implements TypedEventApplier<TimerIntent, Time
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    timerInstanceState.removeDueDate(value.getElementInstanceKey(), key, value.getDueDate());
+    timerInstanceState.suspend(value.getElementInstanceKey(), key, value.getDueDate());
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
@@ -29,7 +29,10 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
   CANCEL((short) 3),
   CANCELED((short) 4),
 
-  MIGRATED((short) 5);
+  MIGRATED((short) 5),
+
+  SUSPENDED((short) 6),
+  RESUMED((short) 7);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -55,6 +58,8 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
       case TRIGGERED:
       case CANCELED:
       case MIGRATED:
+      case SUSPENDED:
+      case RESUMED:
         return true;
       default:
         return false;
@@ -75,6 +80,10 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
         return CANCELED;
       case 5:
         return MIGRATED;
+      case 6:
+        return SUSPENDED;
+      case 7:
+        return RESUMED;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

Rejecting `Timer.TRIGGER` while a process instance was suspended left the due-date index in place, so the due-date checker kept rewriting the same command. Resume then re-armed the checker with `scheduleTimer(-1)` only after drain, so the timer could fire after buffered commands and land out of order.

This PR buffers a due timer trigger through the process-instance suspension gate instead.

- Adds `Timer.SUSPENDED` and `Timer.RESUMED` lifecycle events and state appliers.
- `onSuspended` writes `SUSPENDED` and returns `BUFFER`. The applier drops only the due-date index and keeps the timer instance, so cancel and a later fire still find it.
- `onResuming` writes `RESUMED` for every `TRIGGER` the gate lets through while `RESUMING` (buffered or fresh), then returns `PROCESS`. The applier upserts the due-date entry if the timer still exists, so an already indexed fresh trigger is unchanged and a duplicate drained trigger cannot recreate an index row after the first fire removed it.
- Stops re-arming the due-date checker on `COMPLETE_RESUMING`. Timers that become due after resume take the normal path and are neither suspended nor resumed.
- `remove()` deletes the due-date index with `deleteIfExists`, so a suspended timer can take the normal removal path.
- Start-event timers are unchanged: they have no process instance, so the gate never resolves a suspension marker for them.

Decision recorded in `zeebe/docs/adr/0009-810-suspended-timer-buffering.md`.

### Suspension gate

The gate classifies with `onSuspended` and `onResuming`, each returning a `SuspensionAction` (`PROCESS`, `REJECT`, or `BUFFER`). Events that belong with buffering live in `onSuspended`; events that belong with resume live in `onResuming`. `BUFFER` from `onResuming` throws: drained commands must not re-buffer.

`SuspensionCheck` is renamed to `SuspensionBehavior`. Shared helpers `bufferInternalOnly` and `processInternalOnly` keep processors rejecting external commands while draining instead of re-buffering them. A processor that returns a null action is logged and processed normally.

### Cycling non-interrupting timers

A repeating timer is one timer instance and one due-date index. The first trigger due during suspension is buffered and removes that index, so later checker ticks do not queue every missed interval.

On drain, the buffered trigger fires once. The existing reschedule path then creates the next cycle from the previous due date and snaps an overdue next trigger to now. That is the buffered firing plus at most one overdue catch-up firing, not one firing per missed interval.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #61750