### PR TITLE
feat: add agent instance Zod schema cache and reasoning token metrics

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -22,7 +22,7 @@
 		"@bpmn-io/form-js-carbon-styles": "1.25.0",
 		"@bpmn-io/form-js-viewer": "1.25.0",
 		"@bpmn-io/shadcn-theme": "0.0.1",
-		"@camunda/camunda-api-zod-schemas": "0.0.92",
+		"@camunda/camunda-api-zod-schemas": "0.0.93",
 		"@camunda/camunda-composite-components": "0.25.4",
 		"@camunda/design-system": "0.49.0",
 		"@camunda/session-heartbeat": "0.0.1",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -33,7 +33,7 @@
 				"@bpmn-io/form-js-carbon-styles": "1.25.0",
 				"@bpmn-io/form-js-viewer": "1.25.0",
 				"@bpmn-io/shadcn-theme": "0.0.1",
-				"@camunda/camunda-api-zod-schemas": "0.0.92",
+				"@camunda/camunda-api-zod-schemas": "0.0.93",
 				"@camunda/camunda-composite-components": "0.25.4",
 				"@camunda/design-system": "0.49.0",
 				"@camunda/session-heartbeat": "0.0.1",
@@ -14997,7 +14997,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.92",
+				"@camunda/camunda-api-zod-schemas": "0.0.93",
 				"typescript": "7.0.2"
 			}
 		},
@@ -15038,7 +15038,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.92",
+			"version": "0.0.93",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.4.1",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.92",
+		"@camunda/camunda-api-zod-schemas": "0.0.93",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.93
+
+### 🩹 Fixes
+
+- Add `reasoningTokenCount`, `cacheCreationTokenCount`, and `cacheReadTokenCount` to the 8.10 agent instance metrics and history item metrics schemas [#59320](https://github.com/camunda/camunda/issues/59320)
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.92
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -65,6 +65,9 @@ type AgentInstanceDefinition = z.infer<typeof agentInstanceDefinitionSchema>;
 const agentInstanceMetricsSchema = z.object({
 	inputTokens: z.number(),
 	outputTokens: z.number(),
+	reasoningTokenCount: z.number(),
+	cacheCreationTokenCount: z.number(),
+	cacheReadTokenCount: z.number(),
 	modelCalls: z.number(),
 	toolCalls: z.number(),
 });
@@ -169,6 +172,9 @@ type AgentInstanceToolCall = z.infer<typeof agentInstanceToolCallSchema>;
 const agentInstanceHistoryItemMetricsSchema = z.object({
 	inputTokens: z.number().nullable(),
 	outputTokens: z.number().nullable(),
+	reasoningTokenCount: z.number().nullable(),
+	cacheCreationTokenCount: z.number().nullable(),
+	cacheReadTokenCount: z.number().nullable(),
 	durationMs: z.number().nullable(),
 });
 type AgentInstanceHistoryItemMetrics = z.infer<typeof agentInstanceHistoryItemMetricsSchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.92",
+	"version": "0.0.93",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

This PR syncs the agent-instance Zod schema types with latest API changes. It adds metric fields for cache- and reasoning-tokens.

## Checklist

<!--- Please delete options that are not relevant. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

relates #59321


