### PR TITLE
feat: add Python load test report tool

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -271,7 +271,7 @@ outputs:
         steps.filter-load-test-setup.outputs.load-test-setup-change == 'true'
       }}
   scripts-changes:
-    description: Output whether any file under .github/scripts/ or .ci/db-versions.yml changed, so their Python unit tests should be run
+    description: Output whether any Python-tested script changed, so their Python unit tests should be run
     value: >-
       ${{
         github.event_name == 'push' ||
@@ -543,6 +543,7 @@ runs:
         scripts-change:
           - '.github/scripts/**'
           - '.ci/db-versions.yml'
+          - 'load-tests/docs/scripts/**'
 
   # only works `on: push` and `on: pull_request` GitHub trigger events
   - id: filter-special-branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2720,9 +2720,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install test dependencies
-        run: python3 -m pip install --quiet pytest -r .github/actions/read-db-versions/requirements.txt
-      - name: Run unit tests
+        run: python3 -m pip install --quiet pytest uv==0.8.22 -r .github/actions/read-db-versions/requirements.txt
+      - name: Run repository script unit tests
         run: pytest --verbose --color=yes --tb=short .github/scripts .github/actions/adjust-pom-for-license-analysis .github/actions/read-db-versions
+      - name: Run load-test script unit tests
+        run: make -C load-tests/docs/scripts/load_test_report check
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -75,10 +75,10 @@ Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endp
 ```
 
 **Arguments:**
-- `namespace` — exact namespace label, e.g. `c8-pgoyal-quicker-pr-1234`. Required.
-- `duration_seconds` — PromQL range-vector window. Default: `600`.
-- `endpoint` — Prometheus base URL. Default: `http://localhost:9090` (assumes `kubectl port-forward` is open).
-- `extra_curl_opts` — free-form curl options string, e.g. `--user "u:p"` for HTTP basic auth.
+- `namespace` - exact namespace label, e.g. `c8-pgoyal-quicker-pr-1234`. Required.
+- `duration_seconds` - PromQL range-vector window. Default: `600`.
+- `endpoint` - Prometheus base URL. Default: `http://localhost:9090` (assumes `kubectl port-forward` is open).
+- `extra_curl_opts` - free-form curl options string, e.g. `--user "u:p"` for HTTP basic auth.
 
 **Examples:**
 
@@ -98,6 +98,23 @@ Against the LDAP-protected ingress:
 ```
 
 zsh users: quote regex-looking arguments to avoid `no matches found` glob errors.
+
+## load_test_report
+
+Builds a wide JSON, CSV, or TSV report for one load-test namespace from Prometheus.
+The tool lives in its own Python subproject:
+[`load_test_report/`](load_test_report/).
+
+Quick start:
+
+```bash
+cd load-tests/docs/scripts/load_test_report
+make test
+uv run ./load_test_report.py c8-ck-baseline-20260814 --duration-seconds 1800
+```
+
+See [`load_test_report/README.md`](load_test_report/README.md) for setup, examples,
+query-file documentation, and the Makefile targets used by CI.
 
 ## PartitionDistribution.sh
 

--- a/load-tests/docs/scripts/load_test_report/Makefile
+++ b/load-tests/docs/scripts/load_test_report/Makefile
@@ -1,0 +1,26 @@
+UV ?= uv
+PYTEST_ARGS ?= --verbose --color=yes --tb=short
+
+.PHONY: test compile format lint check
+
+test:
+	$(UV) run --locked pytest $(PYTEST_ARGS) tests
+
+compile:
+	$(UV) run --locked python -m py_compile \
+		cli.py \
+		errors.py \
+		load_test_report.py \
+		prometheus.py \
+		queries.py \
+		report.py
+
+format:
+	$(UV) run --locked ruff check --fix .
+	$(UV) run --locked ruff format .
+
+lint:
+	$(UV) run --locked ruff check .
+	$(UV) run --locked ruff format --check .
+
+check: compile lint test

--- a/load-tests/docs/scripts/load_test_report/README.md
+++ b/load-tests/docs/scripts/load_test_report/README.md
@@ -1,0 +1,206 @@
+# Load test report
+
+`load_test_report.py` builds a wide report for one load-test namespace by querying
+Prometheus. It emits JSON for structured processing and CSV or TSV for spreadsheet
+imports.
+
+## Setup
+
+Install `uv` once:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv --version
+```
+
+If `uv` is not on your `PATH` after installation, restart your shell or add the
+installation directory printed by the installer. A Python-packaged fallback also works:
+
+```bash
+python3 -m pip install --user uv
+uv --version
+```
+
+The project dependencies are declared in [`pyproject.toml`](pyproject.toml) and locked
+in [`uv.lock`](uv.lock). Keep `uv.lock` committed so local runs and CI use the same
+resolved dependency graph.
+
+## Test
+
+Format Python files:
+
+```bash
+make format
+```
+
+Run Ruff linting and formatting checks:
+
+```bash
+make lint
+```
+
+Run the unit tests:
+
+```bash
+make test
+```
+
+Run the same target CI uses:
+
+```bash
+make check
+```
+
+## Usage
+
+```bash
+uv run ./load_test_report.py <namespace> [options]
+```
+
+Common options:
+
+- `--duration-seconds <sec>`: query window duration. Default: `600`.
+- `--rate-interval <dur>`: short Prometheus rate interval for dashboard-style rollups.
+  Default: `5m`.
+- `--sample-step <dur>`: sample resolution for window summaries. Default: `1m`.
+- `--queries <name-or-path>`: built-in query set name or custom YAML/JSON query file
+  path. Default: `camunda`.
+- `--at <time>`: Prometheus query time anchor. The report window ends at this RFC3339
+  or Unix timestamp.
+- `--start <time> --end <time>`: exact reporting window. The duration is derived from
+  the two timestamps.
+- `--endpoint <url>`: Prometheus base URL. Default: `http://localhost:9090`.
+- `--token <token>`: bearer token for Prometheus.
+- `--user <user> --password <password>`: basic auth credentials for Prometheus.
+- `--format json|csv|tsv`: output format. Default: `json`.
+- `--no-header`: omit the CSV or TSV header row for direct spreadsheet row pasting.
+- `--missing-value <value>`: placeholder for missing CSV or TSV metrics. Default:
+  `NaN`.
+- `--output <path>`: write the report to a file.
+
+## Query selection
+
+Use one `--queries` option for both maintained query sets and custom files:
+
+- `camunda`: [`report-queries.yaml`](report-queries.yaml), current Camunda 8.8+
+  orchestration cluster layout plus common metrics.
+- `stable-87`: [`report-queries-stable-87.yaml`](report-queries-stable-87.yaml),
+  Camunda 8.7 Zeebe broker and gateway layout plus common metrics.
+- `<path>`: custom YAML or JSON file with the same top-level `queries:` schema.
+
+The custom file case is useful when a report needs its own column set or PromQL, for
+example a future daily load-test report.
+
+## Output shape
+
+CSV and TSV column order follows the selected query file. The built-in query sets are
+laid out for spreadsheet imports:
+
+1. namespace and Docker image
+2. cluster size
+3. Camunda or Zeebe resources
+4. secondary-storage resources
+5. throughput
+6. latency
+7. backlog
+
+Write IOPS columns appear after disk usage for each storage-backed component. Metrics
+that Prometheus does not return stay visible as `null` in JSON and `NaN` in CSV or TSV
+by default.
+
+## Query window semantics
+
+The report window ends at `--at`, at `--end` when `--start --end` are provided, or at
+Prometheus's current evaluation time.
+
+Different column types use that window differently:
+
+- Literal columns, such as `namespace`, do not query Prometheus.
+- Label columns, such as `docker_image`, read labels from series present during the
+  window. This keeps deleted namespaces reportable while the historical series remains
+  in Prometheus retention.
+- Resource gauges, such as pod counts, CPU limits, memory limits, disk capacity, disk
+  usage, heap, and RSS, use a max over the window so a restart or deleted namespace does
+  not hide the value.
+- CPU usage p50 and p99 use `rate()` samples from `--rate-interval`, then summarize
+  those samples over the window with `quantile_over_time`.
+- Average-rate columns, such as throughput, CPU throttling, write IOPS, backpressure,
+  and backlog, use `rate()` or sampled values at `--rate-interval`, then average those
+  samples over the window.
+- Backpressure and backlog first pick the highest partition value at each sample, then
+  average those sampled maxima over the window.
+- Columns computed from seconds-denominated histograms but labeled in milliseconds,
+  such as `ProcLat p50 (ms)`, multiply the PromQL result by `1000`.
+
+## Query file schema
+
+Each query entry is one report column, in emission order. The order controls the JSON
+key order and the CSV or TSV column order.
+
+Fields:
+
+- `key`: machine key, used as the JSON `metrics` object key and CSV or TSV column
+  identifier.
+- `description`: human-readable explanation of what the column measures.
+- `header`: human column label for CSV or TSV output.
+- `value`: literal value. Mutually exclusive with `query`.
+- `valueLabel`: Prometheus label to extract instead of the sample value. Requires
+  `query`.
+- `query`: PromQL query evaluated against Prometheus. Mutually exclusive with `value`.
+
+Built-in YAML entries keep the field order `key`, `description`, `header`, then
+`value`, `valueLabel`, or `query` fields.
+
+## Query substitutions
+
+Variables are substituted in the raw query file before YAML or JSON decoding:
+
+- `$NAMESPACE`: exact load-test namespace, for example `c8-ck-baseline-20260814`.
+- `$DURATION_S`: report window duration with an `s` suffix, for example `600s`.
+- `$RATE_INTERVAL`: short `--rate-interval` used for dashboard-style rate samples.
+- `$SAMPLE_STEP`: `--sample-step` subquery resolution used for window summaries, for
+  example in `quantile_over_time` or `avg_over_time`.
+
+## Examples
+
+Port-forwarded Prometheus, JSON:
+
+```bash
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090
+cd load-tests/docs/scripts/load_test_report
+uv run ./load_test_report.py c8-ck-baseline-20260814 --duration-seconds 1800
+```
+
+Exact historical window, TSV row ready to paste into a spreadsheet:
+
+```bash
+uv run ./load_test_report.py c8-ck-baseline-20260814 \
+  --start 2026-08-14T10:00:00Z \
+  --end 2026-08-14T10:30:00Z \
+  --format tsv --no-header
+```
+
+Use `--missing-value null` if your spreadsheet should show `null` instead of `NaN` for
+missing metrics.
+
+8.7-style Zeebe broker plus Zeebe Gateway layout:
+
+```bash
+uv run ./load_test_report.py c8-ck-base-8736-endurance \
+  --queries stable-87 \
+  --start 2026-08-12T09:00:00Z \
+  --end 2026-08-13T06:00:00Z \
+  --format tsv --no-header
+```
+
+CI monitor ingress with basic auth:
+
+```bash
+uv run ./load_test_report.py c8-ck-baseline-20260814 \
+  --duration-seconds 1800 \
+  --endpoint https://ci-monitor.benchmark.camunda.cloud \
+  --user "$PROM_USER" \
+  --password "$PROM_PASS" \
+  --format csv > /tmp/load-test-report.csv
+```
+

--- a/load-tests/docs/scripts/load_test_report/cli.py
+++ b/load-tests/docs/scripts/load_test_report/cli.py
@@ -1,0 +1,199 @@
+"""Command-line parsing and orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from errors import ReportError
+from prometheus import PrometheusClient, check_endpoint
+from queries import DEFAULT_QUERIES, load_query_document, query_substitutions, resolve_queries_file
+from report import build_report, render_report
+
+NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+DURATION_PATTERN = re.compile(r"^[1-9][0-9]*(ms|s|m|h|d|w|y)$")
+
+
+@dataclass(frozen=True)
+class Options:
+    namespace: str
+    duration_seconds: int
+    rate_interval: str
+    sample_step: str
+    endpoint: str
+    bearer_token: str
+    basic_auth_user: str
+    basic_auth_password: str
+    time_anchor: str
+    start_label: str
+    end_label: str
+    output_format: str
+    include_header: bool
+    missing_value: str
+    queries_source: str
+    queries_file: Path
+    output_file: Optional[Path]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="load_test_report.py",
+        description="Build a wide load-test report from Prometheus.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  # Port-forwarded Prometheus, JSON:
+  uv run ./load_test_report.py c8-ck-baseline-20260814 --duration-seconds 1800
+
+  # Historical window, spreadsheet-friendly TSV:
+  uv run ./load_test_report.py c8-ck-baseline-20260814 \\
+    --start 2026-08-14T10:00:00Z \\
+    --end 2026-08-14T10:30:00Z \\
+    --format tsv --no-header
+
+  # CI monitor ingress with basic auth:
+  uv run ./load_test_report.py c8-ck-baseline-20260814 \\
+    --duration-seconds 1800 \\
+    --endpoint https://ci-monitor.benchmark.camunda.cloud \\
+    --user "$PROM_USER" \\
+    --password "$PROM_PASS" \\
+    --format csv > /tmp/load-test-report.csv""",
+    )
+    parser.add_argument("namespace_arg", nargs="?", help="Exact load-test namespace.")
+    parser.add_argument("--namespace", dest="namespace_flag", help="Exact load-test namespace.")
+    parser.add_argument("--duration-seconds", default="600", help="Query window duration. Default: 600.")
+    parser.add_argument("--rate-interval", default="5m", help="Short rate interval. Default: 5m.")
+    parser.add_argument(
+        "--sample-step",
+        default="1m",
+        help="Subquery sample resolution for window summaries. Default: 1m.",
+    )
+    parser.add_argument(
+        "--queries",
+        default=DEFAULT_QUERIES,
+        help=("Built-in query set name or custom YAML/JSON query file path. Default: camunda."),
+    )
+    parser.add_argument("--at", default="", help="Prometheus query time anchor, RFC3339 or Unix timestamp.")
+    parser.add_argument("--start", default="", help="Start of the reporting window.")
+    parser.add_argument("--end", default="", help="End of the reporting window.")
+    parser.add_argument("--endpoint", default="http://localhost:9090", help="Prometheus base URL.")
+    parser.add_argument("--token", default="", help="Bearer token value for Prometheus.")
+    parser.add_argument("--user", default="", help="Basic auth user for Prometheus.")
+    parser.add_argument("--password", default="", help="Basic auth password for Prometheus.")
+    parser.add_argument("--format", default="json", choices=("json", "csv", "tsv"), help="Output format.")
+    parser.add_argument("--no-header", action="store_true", help="Omit the CSV/TSV header row.")
+    parser.add_argument("--missing-value", default="NaN", help="CSV/TSV placeholder for missing metrics.")
+    parser.add_argument("--output", default="", help="Write output to a file instead of stdout.")
+    return parser
+
+
+def parse_args(argv: Sequence[str], script_dir: Path) -> Options:
+    args = build_parser().parse_args(argv)
+    namespace = args.namespace_flag or args.namespace_arg or ""
+    if not namespace:
+        raise ReportError("Missing <namespace>.")
+    if len(namespace) > 63 or not NAMESPACE_PATTERN.fullmatch(namespace):
+        raise ReportError(
+            f"namespace '{namespace}' must be a valid Kubernetes DNS label "
+            "(max 63 characters; lowercase alphanumeric or '-', and must start and end "
+            "with an alphanumeric character)."
+        )
+
+    if not args.duration_seconds.isdigit() or args.duration_seconds.startswith("0"):
+        raise ReportError(f"duration-seconds '{args.duration_seconds}' must be a positive integer.")
+    duration_seconds = int(args.duration_seconds)
+
+    if not DURATION_PATTERN.fullmatch(args.rate_interval):
+        raise ReportError(f"rate-interval '{args.rate_interval}' must be a Prometheus duration like 30s, 5m, or 1h.")
+    if not DURATION_PATTERN.fullmatch(args.sample_step):
+        raise ReportError(f"sample-step '{args.sample_step}' must be a Prometheus duration like 30s, 1m, or 5m.")
+
+    time_anchor = args.at
+    start_label = ""
+    end_label = ""
+    if args.start or args.end:
+        if not args.start or not args.end:
+            raise ReportError("--start and --end must be provided together.")
+        if time_anchor:
+            raise ReportError("--at cannot be combined with --start/--end.")
+
+        start_epoch = parse_epoch(args.start, "--start")
+        end_epoch = parse_epoch(args.end, "--end")
+        if end_epoch <= start_epoch:
+            raise ReportError("--end must be after --start.")
+
+        duration_seconds = end_epoch - start_epoch
+        time_anchor = args.end
+        start_label = datetime.fromtimestamp(start_epoch, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        end_label = datetime.fromtimestamp(end_epoch, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    elif time_anchor:
+        anchor_epoch = parse_epoch(time_anchor, "--at")
+        start_label = datetime.fromtimestamp(anchor_epoch - duration_seconds, timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        end_label = datetime.fromtimestamp(anchor_epoch, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    queries_file = resolve_queries_file(script_dir, args.queries)
+
+    return Options(
+        namespace=namespace,
+        duration_seconds=duration_seconds,
+        rate_interval=args.rate_interval,
+        sample_step=args.sample_step,
+        endpoint=args.endpoint,
+        bearer_token=args.token,
+        basic_auth_user=args.user,
+        basic_auth_password=args.password,
+        time_anchor=time_anchor,
+        start_label=start_label,
+        end_label=end_label,
+        output_format=args.format,
+        include_header=not args.no_header,
+        missing_value=args.missing_value,
+        queries_source=args.queries,
+        queries_file=queries_file,
+        output_file=Path(args.output) if args.output else None,
+    )
+
+
+def parse_epoch(value: str, flag: str) -> int:
+    if value.isdigit():
+        return int(value)
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise ReportError(f"Could not parse {flag} '{value}'.") from error
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp())
+
+
+def run(argv: Sequence[str]) -> int:
+    script_dir = Path(__file__).resolve().parent
+    try:
+        options = parse_args(argv, script_dir)
+        client = PrometheusClient(
+            options.endpoint,
+            options.bearer_token,
+            options.basic_auth_user,
+            options.basic_auth_password,
+            options.time_anchor,
+        )
+        check_endpoint(client, options.endpoint)
+        query_document = load_query_document(options.queries_file, query_substitutions(options))
+        report = build_report(options, query_document, client)
+        rendered = render_report(report, options.output_format, options.include_header, options.missing_value)
+        if options.output_file:
+            options.output_file.write_text(f"{rendered}\n", encoding="utf-8")
+        else:
+            print(rendered)
+        return 0
+    except ReportError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1

--- a/load-tests/docs/scripts/load_test_report/errors.py
+++ b/load-tests/docs/scripts/load_test_report/errors.py
@@ -1,0 +1,13 @@
+"""Shared user-facing error types."""
+
+from __future__ import annotations
+
+
+class ReportError(Exception):
+    """User-facing script error."""
+
+
+class MissingMetric(Exception):
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason

--- a/load-tests/docs/scripts/load_test_report/load_test_report.py
+++ b/load-tests/docs/scripts/load_test_report/load_test_report.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Build a wide load-test report from Prometheus."""
+
+from __future__ import annotations
+
+import sys
+
+from cli import Options, build_parser, parse_args, parse_epoch, run
+from errors import MissingMetric, ReportError
+from prometheus import PrometheusClient, auth_headers, check_endpoint, prometheus_endpoint_help
+from queries import (
+    BUILTIN_QUERY_FILES,
+    DEFAULT_QUERIES,
+    load_query_document,
+    parse_query_file,
+    query_substitutions,
+    resolve_queries_file,
+    substitute_query_text,
+    validate_query_document,
+)
+from report import build_report, extract_metric_value, parse_number, render_report, warn
+
+__all__ = [
+    "BUILTIN_QUERY_FILES",
+    "DEFAULT_QUERIES",
+    "MissingMetric",
+    "Options",
+    "PrometheusClient",
+    "ReportError",
+    "auth_headers",
+    "build_parser",
+    "build_report",
+    "check_endpoint",
+    "extract_metric_value",
+    "load_query_document",
+    "parse_args",
+    "parse_epoch",
+    "parse_number",
+    "parse_query_file",
+    "prometheus_endpoint_help",
+    "query_substitutions",
+    "render_report",
+    "resolve_queries_file",
+    "run",
+    "substitute_query_text",
+    "validate_query_document",
+    "warn",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(run(sys.argv[1:]))

--- a/load-tests/docs/scripts/load_test_report/prometheus.py
+++ b/load-tests/docs/scripts/load_test_report/prometheus.py
@@ -1,0 +1,95 @@
+"""Prometheus HTTP client and authentication helpers."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from errors import ReportError
+
+
+class PrometheusClient:
+    def __init__(
+        self,
+        endpoint: str,
+        bearer_token: str,
+        basic_auth_user: str,
+        basic_auth_password: str,
+        time_anchor: str,
+    ):
+        self.endpoint = endpoint.rstrip("/")
+        self.headers = auth_headers(bearer_token, basic_auth_user, basic_auth_password)
+        self.time_anchor = time_anchor
+
+    def runtime_info(self) -> Mapping[str, Any]:
+        return self._get_json(f"{self.endpoint}/api/v1/status/runtimeinfo", timeout=15)
+
+    def query(self, query: str) -> Mapping[str, Any]:
+        params = {"query": query}
+        if self.time_anchor:
+            params["time"] = self.time_anchor
+        return self._get_json(f"{self.endpoint}/api/v1/query?{urlencode(params)}")
+
+    def _get_json(self, url: str, timeout: int = 30) -> Mapping[str, Any]:
+        request = Request(url, headers=self.headers)
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                parsed = json.loads(response.read().decode("utf-8"))
+        except (HTTPError, URLError, TimeoutError, OSError) as error:
+            raise ReportError("query failed") from error
+        except json.JSONDecodeError as error:
+            raise ReportError(f"Prometheus returned invalid JSON: {error}") from error
+        if not isinstance(parsed, Mapping):
+            raise ReportError("Prometheus returned a non-object JSON response.")
+        return parsed
+
+
+def auth_headers(bearer_token: str, basic_auth_user: str, basic_auth_password: str) -> dict[str, str]:
+    if bearer_token and (basic_auth_user or basic_auth_password):
+        raise ReportError("--token cannot be combined with --user/--password.")
+    if bool(basic_auth_user) != bool(basic_auth_password):
+        raise ReportError("--user and --password must be provided together.")
+    headers: dict[str, str] = {}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    if basic_auth_user:
+        credentials = f"{basic_auth_user}:{basic_auth_password}".encode("utf-8")
+        headers["Authorization"] = f"Basic {base64.b64encode(credentials).decode('ascii')}"
+    return headers
+
+
+def check_endpoint(client: PrometheusClient, endpoint: str) -> None:
+    try:
+        response = client.runtime_info()
+    except ReportError as error:
+        raise ReportError(prometheus_endpoint_help(endpoint)) from error
+    if response.get("status") != "success":
+        raise ReportError(
+            f"""Endpoint '{endpoint}' is reachable, but it did not return a Prometheus API success response.
+
+If you are running locally, make sure the port-forward points at Prometheus:
+
+  kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090"""
+        )
+
+
+def prometheus_endpoint_help(endpoint: str) -> str:
+    return f'''Could not reach Prometheus endpoint '{endpoint}'.
+
+If you are running locally, start the port-forward in another terminal:
+
+  kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090
+
+Then rerun this script with:
+
+  --endpoint http://localhost:9090
+
+If you are using the CI monitor ingress, verify the URL and pass credentials with
+--user/--password, for example:
+
+  --endpoint https://ci-monitor.benchmark.camunda.cloud --user "$PROM_USER" --password "$PROM_PASS"'''

--- a/load-tests/docs/scripts/load_test_report/pyproject.toml
+++ b/load-tests/docs/scripts/load_test_report/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "load-test-report"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "pyyaml==6.0.3",
+]
+
+[dependency-groups]
+dev = [
+  "pytest==8.4.2",
+  "ruff==0.14.6",
+]
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/load-tests/docs/scripts/load_test_report/queries.py
+++ b/load-tests/docs/scripts/load_test_report/queries.py
@@ -1,0 +1,116 @@
+"""Query-file loading, substitution, and validation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from errors import ReportError
+
+DEFAULT_QUERIES = "camunda"
+BUILTIN_QUERY_FILES = {
+    "camunda": "report-queries.yaml",
+    "stable-87": "report-queries-stable-87.yaml",
+}
+
+
+def resolve_queries_file(script_dir: Path, queries: str) -> Path:
+    if queries in BUILTIN_QUERY_FILES:
+        return script_dir / BUILTIN_QUERY_FILES[queries]
+
+    queries_file = Path(queries)
+    if queries_file.is_file():
+        return queries_file
+
+    if queries_file.exists():
+        raise ReportError(f"--queries '{queries}' must be a file.")
+
+    supported_queries = ", ".join(BUILTIN_QUERY_FILES)
+    raise ReportError(
+        f"Unsupported --queries '{queries}'. Expected a built-in name ({supported_queries}) or an existing file."
+    )
+
+
+def load_query_document(queries_file: Path, substitutions: Mapping[str, str]) -> Mapping[str, Any]:
+    parsed = parse_query_file(queries_file, substitutions)
+    if not isinstance(parsed, Mapping):
+        raise ReportError(f"queries file {queries_file} must contain a JSON/YAML object.")
+    validate_query_document(parsed, f"queries file {queries_file}")
+    return parsed
+
+
+def parse_query_file(queries_file: Path, substitutions: Mapping[str, str]) -> Any:
+    raw_document = substitute_query_text(queries_file.read_text(encoding="utf-8"), substitutions)
+    if queries_file.suffix.lower() == ".json":
+        try:
+            return json.loads(raw_document)
+        except json.JSONDecodeError as error:
+            raise ReportError(f"Could not parse queries file {queries_file}: {error}") from error
+
+    try:
+        import yaml
+    except ImportError as error:
+        raise ReportError("PyYAML is required to read YAML query files. Install it with uv.") from error
+    try:
+        return yaml.safe_load(raw_document)
+    except yaml.YAMLError as error:
+        raise ReportError(f"Could not parse queries file {queries_file}: {error}") from error
+
+
+def validate_query_document(
+    query_document: Mapping[str, Any], source: str = "query document"
+) -> list[Mapping[str, Any]]:
+    queries = query_document.get("queries")
+    if not isinstance(queries, list) or not queries:
+        raise ReportError(f"{source} must contain a non-empty 'queries' list.")
+
+    validated_queries: list[Mapping[str, Any]] = []
+    seen_keys: set[str] = set()
+    for index, query in enumerate(queries):
+        if not isinstance(query, Mapping):
+            raise ReportError(f"query entry {index} must be an object.")
+
+        key = query.get("key")
+        if not isinstance(key, str) or not key:
+            raise ReportError("each query entry must have a non-empty string key.")
+        if key in seen_keys:
+            raise ReportError(f"duplicate query key: {key}")
+        seen_keys.add(key)
+
+        has_query = is_non_empty_string(query.get("query"))
+        has_value = is_non_empty_string(query.get("value"))
+        if has_query == has_value:
+            raise ReportError(f"query entry {key} must set exactly one of query or value.")
+
+        value_label = query.get("valueLabel")
+        if value_label is not None:
+            if not is_non_empty_string(value_label):
+                raise ReportError(f"query entry {key} has an invalid valueLabel.")
+            if not has_query:
+                raise ReportError(f"query entry {key} sets valueLabel without query.")
+
+        validated_queries.append(query)
+
+    return validated_queries
+
+
+def is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and len(value) > 0
+
+
+def query_substitutions(options: Any) -> Mapping[str, str]:
+    return {
+        "$NAMESPACE": options.namespace,
+        "$DURATION_S": f"{options.duration_seconds}s",
+        "$RATE_INTERVAL": options.rate_interval,
+        "$SAMPLE_STEP": options.sample_step,
+    }
+
+
+def substitute_query_text(value: str, substitutions: Mapping[str, str]) -> str:
+    rendered = value
+    for placeholder, replacement in substitutions.items():
+        rendered = rendered.replace(placeholder, replacement)
+    return rendered

--- a/load-tests/docs/scripts/load_test_report/report-queries-stable-87.yaml
+++ b/load-tests/docs/scripts/load_test_report/report-queries-stable-87.yaml
@@ -1,0 +1,463 @@
+# Built-in Camunda 8.7 query set for load_test_report.py.
+#
+# 8.7 Zeebe broker and gateway layout plus common load-test metrics.
+# Pass --queries <path> to use one custom file with the same top-level `queries:` schema.
+#
+# Variables are substituted by load_test_report.py before this file is decoded:
+#   $NAMESPACE       the exact load-test namespace, e.g. c8-ck-baseline-20260814.
+#   $DURATION_S      the report window duration with an `s` suffix, e.g. 600s.
+#   $RATE_INTERVAL   the short --rate-interval used for dashboard-style rate samples.
+#   $SAMPLE_STEP     the --sample-step subquery resolution used for window summaries.
+#
+# Naming convention: columns computed from a seconds-denominated histogram but
+# labeled "... ms" multiply the query by 1000 to convert seconds to milliseconds.
+
+queries:
+  - key: namespace
+    description: The load-test namespace this report was generated for. A literal value substituted from
+      the namespace argument, not queried from Prometheus.
+    header: Namespace
+    value: $NAMESPACE
+
+  - key: docker_image
+    description: Deployed Docker image tag(s), read from the image label rather than a value field. Extracted
+      from container info over the full report window rather than only the end timestamp, so a namespace
+      that has already been deleted still resolves to the image it ran, as long as the metric series hasn't
+      expired from Prometheus's retention.
+    header: Version
+    valueLabel: image
+    query: |-
+      count by (image) (max_over_time(kube_pod_container_info{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe"}[$DURATION_S]))
+
+  - key: zeebe_nodes
+    description: Number of running Zeebe pods. Counted from the Kubernetes pod-phase gauge (Running) at
+      every --sample-step sample across the report window, so a pod that briefly restarted mid-run still
+      counts as present.
+    header: Nodes
+    query: |-
+      count(max_over_time((kube_pod_status_phase{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", phase="Running"} == 1)[$DURATION_S:$SAMPLE_STEP]))
+
+  - key: zeebe_gateway_nodes
+    description: Number of running Zeebe Gateway pods. Counted from the Kubernetes pod-phase gauge (Running)
+      at every --sample-step sample across the report window, so a pod that briefly restarted mid-run still
+      counts as present.
+    header: Nodes
+    query: |-
+      count(max_over_time((kube_pod_status_phase{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", phase="Running"} == 1)[$DURATION_S:$SAMPLE_STEP]))
+
+  - key: secondary_storage_nodes
+    description: Number of running Secondary Storage pods. Counted from the Kubernetes pod-phase gauge (Running)
+      at every --sample-step sample across the report window, so a pod that briefly restarted mid-run still
+      counts as present.
+    header: Nodes
+    query: |-
+      count(max_over_time((kube_pod_status_phase{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", phase="Running"} == 1)[$DURATION_S:$SAMPLE_STEP]))
+
+  - key: zeebe_cpu_limit
+    description: CPU limit assigned to the Zeebe container, in cores. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe", resource="cpu", unit="core"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_cpu_cores{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe"}[$DURATION_S]))
+
+  - key: zeebe_cpu_used_p50
+    description: p50 of Zeebe CPU usage, in cores, sampled across the report window. Computed by taking
+      a rate() at every --rate-interval sample, then computing the quantile of those samples across the
+      full report window via quantile_over_time - this captures burst behavior a single average would hide.
+    header: used (p50)
+    query: |-
+      quantile_over_time(0.50, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: zeebe_cpu_used_p99
+    description: p99 of Zeebe CPU usage, in cores, sampled across the report window. Computed by taking
+      a rate() at every --rate-interval sample, then computing the quantile of those samples across the
+      full report window via quantile_over_time - this captures burst behavior a single average would hide.
+    header: used(p99)
+    query: |-
+      quantile_over_time(0.99, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: zeebe_cpu_throttling_percent
+    description: Percentage of time the Zeebe container is throttled by the CFS scheduler. Computed as the
+      ratio of throttled to total CFS periods at every --rate-interval sample, averaged across the report
+      window via avg_over_time. Values above ~0% indicate the CPU limit is too tight for the current load.
+    header: throttling (%)
+    query: |-
+      avg_over_time((avg(100 * sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container!=""}[$RATE_INTERVAL])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: zeebe_memory_limit_gib
+    description: Memory limit assigned to the Zeebe container, in GiB. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      (max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe", resource="memory", unit="byte"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_memory_bytes{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe"}[$DURATION_S]))) / 1024 / 1024 / 1024
+
+  - key: zeebe_memory_rss_gib
+    description: Zeebe container RSS memory usage, in GiB. Read as a Kubernetes gauge, taking the max over
+      the report window so a pod restart mid-run doesn't hide the value.
+    header: RSS (GB)
+    query: |-
+      max(max_over_time(container_memory_rss{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: zeebe_heap_gib
+    description: Zeebe JVM heap memory usage, in GiB. Read as the JVM heap-used gauge, summed across pods
+      at every --sample-step sample and taking the max over the report window. Compare against the memory
+      limit to detect leak trends across long-running (weekly/release) tests.
+    header: heap
+    query: |-
+      (max(max_over_time((sum by (pod) (jvm_memory_bytes_used{namespace="$NAMESPACE", area="heap", pod=~"zeebe-[0-9]+"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (pod) (jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", pod=~"zeebe-[0-9]+"}))[$DURATION_S:$SAMPLE_STEP]))) / 1024 / 1024 / 1024
+
+  - key: zeebe_gateway_cpu_limit
+    description: CPU limit assigned to the Zeebe Gateway container, in cores. Read as a Kubernetes gauge,
+      taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container=~"(zeebe-gateway|gateway)", resource="cpu", unit="core"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_cpu_cores{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container=~"(zeebe-gateway|gateway)"}[$DURATION_S]))
+
+  - key: zeebe_gateway_cpu_used_p50
+    description: p50 of Zeebe Gateway CPU usage, in cores, sampled across the report window. Computed by
+      taking a rate() at every --rate-interval sample, then computing the quantile of those samples across
+      the full report window via quantile_over_time - this captures burst behavior a single average would
+      hide.
+    header: used (p50)
+    query: |-
+      quantile_over_time(0.50, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: zeebe_gateway_cpu_used_p99
+    description: p99 of Zeebe Gateway CPU usage, in cores, sampled across the report window. Computed by
+      taking a rate() at every --rate-interval sample, then computing the quantile of those samples across
+      the full report window via quantile_over_time - this captures burst behavior a single average would
+      hide.
+    header: used(p99)
+    query: |-
+      quantile_over_time(0.99, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: zeebe_gateway_cpu_throttling_percent
+    description: Percentage of time the Zeebe Gateway container is throttled by the CFS scheduler. Computed
+      as the ratio of throttled to total CFS periods at every --rate-interval sample, averaged across the
+      report window via avg_over_time. Values above ~0% indicate the CPU limit is too tight for the current
+      load.
+    header: throttling (%)
+    query: |-
+      avg_over_time((avg(100 * sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container!=""}[$RATE_INTERVAL])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: zeebe_gateway_memory_limit_gib
+    description: Memory limit assigned to the Zeebe Gateway container, in GiB. Read as a Kubernetes gauge,
+      taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      (max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container=~"(zeebe-gateway|gateway)", resource="memory", unit="byte"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_memory_bytes{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container=~"(zeebe-gateway|gateway)"}[$DURATION_S]))) / 1024 / 1024 / 1024
+
+  - key: zeebe_gateway_memory_rss_gib
+    description: Zeebe Gateway container RSS memory usage, in GiB. Read as a Kubernetes gauge, taking the
+      max over the report window so a pod restart mid-run doesn't hide the value.
+    header: RSS (GB)
+    query: |-
+      max(max_over_time(container_memory_rss{namespace="$NAMESPACE", pod=~"zeebe-gateway.*", container=~"(zeebe-gateway|gateway)"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: zeebe_gateway_heap_gib
+    description: Zeebe Gateway JVM heap memory usage, in GiB. Read as the JVM heap-used gauge, summed across
+      pods at every --sample-step sample and taking the max over the report window. Compare against the
+      memory limit to detect leak trends across long-running (weekly/release) tests.
+    header: heap
+    query: |-
+      (max(max_over_time((sum by (pod) (jvm_memory_bytes_used{namespace="$NAMESPACE", area="heap", pod=~"zeebe-gateway.*"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (pod) (jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", pod=~"zeebe-gateway.*"}))[$DURATION_S:$SAMPLE_STEP]))) / 1024 / 1024 / 1024
+
+  - key: zeebe_disk_capacity_gib
+    description: Zeebe persistent volume disk capacity, in GiB. Read as a Kubernetes gauge, taking the max
+      over the report window so a pod restart mid-run doesn't hide the value.
+    header: capacity
+    query: |-
+      max(max_over_time(kubelet_volume_stats_capacity_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*zeebe.*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: zeebe_disk_used_gib
+    description: Zeebe persistent volume disk usage, in GiB. Read as a Kubernetes gauge, taking the max
+      over the report window so a pod restart mid-run doesn't hide the value. Compare against capacity to
+      see how close the run is to filling its disk.
+    header: used
+    query: |-
+      max(max_over_time(kubelet_volume_stats_used_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*zeebe.*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: zeebe_write_iops
+    description: Zeebe filesystem write operations per second. Computed as a Prometheus rate() sampled every
+      --rate-interval, then averaged across the full report window via avg_over_time, so a long report window
+      doesn't flatten into one coarse counter-rate.
+    header: write IOPS
+    query: |-
+      avg_over_time((sum(rate(container_fs_writes_total{namespace="$NAMESPACE", pod=~"zeebe-[0-9]+", container="zeebe"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_cpu_limit
+    description: CPU limit assigned to the Secondary Storage container, in cores. Read as a Kubernetes gauge,
+      taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)", resource="cpu", unit="core"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_cpu_cores{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$DURATION_S]))
+
+  - key: secondary_storage_cpu_used_p50
+    description: p50 of Secondary Storage CPU usage, in cores, sampled across the report window. Computed
+      by taking a rate() at every --rate-interval sample, then computing the quantile of those samples across
+      the full report window via quantile_over_time - this captures burst behavior a single average would
+      hide.
+    header: used (p50)
+    query: |-
+      quantile_over_time(0.50, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_cpu_used_p99
+    description: p99 of Secondary Storage CPU usage, in cores, sampled across the report window. Computed
+      by taking a rate() at every --rate-interval sample, then computing the quantile of those samples across
+      the full report window via quantile_over_time - this captures burst behavior a single average would
+      hide.
+    header: used(p99)
+    query: |-
+      quantile_over_time(0.99, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_cpu_throttling_percent
+    description: Percentage of time the Secondary Storage container is throttled by the CFS scheduler. Computed
+      as the ratio of throttled to total CFS periods at every --rate-interval sample, averaged across the
+      report window via avg_over_time. Values above ~0% indicate the CPU limit is too tight for the current
+      load.
+    header: throttling (%)
+    query: |-
+      avg_over_time((avg(100 * sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_memory_limit_gib
+    description: Memory limit assigned to the Secondary Storage container, in GiB. Read as a Kubernetes
+      gauge, taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      (max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)", resource="memory", unit="byte"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_memory_bytes{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$DURATION_S]))) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_memory_rss_gib
+    description: Secondary Storage container RSS memory usage, in GiB. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: RSS (GB)
+    query: |-
+      max(max_over_time(container_memory_rss{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_heap_gib
+    description: Secondary Storage JVM heap memory usage, in GiB. Read as the JVM heap-used gauge, summed
+      across pods at every --sample-step sample and taking the max over the report window. Compare against
+      the memory limit to detect leak trends across long-running (weekly/release) tests.
+    header: heap (GB)
+    query: |-
+      (max(max_over_time((sum by (pod) (jvm_memory_bytes_used{namespace="$NAMESPACE", area="heap", pod=~"(elastic|elasticsearch|opensearch).*"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (pod) (jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", pod=~"(elastic|elasticsearch|opensearch).*"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (name) (elasticsearch_jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", name=~"(elastic|elasticsearch|opensearch).*"}))[$DURATION_S:$SAMPLE_STEP]))) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_disk_capacity_gib
+    description: Secondary Storage persistent volume disk capacity, in GiB. Read as a Kubernetes gauge,
+      taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: capacity
+    query: |-
+      max(max_over_time(kubelet_volume_stats_capacity_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*(elastic|opensearch).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_disk_used_gib
+    description: Secondary Storage persistent volume disk usage, in GiB. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value. Compare against capacity
+      to see how close the run is to filling its disk.
+    header: used
+    query: |-
+      max(max_over_time(kubelet_volume_stats_used_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*(elastic|opensearch).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_write_iops
+    description: Secondary Storage filesystem write operations per second. Computed as a Prometheus rate()
+      sampled every --rate-interval, then averaged across the full report window via avg_over_time, so a
+      long report window doesn't flatten into one coarse counter-rate.
+    header: write IOPS
+    query: |-
+      avg_over_time((sum(rate(container_fs_writes_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: records_processed_per_second
+    description: Average number of records processed per second - the most atomic metric for processing
+      throughput, since every state change in the engine produces one processed record. Computed as a Prometheus
+      rate() sampled every --rate-interval, then averaged across the full report window via avg_over_time,
+      so a long report window doesn't flatten into one coarse counter-rate.
+    header: Proc rec
+    query: |-
+      avg_over_time((sum(rate(zeebe_stream_processor_records_total{namespace="$NAMESPACE", action="processed"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: records_exported_per_second
+    description: Average number of records exported per second - the most atomic metric for export throughput.
+      Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full report
+      window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate. A
+      rate persistently lower than processed-records/s means the exporter cannot keep up and the exporting
+      backlog will grow.
+    header: Export rec
+    query: |-
+      avg_over_time((sum(rate(zeebe_exporter_events_total{namespace="$NAMESPACE", action=~"EXPORTED|exported"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_indexed_documents_per_second
+    description: Average number of documents indexed per second in the secondary storage (Elasticsearch/OpenSearch).
+      Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full report
+      window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate. Records
+      don't map 1:1 to documents - data is duplicated across indices and some records get merged, so this
+      isn't directly comparable to processed-records/s.
+    header: ES idx docs
+    query: |-
+      avg_over_time((avg(rate(elasticsearch_indices_indexing_index_total{namespace="$NAMESPACE"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: process_instances_per_second
+    description: Average process instances completed per second, counting both root and sub-process instances.
+      Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full report
+      window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate. This
+      is the primary throughput SLO metric - compare against the scenario's target in docs/metrics.md (e.g.
+      50 PI/s for the realistic variant).
+    header: PI
+    query: |-
+      avg_over_time((sum(rate(zeebe_element_instance_events_total{namespace="$NAMESPACE", action="completed", type="PROCESS"}[$RATE_INTERVAL])) or sum(rate(zeebe_executed_instances_total{namespace="$NAMESPACE", action="completed", type="ROOT_PROCESS_INSTANCE"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: archived_process_instances_per_second
+    description: Average number of process instances archived per second by the exporter's archiver. Computed
+      as a Prometheus rate() sampled every --rate-interval, then averaged across the full report window
+      via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate.
+    header: Archived PI
+    query: |-
+      avg_over_time((sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace="$NAMESPACE", state="archived"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: flow_node_instances_per_second
+    description: Average number of flow node instances (every element type except PROCESS) completed per
+      second. Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full
+      report window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate.
+      Together with PI/s, this shows whether a run met its SLO.
+    header: FNI
+    query: |-
+      avg_over_time((sum(rate(zeebe_element_instance_events_total{namespace="$NAMESPACE", type!="PROCESS", action="completed"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: service_task_instances_per_second
+    description: Average number of service task instances completed per second. Computed as a Prometheus
+      rate() sampled every --rate-interval, then averaged across the full report window via avg_over_time,
+      so a long report window doesn't flatten into one coarse counter-rate.
+    header: STI
+    query: |-
+      avg_over_time((sum(rate(zeebe_element_instance_events_total{namespace="$NAMESPACE", action="completed", type="SERVICE_TASK"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: jobs_per_second
+    description: Average number of jobs completed per second. Computed as a Prometheus rate() sampled every
+      --rate-interval, then averaged across the full report window via avg_over_time, so a long report window
+      doesn't flatten into one coarse counter-rate.
+    header: Job
+    query: |-
+      avg_over_time((sum(rate(zeebe_job_events_total{namespace="$NAMESPACE", action="completed"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: processing_latency_p50_ms
+    description: 'Time from writing a user command to the append-only log until the processing engine starts
+      processing it (p50, in milliseconds). Computed via histogram_quantile over the underlying histogram''s
+      rate() across the entire report window - one quantile for the whole window, not a windowed series
+      of quantiles like the CPU/resource metrics. High values indicate a growing processing backlog. Threshold
+      in docs/metrics.md: p99 < 250 ms.'
+    header: ProcLat p50 (ms)
+    query: |-
+      1000 * histogram_quantile(0.50, sum(rate(zeebe_stream_processor_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: processing_latency_p99_ms
+    description: 'Time from writing a user command to the append-only log until the processing engine starts
+      processing it (p99, in milliseconds). Computed via histogram_quantile over the underlying histogram''s
+      rate() across the entire report window - one quantile for the whole window, not a windowed series
+      of quantiles like the CPU/resource metrics. High values indicate a growing processing backlog. Threshold
+      in docs/metrics.md: p99 < 250 ms.'
+    header: ProcLat p99 (ms)
+    query: |-
+      1000 * histogram_quantile(0.99, sum(rate(zeebe_stream_processor_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: exporting_latency_p50_ms
+    description: Time from writing an event to the append-only log until the exporter starts exporting it
+      (p50, in milliseconds). Computed via histogram_quantile over the underlying histogram's rate() across
+      the entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. High values indicate a processing and/or exporting backlog.
+    header: ExportLat p50 (ms)
+    query: |-
+      1000 * histogram_quantile(0.50, sum(rate(zeebe_exporting_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_exporting_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: exporting_latency_p99_ms
+    description: Time from writing an event to the append-only log until the exporter starts exporting it
+      (p99, in milliseconds). Computed via histogram_quantile over the underlying histogram's rate() across
+      the entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. High values indicate a processing and/or exporting backlog.
+    header: ExportLat p99 (ms)
+    query: |-
+      1000 * histogram_quantile(0.99, sum(rate(zeebe_exporting_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_exporting_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: process_instance_execution_p50_ms
+    description: 'Full end-to-end process execution time, from instance creation to completion (p50, in
+      milliseconds). Computed via histogram_quantile over the underlying histogram''s rate() across the
+      entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. Threshold in docs/metrics.md: p99 < 1 s.'
+    header: PIExec p50
+    query: |-
+      1000 * histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: process_instance_execution_p99_ms
+    description: 'Full end-to-end process execution time, from instance creation to completion (p99, in
+      milliseconds). Computed via histogram_quantile over the underlying histogram''s rate() across the
+      entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. Threshold in docs/metrics.md: p99 < 1 s.'
+    header: PIExec p99
+    query: |-
+      1000 * histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: data_availability_p50_seconds
+    description: 'Time from creating an instance in the client until it is available via the REST API (p50,
+      in seconds). Computed via histogram_quantile over the underlying histogram''s rate() across the entire
+      report window - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource
+      metrics. The strongest end-to-end signal - it covers the full round-trip: processing, exporting, secondary-storage
+      indexing, and the REST layer. Threshold in docs/metrics.md: p99 < 5 s.'
+    header: DataAvail p50 (sec)
+    query: |-
+      histogram_quantile(0.50, sum by (le) (rate(starter_data_availability_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: data_availability_p99_seconds
+    description: 'Time from creating an instance in the client until it is available via the REST API (p99,
+      in seconds). Computed via histogram_quantile over the underlying histogram''s rate() across the entire
+      report window - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource
+      metrics. The strongest end-to-end signal - it covers the full round-trip: processing, exporting, secondary-storage
+      indexing, and the REST layer. Threshold in docs/metrics.md: p99 < 5 s.'
+    header: DataAvail p99 (sec)
+    query: |-
+      histogram_quantile(0.99, sum by (le) (rate(starter_data_availability_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: response_latency_p50_ms
+    description: 'Time from sending a request in the client to receiving a response (p50, in milliseconds).
+      Computed via histogram_quantile over the underlying histogram''s rate() across the entire report window
+      - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource metrics.
+      Includes processing latency (and its queue) plus authentication/authorization overhead. Threshold
+      in docs/metrics.md: p99 < 5 s.'
+    header: Response p50 (ms)
+    query: |-
+      1000 * histogram_quantile(0.50, sum by (le) (rate(starter_response_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: response_latency_p99_ms
+    description: 'Time from sending a request in the client to receiving a response (p99, in milliseconds).
+      Computed via histogram_quantile over the underlying histogram''s rate() across the entire report window
+      - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource metrics.
+      Includes processing latency (and its queue) plus authentication/authorization overhead. Threshold
+      in docs/metrics.md: p99 < 5 s.'
+    header: Response p99 (ms)
+    query: |-
+      1000 * histogram_quantile(0.99, sum by (le) (rate(starter_response_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: backpressure_percent
+    description: Percentage of requests dropped due to backpressure. Computed as the dropped/received request
+      ratio per partition at every --rate-interval sample, taking the worst (highest) partition value at
+      each sample, then averaging across the report window - one struggling partition dominates the reported
+      value rather than being diluted by healthy ones. Values above ~0% indicate the system is actively
+      rejecting work and is at or near capacity.
+    header: Backpressure (max of 3)
+    query: |-
+      avg_over_time((max(100 * sum by (partition) (rate(zeebe_dropped_request_count_total{namespace="$NAMESPACE"}[$RATE_INTERVAL])) / sum by (partition) (rate(zeebe_received_request_count_total{namespace="$NAMESPACE"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: processing_backlog
+    description: Records appended to the log but not yet processed by the engine. Computed as the difference
+      between the log's last-appended/last-committed position and the last-processed/last-exported position,
+      per partition, taking the highest partition value at every --sample-step sample and averaging across
+      the report window. A stable backlog is normal; a growing one means the engine can't keep up and processing
+      latency will worsen over time.
+    header: Proc backlog
+    query: |-
+      avg_over_time((max(max by (partition) (zeebe_log_appender_last_appended_position{namespace="$NAMESPACE"}) - max by (partition) (zeebe_stream_processor_last_processed_position{namespace="$NAMESPACE"})))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: exporting_backlog
+    description: Records committed to the log but not yet exported. Computed as the difference between the
+      log's last-appended/last-committed position and the last-processed/last-exported position, per partition,
+      taking the highest partition value at every --sample-step sample and averaging across the report window.
+      A growing exporting backlog drives higher data-availability latency and is decoupled from processing
+      throughput - the engine can be healthy while the exporter falls behind.
+    header: Export backlog
+    query: |-
+      avg_over_time((max(max by (partition) (zeebe_log_appender_last_committed_position{namespace="$NAMESPACE"}) - max by (partition) (zeebe_exporter_last_exported_position{namespace="$NAMESPACE"})))[$DURATION_S:$SAMPLE_STEP])

--- a/load-tests/docs/scripts/load_test_report/report-queries.yaml
+++ b/load-tests/docs/scripts/load_test_report/report-queries.yaml
@@ -1,0 +1,399 @@
+# Built-in Camunda 8.8+ query set for load_test_report.py.
+#
+# Current orchestration cluster layout plus common load-test metrics.
+# Pass --queries <path> to use one custom file with the same top-level `queries:` schema.
+#
+# Variables are substituted by load_test_report.py before this file is decoded:
+#   $NAMESPACE       the exact load-test namespace, e.g. c8-ck-baseline-20260814.
+#   $DURATION_S      the report window duration with an `s` suffix, e.g. 600s.
+#   $RATE_INTERVAL   the short --rate-interval used for dashboard-style rate samples.
+#   $SAMPLE_STEP     the --sample-step subquery resolution used for window summaries.
+#
+# Naming convention: columns computed from a seconds-denominated histogram but
+# labeled "... ms" multiply the query by 1000 to convert seconds to milliseconds.
+
+queries:
+  - key: namespace
+    description: The load-test namespace this report was generated for. A literal value substituted from
+      the namespace argument, not queried from Prometheus.
+    header: Namespace
+    value: $NAMESPACE
+
+  - key: docker_image
+    description: Deployed Docker image tag(s), read from the image label rather than a value field. Extracted
+      from container info over the full report window rather than only the end timestamp, so a namespace
+      that has already been deleted still resolves to the image it ran, as long as the metric series hasn't
+      expired from Prometheus's retention.
+    header: Version
+    valueLabel: image
+    query: |-
+      count by (image) (max_over_time(kube_pod_container_info{namespace="$NAMESPACE", pod=~"(camunda|zeebe)-[0-9]+", container=~".*(orchestration|zeebe|camunda).*"}[$DURATION_S]))
+
+  - key: camunda_nodes
+    description: Number of running Camunda pods. Counted from the Kubernetes pod-phase gauge (Running) at
+      every --sample-step sample across the report window, so a pod that briefly restarted mid-run still
+      counts as present.
+    header: Nodes
+    query: |-
+      count(max_over_time((kube_pod_status_phase{namespace="$NAMESPACE", pod=~"(camunda|zeebe)-[0-9]+", phase="Running"} == 1)[$DURATION_S:$SAMPLE_STEP]))
+
+  - key: secondary_storage_nodes
+    description: Number of running Secondary Storage pods. Counted from the Kubernetes pod-phase gauge (Running)
+      at every --sample-step sample across the report window, so a pod that briefly restarted mid-run still
+      counts as present.
+    header: Nodes
+    query: |-
+      count(max_over_time((kube_pod_status_phase{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", phase="Running"} == 1)[$DURATION_S:$SAMPLE_STEP]))
+
+  - key: camunda_cpu_limit
+    description: CPU limit assigned to the Camunda container, in cores. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container=~".*(orchestration|zeebe|camunda).*", resource="cpu", unit="core"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_cpu_cores{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container=~".*(orchestration|zeebe|camunda).*"}[$DURATION_S]))
+
+  - key: camunda_cpu_used_p50
+    description: p50 of Camunda CPU usage, in cores, sampled across the report window. Computed by taking
+      a rate() at every --rate-interval sample, then computing the quantile of those samples across the
+      full report window via quantile_over_time - this captures burst behavior a single average would hide.
+    header: used (p50)
+    query: |-
+      quantile_over_time(0.50, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: camunda_cpu_used_p99
+    description: p99 of Camunda CPU usage, in cores, sampled across the report window. Computed by taking
+      a rate() at every --rate-interval sample, then computing the quantile of those samples across the
+      full report window via quantile_over_time - this captures burst behavior a single average would hide.
+    header: used(p99)
+    query: |-
+      quantile_over_time(0.99, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: camunda_cpu_throttling_percent
+    description: Percentage of time the Camunda container is throttled by the CFS scheduler. Computed as
+      the ratio of throttled to total CFS periods at every --rate-interval sample, averaged across the report
+      window via avg_over_time. Values above ~0% indicate the CPU limit is too tight for the current load.
+    header: throttling (%)
+    query: |-
+      avg_over_time((avg(100 * sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container!=""}[$RATE_INTERVAL])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container!=""}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: camunda_memory_limit_gib
+    description: Memory limit assigned to the Camunda container, in GiB. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      (max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container=~".*(orchestration|zeebe|camunda).*", resource="memory", unit="byte"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_memory_bytes{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container=~".*(orchestration|zeebe|camunda).*"}[$DURATION_S]))) / 1024 / 1024 / 1024
+
+  - key: camunda_memory_rss_gib
+    description: Camunda container RSS memory usage, in GiB. Read as a Kubernetes gauge, taking the max
+      over the report window so a pod restart mid-run doesn't hide the value.
+    header: RSS (GB)
+    query: |-
+      max(max_over_time(container_memory_rss{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container=~".*(orchestration|zeebe|camunda).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: camunda_heap_gib
+    description: Camunda JVM heap memory usage, in GiB. Read as the JVM heap-used gauge, summed across pods
+      at every --sample-step sample and taking the max over the report window. Compare against the memory
+      limit to detect leak trends across long-running (weekly/release) tests.
+    header: heap
+    query: |-
+      (max(max_over_time((sum by (pod) (jvm_memory_bytes_used{namespace="$NAMESPACE", area="heap", pod=~"(camunda|zeebe).*"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (pod) (jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", pod=~"(camunda|zeebe).*"}))[$DURATION_S:$SAMPLE_STEP]))) / 1024 / 1024 / 1024
+
+  - key: camunda_disk_capacity_gib
+    description: Camunda persistent volume disk capacity, in GiB. Read as a Kubernetes gauge, taking the
+      max over the report window so a pod restart mid-run doesn't hide the value.
+    header: capacity
+    query: |-
+      max(max_over_time(kubelet_volume_stats_capacity_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*(camunda|zeebe).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: camunda_disk_used_gib
+    description: Camunda persistent volume disk usage, in GiB. Read as a Kubernetes gauge, taking the max
+      over the report window so a pod restart mid-run doesn't hide the value. Compare against capacity to
+      see how close the run is to filling its disk.
+    header: used
+    query: |-
+      max(max_over_time(kubelet_volume_stats_used_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*(camunda|zeebe).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: camunda_write_iops
+    description: Camunda filesystem write operations per second. Computed as a Prometheus rate() sampled
+      every --rate-interval, then averaged across the full report window via avg_over_time, so a long report
+      window doesn't flatten into one coarse counter-rate.
+    header: write IOPS
+    query: |-
+      avg_over_time((sum(rate(container_fs_writes_total{namespace="$NAMESPACE", pod=~"(camunda|zeebe).*", container!=""}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_cpu_limit
+    description: CPU limit assigned to the Secondary Storage container, in cores. Read as a Kubernetes gauge,
+      taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)", resource="cpu", unit="core"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_cpu_cores{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$DURATION_S]))
+
+  - key: secondary_storage_cpu_used_p50
+    description: p50 of Secondary Storage CPU usage, in cores, sampled across the report window. Computed
+      by taking a rate() at every --rate-interval sample, then computing the quantile of those samples across
+      the full report window via quantile_over_time - this captures burst behavior a single average would
+      hide.
+    header: used (p50)
+    query: |-
+      quantile_over_time(0.50, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_cpu_used_p99
+    description: p99 of Secondary Storage CPU usage, in cores, sampled across the report window. Computed
+      by taking a rate() at every --rate-interval sample, then computing the quantile of those samples across
+      the full report window via quantile_over_time - this captures burst behavior a single average would
+      hide.
+    header: used(p99)
+    query: |-
+      quantile_over_time(0.99, (max(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_cpu_throttling_percent
+    description: Percentage of time the Secondary Storage container is throttled by the CFS scheduler. Computed
+      as the ratio of throttled to total CFS periods at every --rate-interval sample, averaged across the
+      report window via avg_over_time. Values above ~0% indicate the CPU limit is too tight for the current
+      load.
+    header: throttling (%)
+    query: |-
+      avg_over_time((avg(100 * sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_memory_limit_gib
+    description: Memory limit assigned to the Secondary Storage container, in GiB. Read as a Kubernetes
+      gauge, taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: limit
+    query: |-
+      (max(max_over_time(kube_pod_container_resource_limits{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)", resource="memory", unit="byte"}[$DURATION_S])) or max(max_over_time(kube_pod_container_resource_limits_memory_bytes{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$DURATION_S]))) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_memory_rss_gib
+    description: Secondary Storage container RSS memory usage, in GiB. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: RSS (GB)
+    query: |-
+      max(max_over_time(container_memory_rss{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_heap_gib
+    description: Secondary Storage JVM heap memory usage, in GiB. Read as the JVM heap-used gauge, summed
+      across pods at every --sample-step sample and taking the max over the report window. Compare against
+      the memory limit to detect leak trends across long-running (weekly/release) tests.
+    header: heap (GB)
+    query: |-
+      (max(max_over_time((sum by (pod) (jvm_memory_bytes_used{namespace="$NAMESPACE", area="heap", pod=~"(elastic|elasticsearch|opensearch).*"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (pod) (jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", pod=~"(elastic|elasticsearch|opensearch).*"}))[$DURATION_S:$SAMPLE_STEP])) or max(max_over_time((sum by (name) (elasticsearch_jvm_memory_used_bytes{namespace="$NAMESPACE", area="heap", name=~"(elastic|elasticsearch|opensearch).*"}))[$DURATION_S:$SAMPLE_STEP]))) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_disk_capacity_gib
+    description: Secondary Storage persistent volume disk capacity, in GiB. Read as a Kubernetes gauge,
+      taking the max over the report window so a pod restart mid-run doesn't hide the value.
+    header: capacity
+    query: |-
+      max(max_over_time(kubelet_volume_stats_capacity_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*(elastic|opensearch).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_disk_used_gib
+    description: Secondary Storage persistent volume disk usage, in GiB. Read as a Kubernetes gauge, taking
+      the max over the report window so a pod restart mid-run doesn't hide the value. Compare against capacity
+      to see how close the run is to filling its disk.
+    header: used
+    query: |-
+      max(max_over_time(kubelet_volume_stats_used_bytes{namespace="$NAMESPACE", persistentvolumeclaim=~".*(elastic|opensearch).*"}[$DURATION_S])) / 1024 / 1024 / 1024
+
+  - key: secondary_storage_write_iops
+    description: Secondary Storage filesystem write operations per second. Computed as a Prometheus rate()
+      sampled every --rate-interval, then averaged across the full report window via avg_over_time, so a
+      long report window doesn't flatten into one coarse counter-rate.
+    header: write IOPS
+    query: |-
+      avg_over_time((sum(rate(container_fs_writes_total{namespace="$NAMESPACE", pod=~"(elastic|elasticsearch|opensearch).*", container=~"(elasticsearch|opensearch)"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: records_processed_per_second
+    description: Average number of records processed per second - the most atomic metric for processing
+      throughput, since every state change in the engine produces one processed record. Computed as a Prometheus
+      rate() sampled every --rate-interval, then averaged across the full report window via avg_over_time,
+      so a long report window doesn't flatten into one coarse counter-rate.
+    header: Proc rec
+    query: |-
+      avg_over_time((sum(rate(zeebe_stream_processor_records_total{namespace="$NAMESPACE", action="processed"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: records_exported_per_second
+    description: Average number of records exported per second - the most atomic metric for export throughput.
+      Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full report
+      window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate. A
+      rate persistently lower than processed-records/s means the exporter cannot keep up and the exporting
+      backlog will grow.
+    header: Export rec
+    query: |-
+      avg_over_time((sum(rate(zeebe_exporter_events_total{namespace="$NAMESPACE", action=~"EXPORTED|exported"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: secondary_storage_indexed_documents_per_second
+    description: Average number of documents indexed per second in the secondary storage (Elasticsearch/OpenSearch).
+      Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full report
+      window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate. Records
+      don't map 1:1 to documents - data is duplicated across indices and some records get merged, so this
+      isn't directly comparable to processed-records/s.
+    header: ES idx docs
+    query: |-
+      avg_over_time((avg(rate(elasticsearch_indices_indexing_index_total{namespace="$NAMESPACE"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: process_instances_per_second
+    description: Average process instances completed per second, counting both root and sub-process instances.
+      Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full report
+      window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate. This
+      is the primary throughput SLO metric - compare against the scenario's target in docs/metrics.md (e.g.
+      50 PI/s for the realistic variant).
+    header: PI
+    query: |-
+      avg_over_time((sum(rate(zeebe_element_instance_events_total{namespace="$NAMESPACE", action="completed", type="PROCESS"}[$RATE_INTERVAL])) or sum(rate(zeebe_executed_instances_total{namespace="$NAMESPACE", action="completed", type="ROOT_PROCESS_INSTANCE"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: archived_process_instances_per_second
+    description: Average number of process instances archived per second by the exporter's archiver. Computed
+      as a Prometheus rate() sampled every --rate-interval, then averaged across the full report window
+      via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate.
+    header: Archived PI
+    query: |-
+      avg_over_time((sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace="$NAMESPACE", state="archived"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: flow_node_instances_per_second
+    description: Average number of flow node instances (every element type except PROCESS) completed per
+      second. Computed as a Prometheus rate() sampled every --rate-interval, then averaged across the full
+      report window via avg_over_time, so a long report window doesn't flatten into one coarse counter-rate.
+      Together with PI/s, this shows whether a run met its SLO.
+    header: FNI
+    query: |-
+      avg_over_time((sum(rate(zeebe_element_instance_events_total{namespace="$NAMESPACE", type!="PROCESS", action="completed"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: service_task_instances_per_second
+    description: Average number of service task instances completed per second. Computed as a Prometheus
+      rate() sampled every --rate-interval, then averaged across the full report window via avg_over_time,
+      so a long report window doesn't flatten into one coarse counter-rate.
+    header: STI
+    query: |-
+      avg_over_time((sum(rate(zeebe_element_instance_events_total{namespace="$NAMESPACE", action="completed", type="SERVICE_TASK"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: jobs_per_second
+    description: Average number of jobs completed per second. Computed as a Prometheus rate() sampled every
+      --rate-interval, then averaged across the full report window via avg_over_time, so a long report window
+      doesn't flatten into one coarse counter-rate.
+    header: Job
+    query: |-
+      avg_over_time((sum(rate(zeebe_job_events_total{namespace="$NAMESPACE", action="completed"}[$RATE_INTERVAL])))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: processing_latency_p50_ms
+    description: 'Time from writing a user command to the append-only log until the processing engine starts
+      processing it (p50, in milliseconds). Computed via histogram_quantile over the underlying histogram''s
+      rate() across the entire report window - one quantile for the whole window, not a windowed series
+      of quantiles like the CPU/resource metrics. High values indicate a growing processing backlog. Threshold
+      in docs/metrics.md: p99 < 250 ms.'
+    header: ProcLat p50 (ms)
+    query: |-
+      1000 * histogram_quantile(0.50, sum(rate(zeebe_stream_processor_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: processing_latency_p99_ms
+    description: 'Time from writing a user command to the append-only log until the processing engine starts
+      processing it (p99, in milliseconds). Computed via histogram_quantile over the underlying histogram''s
+      rate() across the entire report window - one quantile for the whole window, not a windowed series
+      of quantiles like the CPU/resource metrics. High values indicate a growing processing backlog. Threshold
+      in docs/metrics.md: p99 < 250 ms.'
+    header: ProcLat p99 (ms)
+    query: |-
+      1000 * histogram_quantile(0.99, sum(rate(zeebe_stream_processor_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: exporting_latency_p50_ms
+    description: Time from writing an event to the append-only log until the exporter starts exporting it
+      (p50, in milliseconds). Computed via histogram_quantile over the underlying histogram's rate() across
+      the entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. High values indicate a processing and/or exporting backlog.
+    header: ExportLat p50 (ms)
+    query: |-
+      1000 * histogram_quantile(0.50, sum(rate(zeebe_exporting_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_exporting_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: exporting_latency_p99_ms
+    description: Time from writing an event to the append-only log until the exporter starts exporting it
+      (p99, in milliseconds). Computed via histogram_quantile over the underlying histogram's rate() across
+      the entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. High values indicate a processing and/or exporting backlog.
+    header: ExportLat p99 (ms)
+    query: |-
+      1000 * histogram_quantile(0.99, sum(rate(zeebe_exporting_latency_bucket{namespace="$NAMESPACE"}[$DURATION_S]) or rate(zeebe_exporting_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: process_instance_execution_p50_ms
+    description: 'Full end-to-end process execution time, from instance creation to completion (p50, in
+      milliseconds). Computed via histogram_quantile over the underlying histogram''s rate() across the
+      entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. Threshold in docs/metrics.md: p99 < 1 s.'
+    header: PIExec p50
+    query: |-
+      1000 * histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: process_instance_execution_p99_ms
+    description: 'Full end-to-end process execution time, from instance creation to completion (p99, in
+      milliseconds). Computed via histogram_quantile over the underlying histogram''s rate() across the
+      entire report window - one quantile for the whole window, not a windowed series of quantiles like
+      the CPU/resource metrics. Threshold in docs/metrics.md: p99 < 1 s.'
+    header: PIExec p99
+    query: |-
+      1000 * histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])) by (le))
+
+  - key: data_availability_p50_seconds
+    description: 'Time from creating an instance in the client until it is available via the REST API (p50,
+      in seconds). Computed via histogram_quantile over the underlying histogram''s rate() across the entire
+      report window - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource
+      metrics. The strongest end-to-end signal - it covers the full round-trip: processing, exporting, secondary-storage
+      indexing, and the REST layer. Threshold in docs/metrics.md: p99 < 5 s.'
+    header: DataAvail p50 (sec)
+    query: |-
+      histogram_quantile(0.50, sum by (le) (rate(starter_data_availability_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: data_availability_p99_seconds
+    description: 'Time from creating an instance in the client until it is available via the REST API (p99,
+      in seconds). Computed via histogram_quantile over the underlying histogram''s rate() across the entire
+      report window - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource
+      metrics. The strongest end-to-end signal - it covers the full round-trip: processing, exporting, secondary-storage
+      indexing, and the REST layer. Threshold in docs/metrics.md: p99 < 5 s.'
+    header: DataAvail p99 (sec)
+    query: |-
+      histogram_quantile(0.99, sum by (le) (rate(starter_data_availability_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: response_latency_p50_ms
+    description: 'Time from sending a request in the client to receiving a response (p50, in milliseconds).
+      Computed via histogram_quantile over the underlying histogram''s rate() across the entire report window
+      - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource metrics.
+      Includes processing latency (and its queue) plus authentication/authorization overhead. Threshold
+      in docs/metrics.md: p99 < 5 s.'
+    header: Response p50 (ms)
+    query: |-
+      1000 * histogram_quantile(0.50, sum by (le) (rate(starter_response_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: response_latency_p99_ms
+    description: 'Time from sending a request in the client to receiving a response (p99, in milliseconds).
+      Computed via histogram_quantile over the underlying histogram''s rate() across the entire report window
+      - one quantile for the whole window, not a windowed series of quantiles like the CPU/resource metrics.
+      Includes processing latency (and its queue) plus authentication/authorization overhead. Threshold
+      in docs/metrics.md: p99 < 5 s.'
+    header: Response p99 (ms)
+    query: |-
+      1000 * histogram_quantile(0.99, sum by (le) (rate(starter_response_latency_seconds_bucket{namespace="$NAMESPACE"}[$DURATION_S])))
+
+  - key: backpressure_percent
+    description: Percentage of requests dropped due to backpressure. Computed as the dropped/received request
+      ratio per partition at every --rate-interval sample, taking the worst (highest) partition value at
+      each sample, then averaging across the report window - one struggling partition dominates the reported
+      value rather than being diluted by healthy ones. Values above ~0% indicate the system is actively
+      rejecting work and is at or near capacity.
+    header: Backpressure (max of 3)
+    query: |-
+      avg_over_time((max(100 * sum by (partition) (rate(zeebe_dropped_request_count_total{namespace="$NAMESPACE"}[$RATE_INTERVAL])) / sum by (partition) (rate(zeebe_received_request_count_total{namespace="$NAMESPACE"}[$RATE_INTERVAL]))))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: processing_backlog
+    description: Records appended to the log but not yet processed by the engine. Computed as the difference
+      between the log's last-appended/last-committed position and the last-processed/last-exported position,
+      per partition, taking the highest partition value at every --sample-step sample and averaging across
+      the report window. A stable backlog is normal; a growing one means the engine can't keep up and processing
+      latency will worsen over time.
+    header: Proc backlog
+    query: |-
+      avg_over_time((max(max by (partition) (zeebe_log_appender_last_appended_position{namespace="$NAMESPACE"}) - max by (partition) (zeebe_stream_processor_last_processed_position{namespace="$NAMESPACE"})))[$DURATION_S:$SAMPLE_STEP])
+
+  - key: exporting_backlog
+    description: Records committed to the log but not yet exported. Computed as the difference between the
+      log's last-appended/last-committed position and the last-processed/last-exported position, per partition,
+      taking the highest partition value at every --sample-step sample and averaging across the report window.
+      A growing exporting backlog drives higher data-availability latency and is decoupled from processing
+      throughput - the engine can be healthy while the exporter falls behind.
+    header: Export backlog
+    query: |-
+      avg_over_time((max(max by (partition) (zeebe_log_appender_last_committed_position{namespace="$NAMESPACE"}) - max by (partition) (zeebe_exporter_last_exported_position{namespace="$NAMESPACE"})))[$DURATION_S:$SAMPLE_STEP])

--- a/load-tests/docs/scripts/load_test_report/report.py
+++ b/load-tests/docs/scripts/load_test_report/report.py
@@ -1,0 +1,134 @@
+"""Report construction and rendering."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import sys
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from typing import Any, Optional, Union
+
+from errors import MissingMetric, ReportError
+from queries import validate_query_document
+
+NUMBER_PATTERN = re.compile(r"^-?([0-9]+([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)?$")
+MetricValue = Union[str, int, float]
+WarningSink = Callable[[str], None]
+
+
+def warn(message: str) -> None:
+    print(f"Warning: {message}", file=sys.stderr)
+
+
+def missing_metric(key: str, reason: str, warning_sink: WarningSink) -> None:
+    warning_sink(f"{key}: {reason}")
+    raise MissingMetric(reason)
+
+
+def extract_metric_value(
+    response: Mapping[str, Any],
+    value_label: str,
+    key: str,
+    warning_sink: WarningSink = warn,
+) -> MetricValue:
+    if response.get("status") != "success":
+        missing_metric(key, "Prometheus returned non-success status", warning_sink)
+
+    data = response.get("data", {})
+    result = data.get("result", []) if isinstance(data, Mapping) else []
+    if not isinstance(result, list):
+        result = []
+
+    if value_label:
+        values = sorted(
+            {
+                str(series.get("metric", {}).get(value_label))
+                for series in result
+                if isinstance(series, Mapping)
+                and isinstance(series.get("metric"), Mapping)
+                and series["metric"].get(value_label) is not None
+            }
+        )
+        if not values:
+            missing_metric(key, "no label sample", warning_sink)
+        return ", ".join(values)
+
+    raw_value = ""
+    if result and isinstance(result[0], Mapping):
+        sample = result[0].get("value", [])
+        if isinstance(sample, list) and len(sample) > 1:
+            raw_value = str(sample[1])
+
+    if not NUMBER_PATTERN.fullmatch(raw_value):
+        missing_metric(key, "no numeric sample", warning_sink)
+    return parse_number(raw_value)
+
+
+def parse_number(raw_value: str) -> Union[int, float]:
+    if re.fullmatch(r"-?[0-9]+", raw_value):
+        return int(raw_value)
+    return float(raw_value)
+
+
+def build_report(
+    options: Any,
+    query_document: Mapping[str, Any],
+    client: Any,
+    generated_at: Optional[str] = None,
+    warning_sink: WarningSink = warn,
+) -> Mapping[str, Any]:
+    queries = validate_query_document(query_document)
+
+    columns: list[str] = []
+    headers: list[str] = []
+    metrics: dict[str, Optional[MetricValue]] = {}
+
+    for query in queries:
+        key = query["key"]
+        columns.append(key)
+        headers.append(str(query.get("header", key)))
+
+        if "value" in query and query["value"] is not None:
+            metrics[key] = str(query["value"])
+            continue
+
+        try:
+            response = client.query(str(query["query"]))
+            metrics[key] = extract_metric_value(response, str(query.get("valueLabel", "")), key, warning_sink)
+        except MissingMetric:
+            metrics[key] = None
+        except ReportError:
+            metrics[key] = None
+            warning_sink(f"{key}: query failed")
+
+    return {
+        "namespace": options.namespace,
+        "durationSeconds": options.duration_seconds,
+        "start": options.start_label or None,
+        "end": options.end_label or None,
+        "endpoint": options.endpoint,
+        "generatedAt": generated_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "columns": columns,
+        "headers": headers,
+        "metrics": metrics,
+    }
+
+
+def render_report(report: Mapping[str, Any], output_format: str, include_header: bool, missing_value: str) -> str:
+    if output_format == "json":
+        return json.dumps(report, indent=2)
+
+    delimiter = "," if output_format == "csv" else "\t"
+    output = io.StringIO()
+    writer = csv.writer(output, delimiter=delimiter, lineterminator="\n")
+
+    if include_header:
+        writer.writerow(report["headers"])
+
+    metrics = report["metrics"]
+    row = [missing_value if metrics[column] is None else metrics[column] for column in report["columns"]]
+    writer.writerow(row)
+    return output.getvalue().rstrip("\n")

--- a/load-tests/docs/scripts/load_test_report/tests/test_load_test_report.py
+++ b/load-tests/docs/scripts/load_test_report/tests/test_load_test_report.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import load_test_report
+import prometheus
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+
+
+class FakePrometheusClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.queries = []
+
+    def query(self, query):
+        self.queries.append(query)
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class FakeHttpResponse:
+    def __init__(self, payload):
+        self.payload = payload.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+class ExtractMetricValueTest(unittest.TestCase):
+    def test_should_extract_numeric_sample(self):
+        response = {
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {
+                        "metric": {
+                            "__name__": "up",
+                            "job": "prometheus",
+                            "instance": "localhost:9090",
+                        },
+                        "value": [1435781451.781, "42.5"],
+                    }
+                ],
+            },
+        }
+
+        self.assertEqual(load_test_report.extract_metric_value(response, "", "throughput"), 42.5)
+
+    def test_should_extract_sorted_unique_label_values(self):
+        response = {
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {"metric": {"image": "registry/camunda:2"}, "value": [1435781451.781, "1"]},
+                    {"metric": {"image": "registry/camunda:1"}, "value": [1435781451.781, "1"]},
+                    {"metric": {"image": "registry/camunda:2"}, "value": [1435781451.781, "1"]},
+                ],
+            },
+        }
+
+        self.assertEqual(
+            load_test_report.extract_metric_value(response, "image", "image"),
+            "registry/camunda:1, registry/camunda:2",
+        )
+
+    def test_should_warn_when_numeric_sample_is_missing(self):
+        response = {"status": "success", "data": {"result": []}}
+        warnings = []
+
+        with self.assertRaisesRegex(load_test_report.MissingMetric, "no numeric sample"):
+            load_test_report.extract_metric_value(response, "", "throughput", warnings.append)
+
+        self.assertEqual(warnings, ["throughput: no numeric sample"])
+
+    def test_should_warn_when_label_sample_is_missing(self):
+        response = {"status": "success", "data": {"result": []}}
+        warnings = []
+
+        with self.assertRaisesRegex(load_test_report.MissingMetric, "no label sample"):
+            load_test_report.extract_metric_value(response, "image", "image", warnings.append)
+
+        self.assertEqual(warnings, ["image: no label sample"])
+
+    def test_should_warn_when_prometheus_status_is_not_success(self):
+        response = {"status": "error", "data": {"result": []}}
+        warnings = []
+
+        with self.assertRaisesRegex(load_test_report.MissingMetric, "Prometheus returned non-success status"):
+            load_test_report.extract_metric_value(response, "", "throughput", warnings.append)
+
+        self.assertEqual(warnings, ["throughput: Prometheus returned non-success status"])
+
+
+class BuildReportTest(unittest.TestCase):
+    def test_should_build_report_without_network_side_effects(self):
+        options = load_test_report.Options(
+            namespace="c8-ck-test",
+            duration_seconds=900,
+            rate_interval="30s",
+            sample_step="15s",
+            endpoint="http://prometheus.example",
+            bearer_token="",
+            basic_auth_user="",
+            basic_auth_password="",
+            time_anchor="",
+            start_label="",
+            end_label="",
+            output_format="json",
+            include_header=True,
+            missing_value="NaN",
+            queries_source="custom",
+            queries_file=Path("queries.json"),
+            output_file=None,
+        )
+        query_document = {
+            "queries": [
+                {"key": "namespace", "header": "Namespace", "value": "c8-ck-test"},
+                {
+                    "key": "throughput",
+                    "header": "Throughput",
+                    "query": 'rate(total{namespace="c8-ck-test"}[30s])',
+                },
+                {
+                    "key": "image",
+                    "header": "Image",
+                    "query": "image_query[900s:15s]",
+                    "valueLabel": "image",
+                },
+                {"key": "missing", "header": "Missing", "query": "missing_query"},
+            ]
+        }
+        client = FakePrometheusClient(
+            [
+                {"status": "success", "data": {"result": [{"value": [123, "10"]}]}},
+                {"status": "success", "data": {"result": [{"metric": {"image": "camunda:SNAPSHOT"}}]}},
+                {"status": "success", "data": {"result": []}},
+            ]
+        )
+        warnings = []
+
+        report = load_test_report.build_report(
+            options,
+            query_document,
+            client,
+            generated_at="2026-09-07T18:00:00Z",
+            warning_sink=warnings.append,
+        )
+
+        self.assertEqual(
+            client.queries,
+            [
+                'rate(total{namespace="c8-ck-test"}[30s])',
+                "image_query[900s:15s]",
+                "missing_query",
+            ],
+        )
+        self.assertEqual(report["metrics"]["namespace"], "c8-ck-test")
+        self.assertEqual(report["metrics"]["throughput"], 10)
+        self.assertEqual(report["metrics"]["image"], "camunda:SNAPSHOT")
+        self.assertIsNone(report["metrics"]["missing"])
+        self.assertNotIn("missing", report)
+        self.assertEqual(warnings, ["missing: no numeric sample"])
+
+    def test_should_warn_when_query_fails(self):
+        options = load_test_report.Options(
+            namespace="c8-ck-test",
+            duration_seconds=900,
+            rate_interval="30s",
+            sample_step="15s",
+            endpoint="http://prometheus.example",
+            bearer_token="",
+            basic_auth_user="",
+            basic_auth_password="",
+            time_anchor="",
+            start_label="",
+            end_label="",
+            output_format="json",
+            include_header=True,
+            missing_value="NaN",
+            queries_source="custom",
+            queries_file=Path("queries.json"),
+            output_file=None,
+        )
+        query_document = {"queries": [{"key": "throughput", "query": "throughput_query"}]}
+        client = FakePrometheusClient([load_test_report.ReportError("query failed")])
+        warnings = []
+
+        report = load_test_report.build_report(options, query_document, client, warning_sink=warnings.append)
+
+        self.assertIsNone(report["metrics"]["throughput"])
+        self.assertNotIn("missing", report)
+        self.assertEqual(warnings, ["throughput: query failed"])
+
+
+class AuthHeadersTest(unittest.TestCase):
+    def test_should_build_basic_auth_header(self):
+        headers = load_test_report.auth_headers("", "user", "pass")
+
+        self.assertEqual(headers["Authorization"], "Basic dXNlcjpwYXNz")
+
+    def test_should_build_bearer_auth_header(self):
+        headers = load_test_report.auth_headers("abc123", "", "")
+
+        self.assertEqual(headers["Authorization"], "Bearer abc123")
+
+    def test_should_reject_combined_auth_modes(self):
+        with self.assertRaisesRegex(load_test_report.ReportError, "--token cannot be combined"):
+            load_test_report.auth_headers("abc123", "user", "pass")
+
+    def test_should_reject_incomplete_basic_auth(self):
+        with self.assertRaisesRegex(load_test_report.ReportError, "--user and --password"):
+            load_test_report.auth_headers("", "user", "")
+
+
+class PrometheusClientTest(unittest.TestCase):
+    def test_should_query_prometheus_with_urlencoded_query_and_headers(self):
+        seen_requests = []
+
+        def fake_urlopen(request, timeout):
+            seen_requests.append((request, timeout))
+            return FakeHttpResponse('{"status":"success","data":{"result":[]}}')
+
+        with mock.patch.object(prometheus, "urlopen", side_effect=fake_urlopen):
+            client = load_test_report.PrometheusClient(
+                "https://prometheus.example/",
+                "",
+                "user",
+                "pass",
+                "2026-09-07T18:00:00Z",
+            )
+
+            response = client.query('rate(total{namespace="c8-ck-test"}[5m])')
+
+        self.assertEqual(response["status"], "success")
+        request, timeout = seen_requests[0]
+        self.assertEqual(timeout, 30)
+        self.assertIn("query=rate%28total%7Bnamespace%3D%22c8-ck-test%22%7D%5B5m%5D%29", request.full_url)
+        self.assertIn("time=2026-09-07T18%3A00%3A00Z", request.full_url)
+        self.assertEqual(request.get_header("Authorization"), "Basic dXNlcjpwYXNz")
+
+
+class LoadQueryDocumentTest(unittest.TestCase):
+    def test_should_load_yaml_query_file_with_pyyaml(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.yaml"
+            queries_file.write_text("queries:\n- key: namespace\n  value: $NAMESPACE\n", encoding="utf-8")
+
+            document = load_test_report.load_query_document(queries_file, {"$NAMESPACE": "c8-ck-test"})
+
+        self.assertEqual(document["queries"][0]["key"], "namespace")
+        self.assertEqual(document["queries"][0]["value"], "c8-ck-test")
+
+    def test_should_substitute_query_file_before_json_decoding(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.json"
+            queries_file.write_text(
+                '{"queries":[{"key":"throughput","query":"rate(total{namespace=\\"$NAMESPACE\\"}[$RATE_INTERVAL])"}]}',
+                encoding="utf-8",
+            )
+
+            document = load_test_report.load_query_document(
+                queries_file,
+                {"$NAMESPACE": "c8-ck-test", "$RATE_INTERVAL": "30s"},
+            )
+
+        self.assertEqual(document["queries"][0]["query"], 'rate(total{namespace="c8-ck-test"}[30s])')
+
+    def test_should_report_invalid_json_query_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.json"
+            queries_file.write_text('{"queries":[', encoding="utf-8")
+
+            with self.assertRaisesRegex(load_test_report.ReportError, "Could not parse queries file"):
+                load_test_report.load_query_document(queries_file, {})
+
+    def test_should_reject_legacy_load_test_metrics_schema(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.yaml"
+            queries_file.write_text(
+                """queries:
+- name: throughput-per-second
+  description: Client Process Instance Started Rate (avg)
+  query: numeric_metric{namespace="$NAMESPACE"}
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(load_test_report.ReportError, "non-empty string key"):
+                load_test_report.load_query_document(queries_file, {})
+
+    def test_should_reject_duplicate_query_keys(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.yaml"
+            queries_file.write_text(
+                """queries:
+- key: duplicate_metric
+  header: Duplicate 1
+  query: numeric_metric{namespace="$NAMESPACE"}
+- key: duplicate_metric
+  header: Duplicate 2
+  value: static
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(load_test_report.ReportError, "duplicate query key: duplicate_metric"):
+                load_test_report.load_query_document(queries_file, {})
+
+    def test_should_reject_entries_without_exactly_one_value_source(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.yaml"
+            queries_file.write_text(
+                """queries:
+- key: missing_source
+  header: Missing source
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(load_test_report.ReportError, "must set exactly one of query or value"):
+                load_test_report.load_query_document(queries_file, {})
+
+    def test_should_reject_value_label_without_query(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.yaml"
+            queries_file.write_text(
+                """queries:
+- key: invalid_label
+  header: Invalid label
+  value: static
+  valueLabel: image
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(load_test_report.ReportError, "sets valueLabel without query"):
+                load_test_report.load_query_document(queries_file, {})
+
+    def test_should_load_builtin_query_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "report-queries.yaml"
+            queries_file.write_text(
+                """queries:
+- key: namespace
+  value: $NAMESPACE
+
+- key: throughput
+  query: rate(total{namespace="$NAMESPACE"}[30s])
+""",
+                encoding="utf-8",
+            )
+
+            document = load_test_report.load_query_document(
+                queries_file,
+                {"$NAMESPACE": "c8-ck-test"},
+            )
+
+        self.assertEqual([query["key"] for query in document["queries"]], ["namespace", "throughput"])
+        self.assertEqual(document["queries"][0]["value"], "c8-ck-test")
+        self.assertEqual(document["queries"][1]["query"], 'rate(total{namespace="c8-ck-test"}[30s])')
+
+    def test_should_reject_duplicate_keys_in_query_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "report-queries.yaml"
+            queries_file.write_text(
+                """queries:
+- key: duplicate
+  value: first
+
+- key: duplicate
+  value: second
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(load_test_report.ReportError, "duplicate query key: duplicate"):
+                load_test_report.load_query_document(queries_file, {})
+
+    def test_should_load_all_builtin_query_files(self):
+        script_dir = PROJECT_DIR
+        substitutions = {
+            "$NAMESPACE": "c8-ck-test",
+            "$DURATION_S": "600s",
+            "$RATE_INTERVAL": "5m",
+            "$SAMPLE_STEP": "1m",
+        }
+
+        for queries_name, query_file_name in load_test_report.BUILTIN_QUERY_FILES.items():
+            with self.subTest(queries_name=queries_name):
+                document = load_test_report.load_query_document(script_dir / query_file_name, substitutions)
+                self.assertGreater(len(document["queries"]), 0)
+
+    def test_should_keep_builtin_spreadsheet_column_order(self):
+        script_dir = PROJECT_DIR
+        substitutions = {
+            "$NAMESPACE": "c8-ck-test",
+            "$DURATION_S": "600s",
+            "$RATE_INTERVAL": "5m",
+            "$SAMPLE_STEP": "1m",
+        }
+        expected_columns = {
+            "camunda": [
+                ("namespace", "Namespace"),
+                ("docker_image", "Version"),
+                ("camunda_nodes", "Nodes"),
+                ("secondary_storage_nodes", "Nodes"),
+                ("camunda_cpu_limit", "limit"),
+                ("camunda_cpu_used_p50", "used (p50)"),
+                ("camunda_cpu_used_p99", "used(p99)"),
+                ("camunda_cpu_throttling_percent", "throttling (%)"),
+                ("camunda_memory_limit_gib", "limit"),
+                ("camunda_memory_rss_gib", "RSS (GB)"),
+                ("camunda_heap_gib", "heap"),
+                ("camunda_disk_capacity_gib", "capacity"),
+                ("camunda_disk_used_gib", "used"),
+                ("camunda_write_iops", "write IOPS"),
+                ("secondary_storage_cpu_limit", "limit"),
+                ("secondary_storage_cpu_used_p50", "used (p50)"),
+                ("secondary_storage_cpu_used_p99", "used(p99)"),
+                ("secondary_storage_cpu_throttling_percent", "throttling (%)"),
+                ("secondary_storage_memory_limit_gib", "limit"),
+                ("secondary_storage_memory_rss_gib", "RSS (GB)"),
+                ("secondary_storage_heap_gib", "heap (GB)"),
+                ("secondary_storage_disk_capacity_gib", "capacity"),
+                ("secondary_storage_disk_used_gib", "used"),
+                ("secondary_storage_write_iops", "write IOPS"),
+                ("records_processed_per_second", "Proc rec"),
+                ("records_exported_per_second", "Export rec"),
+                ("secondary_storage_indexed_documents_per_second", "ES idx docs"),
+                ("process_instances_per_second", "PI"),
+                ("archived_process_instances_per_second", "Archived PI"),
+                ("flow_node_instances_per_second", "FNI"),
+                ("service_task_instances_per_second", "STI"),
+                ("jobs_per_second", "Job"),
+                ("processing_latency_p50_ms", "ProcLat p50 (ms)"),
+                ("processing_latency_p99_ms", "ProcLat p99 (ms)"),
+                ("exporting_latency_p50_ms", "ExportLat p50 (ms)"),
+                ("exporting_latency_p99_ms", "ExportLat p99 (ms)"),
+                ("process_instance_execution_p50_ms", "PIExec p50"),
+                ("process_instance_execution_p99_ms", "PIExec p99"),
+                ("data_availability_p50_seconds", "DataAvail p50 (sec)"),
+                ("data_availability_p99_seconds", "DataAvail p99 (sec)"),
+                ("response_latency_p50_ms", "Response p50 (ms)"),
+                ("response_latency_p99_ms", "Response p99 (ms)"),
+                ("backpressure_percent", "Backpressure (max of 3)"),
+                ("processing_backlog", "Proc backlog"),
+                ("exporting_backlog", "Export backlog"),
+            ],
+            "stable-87": [
+                ("namespace", "Namespace"),
+                ("docker_image", "Version"),
+                ("zeebe_nodes", "Nodes"),
+                ("zeebe_gateway_nodes", "Nodes"),
+                ("secondary_storage_nodes", "Nodes"),
+                ("zeebe_cpu_limit", "limit"),
+                ("zeebe_cpu_used_p50", "used (p50)"),
+                ("zeebe_cpu_used_p99", "used(p99)"),
+                ("zeebe_cpu_throttling_percent", "throttling (%)"),
+                ("zeebe_memory_limit_gib", "limit"),
+                ("zeebe_memory_rss_gib", "RSS (GB)"),
+                ("zeebe_heap_gib", "heap"),
+                ("zeebe_gateway_cpu_limit", "limit"),
+                ("zeebe_gateway_cpu_used_p50", "used (p50)"),
+                ("zeebe_gateway_cpu_used_p99", "used(p99)"),
+                ("zeebe_gateway_cpu_throttling_percent", "throttling (%)"),
+                ("zeebe_gateway_memory_limit_gib", "limit"),
+                ("zeebe_gateway_memory_rss_gib", "RSS (GB)"),
+                ("zeebe_gateway_heap_gib", "heap"),
+                ("zeebe_disk_capacity_gib", "capacity"),
+                ("zeebe_disk_used_gib", "used"),
+                ("zeebe_write_iops", "write IOPS"),
+                ("secondary_storage_cpu_limit", "limit"),
+                ("secondary_storage_cpu_used_p50", "used (p50)"),
+                ("secondary_storage_cpu_used_p99", "used(p99)"),
+                ("secondary_storage_cpu_throttling_percent", "throttling (%)"),
+                ("secondary_storage_memory_limit_gib", "limit"),
+                ("secondary_storage_memory_rss_gib", "RSS (GB)"),
+                ("secondary_storage_heap_gib", "heap (GB)"),
+                ("secondary_storage_disk_capacity_gib", "capacity"),
+                ("secondary_storage_disk_used_gib", "used"),
+                ("secondary_storage_write_iops", "write IOPS"),
+                ("records_processed_per_second", "Proc rec"),
+                ("records_exported_per_second", "Export rec"),
+                ("secondary_storage_indexed_documents_per_second", "ES idx docs"),
+                ("process_instances_per_second", "PI"),
+                ("archived_process_instances_per_second", "Archived PI"),
+                ("flow_node_instances_per_second", "FNI"),
+                ("service_task_instances_per_second", "STI"),
+                ("jobs_per_second", "Job"),
+                ("processing_latency_p50_ms", "ProcLat p50 (ms)"),
+                ("processing_latency_p99_ms", "ProcLat p99 (ms)"),
+                ("exporting_latency_p50_ms", "ExportLat p50 (ms)"),
+                ("exporting_latency_p99_ms", "ExportLat p99 (ms)"),
+                ("process_instance_execution_p50_ms", "PIExec p50"),
+                ("process_instance_execution_p99_ms", "PIExec p99"),
+                ("data_availability_p50_seconds", "DataAvail p50 (sec)"),
+                ("data_availability_p99_seconds", "DataAvail p99 (sec)"),
+                ("response_latency_p50_ms", "Response p50 (ms)"),
+                ("response_latency_p99_ms", "Response p99 (ms)"),
+                ("backpressure_percent", "Backpressure (max of 3)"),
+                ("processing_backlog", "Proc backlog"),
+                ("exporting_backlog", "Export backlog"),
+            ],
+        }
+
+        for queries_name, query_file_name in load_test_report.BUILTIN_QUERY_FILES.items():
+            with self.subTest(queries_name=queries_name):
+                document = load_test_report.load_query_document(script_dir / query_file_name, substitutions)
+
+                self.assertEqual(
+                    [(query["key"], query["header"]) for query in document["queries"]],
+                    expected_columns[queries_name],
+                )
+
+    def test_should_keep_builtin_descriptions_before_headers(self):
+        script_dir = PROJECT_DIR
+
+        for query_file_name in load_test_report.BUILTIN_QUERY_FILES.values():
+            with self.subTest(query_file_name=query_file_name):
+                query_text = (script_dir / query_file_name).read_text(encoding="utf-8").split("queries:\n", 1)[1]
+                entries = [entry for entry in query_text.split("\n\n") if entry.startswith("  - key:")]
+
+                self.assertGreater(len(entries), 0)
+                for entry in entries:
+                    description_index = entry.find("\n    description:")
+                    header_index = entry.find("\n    header:")
+                    self.assertNotEqual(description_index, -1)
+                    self.assertNotEqual(header_index, -1)
+                    self.assertLess(description_index, header_index)
+
+    def test_should_resolve_stable_87_builtin_queries(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "report-queries-stable-87.yaml").write_text(
+                """queries:
+- key: namespace
+  value: $NAMESPACE
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                load_test_report.resolve_queries_file(Path(temp_dir), "stable-87"),
+                Path(temp_dir) / "report-queries-stable-87.yaml",
+            )
+
+    def test_should_resolve_custom_queries_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.yaml"
+            queries_file.write_text(
+                """queries:
+- key: namespace
+  value: $NAMESPACE
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                load_test_report.resolve_queries_file(Path(temp_dir), str(queries_file)),
+                queries_file,
+            )
+
+
+class WarningTest(unittest.TestCase):
+    def test_should_prefix_default_stderr_warnings(self):
+        stderr = io.StringIO()
+
+        with mock.patch.object(sys, "stderr", stderr):
+            load_test_report.warn("throughput: no numeric sample")
+
+        self.assertEqual(stderr.getvalue(), "Warning: throughput: no numeric sample\n")
+
+
+class RenderReportTest(unittest.TestCase):
+    def test_should_render_tsv_without_header(self):
+        report = {
+            "columns": ["namespace", "throughput", "missing"],
+            "headers": ["Namespace", "Throughput", "Missing"],
+            "metrics": {"namespace": "c8-ck-test", "throughput": 10, "missing": None},
+        }
+
+        rendered = load_test_report.render_report(report, "tsv", include_header=False, missing_value="NaN")
+
+        self.assertEqual(rendered, "c8-ck-test\t10\tNaN")
+
+    def test_should_quote_csv_cells(self):
+        report = {
+            "columns": ["namespace", "image"],
+            "headers": ["Namespace", "Image"],
+            "metrics": {"namespace": "c8-ck-test", "image": "camunda:1, camunda:2"},
+        }
+
+        rendered = load_test_report.render_report(report, "csv", include_header=True, missing_value="NaN")
+
+        self.assertEqual(rendered, 'Namespace,Image\nc8-ck-test,"camunda:1, camunda:2"')
+
+
+class ParseArgsTest(unittest.TestCase):
+    def test_should_parse_auth_flags(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.json"
+            queries_file.write_text('{"queries":[]}', encoding="utf-8")
+
+            options = load_test_report.parse_args(
+                [
+                    "c8-ck-test",
+                    "--token",
+                    "abc123",
+                    "--queries",
+                    str(queries_file),
+                ],
+                Path(temp_dir),
+            )
+
+        self.assertEqual(options.bearer_token, "abc123")
+        self.assertEqual(options.basic_auth_user, "")
+        self.assertEqual(options.basic_auth_password, "")
+        self.assertEqual(options.queries_source, str(queries_file))
+        self.assertEqual(options.queries_file, queries_file)
+
+    def test_should_derive_duration_from_start_and_end(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            queries_file = Path(temp_dir) / "queries.json"
+            queries_file.write_text('{"queries":[]}', encoding="utf-8")
+
+            options = load_test_report.parse_args(
+                [
+                    "c8-ck-test",
+                    "--start",
+                    "2026-08-14T10:00:00Z",
+                    "--end",
+                    "2026-08-14T10:30:00Z",
+                    "--queries",
+                    str(queries_file),
+                ],
+                Path(temp_dir),
+            )
+
+        self.assertEqual(options.duration_seconds, 1800)
+        self.assertEqual(options.time_anchor, "2026-08-14T10:30:00Z")
+        self.assertEqual(options.start_label, "2026-08-14T10:00:00Z")
+        self.assertEqual(options.end_label, "2026-08-14T10:30:00Z")
+
+    def test_should_use_camunda_queries_by_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "report-queries.yaml").write_text(
+                """queries:
+- key: namespace
+  value: test
+""",
+                encoding="utf-8",
+            )
+            options = load_test_report.parse_args(["c8-ck-test"], Path(temp_dir))
+
+        self.assertEqual(options.queries_source, "camunda")
+        self.assertEqual(options.queries_file.name, "report-queries.yaml")
+
+    def test_should_use_stable_87_queries_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "report-queries-stable-87.yaml").write_text(
+                """queries:
+- key: namespace
+  value: test
+""",
+                encoding="utf-8",
+            )
+
+            options = load_test_report.parse_args(["c8-ck-test", "--queries", "stable-87"], Path(temp_dir))
+
+        self.assertEqual(options.queries_source, "stable-87")
+        self.assertEqual(options.queries_file.name, "report-queries-stable-87.yaml")
+
+    def test_should_reject_unknown_queries_source(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(load_test_report.ReportError, "Unsupported --queries"):
+                load_test_report.parse_args(
+                    ["c8-ck-test", "--queries", "daily"],
+                    Path(temp_dir),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/load-tests/docs/scripts/load_test_report/uv.lock
+++ b/load-tests/docs/scripts/load_test_report/uv.lock
@@ -1,0 +1,254 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "load-test-report"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = "==6.0.3" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = "==8.4.2" },
+    { name = "ruff", specifier = "==0.14.6" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f0/62b5a1a723fe183650109407fa56abb433b00aa1c0b9ba555f9c4efec2c6/ruff-0.14.6.tar.gz", hash = "sha256:6f0c742ca6a7783a736b867a263b9a7a80a45ce9bee391eeda296895f1b4e1cc", size = 5669501, upload-time = "2025-11-21T14:26:17.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/d2/7dd544116d107fffb24a0064d41a5d2ed1c9d6372d142f9ba108c8e39207/ruff-0.14.6-py3-none-linux_armv6l.whl", hash = "sha256:d724ac2f1c240dbd01a2ae98db5d1d9a5e1d9e96eba999d1c48e30062df578a3", size = 13326119, upload-time = "2025-11-21T14:25:24.2Z" },
+    { url = "https://files.pythonhosted.org/packages/36/6a/ad66d0a3315d6327ed6b01f759d83df3c4d5f86c30462121024361137b6a/ruff-0.14.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9f7539ea257aa4d07b7ce87aed580e485c40143f2473ff2f2b75aee003186004", size = 13526007, upload-time = "2025-11-21T14:25:26.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9d/dae6db96df28e0a15dea8e986ee393af70fc97fd57669808728080529c37/ruff-0.14.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7f6007e55b90a2a7e93083ba48a9f23c3158c433591c33ee2e99a49b889c6332", size = 12676572, upload-time = "2025-11-21T14:25:29.826Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a4/f319e87759949062cfee1b26245048e92e2acce900ad3a909285f9db1859/ruff-0.14.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a8e7b9d73d8728b68f632aa8e824ef041d068d231d8dbc7808532d3629a6bef", size = 13140745, upload-time = "2025-11-21T14:25:32.788Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d3/248c1efc71a0a8ed4e8e10b4b2266845d7dfc7a0ab64354afe049eaa1310/ruff-0.14.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d50d45d4553a3ebcbd33e7c5e0fe6ca4aafd9a9122492de357205c2c48f00775", size = 13076486, upload-time = "2025-11-21T14:25:35.601Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/19/b68d4563fe50eba4b8c92aa842149bb56dd24d198389c0ed12e7faff4f7d/ruff-0.14.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:118548dd121f8a21bfa8ab2c5b80e5b4aed67ead4b7567790962554f38e598ce", size = 13727563, upload-time = "2025-11-21T14:25:38.514Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ac/943169436832d4b0e867235abbdb57ce3a82367b47e0280fa7b4eabb7593/ruff-0.14.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:57256efafbfefcb8748df9d1d766062f62b20150691021f8ab79e2d919f7c11f", size = 15199755, upload-time = "2025-11-21T14:25:41.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b9/288bb2399860a36d4bb0541cb66cce3c0f4156aaff009dc8499be0c24bf2/ruff-0.14.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff18134841e5c68f8e5df1999a64429a02d5549036b394fafbe410f886e1989d", size = 14850608, upload-time = "2025-11-21T14:25:44.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b1/a0d549dd4364e240f37e7d2907e97ee80587480d98c7799d2d8dc7a2f605/ruff-0.14.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:29c4b7ec1e66a105d5c27bd57fa93203637d66a26d10ca9809dc7fc18ec58440", size = 14118754, upload-time = "2025-11-21T14:25:47.214Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ac/9b9fe63716af8bdfddfacd0882bc1586f29985d3b988b3c62ddce2e202c3/ruff-0.14.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:167843a6f78680746d7e226f255d920aeed5e4ad9c03258094a2d49d3028b105", size = 13949214, upload-time = "2025-11-21T14:25:50.002Z" },
+    { url = "https://files.pythonhosted.org/packages/12/27/4dad6c6a77fede9560b7df6802b1b697e97e49ceabe1f12baf3ea20862e9/ruff-0.14.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:16a33af621c9c523b1ae006b1b99b159bf5ac7e4b1f20b85b2572455018e0821", size = 14106112, upload-time = "2025-11-21T14:25:52.841Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/db/23e322d7177873eaedea59a7932ca5084ec5b7e20cb30f341ab594130a71/ruff-0.14.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1432ab6e1ae2dc565a7eea707d3b03a0c234ef401482a6f1621bc1f427c2ff55", size = 13035010, upload-time = "2025-11-21T14:25:55.536Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9c/20e21d4d69dbb35e6a1df7691e02f363423658a20a2afacf2a2c011800dc/ruff-0.14.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4c55cfbbe7abb61eb914bfd20683d14cdfb38a6d56c6c66efa55ec6570ee4e71", size = 13054082, upload-time = "2025-11-21T14:25:58.625Z" },
+    { url = "https://files.pythonhosted.org/packages/66/25/906ee6a0464c3125c8d673c589771a974965c2be1a1e28b5c3b96cb6ef88/ruff-0.14.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:efea3c0f21901a685fff4befda6d61a1bf4cb43de16da87e8226a281d614350b", size = 13303354, upload-time = "2025-11-21T14:26:01.816Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/58/60577569e198d56922b7ead07b465f559002b7b11d53f40937e95067ca1c/ruff-0.14.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:344d97172576d75dc6afc0e9243376dbe1668559c72de1864439c4fc95f78185", size = 14054487, upload-time = "2025-11-21T14:26:05.058Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/8e4e0639e4cc12547f41cb771b0b44ec8225b6b6a93393176d75fe6f7d40/ruff-0.14.6-py3-none-win32.whl", hash = "sha256:00169c0c8b85396516fdd9ce3446c7ca20c2a8f90a77aa945ba6b8f2bfe99e85", size = 13013361, upload-time = "2025-11-21T14:26:08.152Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/02/82240553b77fd1341f80ebb3eaae43ba011c7a91b4224a9f317d8e6591af/ruff-0.14.6-py3-none-win_amd64.whl", hash = "sha256:390e6480c5e3659f8a4c8d6a0373027820419ac14fa0d2713bd8e6c3e125b8b9", size = 14432087, upload-time = "2025-11-21T14:26:10.891Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/1f/93f9b0fad9470e4c829a5bb678da4012f0c710d09331b860ee555216f4ea/ruff-0.14.6-py3-none-win_arm64.whl", hash = "sha256:d43c81fbeae52cfa8728d8766bbf46ee4298c888072105815b392da70ca836b2", size = 13520930, upload-time = "2025-11-21T14:26:13.951Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Description

Adds a Python `load_test_report.py` subproject for wide load-test reports in JSON, CSV, and TSV. It gives load-test reporting a testable command-line tool with validated query definitions, explicit Prometheus auth, visible missing metrics, and reproducible dependencies through `uv`.

The report tool lives under `load-tests/docs/scripts/load_test_report/` with a Makefile, focused modules, tests, docs, uv metadata, Ruff formatting/linting, and separate built-in query sets for current Camunda 8.8+ and stable 8.7 layouts. CSV and TSV headers stay spreadsheet-oriented, with write IOPS retained after disk usage columns.

This follows the Python tooling direction documented in PR #62391. Query selection uses one `--queries` option: pass `camunda` or `stable-87` for a built-in query set, or pass a custom YAML/JSON file path for dedicated future reports such as daily load-test reports.

Validation: load-test report `make check`, Spotless/license formatting, conftest workflow policy, and diff checks pass. `actionlint .github/workflows/ci.yml` still reports pre-existing runner-label/concurrency issues outside this change, and `./mvnw -q install -Dquickly -T1C` currently stops in unrelated Zeebe scheduler NullAway errors.

## Checklist

- [x] Backports are not needed for exploratory load-test reporting tooling.
- [x] C8 Orchestration Cluster E2E Test Suite is not modified.

## Related issues

- [x] This PR does not need a linked issue.
