### PR TITLE
deps: source the infra-global-github-actions version manager from its preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,8 @@
     "config:recommended",
     "github>camunda/infra-renovate-config:herodevs.json5",
     "github>camunda/infra-renovate-config:rebase.json5",
+    // Version-tracks camunda/infra-global-github-actions sub-action pins (`# <family>-X.Y.Z`).
+    "github>camunda/infra-global-github-actions:renovate-action-versions.json5",
     // Team-specific configuration
     "local>camunda/camunda//.github/renovate/team-reliability-testing.json5",
   ],
@@ -946,21 +948,6 @@
         "action:\\s+(?<depName>[\\w.-]+/[\\w.-]+)@(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)",
       ],
       datasourceTemplate: "github-tags",
-    },
-    {
-      // Per-family extractVersion keeps each sub-action's tags from matching another family's release line.
-      description: "Track camunda/infra-global-github-actions sub-actions pinned to a per-action release tag (comment format '# <action>-X.Y.Z'), which the default github-actions manager cannot version-track because it drops the sub-action path from depName.",
-      customType: "regex",
-      managerFilePatterns: [
-        "/^\\.github/.+\\.ya?ml$/",
-      ],
-      matchStrings: [
-        "uses:\\s*camunda/infra-global-github-actions/[\\w./-]+@(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<family>[a-z0-9-]+?)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b",
-      ],
-      depNameTemplate: "camunda/infra-global-github-actions/{{{family}}}",
-      packageNameTemplate: "camunda/infra-global-github-actions",
-      datasourceTemplate: "github-tags",
-      extractVersionTemplate: "^{{{family}}}-(?<version>\\d+\\.\\d+\\.\\d+)$",
     },
   ],
 }


### PR DESCRIPTION
## Description

`camunda/infra-global-github-actions` now publishes the custom manager that version-tracks its sub-actions as a Renovate preset ([#810](https://github.com/camunda/infra-global-github-actions/pull/810)), so this repository's hand-copied version can be replaced by extending it.

The regex decodes that repository's own `release-please` tagging scheme (`include-component-in-tag`, `tag-separator`), so keeping it there means the scheme and the regex change together in one PR, instead of every consumer carrying a copy that silently drifts. `camunda/infra-github-demo` had a copy too, and `camunda/mcp` had none, which is exactly how its pins went five months stale unnoticed.

No behaviour change here: the preset's regex, `depNameTemplate`, `packageNameTemplate`, `datasourceTemplate` and per-family `extractVersionTemplate` are identical to the block being removed. It only widens `managerFilePatterns` to also cover `action.yml` at any path, and all 69 pins in this repository live under `.github/`, so nothing changes for them.

<details>
<summary>Verification</summary>

- `renovate-config-validator --strict`: `Config validated successfully`.
- The 69 pins here span 13 families (`generate-github-app-token-from-vault-secrets` 29, `fossa` 11, `preview-env` 8, `sanitize-branch-name` 6, `rerun-failed-run` 4, plus 8 more), all under `.github/`.
- Sandbox-tested in `camunda/infra-github-demo` before rollout: with the local copy removed and only the preset extended, Renovate detected an identical set of dependencies and available updates, byte-for-byte, and both fixture controls (an unparseable comment and a `@main` branch pin) stayed correctly out of version tracking.
- `customManagers` is a `mergeable: true` option in Renovate, so the preset's manager concatenates with the ones this repository keeps (wretry, connectors-bundle and the rest) rather than replacing them.

</details>

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

- [x] This PR does not need a linked issue
