### PR TITLE
test: update instance action buttons locators

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -302,15 +302,17 @@ class OperateProcessesPage {
   }
 
   getRetryInstanceButton(processInstanceKey: string): Locator {
-    return this.page.getByRole('button', {
-      name: `Retry Instance ${processInstanceKey}`,
-    });
+    return OperateProcessesPage.getRowByProcessInstanceKey(
+      this.page,
+      processInstanceKey,
+    ).getByTestId('retry-operation');
   }
 
   getCancelInstanceButton(processInstanceKey: string): Locator {
-    return this.page.getByRole('button', {
-      name: `Cancel Instance ${processInstanceKey}`,
-    });
+    return OperateProcessesPage.getRowByProcessInstanceKey(
+      this.page,
+      processInstanceKey,
+    ).getByTestId('cancel-operation');
   }
 
   // The per-row operation spinner is a Carbon InlineLoading (no data-testid)


### PR DESCRIPTION
## Description

`data-testid` property of corresponding locators were changed, adjusted locators

Parent PR of causing failures in the first place https://github.com/camunda/camunda/pull/61887
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. [here](https://github.com/camunda/camunda/actions/runs/34133591006/job/101779713906) - no operate failure, swagger failures will be handled separately

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

