### PR TITLE
refactor: configure load-test history via chart values, not raw exporter overrides

### DIFF
--- a/load-tests/setup/stable-810/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-810/values/camunda-platform-values-defaults.yaml
@@ -225,10 +225,6 @@ orchestration:
         zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
 
-        # Camunda Exporter configuration
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-        zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
-
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000
@@ -253,6 +249,10 @@ orchestration:
     minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # Retention for the Camunda Exporter
   history:
+    ## @param core.history.rolloverBatchSize defines the maximum number of process instances per batch during archiving.
+    rolloverBatchSize: 500
+    ## @param core.history.waitPeriodBeforeArchiving defines the grace period for processes to be excluded from archiving.
+    waitPeriodBeforeArchiving: "1m"
     retention:
       ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
       enabled: true

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -224,10 +224,6 @@ orchestration:
         zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
 
-        # Camunda Exporter configuration
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-        zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
-
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000
@@ -252,6 +248,10 @@ orchestration:
     minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # Retention for the Camunda Exporter
   history:
+    ## @param core.history.rolloverBatchSize defines the maximum number of process instances per batch during archiving.
+    rolloverBatchSize: 500
+    ## @param core.history.waitPeriodBeforeArchiving defines the grace period for processes to be excluded from archiving.
+    waitPeriodBeforeArchiving: "1m"
     retention:
       ## @param core.history.retention.enabled if true, the ILM Policy is created and applied to the index templates.
       enabled: true

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -253,8 +253,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -270,10 +270,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-physical-tenants/platform/templates/orchestration/configmap.yaml
@@ -264,8 +264,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -281,10 +281,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -264,8 +264,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -281,10 +281,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -264,8 +264,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -281,10 +281,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-optimize/platform/templates/common/configmap-warnings.yaml
@@ -35,8 +35,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/none-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/none-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -35,8 +35,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/none/platform/templates/common/configmap-warnings.yaml
@@ -35,8 +35,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -253,8 +253,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -270,10 +270,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-physical-tenants/platform/templates/orchestration/configmap.yaml
@@ -267,8 +267,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -284,10 +284,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -267,8 +267,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -284,10 +284,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/common/configmap-warnings.yaml
@@ -37,8 +37,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-810/opensearch/platform/templates/orchestration/configmap.yaml
@@ -267,8 +267,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -284,10 +284,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-optimize/platform/templates/common/configmap-warnings.yaml
@@ -57,8 +57,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-physical-tenants/platform/templates/common/configmap-warnings.yaml
@@ -57,8 +57,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms-stable/platform/templates/common/configmap-warnings.yaml
@@ -57,8 +57,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-warnings.yaml
+++ b/load-tests/setup/test/golden/stable-810/rdbms/platform/templates/common/configmap-warnings.yaml
@@ -57,8 +57,10 @@ data:
         
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.rolloverBatchSize" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
+    [camunda][warning] DEPRECATION: The Helm values file key "orchestration.history.waitPeriodBeforeArchiving" is deprecated and will be removed in chart v16 (Camunda 8.11). Configure this via "orchestration.extraConfiguration" instead. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
         
         
         

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -253,8 +253,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -270,10 +270,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -264,8 +264,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -281,10 +281,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -264,8 +264,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -281,10 +281,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -266,8 +266,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -283,10 +283,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -280,8 +280,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -297,10 +297,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
@@ -280,8 +280,8 @@ data:
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"
-                rolloverBatchSize: 100
-                waitPeriodBeforeArchiving: "1h"
+                rolloverBatchSize: 500
+                waitPeriodBeforeArchiving: "1m"
                 delayBetweenRuns: 2000
                 maxDelayBetweenRuns: 60000
     
@@ -297,10 +297,6 @@ data:
     # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
-    
-    # Camunda Exporter configuration
-    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 500
-    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
     
     # Configure a rate limit for all writes, so that we can visualize flow control metrics.
     zeebe.broker.flowControl.write.enabled: "true"


### PR DESCRIPTION
## Description

The stable-89 and stable-810 load-test setups tune Camunda Exporter archiving (`rolloverBatchSize`/`waitPeriodBeforeArchiving`) via a raw property override under `zeebe.broker.exporters.camundaexporter.args` in an `application.yml` `extraConfiguration` block.

camunda-platform-helm's "Remove redundant camundaexporter from zeebe.broker.exporters" change ([camunda-platform-helm#6454](https://github.com/camunda/camunda-platform-helm/issues/6454), shipped in `camunda-platform-8.9-14.9.0`) drops that exporter block from the rendered chart entirely, since it is now auto-configured from the chart's own history values. Once stable-89's pinned chart version bumps past `14.8.5` (see #62121), this override targets a path with no `className`, orphaning it and crashing the broker on startup ("Not all Camunda platform pods are ready").

This PR replaces the raw override with the chart's own history values (`orchestration.history.rolloverBatchSize` / `waitPeriodBeforeArchiving`, aliased here as `core.history`), the same mechanism this file already uses for `history.retention.*`. This keeps a single source of truth for history tuning and renders unchanged runtime values (`500` / `"1m"`) on both branches today; it also survives stable-89's upcoming chart bump, since the value threads into the auto-configured path instead of the removed exporter block.

Note: stable-810's chart (`15.0.0-alpha4`) already deprecates this same key in favor of `orchestration.extraConfiguration` (planned removal in chart v16 / Camunda 8.11) - consistent with the pre-existing, untouched deprecation already on `core.history.retention.*` in that same file. A further migration to `extraConfiguration` there can follow separately when that chart line requires it.

Golden files regenerated via `make update-golden` (see `load-tests/setup/test/README.md`); `make test` passes.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

<!-- Not applicable: changes under load-tests/setup/** are never backported (per .github/instructions/load-tests.instructions.md) -->

## Related issues

- [x] This PR does not need a linked issue
