### PR TITLE
ci: disable release cool down for camunda-load-tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -770,6 +770,7 @@
         "dmn-js-drd",
         "dmn-js-literal-expression",
         "dmn-js-shared",
+        "camunda-load-test",
       ],
       minimumReleaseAge: "0 days",
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -770,7 +770,7 @@
         "dmn-js-drd",
         "dmn-js-literal-expression",
         "dmn-js-shared",
-        "camunda-load-test",
+        "camunda-load-tests",
       ],
       minimumReleaseAge: "0 days",
     },


### PR DESCRIPTION
## Description

- camunda-load-tests - helm chart is a trusted dependency we want to update as soon we release it
- https://github.com/camunda/camunda/blob/main/load-tests/setup/charts/load-test-setup/Chart.yaml#L11

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

