### PR TITLE
fix: scope golden test PATTERN to the version/scenario, not the test function

### DIFF
--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -34,9 +34,15 @@ PARALLEL ?= 4
 
 # Optional: scope test/update-golden to one setup version (e.g. PATTERN=stable-89).
 # Leave unset to run/update every version listed in golden_test.go.
+#
+# Version/scenario names live in the sub-test name (e.g. TestGoldenFiles/c8-golden-stable-89-elasticsearch),
+# not the top-level Go test function name. go test's -run splits on unescaped "/" into one regexp per
+# test-name level, so an unslashed pattern only ever matches level 0 (the function name) and silently
+# selects zero tests for any PATTERN that isn't itself a function name. The leading "/" below adds an
+# empty (always-matching) level-0 regexp so filtering applies to the sub-test level instead.
 PATTERN ?=
 ifneq ($(PATTERN),)
-run_filter := -run '.*$(PATTERN).*'
+run_filter := -run '/.*$(PATTERN).*'
 endif
 
 # Ephemeral chart cache consumed by newLoadTest.sh (via LOAD_TEST_CHART_CACHE_DIR,


### PR DESCRIPTION
## Description

`make test PATTERN=<version>` / `make update-golden PATTERN=<version>` (documented in `load-tests/setup/test/README.md`) silently ran **zero tests** instead of scoping to that version.

Version and scenario names live in the sub-test name (e.g. `TestGoldenFiles/c8-golden-stable-89-elasticsearch`), not the top-level Go test function name. `go test`'s `-run` splits its pattern on unescaped `/` into one regexp per test-name level, so an unslashed pattern (`.*stable-89.*`) only ever matches level 0 - the function name itself, which never contains a version string - so it matched nothing and the run reported `testing: warning: no tests to run`.

Fix: add a leading `/` to the pattern so level 0 gets an empty (always-matching) regexp, and the version/scenario filter applies at the sub-test level where it actually lives.

Verified with `make test PATTERN=stable-89`: now runs exactly the 16 `stable-89` sub-tests plus the version-agnostic unit tests (23 total) in ~11s, instead of matching nothing.

Found while migrating history config in #62352.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

<!-- Not applicable: changes under load-tests/setup/** are never backported (per .github/instructions/load-tests.instructions.md) -->

## Related issues

- [x] This PR does not need a linked issue
