### PR TITLE
ci: load-test: update database versions

### DIFF
--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -98,7 +98,7 @@ platform_values = -f camunda-platform-values-defaults.yaml
 
 # The configuration for the "load test setup" local Helm Chart
 helm_chart_load_test_setup = charts/load-test-setup
-load_test_setup_values = -f load-test-setup-values.yaml
+load_test_setup_values = -f load-test-setup-values-defaults.yaml -f load-test-setup-values.yaml
 additional_load_test_setup_configuration ?=
 # Makefile-side load-test-setup flags. Separate from `additional_load_test_setup_configuration`,
 # which CI sets on the make command line and would suppress `+=` here.

--- a/load-tests/setup/main/values/load-test-setup-values-defaults.yaml
+++ b/load-tests/setup/main/values/load-test-setup-values-defaults.yaml
@@ -1,0 +1,14 @@
+# Default configuration for the version this folder configures.
+
+elasticsearch:
+  # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+  version: '9.5.2'
+
+opensearch:
+  image:
+    # renovate: datasource=docker depName=opensearchproject/opensearch
+    tag: '3.8.0'
+
+postgresql:
+  # renovate: datasource=docker depName=postgres
+  version: 18-alpine

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -193,12 +193,13 @@ mkdir -p "$TARGET_DIRECTORY"
 # per-namespace Makefile's -f <file>.yaml references resolve unchanged.
 cp -v  "$VERSION_DIR/Makefile"                                                  "$TARGET_DIRECTORY/"
 cp -rv "$SCRIPT_DIR/charts"                                                     "$TARGET_DIRECTORY/"
+cp -v  "$VERSION_DIR/values/load-test-setup-values-defaults.yaml"               "$TARGET_DIRECTORY/"
 cp -v  "$VERSION_DIR/values/camunda-platform-override-values.yaml"              "$TARGET_DIRECTORY/"
 cp -v  "$SCRIPT_DIR/scenarios/load-tester-values-defaults.yaml"                 "$TARGET_DIRECTORY/"
 cp -v  "$VERSION_DIR/values/values-stable.yaml"                                 "$TARGET_DIRECTORY/"
 cp -v  "$SCRIPT_DIR/scenarios/load-tester-values-realistic-benchmark.yaml"      "$TARGET_DIRECTORY/"
 cp -v  "$VERSION_DIR/values/camunda-platform-values-defaults.yaml"              "$TARGET_DIRECTORY/"
-cp -v  "$VERSION_DIR/values/camunda-platform-values-${secondary_storage}.yaml"   "$TARGET_DIRECTORY/"
+cp -v  "$VERSION_DIR/values/camunda-platform-values-${secondary_storage}.yaml"  "$TARGET_DIRECTORY/"
 
 # Don't configure Elasticsearch unless specifically enabled (secondary storage,
 # or via Optimize)

--- a/load-tests/setup/stable-810/values/load-test-setup-values-defaults.yaml
+++ b/load-tests/setup/stable-810/values/load-test-setup-values-defaults.yaml
@@ -1,0 +1,14 @@
+# Default configuration for the version this folder configures.
+
+elasticsearch:
+  # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+  version: '9.5.2'
+
+opensearch:
+  image:
+    # renovate: datasource=docker depName=opensearchproject/opensearch
+    tag: '3.8.0'
+
+postgresql:
+  # renovate: datasource=docker depName=postgres
+  version: 18-alpine

--- a/load-tests/setup/stable-87/values/load-test-setup-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/load-test-setup-values-defaults.yaml
@@ -1,0 +1,5 @@
+# Default configuration for the version this folder configures.
+
+elasticsearch:
+  # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+  version: '8.19.16'

--- a/load-tests/setup/stable-88/values/load-test-setup-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/load-test-setup-values-defaults.yaml
@@ -1,0 +1,10 @@
+# Default configuration for the version this folder configures.
+
+elasticsearch:
+  # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+  version: '8.19.16'
+
+opensearch:
+  image:
+    # renovate: datasource=docker depName=opensearchproject/opensearch
+    tag: '2.19.6'

--- a/load-tests/setup/stable-89/values/load-test-setup-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/load-test-setup-values-defaults.yaml
@@ -1,0 +1,14 @@
+# Default configuration for the version this folder configures.
+
+elasticsearch:
+  # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
+  version: '8.19.16'
+
+opensearch:
+  image:
+    # renovate: datasource=docker depName=opensearchproject/opensearch
+    tag: '2.19.6'
+
+postgresql:
+  # renovate: datasource=docker depName=postgres
+  version: 18-alpine

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-physical-tenants/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/main/max/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/max/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-physical-tenants/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-test-setup/templates/elasticsearch.yaml
@@ -8,7 +8,7 @@ metadata:
     camunda.io/created-by: "golden-test"
     camunda.io/purpose: load-test
 spec:
-  version: 8.18.0
+  version: 9.5.2
 
   nodeSets:
   - config:

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:3.8.0"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/charts/opensearch/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
         resources:
           {}
       - name: configfile
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -147,7 +147,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
 
-        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.0"
+        image: "europe-west1-docker.pkg.dev/camunda-benchmark/dockerhub/opensearchproject/opensearch:2.19.6"
         imagePullPolicy: "IfNotPresent"
         readinessProbe:
           failureThreshold: 3


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

