### PR TITLE
refactor: stabilize next-record scheduling profile frames

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -139,6 +139,9 @@ public final class ProcessingStateMachine implements CloseableSilently {
   private final MutableLastProcessedPositionState lastProcessedPositionState;
   private final RecordMetadata metadata = new RecordMetadata();
   private final ActorControl actor;
+  // When comparing partition CPU profiles, use a named reusable task so this path is aggregated
+  // under stable frames instead of being split across synthetic lambda frames.
+  private final ReadNextRecordTask readNextRecordTask = new ReadNextRecordTask();
   private final LogStreamReader logStreamReader;
   private final TransactionContext transactionContext;
   private final RetryStrategy writeRetryStrategy;
@@ -221,7 +224,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
             processingMetrics,
             context.getCommandResponseWriter(),
             maxPendingSideEffects,
-            () -> actor.submit(this::tryToReadNextRecord));
+            readNextRecordTask);
     context.getLogStream().registerCommittedPositionListener(sideEffectRunner);
     final EventFilter commandFilter =
         event -> {
@@ -237,10 +240,14 @@ public final class ProcessingStateMachine implements CloseableSilently {
     return currentStateDescription.toString();
   }
 
+  Runnable getReadNextRecordTask() {
+    return readNextRecordTask;
+  }
+
   private void skipRecord() {
     notifySkippedListener(requireNonNull(currentRecord));
     markProcessingCompleted();
-    actor.submit(this::tryToReadNextRecord);
+    actor.submit(readNextRecordTask);
     processingMetrics.eventSkipped();
   }
 
@@ -754,7 +761,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
                 metadata.getIntent(), requireNonNull(currentRecord).getKey());
             registerSideEffects();
             markProcessingCompleted();
-            actor.submit(this::tryToReadNextRecord);
+            actor.submit(readNextRecordTask);
           }
         });
   }
@@ -825,7 +832,7 @@ public final class ProcessingStateMachine implements CloseableSilently {
     }
 
     sideEffectRunner.onCommittedPosition(lastProcessingPositions.getLastWrittenPosition());
-    actor.submit(this::tryToReadNextRecord);
+    actor.submit(readNextRecordTask);
   }
 
   @Override
@@ -906,5 +913,12 @@ public final class ProcessingStateMachine implements CloseableSilently {
     USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED,
     // All attempted error handling failed.
     ENDLESS_ERROR_LOOP
+  }
+
+  private final class ReadNextRecordTask implements Runnable {
+    @Override
+    public void run() {
+      tryToReadNextRecord();
+    }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SideEffectRunner.java
@@ -180,7 +180,7 @@ final class SideEffectRunner implements CommittedPositionListener {
       // the records it stopped on are already appended, so no append notification is coming.
       // Signalling only on the full -> not-full transition keeps this to one job per stall
       // instead of one per side effect.
-      onCapacityAvailable.run();
+      actor.submit(onCapacityAvailable);
     }
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -628,7 +628,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
               metrics.setStreamProcessorProcessing();
               if (processingStateMachine != null) {
-                actor.submit(processingStateMachine::tryToReadNextRecord);
+                actor.submit(processingStateMachine.getReadNextRecordTask());
               }
               LOG.debug("Resumed processing for partition {}", partitionId);
             }
@@ -639,7 +639,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   @Override
   public void onRecordAvailable() {
     final var processingStateMachine = requireNonNull(this.processingStateMachine);
-    actor.run(processingStateMachine::tryToReadNextRecord);
+    actor.run(processingStateMachine.getReadNextRecordTask());
   }
 
   /**


### PR DESCRIPTION

## Description

CPU profiles currently show synthetic method-reference frames for each partition when the processing state machine schedules its next record. This makes the hot path harder to compare across partitions.

Replace those references with reusable named tasks and expose the task to StreamProcessor so all scheduling entry points share the same profile frame. The submission behavior remains asynchronous.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [X] This PR does not need a linked issue

