### PR TITLE
test: retry flow control actuator requests after transient failures

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -110,7 +110,7 @@ public class FlowControlServiceImpl implements FlowControlService {
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return client
-                      .sendRequest(request)
+                      .sendRequestWithRetry(request)
                       .thenApply(response -> response.getResponseOrThrow());
                 })
             .toArray(CompletableFuture<?>[]::new);
@@ -133,7 +133,7 @@ public class FlowControlServiceImpl implements FlowControlService {
     request.getFLowControlConfiguration();
 
     return client
-        .sendRequest(request)
+        .sendRequestWithRetry(request)
         .thenApply(
             response -> {
               final var payload = response.getResponseOrThrow().getPayload();

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/FlowControlServiceImplTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/FlowControlServiceImplTest.java
@@ -101,12 +101,12 @@ final class FlowControlServiceImplTest {
     when(response.getPayload()).thenReturn("{}".getBytes(StandardCharsets.UTF_8));
     doReturn(CompletableFuture.completedFuture(new BrokerResponse<>(response)))
         .when(client)
-        .sendRequest(any());
+        .sendRequestWithRetry(any());
   }
 
   private List<BrokerRequest> capturedRequests() {
     final ArgumentCaptor<BrokerRequest> captor = ArgumentCaptor.forClass(BrokerRequest.class);
-    verify(client, atLeastOnce()).sendRequest(captor.capture());
+    verify(client, atLeastOnce()).sendRequestWithRetry(captor.capture());
     return captor.getAllValues();
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
+import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
@@ -35,8 +38,13 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
+import java.net.ConnectException;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /** Forwards all requests to the coordinator. */
@@ -222,14 +230,53 @@ public final class ClusterConfigurationManagementRequestSender {
         TIMEOUT);
   }
 
+  /**
+   * Queries the topology from the default coordinator, falling back to another configured member
+   * when the selected member cannot be reached. Unlike configuration changes, a topology query is
+   * read-only and can be served by any member.
+   */
   public CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> getTopology() {
-    return communicationService.send(
-        ClusterConfigurationRequestTopics.QUERY_TOPOLOGY.topic(),
-        new byte[0],
-        Function.identity(),
-        serializer::decodeClusterConfigurationResponse,
-        coordinatorSupplier.getDefaultCoordinator(),
-        TIMEOUT);
+    return getTopology(coordinatorSupplier.getDefaultCoordinator(), Set.of());
+  }
+
+  private CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> getTopology(
+      final MemberId coordinator, final Set<MemberId> attemptedCoordinators) {
+    final var attempted = new HashSet<>(attemptedCoordinators);
+    attempted.add(coordinator);
+
+    return communicationService
+        .send(
+            ClusterConfigurationRequestTopics.QUERY_TOPOLOGY.topic(),
+            new byte[0],
+            Function.identity(),
+            serializer::decodeClusterConfigurationResponse,
+            coordinator,
+            TIMEOUT)
+        .exceptionallyCompose(
+            error -> {
+              if (!isRetryable(error)) {
+                return CompletableFuture.failedFuture(error);
+              }
+
+              final var nextCoordinator =
+                  coordinatorSupplier.getNextCoordinatorExcluding(attempted);
+              if (attempted.contains(nextCoordinator)) {
+                return CompletableFuture.failedFuture(error);
+              }
+
+              return getTopology(nextCoordinator, attempted);
+            });
+  }
+
+  private static boolean isRetryable(final Throwable error) {
+    return switch (FuturesUtil.unwrapCompletionException(error)) {
+      case final ConnectionClosed ignored -> true;
+      case final ConnectException ignored -> true;
+      case final NoRemoteHandler ignored -> true;
+      case final NoSuchMemberException ignored -> true;
+      case final TimeoutException ignored -> true;
+      default -> false;
+    };
   }
 
   public CompletableFuture<Either<ErrorResponse, CurrentClusterConfiguration>> cancelTopologyChange(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSenderTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSenderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
+import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+final class ClusterConfigurationManagementRequestSenderTest {
+
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+  private static final MemberId DEFAULT_COORDINATOR = MemberId.from("0");
+  private static final MemberId NEXT_COORDINATOR = MemberId.from("1");
+
+  private final ClusterCommunicationService communicationService =
+      mock(ClusterCommunicationService.class);
+  private final ClusterConfigurationRequestsSerializer serializer =
+      mock(ClusterConfigurationRequestsSerializer.class);
+  private final CurrentClusterConfiguration expectedTopology =
+      mock(CurrentClusterConfiguration.class);
+
+  @Test
+  void shouldQueryAnotherMemberWhenTheDefaultCoordinatorIsNotKnown() {
+    // given
+    doAnswer(
+            invocation -> {
+              final var coordinator = invocation.<MemberId>getArgument(4);
+              if (coordinator.equals(DEFAULT_COORDINATOR)) {
+                return CompletableFuture.failedFuture(
+                    new NoSuchMemberException("default coordinator is not known"));
+              }
+              return CompletableFuture.completedFuture(Either.right(expectedTopology));
+            })
+        .when(communicationService)
+        .send(
+            eq(ClusterConfigurationRequestTopics.QUERY_TOPOLOGY.topic()),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(REQUEST_TIMEOUT));
+    final var sender =
+        new ClusterConfigurationManagementRequestSender(
+            communicationService,
+            ClusterConfigurationCoordinatorSupplier.ofMembers(
+                Set.of(DEFAULT_COORDINATOR, NEXT_COORDINATOR)),
+            serializer,
+            MemberId.from("gateway"));
+
+    // when
+    final var result = sender.getTopology();
+
+    // then
+    assertThat(result)
+        .succeedsWithin(Duration.ofSeconds(1))
+        .satisfies(response -> assertThat(response.get()).isSameAs(expectedTopology));
+    final var coordinators = ArgumentCaptor.forClass(MemberId.class);
+    verify(communicationService, times(2))
+        .send(
+            eq(ClusterConfigurationRequestTopics.QUERY_TOPOLOGY.topic()),
+            any(),
+            any(),
+            any(),
+            coordinators.capture(),
+            eq(REQUEST_TIMEOUT));
+    assertThat(coordinators.getAllValues()).containsExactly(DEFAULT_COORDINATOR, NEXT_COORDINATOR);
+  }
+}


### PR DESCRIPTION
## Summary

A CPU-starved broker can temporarily disappear from a broker's membership view. Flow-control actuator requests were sent with retries disabled, so the first missing broker failed the complete operation. Cluster topology reads were also always sent to the default coordinator, preventing a surviving broker from answering a read while that coordinator was unreachable.

This change:

- uses the retrying broker client for flow-control reads and writes;
- retries read-only topology queries against the next configured cluster member when the selected member is unreachable;
- keeps configuration-changing requests coordinator-bound because only the coordinator may advance changes.

## Validation

- `just utOnly ClusterConfigurationManagementRequestSenderTest -pl zeebe/dynamic-config -DskipITs`
- `just utOnly FlowControlServiceImplTest -pl dist -DskipITs`
- `just ut -pl dist -DskipITs`
- `just itOnly FlowControlEndpointIT -pl zeebe/qa/integration-tests`
- `just checks -pl zeebe/dynamic-config,dist`
- `just install`
- The complete `zeebe/dynamic-config` unit suite ran 1,191 tests; two unrelated `ZoneAwareClusterConfigurationManagementApiTest` cases failed twice with local Netty `Address already in use`. The affected class passes when run in isolation.

## Related issues

closes #58821
