### PR TITLE
fix(operate): keep Result tab selected across decision switches

### DIFF
--- a/operate/client/src/App/DecisionInstance/VariablesPanel/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/index.test.tsx
@@ -143,4 +143,47 @@ describe('<VariablesPanel />', () => {
       }),
     ).not.toBeInTheDocument();
   });
+
+  it('should keep the Result tab selected when switching back to a decision with both tabs', async () => {
+    mockFetchDecisionInstance().withSuccess(invoiceClassification);
+
+    const {user, rerender} = render(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="1"
+        decisionDefinitionType="DECISION_TABLE"
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('tab', {name: /result/i}));
+    expect(await screen.findByTestId('monaco-editor')).toBeVisible();
+
+    // Switch to a literal expression decision, which only has a Result tab.
+    rerender(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="2"
+        decisionDefinitionType="LITERAL_EXPRESSION"
+      />,
+    );
+
+    expect(
+      screen.queryByRole('tab', {name: /inputs and outputs/i}),
+    ).not.toBeInTheDocument();
+
+    // Switch back to a decision with both tabs — Result should still be
+    // selected instead of resetting to Inputs and Outputs.
+    rerender(
+      <VariablesPanel
+        decisionEvaluationInstanceKey="1"
+        decisionDefinitionType="DECISION_TABLE"
+      />,
+    );
+
+    expect(
+      screen.getByRole('tab', {name: /result/i}),
+    ).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.getByRole('tab', {name: /inputs and outputs/i}),
+    ).toHaveAttribute('aria-selected', 'false');
+  });
 });

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/index.test.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/index.test.tsx
@@ -145,6 +145,9 @@ describe('<VariablesPanel />', () => {
   });
 
   it('should keep the Result tab selected when switching back to a decision with both tabs', async () => {
+    // A fresh mock is registered before each render below, since switching
+    // decisionEvaluationInstanceKey triggers a new GET request per render
+    // (mockFetchDecisionInstance's handlers are one-time use).
     mockFetchDecisionInstance().withSuccess(invoiceClassification);
 
     const {user, rerender} = render(
@@ -155,10 +158,15 @@ describe('<VariablesPanel />', () => {
       {wrapper: Wrapper},
     );
 
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('inputs-skeleton'),
+    );
+
     await user.click(screen.getByRole('tab', {name: /result/i}));
     expect(await screen.findByTestId('monaco-editor')).toBeVisible();
 
     // Switch to a literal expression decision, which only has a Result tab.
+    mockFetchDecisionInstance().withSuccess(literalExpression);
     rerender(
       <VariablesPanel
         decisionEvaluationInstanceKey="2"
@@ -167,11 +175,15 @@ describe('<VariablesPanel />', () => {
     );
 
     expect(
+      await screen.findByTestId('results-json-viewer'),
+    ).toBeInTheDocument();
+    expect(
       screen.queryByRole('tab', {name: /inputs and outputs/i}),
     ).not.toBeInTheDocument();
 
     // Switch back to a decision with both tabs — Result should still be
     // selected instead of resetting to Inputs and Outputs.
+    mockFetchDecisionInstance().withSuccess(invoiceClassification);
     rerender(
       <VariablesPanel
         decisionEvaluationInstanceKey="1"
@@ -180,7 +192,7 @@ describe('<VariablesPanel />', () => {
     );
 
     expect(
-      screen.getByRole('tab', {name: /result/i}),
+      await screen.findByRole('tab', {name: /result/i}),
     ).toHaveAttribute('aria-selected', 'true');
     expect(
       screen.getByRole('tab', {name: /inputs and outputs/i}),

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import {TabView} from 'modules/components/TabView';
 import {InputsAndOutputs} from './InputsAndOutputs';
 import {Result} from './Result';
@@ -21,6 +21,10 @@ const VariablesPanel: React.FC<VariablesPanelProps> = ({
   decisionEvaluationInstanceKey,
   decisionDefinitionType,
 }) => {
+  const [lastSelectedTabId, setLastSelectedTabId] = useState<
+    string | undefined
+  >(undefined);
+
   const tabs = useMemo(() => {
     let tabs: React.ComponentProps<typeof TabView>['tabs'] = [
       {
@@ -51,11 +55,25 @@ const VariablesPanel: React.FC<VariablesPanelProps> = ({
     return tabs;
   }, [decisionDefinitionType, decisionEvaluationInstanceKey]);
 
+  // Preserve the previously selected tab (e.g. "Result") when switching
+  // between decisions. Left undefined until the user actually picks a tab,
+  // so the default tab order (Inputs and Outputs first) is unaffected; once
+  // set, falls back to letting TabView pick the default again if the newly
+  // selected decision doesn't have that tab (e.g. a literal expression
+  // decision, which has no "Inputs and Outputs" tab).
+  const activeTabId =
+    lastSelectedTabId !== undefined &&
+    tabs.some(({id}) => id === lastSelectedTabId)
+      ? lastSelectedTabId
+      : undefined;
+
   return (
     <TabView
       dataTestId="decision-instance-variables-panel"
       tabs={tabs}
       eventName="variables-panel-used"
+      activeTabId={activeTabId}
+      onTabChange={setLastSelectedTabId}
     />
   );
 };

--- a/operate/client/src/modules/components/TabView/index.tsx
+++ b/operate/client/src/modules/components/TabView/index.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useState} from 'react';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container, Tab, Content, TabPanel, TabList} from './styled';
 import {tracking} from 'modules/tracking';
@@ -25,6 +26,11 @@ type Props<TabId extends string = string> = {
   tabs: TabType<TabId>[];
   eventName?: 'variables-panel-used';
   dataTestId?: string;
+  /**
+   * Id of the tab that should be selected. Left unset (or pointing at a
+   * tab that no longer exists), defaults to the first tab.
+   */
+  activeTabId?: TabId;
   onTabChange?: (id: TabId) => void;
 };
 
@@ -32,8 +38,24 @@ function TabView<TabId extends string = string>({
   tabs = [],
   eventName,
   dataTestId,
+  activeTabId,
   onTabChange,
 }: Props<TabId>) {
+  // Falls back to internal state so TabView still behaves as an
+  // uncontrolled component when the caller doesn't pass `activeTabId`.
+  const [internalActiveTabId, setInternalActiveTabId] = useState<
+    TabId | undefined
+  >(undefined);
+  const effectiveActiveTabId = activeTabId ?? internalActiveTabId;
+
+  const selectedIndex =
+    effectiveActiveTabId === undefined
+      ? 0
+      : Math.max(
+          0,
+          tabs.findIndex(({id}) => id === effectiveActiveTabId),
+        );
+
   return (
     <Container data-testid={dataTestId}>
       {tabs.length === 1 && tabs[0] !== undefined ? (
@@ -42,23 +64,27 @@ function TabView<TabId extends string = string>({
           <Content>{tabs[0].content}</Content>
         </>
       ) : (
-        <Tabs>
+        <Tabs
+          selectedIndex={selectedIndex}
+          onChange={({selectedIndex: newIndex}) => {
+            const tab = tabs[newIndex];
+            if (tab === undefined) {
+              return;
+            }
+            tab.onClick?.();
+            setInternalActiveTabId(tab.id);
+            onTabChange?.(tab.id);
+            if (eventName !== undefined) {
+              tracking.track({
+                eventName,
+                toTab: tab.id,
+              });
+            }
+          }}
+        >
           <TabList aria-label="Variable Panel Tabs">
-            {tabs.map(({id, labelIcon, label, testId, onClick}) => (
-              <Tab
-                key={id}
-                data-testid={testId}
-                onClick={() => {
-                  onClick?.();
-                  onTabChange?.(id);
-                  if (eventName !== undefined) {
-                    tracking.track({
-                      eventName,
-                      toTab: id,
-                    });
-                  }
-                }}
-              >
+            {tabs.map(({id, labelIcon, label, testId}) => (
+              <Tab key={id} data-testid={testId}>
                 <Stack orientation="horizontal" gap={3}>
                   {label}
                   {labelIcon}


### PR DESCRIPTION
## What

In the Decision Instance view, switching between decisions that both have an "Inputs and Outputs" tab, via a decision that only has "Result" (a `LITERAL_EXPRESSION` decision, rendered without the tab strip at all), resets the tab selection to "Inputs and Outputs" — even if the user had explicitly selected "Result" before. Reported in #32875 with concrete repro steps.

## Root cause

`VariablesPanel` rendered Carbon's `<Tabs>` uncontrolled (via the shared `TabView` component), so `Tabs` always initializes to index 0 on every render where the tab list changes shape. Since a literal-expression decision only has one tab (bypassing `<Tabs>` entirely, see `TabView`'s single-tab branch) and a two-tab decision always mounts `<Tabs>` fresh, switching decisions repeatedly always lands back on the first tab.

## Fix

- `TabView` gains an optional `activeTabId` prop, making tab selection controllable while still behaving exactly as before (self-managed, defaulting to the first tab) when the prop isn't passed.
- `VariablesPanel` tracks the last tab id the user actually clicked and passes it back in as `activeTabId`, falling back to the default first tab when the newly selected decision doesn't have that tab.

## Testing

- Added a regression test in `VariablesPanel/index.test.tsx` reproducing the exact repro: select Result → switch to a literal-expression decision → switch back to a two-tab decision → assert Result is still selected.
- `npx vitest run` on `TabView` and `VariablesPanel` — all green, no new warnings.
- Ran the wider `BottomPanelTabs`/`Decisions` suites; the failures present are reproducible identically against unmodified `main` (locale-dependent number formatting and test timeouts unrelated to this change).

Closes #32875

🤖 Generated with [Claude Code](https://claude.com/claude-code)