### PR TITLE
fix(operate): add left padding to metadata popover values

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -601,7 +601,7 @@ const DetailsTab: React.FC = () => {
               {cellContent: 'Property', width: '30%'},
               {cellContent: 'Value', width: '70%'},
             ]}
-            valueCellPadding="8px"
+            valueCellLeftPadding="var(--cds-spacing-03)"
             rows={rows}
           />
         )}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -601,6 +601,7 @@ const DetailsTab: React.FC = () => {
               {cellContent: 'Property', width: '30%'},
               {cellContent: 'Value', width: '70%'},
             ]}
+            valueCellPadding="8px"
             rows={rows}
           />
         )}

--- a/operate/client/src/modules/components/StructuredList/index.test.tsx
+++ b/operate/client/src/modules/components/StructuredList/index.test.tsx
@@ -20,31 +20,32 @@ describe('<StructuredList />', () => {
       columns: [{cellContent: 'Flow Node Instance Key'}, {cellContent: '123'}],
     },
   ];
+  const TEST_PADDING = '13px';
 
-  it('should not apply left padding to any cell when valueCellPadding is not set', () => {
+  it('should not apply left padding to any cell when valueCellLeftPadding is not set', () => {
     render(
       <StructuredList label="Details" headerColumns={headerColumns} rows={rows} />,
     );
 
     expect(screen.getByText('Flow Node Instance Key')).not.toHaveStyle({
-      paddingLeft: '8px',
+      paddingLeft: TEST_PADDING,
     });
-    expect(screen.getByText('123')).not.toHaveStyle({paddingLeft: '8px'});
+    expect(screen.getByText('123')).not.toHaveStyle({paddingLeft: TEST_PADDING});
   });
 
-  it('should apply left padding only to the value column when valueCellPadding is set', () => {
+  it('should apply left padding only to the value column when valueCellLeftPadding is set', () => {
     render(
       <StructuredList
         label="Details"
         headerColumns={headerColumns}
         rows={rows}
-        valueCellPadding="8px"
+        valueCellLeftPadding={TEST_PADDING}
       />,
     );
 
     expect(screen.getByText('Flow Node Instance Key')).not.toHaveStyle({
-      paddingLeft: '8px',
+      paddingLeft: TEST_PADDING,
     });
-    expect(screen.getByText('123')).toHaveStyle({paddingLeft: '8px'});
+    expect(screen.getByText('123')).toHaveStyle({paddingLeft: TEST_PADDING});
   });
 });

--- a/operate/client/src/modules/components/StructuredList/index.test.tsx
+++ b/operate/client/src/modules/components/StructuredList/index.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {StructuredList} from '.';
+
+describe('<StructuredList />', () => {
+  const headerColumns = [
+    {cellContent: 'Property', width: '30%'},
+    {cellContent: 'Value', width: '70%'},
+  ];
+  const rows = [
+    {
+      key: 'row-1',
+      columns: [{cellContent: 'Flow Node Instance Key'}, {cellContent: '123'}],
+    },
+  ];
+
+  it('should not apply left padding to any cell when valueCellPadding is not set', () => {
+    render(
+      <StructuredList label="Details" headerColumns={headerColumns} rows={rows} />,
+    );
+
+    expect(screen.getByText('Flow Node Instance Key')).not.toHaveStyle({
+      paddingLeft: '8px',
+    });
+    expect(screen.getByText('123')).not.toHaveStyle({paddingLeft: '8px'});
+  });
+
+  it('should apply left padding only to the value column when valueCellPadding is set', () => {
+    render(
+      <StructuredList
+        label="Details"
+        headerColumns={headerColumns}
+        rows={rows}
+        valueCellPadding="8px"
+      />,
+    );
+
+    expect(screen.getByText('Flow Node Instance Key')).not.toHaveStyle({
+      paddingLeft: '8px',
+    });
+    expect(screen.getByText('123')).toHaveStyle({paddingLeft: '8px'});
+  });
+});

--- a/operate/client/src/modules/components/StructuredList/index.tsx
+++ b/operate/client/src/modules/components/StructuredList/index.tsx
@@ -34,6 +34,12 @@ type Props = {
   className?: string;
   dynamicRows?: React.ReactNode;
   verticalCellPadding?: string;
+  /**
+   * Adds left padding to the second column of each row (the "value"
+   * column in a Property/Value list) so long values are easier to scan.
+   * Left unset, existing consumers of this shared component are unaffected.
+   */
+  valueCellPadding?: string;
   dataTestId?: string;
   isFlush?: boolean;
 } & Pick<
@@ -41,10 +47,9 @@ type Props = {
   'onVerticalScrollStartReach' | 'onVerticalScrollEndReach'
 >;
 
-const StructuredRows: React.FC<Pick<Props, 'rows' | 'verticalCellPadding'>> = ({
-  rows,
-  verticalCellPadding,
-}) => {
+const StructuredRows: React.FC<
+  Pick<Props, 'rows' | 'verticalCellPadding' | 'valueCellPadding'>
+> = ({rows, verticalCellPadding, valueCellPadding}) => {
   return (
     <>
       {rows.map(({key, dataTestId, columns}) => (
@@ -54,6 +59,7 @@ const StructuredRows: React.FC<Pick<Props, 'rows' | 'verticalCellPadding'>> = ({
               <StructuredListCell
                 key={index}
                 $verticalCellPadding={verticalCellPadding}
+                $leftCellPadding={index === 1 ? valueCellPadding : undefined}
                 $width={width}
                 onFocus={(e) => {
                   e.stopPropagation();
@@ -77,6 +83,7 @@ const StructuredList: React.FC<Props> = ({
   className,
   dynamicRows,
   verticalCellPadding,
+  valueCellPadding,
   dataTestId,
   onVerticalScrollStartReach,
   onVerticalScrollEndReach,
@@ -117,6 +124,7 @@ const StructuredList: React.FC<Props> = ({
             <StructuredRows
               rows={rows}
               verticalCellPadding={verticalCellPadding}
+              valueCellPadding={valueCellPadding}
             />
           </div>
         </InfiniteScroller>

--- a/operate/client/src/modules/components/StructuredList/index.tsx
+++ b/operate/client/src/modules/components/StructuredList/index.tsx
@@ -39,7 +39,7 @@ type Props = {
    * column in a Property/Value list) so long values are easier to scan.
    * Left unset, existing consumers of this shared component are unaffected.
    */
-  valueCellPadding?: string;
+  valueCellLeftPadding?: string;
   dataTestId?: string;
   isFlush?: boolean;
 } & Pick<
@@ -48,8 +48,8 @@ type Props = {
 >;
 
 const StructuredRows: React.FC<
-  Pick<Props, 'rows' | 'verticalCellPadding' | 'valueCellPadding'>
-> = ({rows, verticalCellPadding, valueCellPadding}) => {
+  Pick<Props, 'rows' | 'verticalCellPadding' | 'valueCellLeftPadding'>
+> = ({rows, verticalCellPadding, valueCellLeftPadding}) => {
   return (
     <>
       {rows.map(({key, dataTestId, columns}) => (
@@ -59,7 +59,7 @@ const StructuredRows: React.FC<
               <StructuredListCell
                 key={index}
                 $verticalCellPadding={verticalCellPadding}
-                $leftCellPadding={index === 1 ? valueCellPadding : undefined}
+                $leftCellPadding={index === 1 ? valueCellLeftPadding : undefined}
                 $width={width}
                 onFocus={(e) => {
                   e.stopPropagation();
@@ -83,7 +83,7 @@ const StructuredList: React.FC<Props> = ({
   className,
   dynamicRows,
   verticalCellPadding,
-  valueCellPadding,
+  valueCellLeftPadding,
   dataTestId,
   onVerticalScrollStartReach,
   onVerticalScrollEndReach,
@@ -124,7 +124,7 @@ const StructuredList: React.FC<Props> = ({
             <StructuredRows
               rows={rows}
               verticalCellPadding={verticalCellPadding}
-              valueCellPadding={valueCellPadding}
+              valueCellLeftPadding={valueCellLeftPadding}
             />
           </div>
         </InfiniteScroller>

--- a/operate/client/src/modules/components/StructuredList/styled.tsx
+++ b/operate/client/src/modules/components/StructuredList/styled.tsx
@@ -18,12 +18,13 @@ type StructuredListCellProps = {
   $size?: 'sm' | 'md';
   $width?: string;
   $verticalCellPadding?: string;
+  $leftCellPadding?: string;
 };
 
 const StructuredListCell = styled(
   BaseStructuredListCell,
 )<StructuredListCellProps>`
-  ${({$size = 'md', $width, $verticalCellPadding}) => {
+  ${({$size = 'md', $width, $verticalCellPadding, $leftCellPadding}) => {
     return css`
       vertical-align: top;
       ${
@@ -43,6 +44,12 @@ const StructuredListCell = styled(
         css`
           padding-top: ${$verticalCellPadding} !important;
           padding-bottom: ${$verticalCellPadding} !important;
+        `
+      }
+      ${
+        $leftCellPadding &&
+        css`
+          padding-left: ${$leftCellPadding} !important;
         `
       }
     `;


### PR DESCRIPTION
## What

The flow node **Details** popover (Element Instance Key, Execution Duration, Retries Left, Incident details, etc.) renders each value flush against the left edge of its cell, making it harder to scan long values — matching the mockup attached to #32827.

## Fix

Adds an opt-in `valueCellPadding` prop to the shared `StructuredList` component, applied only to the second ("Value") column of each row, and sets it to `8px` in the Details tab (`DetailsTab/index.tsx`). `StructuredList` is also used by six other places in Operate (Variables tab, Decision Instance Inputs/Outputs, Input/Output Mappings, Listeners, Process/Decision Operations) — none of them pass the new prop, so their rendering is unaffected.

## Testing

- Added `StructuredList/index.test.tsx` covering that the padding applies only to the value column, and only when the prop is set.
- `npx vitest run` on `StructuredList`, `DetailsTab`, and the wider `BottomPanelTabs`/`Decisions` suites — all pre-existing failures I saw are reproducible identically against unmodified `main` (locale-dependent number formatting and test timeouts unrelated to this change), confirmed by running the same suite with these files reverted to `main`.

Closes #32827

🤖 Generated with [Claude Code](https://claude.com/claude-code)