### PR TITLE
feat: Prepare CPT for version 8.11

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -29,6 +29,9 @@ jobs:
           - branch: stable/8.9
             camunda_image_version: 8.10-SNAPSHOT
             connectors_image_version: 8.10-SNAPSHOT
+          - branch: stable/8.10
+            camunda_image_version: 8.11-SNAPSHOT
+            connectors_image_version: 8.11-SNAPSHOT
     steps:
       - name: Trigger CPT compatibility tests
         env:

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -29,9 +29,9 @@ import java.util.Map;
 public class CamundaProcessTestRuntimeDefaults {
 
   public static final String DEFAULT_CAMUNDA_DOCKER_IMAGE_NAME = "camunda/camunda";
-  public static final String DEFAULT_CAMUNDA_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+  public static final String DEFAULT_CAMUNDA_DOCKER_IMAGE_VERSION = "8.11-SNAPSHOT";
   public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_NAME = "camunda/connectors-bundle";
-  public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+  public static final String DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION = "8.11-SNAPSHOT";
   public static final String DEFAULT_ELASTICSEARCH_VERSION = "8.19.16";
 
   public static final String DEFAULT_ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -40,6 +40,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class ContainerRuntimePropertiesUtilTest {
 
+  /** The expected Camunda/Connectors Docker image version of this branch. */
+  private static final String DEFAULT_SNAPSHOT_IMAGE_VERSION = "8.11-SNAPSHOT";
+
   @Test
   void shouldReturnDefaults() {
     // given
@@ -52,10 +55,12 @@ public class ContainerRuntimePropertiesUtilTest {
     // then
     assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("8.19.16");
     assertThat(propertiesUtil.getCamundaDockerImageName()).isEqualTo("camunda/camunda");
-    assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getCamundaDockerImageVersion())
+        .isEqualTo(DEFAULT_SNAPSHOT_IMAGE_VERSION);
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
-    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getConnectorsDockerImageVersion())
+        .isEqualTo(DEFAULT_SNAPSHOT_IMAGE_VERSION);
 
     assertThat(propertiesUtil.getCoverageReportProperties().getCoverageReportDirectory())
         .isEqualTo("target/coverage-report");
@@ -94,25 +99,12 @@ public class ContainerRuntimePropertiesUtilTest {
     // then
     assertThat(propertiesUtil.getElasticsearchVersion()).isEqualTo("8.19.16");
     assertThat(propertiesUtil.getCamundaDockerImageName()).isEqualTo("camunda/camunda");
-    assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getCamundaDockerImageVersion())
+        .isEqualTo(DEFAULT_SNAPSHOT_IMAGE_VERSION);
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
-    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
-  }
-
-  @ParameterizedTest
-  @CsvSource({"SNAPSHOT"})
-  void shouldReturnDefaultVersions(final String expectedVersion) {
-    // given
-    final Properties properties = new Properties();
-
-    // when
-    final ContainerRuntimePropertiesUtil propertiesUtil =
-        new ContainerRuntimePropertiesUtil(properties);
-
-    // then
-    assertThat(propertiesUtil.getCamundaDockerImageVersion()).isEqualTo(expectedVersion);
-    assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo(expectedVersion);
+    assertThat(propertiesUtil.getConnectorsDockerImageVersion())
+        .isEqualTo(DEFAULT_SNAPSHOT_IMAGE_VERSION);
   }
 
   @ParameterizedTest
@@ -165,10 +157,10 @@ public class ContainerRuntimePropertiesUtilTest {
     // patch releases
     "8.8.1, 8.8.1",
     // SNAPSHOT versions
-    "8.9.0-SNAPSHOT, SNAPSHOT",
-    "8.8.1-SNAPSHOT, SNAPSHOT",
-    "8.8.2-SNAPSHOT, SNAPSHOT",
-    "8.9.0-snapshot, SNAPSHOT",
+    "8.9.0-SNAPSHOT, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
+    "8.8.1-SNAPSHOT, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
+    "8.8.2-SNAPSHOT, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
+    "8.9.0-snapshot, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
     // rc/alpha versions
     "8.8.0-rc1, 8.8.0-rc1",
     "8.8.0-alpha1, 8.8.0-alpha1",
@@ -223,10 +215,10 @@ public class ContainerRuntimePropertiesUtilTest {
     // patch releases
     "8.8.1, 8.8.1",
     // SNAPSHOT versions
-    "8.9.0-SNAPSHOT, SNAPSHOT",
-    "8.8.1-SNAPSHOT, SNAPSHOT",
-    "8.8.2-SNAPSHOT, SNAPSHOT",
-    "8.9.0-snapshot, SNAPSHOT",
+    "8.9.0-SNAPSHOT, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
+    "8.8.1-SNAPSHOT, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
+    "8.8.2-SNAPSHOT, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
+    "8.9.0-snapshot, " + DEFAULT_SNAPSHOT_IMAGE_VERSION,
     // rc/alpha versions
     "8.8.0-rc1, 8.8.0-rc1",
     "8.8.0-alpha1, 8.8.0-alpha1",

--- a/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
+++ b/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://camunda.com/json-schema/cpt-test-cases/8.10/schema.json",
+  "$id": "https://camunda.com/json-schema/cpt-test-cases/8.11/schema.json",
   "title": "CPT JSON test cases",
   "description": "A collection of test cases to validate the business process in a JSON format compatible with Camunda Process Test (CPT).",
   "type": "object",


### PR DESCRIPTION
## Description

This PR prepares CPT for version 8.11 and aligns with the branch version. 

- Set the default Camunda and Connector versions to `8.11-SNAPSHOT`
- Dump CPT's JSON schema version to `8.11`
- Add a new CI job entry to run the compatibility tests on the `stable/8.10` branch

Part of CPT's release procedure: https://github.com/camunda/camunda/blob/main/testing/CONTRIBUTING.md#7-release-management

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

- [x] This PR does not need a linked issue

