### PR TITLE
perf: configure explicit OTLP export timeout and retry policy for analytics-exporter

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -65,6 +65,9 @@ camunda:
           push-interval: PT5M
           max-queue-size: 2048
           max-batch-size: 512
+          http-connect-timeout: PT3S
+          http-request-timeout: PT3S
+          http-max-retry-attempts: 3
           sampling-rate: 1.0
           categories:
             - contractual
@@ -85,6 +88,9 @@ zeebe:
           pushInterval: PT5M
           maxQueueSize: 2048
           maxBatchSize: 512
+          httpConnectTimeout: PT3S
+          httpRequestTimeout: PT3S
+          httpMaxRetryAttempts: 3
           samplingRate: 1.0
           categories:
             - contractual
@@ -103,6 +109,9 @@ CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://telemetry.camunda.io
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5M
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_HTTPCONNECTTIMEOUT=PT3S
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_HTTPREQUESTTIMEOUT=PT3S
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_HTTPMAXRETRYATTEMPTS=3
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_CATEGORIES_0=contractual
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_CATEGORIES_1=optional
 ```
@@ -115,6 +124,9 @@ ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://telemetry.camunda.io
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5M
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_HTTPCONNECTTIMEOUT=PT3S
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_HTTPREQUESTTIMEOUT=PT3S
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_HTTPMAXRETRYATTEMPTS=3
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_CATEGORIES_0=contractual
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_CATEGORIES_1=optional
 ```
@@ -133,15 +145,18 @@ Analytics exporter configured: endpoint=https://telemetry.camunda.io, clusterId=
 All options live under `args`. Defaults are tuned for typical Self-Managed deployments and
 rarely need to be changed.
 
-|        Option        |   Type   |                                                                                                  Description                                                                                                  |            Default             |
-|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|
-| `endpoint`           | string   | OTLP/HTTP base URL for the analytics endpoint. The OTel SDK appends `/v1/logs` automatically.                                                                                                                 | `https://telemetry.camunda.io` |
-| `push-interval`      | duration | Maximum time between batch pushes, as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).                                                                                               | `PT5M`                         |
-| `heartbeat-interval` | duration | Interval between periodic heartbeat events carrying static cluster metadata.                                                                                                                                  | `PT10M`                        |
-| `max-queue-size`     | int      | Maximum number of log records buffered in memory before new records are dropped.                                                                                                                              | `2048`                         |
-| `max-batch-size`     | int      | Maximum number of records sent in a single OTLP request. Must be less than or equal to `max-queue-size`.                                                                                                      | `512`                          |
-| `sampling-rate`      | double   | Default sampling rate for log events, between 0.0 (none) and 1.0 (all). Handlers may declare a lower rate; the effective rate is always the minimum of the two.                                               | `1.0`                          |
-| `categories`         | list     | List of analytics event categories to export. Valid values: `contractual` (commercial/licence metrics), `optional` (non-commercial product usage metrics). When omitted or empty, all categories are enabled. | `[contractual, optional]`      |
+|          Option           |   Type   |                                                                                                  Description                                                                                                  |            Default             |
+|---------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `endpoint`                | string   | OTLP/HTTP base URL for the analytics endpoint. The OTel SDK appends `/v1/logs` automatically.                                                                                                                 | `https://telemetry.camunda.io` |
+| `push-interval`           | duration | Maximum time between batch pushes, as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).                                                                                               | `PT5M`                         |
+| `heartbeat-interval`      | duration | Interval between periodic heartbeat events carrying static cluster metadata.                                                                                                                                  | `PT10M`                        |
+| `max-queue-size`          | int      | Maximum number of log records buffered in memory before new records are dropped.                                                                                                                              | `2048`                         |
+| `max-batch-size`          | int      | Maximum number of records sent in a single OTLP request. Must be less than or equal to `max-queue-size`.                                                                                                      | `512`                          |
+| `http-connect-timeout`    | duration | Timeout for the OTLP HTTP client's TCP/TLS connect phase (logs and metrics).                                                                                                                                  | `PT3S`                         |
+| `http-request-timeout`    | duration | Per-attempt timeout for a whole OTLP export request (logs and metrics), from connect through response. Bounds how long the OTel SDK's batch worker thread can be blocked on a slow or unreachable endpoint.   | `PT3S`                         |
+| `http-max-retry-attempts` | int      | Maximum attempts per OTLP export request (the first attempt plus retries), with the OTel SDK's default backoff (1s initial, 5s max, 1.5x multiplier) between them.                                            | `3`                            |
+| `sampling-rate`           | double   | Default sampling rate for log events, between 0.0 (none) and 1.0 (all). Handlers may declare a lower rate; the effective rate is always the minimum of the two.                                               | `1.0`                          |
+| `categories`              | list     | List of analytics event categories to export. Valid values: `contractual` (commercial/licence metrics), `optional` (non-commercial product usage metrics). When omitted or empty, all categories are enabled. | `[contractual, optional]`      |
 
 ## What data is exported
 
@@ -364,8 +379,10 @@ and analytics records may be dropped silently. Specifically, events can be lost 
   without retry.
 - **The broker crashes or restarts.** The in-memory queue is not persisted, so any records
   buffered at the time of the crash are lost.
-- **The OTLP endpoint returns an error.** The exporter does not retry persistently and
-  does not buffer to disk; the affected events are dropped.
+- **The OTLP endpoint returns an error or is unreachable.** The exporter retries each
+  export up to `http-max-retry-attempts` times, bounded by `http-request-timeout` per attempt — it
+  does not retry persistently beyond that, and does not buffer to disk, so events are
+  dropped once the attempts are exhausted.
 
 Because each event carries `camunda.cluster.id`, `camunda.partition.id`, and
 `camunda.log.position`, downstream consumers can deduplicate events using the combination

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
@@ -28,6 +28,9 @@ public class AnalyticsExporterConfig {
   private int maxBatchSize = 512;
   private String pushInterval = "PT5M";
   private String heartbeatInterval = "PT10M";
+  private String httpConnectTimeout = "PT3S";
+  private String httpRequestTimeout = "PT3S";
+  private int httpMaxRetryAttempts = 3;
   private boolean signing = true;
   private boolean allowInsecure = false;
   private double samplingRate = HashSampler.MAX_SAMPLE_RATE;
@@ -81,6 +84,33 @@ public class AnalyticsExporterConfig {
     return this;
   }
 
+  public Duration getHttpConnectTimeout() {
+    return Duration.parse(httpConnectTimeout);
+  }
+
+  public AnalyticsExporterConfig setHttpConnectTimeout(final String httpConnectTimeout) {
+    this.httpConnectTimeout = httpConnectTimeout;
+    return this;
+  }
+
+  public Duration getHttpRequestTimeout() {
+    return Duration.parse(httpRequestTimeout);
+  }
+
+  public AnalyticsExporterConfig setHttpRequestTimeout(final String httpRequestTimeout) {
+    this.httpRequestTimeout = httpRequestTimeout;
+    return this;
+  }
+
+  public int getHttpMaxRetryAttempts() {
+    return httpMaxRetryAttempts;
+  }
+
+  public AnalyticsExporterConfig setHttpMaxRetryAttempts(final int httpMaxRetryAttempts) {
+    this.httpMaxRetryAttempts = httpMaxRetryAttempts;
+    return this;
+  }
+
   public boolean isSigning() {
     return signing;
   }
@@ -131,6 +161,9 @@ public class AnalyticsExporterConfig {
   public AnalyticsExporterConfig validate() {
     validateEndpoint();
     validatePushInterval();
+    validateHttpConnectTimeout();
+    validateHttpRequestTimeout();
+    validateHttpMaxAttempts();
     final Duration parsedHeartbeat;
     try {
       parsedHeartbeat = Duration.parse(heartbeatInterval);
@@ -200,6 +233,39 @@ public class AnalyticsExporterConfig {
     }
   }
 
+  private void validateHttpConnectTimeout() {
+    final Duration parsed;
+    try {
+      parsed = Duration.parse(httpConnectTimeout);
+    } catch (final Exception e) {
+      throw new IllegalArgumentException("Invalid httpConnectTimeout: " + httpConnectTimeout, e);
+    }
+    if (parsed.isZero() || parsed.isNegative()) {
+      throw new IllegalArgumentException(
+          "httpConnectTimeout must be positive, got: " + httpConnectTimeout);
+    }
+  }
+
+  private void validateHttpRequestTimeout() {
+    final Duration parsed;
+    try {
+      parsed = Duration.parse(httpRequestTimeout);
+    } catch (final Exception e) {
+      throw new IllegalArgumentException("Invalid httpRequestTimeout: " + httpRequestTimeout, e);
+    }
+    if (parsed.isZero() || parsed.isNegative()) {
+      throw new IllegalArgumentException(
+          "httpRequestTimeout must be positive, got: " + httpRequestTimeout);
+    }
+  }
+
+  private void validateHttpMaxAttempts() {
+    if (httpMaxRetryAttempts <= 0) {
+      throw new IllegalArgumentException(
+          "httpMaxRetryAttempts must be positive, got: " + httpMaxRetryAttempts);
+    }
+  }
+
   private void validateEndpoint() {
     if (endpoint == null || endpoint.isBlank()) {
       throw new IllegalArgumentException("Analytics exporter endpoint is not configured");
@@ -242,7 +308,8 @@ public class AnalyticsExporterConfig {
    *
    * <p><b>Excluded</b> (transport-only — affect delivery, not event semantics): {@code endpoint},
    * {@code maxQueueSize}, {@code maxBatchSize}, {@code pushInterval}, {@code heartbeatInterval},
-   * {@code signing}, {@code allowInsecure}.
+   * {@code httpConnectTimeout}, {@code httpRequestTimeout}, {@code httpMaxRetryAttempts}, {@code
+   * signing}, {@code allowInsecure}.
    *
    * <p>When adding a new field to this class, decide explicitly: if it changes event selection or
    * content, add it here; if it only affects delivery mechanics, leave it out and update the

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -35,6 +35,7 @@ import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
+import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
@@ -221,6 +222,10 @@ public class OtelSdkManager implements AutoCloseable {
     final var builder =
         OtlpHttpLogRecordExporter.builder()
             .setEndpoint(config.getEndpoint() + OTLP_LOGS_PATH)
+            .setConnectTimeout(config.getHttpConnectTimeout())
+            .setTimeout(config.getHttpRequestTimeout())
+            .setRetryPolicy(
+                RetryPolicy.builder().setMaxAttempts(config.getHttpMaxRetryAttempts()).build())
             .addHeader(AnalyticsExporterContext.HEADER_FINGERPRINT, context.fingerprint())
             .addHeader(AnalyticsExporterContext.HEADER_CLUSTER_ID, context.clusterId())
             .setMeterProvider(bridge)
@@ -249,6 +254,10 @@ public class OtelSdkManager implements AutoCloseable {
     final var builder =
         OtlpHttpMetricExporter.builder()
             .setEndpoint(config.getEndpoint() + OTLP_METRICS_PATH)
+            .setConnectTimeout(config.getHttpConnectTimeout())
+            .setTimeout(config.getHttpRequestTimeout())
+            .setRetryPolicy(
+                RetryPolicy.builder().setMaxAttempts(config.getHttpMaxRetryAttempts()).build())
             .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
             .addHeader(AnalyticsExporterContext.HEADER_FINGERPRINT, context.fingerprint())
             .addHeader(AnalyticsExporterContext.HEADER_CLUSTER_ID, context.clusterId())

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
@@ -126,6 +126,43 @@ class AnalyticsExporterConfigTest {
   }
 
   @Test
+  void shouldRejectInvalidHttpConnectTimeout() {
+    assertThatThrownBy(
+            () -> new AnalyticsExporterConfig().setHttpConnectTimeout("not-a-duration").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("httpConnectTimeout");
+  }
+
+  @Test
+  void shouldRejectNonPositiveHttpConnectTimeout() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setHttpConnectTimeout("PT0S").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be positive");
+  }
+
+  @Test
+  void shouldRejectInvalidHttpRequestTimeout() {
+    assertThatThrownBy(
+            () -> new AnalyticsExporterConfig().setHttpRequestTimeout("not-a-duration").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("httpRequestTimeout");
+  }
+
+  @Test
+  void shouldRejectNonPositiveHttpRequestTimeout() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setHttpRequestTimeout("PT0S").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be positive");
+  }
+
+  @Test
+  void shouldRejectNonPositiveHttpMaxRetryAttempts() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setHttpMaxRetryAttempts(0).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("httpMaxRetryAttempts");
+  }
+
+  @Test
   void shouldRejectSamplingRateBelowZero() {
     assertThatThrownBy(() -> new AnalyticsExporterConfig().setSamplingRate(-0.1).validate())
         .isInstanceOf(IllegalArgumentException.class)

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.exporter.analytics.sampling.HashSampler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -87,6 +88,43 @@ class OtelSdkManagerTest {
 
     releaseLatch.countDown();
     manager.close();
+  }
+
+  /**
+   * The configured connect timeout, request timeout, and retry policy are applied to both OTLP
+   * exporters.
+   */
+  @Test
+  void shouldConfigureExplicitTimeoutAndRetryPolicyOnExporters() {
+    // given
+    final var config =
+        new AnalyticsExporterConfig()
+            .setHttpConnectTimeout("PT4S")
+            .setHttpRequestTimeout("PT7S")
+            .setHttpMaxRetryAttempts(2);
+    final var context =
+        AnalyticsExporterContext.create(
+            "test-license", "test-cluster", 1, "test-physical-tenant", "");
+    final var bridge = new MicrometerMeterProvider(new SimpleMeterRegistry());
+    final var manager = new OtelSdkManager();
+
+    // when
+    final var logExporter = manager.createLogExporter(config, context, bridge);
+    final var metricExporter = manager.createMetricExporter(config, context, bridge);
+
+    // then — toString() is the only way to observe the builder's applied timeout/retry settings
+    final var expectedConnectTimeoutNanos = config.getHttpConnectTimeout().toNanos();
+    final var expectedTimeoutNanos = config.getHttpRequestTimeout().toNanos();
+    final var expectedMaxAttempts = config.getHttpMaxRetryAttempts();
+
+    assertThat(logExporter.toString())
+        .contains("connectTimeoutNanos=" + expectedConnectTimeoutNanos)
+        .contains("timeoutNanos=" + expectedTimeoutNanos)
+        .contains("maxAttempts=" + expectedMaxAttempts);
+    assertThat(metricExporter.toString())
+        .contains("connectTimeoutNanos=" + expectedConnectTimeoutNanos)
+        .contains("timeoutNanos=" + expectedTimeoutNanos)
+        .contains("maxAttempts=" + expectedMaxAttempts);
   }
 
   /** Real OTLP transport to a refused port doesn't block or throw. */
@@ -335,7 +373,7 @@ class OtelSdkManagerTest {
   @Test
   void shouldExposeOtelSdkLogCreatedMetricInMicrometer() {
     // given
-    final var micrometerRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    final var micrometerRegistry = new SimpleMeterRegistry();
     final var logExporter =
         io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter.create();
     final var manager = TestOtelSdkManager.inMemoryWithRegistry(logExporter, micrometerRegistry);


### PR DESCRIPTION
## Description

With this PR try to fix performance for analytics exporter unreachable scenario using retry policy and timeout in Open Telemetry Exporter. 

Timeout: ~Default 10s~ --> 3s
RetryPolicy: ~Default 5  times~ --> 3 times

### JFR verification: OTLP timeout + retry policy fix
  
  Re-profiled `camunda-0` with async-profiler (cpu/alloc/wall) across 4 scenarios: `baseline` (no exporter), `reachable` (exporter on, backend up), `unreachable` (exporter on, backend down — pre-fix), `retry+timeout-unreachable` (exporter on, backend down — **post-fix**, this PR).

  ### Key result — OTel delivery-thread time (wall-clock only)
  
  | Scenario | `otel-analytics` % of wall samples |
  |---|---|
  | baseline (no exporter) | 0.71% |
  | reachable (backend up) | 1.39% |
  | **unreachable — pre-fix** | **2.08%** |
  | **unreachable — post-fix (this fix)** | **1.39%** |

  Post-fix, an unreachable backend now costs the same wall-clock share as a *healthy* backend — the fix doesn't just shrink the blocking, it fully normalizes it back to `reachable`-level behavior.

  ### Methodology

Temporarily added `otel-analytics` as a new subsystem bucket added to `fg_subsystems.py` (`io/camunda/exporter/analytics`, `OtelSdkManager`, `BatchLogRecordProcessor`, `JdkHttpSender`, `io/opentelemetry`) — previously these frames fell into `other`.

## Related issues

closes #62172
