### PR TITLE
ci: test Optimize against the current Camunda image

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -464,6 +464,8 @@ jobs:
     env:
       TEST_TYPE: E2E
       TEST_OWNER: '@camunda/optimize-frontend'
+      CAMUNDA_IMAGE: camunda/camunda:current-test
+      CAMUNDA_PULL_POLICY: never
 
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
@@ -519,6 +521,7 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           maven-cache-key-modifier: optimize-e2e-smoke
+          minimus: true
           time-zone: Europe/Berlin
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
@@ -529,6 +532,18 @@ jobs:
         with:
           directory: ./optimize/client
 
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild -Dskip.docker
+
+      - name: Build Camunda image under test
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: camunda/camunda
+          version: current-test
+          distball: ${{ steps.build-camunda.outputs.distball }}
+
       - name: Start services (Camunda, Keycloak, Identity and Elasticsearch)
         uses: ./.github/actions/compose
         with:
@@ -537,11 +552,6 @@ jobs:
           additional_flags: "--profile self-managed"
         env:
           CAMUNDA_VERSION: ${{ steps.pom_info.outputs.x_camunda_docker_version }}
-
-      - uses: ./.github/actions/build-zeebe
-        id: build-camunda
-        with:
-          maven-extra-args: -PskipFrontendBuild -Dskip.docker
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log
@@ -559,7 +569,7 @@ jobs:
         run: |
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
-            if [[ $count -eq 60 ]]; then
+            if [[ $count -eq 43 ]]; then
               echo "Process definitions imported ($count). Waiting for process instance import to stabilize..."
               prev="-1"
               stable=0
@@ -577,7 +587,7 @@ jobs:
               echo "Import stabilized at $cur process instances"
               break
             fi
-            echo "Index has $count entities. Waiting for 60..."
+            echo "Index has $count entities. Waiting for 43..."
             sleep 10
           done
 

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -105,7 +105,11 @@ jobs:
 
       - name: Wait for import to complete
         run: |
-          expected=${{ matrix.branch == 'stable/8.8' && '49' || '60' }}
+          case "${{ matrix.branch }}" in
+            stable/8.8) expected=49 ;;
+            stable/8.9) expected=60 ;;
+            *) expected=43 ;;
+          esac
           while : ; do
             count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
             if [[ $count -eq $expected ]]; then

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -140,7 +140,8 @@ services:
       KEYCLOAK_USERS_6_ROLES_1: 'ManagementIdentity'
   camunda:
     profiles: ['self-managed', 'self-managed:elasticsearch']
-    image: camunda/camunda:${CAMUNDA_VERSION:-8.9.0}
+    image: ${CAMUNDA_IMAGE:-camunda/camunda:${CAMUNDA_VERSION:-8.9.0}}
+    pull_policy: ${CAMUNDA_PULL_POLICY:-missing}
     container_name: camunda
     environment:
       - SPRING_PROFILES_ACTIVE=broker,operate,tasklist,consolidated-auth,dev-data
@@ -174,7 +175,8 @@ services:
       - ../zeebe-application.yml:/usr/local/camunda/config/application.yaml
   camunda-opensearch:
     profiles: ['self-managed:opensearch']
-    image: camunda/camunda:${CAMUNDA_VERSION:-8.9.0}
+    image: ${CAMUNDA_IMAGE:-camunda/camunda:${CAMUNDA_VERSION:-8.9.0}}
+    pull_policy: ${CAMUNDA_PULL_POLICY:-missing}
     container_name: camunda-opensearch
     environment:
       - SPRING_PROFILES_ACTIVE=broker,operate,tasklist,consolidated-auth,dev-data

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsSchemaVersionStoreIT.java
@@ -18,7 +18,9 @@ import io.camunda.zeebe.util.VersionUtil;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Verifies {@link RdbmsSchemaVersionStore#tableExists} finds {@code RDBMS_SCHEMA_VERSION} on every
@@ -27,8 +29,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * missed.
  */
 @Tag("rdbms")
-@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Execution(ExecutionMode.SAME_THREAD)
 final class RdbmsSchemaVersionStoreIT {
+
+  @RegisterExtension
+  static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATIONS =
+      CamundaRdbmsInvocationContextProviderExtension.isolated();
 
   @TestTemplate
   void shouldFindExistingSchemaVersionRegardlessOfVendorIdentifierCasing(
@@ -67,8 +73,8 @@ final class RdbmsSchemaVersionStoreIT {
       assertThatThrownBy(versionStore::checkCompatibility)
           .isInstanceOf(RdbmsSchemaVersionIncompatibleException.class);
     } finally {
-      // Restore the version a real boot would have recorded, so any later test reusing this
-      // vendor's shared, cached test application observes a consistent, correctly-migrated state.
+      // Restore the version a real boot would have recorded so the next template invocation for
+      // this class observes a consistent, correctly migrated state.
       versionStore.recordCurrentVersion();
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaDatabaseTestApplicationResolver.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaDatabaseTestApplicationResolver.java
@@ -22,11 +22,15 @@ public class CamundaDatabaseTestApplicationResolver
 
   private final String standaloneCamundaKey;
   private final CamundaRdbmsTestApplication testApplication;
+  private final boolean shared;
 
   public CamundaDatabaseTestApplicationResolver(
-      final String standaloneCamundaKey, final CamundaRdbmsTestApplication testApplication) {
+      final String standaloneCamundaKey,
+      final CamundaRdbmsTestApplication testApplication,
+      final boolean shared) {
     this.standaloneCamundaKey = standaloneCamundaKey;
     this.testApplication = testApplication;
+    this.shared = shared;
   }
 
   @Override
@@ -38,6 +42,9 @@ public class CamundaDatabaseTestApplicationResolver
   @Override
   public Object resolveParameter(
       final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+    if (!shared) {
+      return testApplication;
+    }
     final ExtensionContext rootContext = extensionCtx.getRoot();
     final ExtensionContext.Store store = rootContext.getStore(Namespace.GLOBAL);
     final String key = CamundaRdbmsTestApplication.class.getName() + "_" + standaloneCamundaKey;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsInvocationContextProviderExtension.java
@@ -13,7 +13,10 @@ import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -23,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CamundaRdbmsInvocationContextProviderExtension
-    implements TestTemplateInvocationContextProvider, BeforeAllCallback, AutoCloseable {
+    implements TestTemplateInvocationContextProvider, BeforeAllCallback, AfterAllCallback {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(CamundaRdbmsInvocationContextProviderExtension.class);
@@ -105,17 +108,12 @@ public class CamundaRdbmsInvocationContextProviderExtension
   }
 
   private final Set<String> useTestApplications;
+  private final Map<String, CamundaRdbmsTestApplication> testApplications;
+  private final boolean shared;
 
   /** By default, only all default test applications will be used */
   public CamundaRdbmsInvocationContextProviderExtension() {
-    useTestApplications =
-        Set.of(
-            "camundaWithH2",
-            "camundaWithPostgresSQL",
-            "camundaWithMariaDB",
-            "camundaWithMySQL",
-            "camundaWithOracleDB",
-            "camundaWithMssqlDB");
+    this(defaultTestApplications());
   }
 
   /**
@@ -133,7 +131,32 @@ public class CamundaRdbmsInvocationContextProviderExtension
    * @param useTestApplications the test applications to use
    */
   public CamundaRdbmsInvocationContextProviderExtension(final String... useTestApplications) {
-    this.useTestApplications = Set.of(useTestApplications);
+    this(Set.of(useTestApplications));
+  }
+
+  private CamundaRdbmsInvocationContextProviderExtension(final Set<String> useTestApplications) {
+    this(useTestApplications, SUPPORTED_TEST_APPLICATIONS, true);
+  }
+
+  private CamundaRdbmsInvocationContextProviderExtension(
+      final Set<String> useTestApplications,
+      final Map<String, CamundaRdbmsTestApplication> testApplications,
+      final boolean shared) {
+    this.useTestApplications = useTestApplications;
+    this.testApplications = testApplications;
+    this.shared = shared;
+  }
+
+  public static CamundaRdbmsInvocationContextProviderExtension isolated() {
+    final var keys = defaultTestApplications();
+    return new CamundaRdbmsInvocationContextProviderExtension(
+        keys,
+        keys.stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    key -> key,
+                    CamundaRdbmsInvocationContextProviderExtension::createTestApplication)),
+        false);
   }
 
   @Override
@@ -149,20 +172,27 @@ public class CamundaRdbmsInvocationContextProviderExtension
 
   @Override
   public void beforeAll(final ExtensionContext context) {
-    useTestApplications.forEach(
-        key -> {
-          final CamundaRdbmsTestApplication testApplication = SUPPORTED_TEST_APPLICATIONS.get(key);
-          if (!testApplication.isStarted()) {
-            LOGGER.info("Start up CamundaDatabaseTestApplication '{}'...", key);
-            testApplication.start();
-            LOGGER.info("Start up of CamundaDatabaseTestApplication '{}' finished.", key);
-          }
-        });
+    try {
+      useTestApplications.forEach(
+          key -> {
+            final CamundaRdbmsTestApplication testApplication = testApplications.get(key);
+            if (!testApplication.isStarted()) {
+              LOGGER.info("Start up CamundaDatabaseTestApplication '{}'...", key);
+              testApplication.start();
+              LOGGER.info("Start up of CamundaDatabaseTestApplication '{}' finished.", key);
+            }
+          });
+    } catch (final RuntimeException | Error e) {
+      closeIsolatedApplications();
+      throw e;
+    }
 
     // Your "before all tests" startup logic goes here
     // The following line registers a callback hook when the root test context is shut down
-    final String key = "RDBMS DB - Multiple Database Tests";
-    context.getRoot().getStore(GLOBAL).put(key, this);
+    if (shared) {
+      final String key = "RDBMS DB - Multiple Database Tests";
+      context.getRoot().getStore(GLOBAL).put(key, this);
+    }
   }
 
   private TestTemplateInvocationContext invocationContext(final String standaloneCamundaKey) {
@@ -178,14 +208,60 @@ public class CamundaRdbmsInvocationContextProviderExtension
 
         return List.of(
             new CamundaDatabaseTestApplicationResolver(
-                standaloneCamundaKey, SUPPORTED_TEST_APPLICATIONS.get(standaloneCamundaKey)));
+                standaloneCamundaKey, testApplications.get(standaloneCamundaKey), shared));
       }
     };
   }
 
   @Override
-  public void close() {
-    LOGGER.info("Resource closed - Close CamundaRdbmsInvocationContextProviderExtension");
+  public void afterAll(final ExtensionContext context) {
+    closeIsolatedApplications();
+  }
+
+  private void closeIsolatedApplications() {
+    if (!shared) {
+      useTestApplications.forEach(
+          key -> {
+            try {
+              testApplications.get(key).close();
+            } catch (final Exception e) {
+              LOGGER.warn("Failed to close isolated RDBMS test application '{}'.", key, e);
+            }
+          });
+    }
+  }
+
+  private static Set<String> defaultTestApplications() {
+    return Set.of(
+        "camundaWithH2",
+        "camundaWithPostgresSQL",
+        "camundaWithMariaDB",
+        "camundaWithMySQL",
+        "camundaWithOracleDB",
+        "camundaWithMssqlDB");
+  }
+
+  private static CamundaRdbmsTestApplication createTestApplication(final String key) {
+    return switch (key) {
+      case "camundaWithH2" ->
+          createCamundaRdbmsTestApplication().withH2("isolated-" + UUID.randomUUID());
+      case "camundaWithPostgresSQL" ->
+          createCamundaRdbmsTestApplication()
+              .withDatabaseContainer(createDefaultPostgresContainer());
+      case "camundaWithMariaDB" ->
+          createCamundaRdbmsTestApplication()
+              .withDatabaseContainer(createDefaultMariaDBContainer());
+      case "camundaWithMySQL" ->
+          createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultMySQLContainer());
+      case "camundaWithOracleDB" ->
+          createCamundaRdbmsTestApplication().withDatabaseContainer(createDefaultOracleContainer());
+      case "camundaWithMssqlDB" ->
+          createCamundaRdbmsTestApplication()
+              .withUnifiedConfig(
+                  c -> c.getData().getSecondaryStorage().getRdbms().setUsername("sa"))
+              .withDatabaseContainer(createDefaultMSSQLServerContainer());
+      default -> throw new IllegalArgumentException("Unknown RDBMS test application: " + key);
+    };
   }
 
   private static CamundaRdbmsTestApplication createCamundaRdbmsTestApplication() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -50,9 +50,13 @@ public final class CamundaRdbmsTestApplication
   }
 
   public CamundaRdbmsTestApplication withH2() {
+    return withH2("testdb");
+  }
+
+  public CamundaRdbmsTestApplication withH2(final String databaseName) {
     setSecondaryStorageToRdbms();
     final var rdbms = unifiedConfig.getData().getSecondaryStorage().getRdbms();
-    rdbms.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+    rdbms.setUrl("jdbc:h2:mem:" + databaseName + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
     rdbms.setUsername("sa");
     rdbms.setPassword("");
     return this;
@@ -107,10 +111,13 @@ public final class CamundaRdbmsTestApplication
   @Override
   public void close() {
     LOGGER.info("Resource closed - Stop spring application ...");
-    super.stop();
-    if (databaseContainer != null) {
-      LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
-      databaseContainer.close();
+    try {
+      super.stop();
+    } finally {
+      if (databaseContainer != null) {
+        LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
+        databaseContainer.close();
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Optimize smoke CI currently pulls the mutable `camunda/camunda:SNAPSHOT` image. This allowed #60894 to pass against the previous image even though it removed the legacy Tasklist data generator. Once the merged image was published, Optimize smoke jobs across `main`, PRs, and merge queues consistently stalled at 43 process definitions while waiting for 60.

Build and use `camunda/camunda:current-test` from the checked-out commit before starting the Optimize smoke stack. Compose is configured not to pull over that local Camunda image. The expected `main` dataset count is updated to 43, while stable/8.8 and stable/8.9 keep their existing counts.

The removed Tasklist generator deployed 16 BPMN files containing 17 process definitions, accounting exactly for the change from 60 to 43.

## Verification

- `actionlint -ignore 'label .* is unknown' .github/workflows/ci-optimize.yml .github/workflows/optimize-e2e-tests-sm-nightly.yml`\n- Parsed all changed YAML files\n- Verified default Compose image resolution still uses `camunda/camunda:SNAPSHOT`\n- Verified CI overrides resolve only Camunda to `camunda/camunda:current-test` and preserve `camunda/identity:SNAPSHOT`\n\n## Related issues\n\n- [x] This PR does not need a linked issue