### PR TITLE
ci: derive Optimize E2E import wait from the broker's actual state

### DIFF
--- a/.github/optimize/scripts/wait-for-import.sh
+++ b/.github/optimize/scripts/wait-for-import.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Waits for the Optimize E2E data import to complete, without depending on a hardcoded entity count
+# (the `dev-data` seed changes over time and per branch). Process definitions are gated against the
+# broker's authoritative count via the v2 API; instances have no clean source-of-truth count
+# (completion timing, retention) so their imported count is waited on until it settles.
+set -euo pipefail
+
+ZEEBE_URL="${ZEEBE_URL:-http://localhost:8080}"
+ES_URL="${ES_URL:-http://localhost:9200}"
+
+zeebe_definition_count() {
+  curl -sf -u demo:demo -H 'Content-Type: application/json' \
+    -X POST "${ZEEBE_URL}/v2/process-definitions/search" \
+    -d '{"page":{"limit":0}}' 2>/dev/null | jq '.page.totalItems // 0' || echo 0
+}
+
+optimize_count() {
+  curl -sf "${ES_URL}/$1/_count" 2>/dev/null | jq '.count // 0' || echo 0
+}
+
+# Wait for the broker's deployment to finish: count non-zero and stable across two reads.
+prev=-1; stable=0; expected=0
+for _ in $(seq 1 30); do
+  expected=$(zeebe_definition_count)
+  echo "Zeebe process definitions: ${expected}"
+  if [[ "$expected" -gt 0 && "$expected" == "$prev" ]]; then
+    stable=$((stable + 1))
+    [[ $stable -ge 2 ]] && break
+  else
+    stable=0
+  fi
+  prev="$expected"
+  sleep 10
+done
+if [[ "$expected" -le 0 ]]; then
+  echo "::error::Broker deployed no process definitions"; exit 1
+fi
+echo "Broker deployment settled at ${expected} process definitions"
+
+# Wait until Optimize has imported all of them (>= guards against Optimize holding extras).
+for _ in $(seq 1 30); do
+  cur=$(optimize_count optimize-process-definition)
+  echo "Optimize process definitions: ${cur}/${expected}"
+  [[ "$cur" -ge "$expected" ]] && break
+  sleep 10
+done
+cur=$(optimize_count optimize-process-definition)
+if [[ "$cur" -lt "$expected" ]]; then
+  echo "::error::Optimize imported only ${cur}/${expected} process definitions"; exit 1
+fi
+echo "Optimize imported all ${expected} process definitions"
+
+# Instances have no clean source-of-truth count, so wait for the imported count to settle non-zero.
+prev=-1; stable=0; cur=0
+for _ in $(seq 1 60); do
+  cur=$(optimize_count optimize-process-instance)
+  echo "Optimize process instances: ${cur}"
+  if [[ "$cur" -gt 0 && "$cur" == "$prev" ]]; then
+    stable=$((stable + 1))
+    [[ $stable -ge 2 ]] && break
+  else
+    stable=0
+  fi
+  prev="$cur"
+  sleep 10
+done
+echo "Process instance import stabilized at ${cur}"

--- a/.github/optimize/scripts/wait-for-import.sh
+++ b/.github/optimize/scripts/wait-for-import.sh
@@ -11,7 +11,7 @@ ES_URL="${ES_URL:-http://localhost:9200}"
 zeebe_definition_count() {
   curl -sf -u demo:demo -H 'Content-Type: application/json' \
     -X POST "${ZEEBE_URL}/v2/process-definitions/search" \
-    -d '{"page":{"limit":0}}' 2>/dev/null | jq '.page.totalItems // 0' || echo 0
+    -d '{"page":{"limit":1}}' 2>/dev/null | jq '.page.totalItems // 0' || echo 0
 }
 
 optimize_count() {

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -566,30 +566,7 @@ jobs:
         run: yarn start &
 
       - name: Wait for import to complete
-        run: |
-          while : ; do
-            count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
-            if [[ $count -eq 43 ]]; then
-              echo "Process definitions imported ($count). Waiting for process instance import to stabilize..."
-              prev="-1"
-              stable=0
-              while [[ $stable -lt 2 ]]; do
-                cur=$(curl -s -X GET "http://localhost:9200/optimize-process-instance/_count" | jq '.count // 0')
-                echo "Process instances: $cur"
-                if [[ "$cur" == "$prev" ]]; then
-                  stable=$((stable + 1))
-                else
-                  stable=0
-                fi
-                prev="$cur"
-                sleep 10
-              done
-              echo "Import stabilized at $cur process instances"
-              break
-            fi
-            echo "Index has $count entities. Waiting for 43..."
-            sleep 10
-          done
+        run: ./.github/optimize/scripts/wait-for-import.sh
 
       - name: Wait for frontend to start
         run: ./.github/optimize/scripts/wait-for.sh http://localhost:3000/ready

--- a/.github/workflows/optimize-e2e-tests-sm-nightly.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-nightly.yml
@@ -104,21 +104,7 @@ jobs:
           yarn run start-backend ci &> ./build/backendLogs.log &
 
       - name: Wait for import to complete
-        run: |
-          case "${{ matrix.branch }}" in
-            stable/8.8) expected=49 ;;
-            stable/8.9) expected=60 ;;
-            *) expected=43 ;;
-          esac
-          while : ; do
-            count=$(curl -s -X GET "http://localhost:9200/optimize-process-definition/_count" | jq '.count')
-            if [[ $count -eq $expected ]]; then
-              echo "Import Completed"
-              break
-            fi
-            echo "Index has $count entities. Waiting for $expected..."
-            sleep 10
-          done
+        run: ./.github/optimize/scripts/wait-for-import.sh
 
       - name: Wait for frontend to start
         run: ./.github/optimize/scripts/wait-for.sh http://localhost:3000/ready


### PR DESCRIPTION
## Description

The Optimize E2E **"Wait for import to complete"** step polled Elasticsearch until the process-definition count hit a hardcoded total (`60`, or `49` on `stable/8.8`). Removing the legacy tasklist data-generator (#60894) changed how many definitions `dev-data` seeds, so the fixed number was never reached and the step hung until the 30-minute job timeout.

This derives the target from the broker's own state instead of a magic number:

- Query the v2 `process-definitions` API for the authoritative number of deployed definitions, wait for it to stabilize, then wait for Optimize to import **at least** that many.
- Process instances have no clean source-of-truth count (completion timing, retention), so wait for their imported count to settle non-zero instead.
- Every loop has a bounded attempt budget and fails fast with a `::error::` annotation rather than hanging until the job timeout.

The logic is extracted into a shared `.github/optimize/scripts/wait-for-import.sh` so the CI smoke job and the nightly E2E matrix stay in sync, and the nightly no longer needs per-branch magic numbers.

## Validation

Both workflows were dispatched against this branch:

- **Smoke** (`Optimize CI`) — :white_check_mark: success: https://github.com/camunda/camunda/actions/runs/34143301139
- **Nightly** (`Optimize E2E Self-Managed`) — the `Wait for import to complete` step :white_check_mark: succeeded; the run was cancelled later at the visual-regression stage (unrelated to this change): https://github.com/camunda/camunda/actions/runs/34143303760

## Backporting

The scheduled nightly always runs `main`'s workflow YAML but checks out each matrix branch (`stable/8.8`, `stable/8.9`) via `ref: matrix.branch`. Those branches must have `wait-for-import.sh` present or the step fails, so this is labelled for backport to both.

## Checklist

- [x] Enable backports when necessary ([for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

- [x] This PR does not need a linked issue
