### PR TITLE
ci: add 8.10 version for fix agent

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Camunda version (8.7, 8.8, 8.9, 8.10 or main)'
+        description: 'Camunda version (8.7, 8.8, 8.9, 8.10, or main)'
         required: true
       test_specs:
         description: 'JSON array of {file, test_name, error, test_type, tasklist_mode?, database?}'
@@ -90,7 +90,7 @@ jobs:
               } >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "::error::Unsupported version: $version (must be 8.7, 8.8, 8.9, 8.10 or main)"
+              echo "::error::Unsupported version: $version (must be 8.7, 8.8, 8.9, 8.10, or main)"
               exit 1
               ;;
           esac

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Camunda version (8.7, 8.8, 8.9, or main)'
+        description: 'Camunda version (8.7, 8.8, 8.9, 8.10 or main)'
         required: true
       test_specs:
         description: 'JSON array of {file, test_name, error, test_type, tasklist_mode?, database?}'
@@ -83,14 +83,14 @@ jobs:
                 echo "safe_version=main"
               } >> "$GITHUB_OUTPUT"
               ;;
-            8.7|8.8|8.9)
+            8.7|8.8|8.9|8.10)
               {
                 echo "ref=stable/${version}"
                 echo "safe_version=stable-${version}"
               } >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "::error::Unsupported version: $version (must be 8.7, 8.8, 8.9, or main)"
+              echo "::error::Unsupported version: $version (must be 8.7, 8.8, 8.9, 8.10 or main)"
               exit 1
               ;;
           esac

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -1,6 +1,6 @@
 # description: Discovery + classification + dispatch for C8 Orchestration Cluster nightly
 #              E2E and API test failures. Scans the latest run of each in-scope nightly
-#              workflow for every supported version (8.7 / 8.8 / 8.9 / main), extracts
+#              workflow for every supported version (8.7 / 8.8 / 8.9 / 8.10 / main), extracts
 #              failing tests from json-report artifacts, groups by version, and dispatches
 #              one fix-agent run per version. Skips dispatch when an open failing-test-fix
 #              PR already exists for the same base branch.
@@ -28,8 +28,8 @@ on:
         default: true
         required: false
       daily_cap:
-        description: 'Max fix-agent dispatches this run (default: 4 -- one per supported version)'
-        default: '4'
+        description: 'Max fix-agent dispatches this run (default: 5 -- one per supported version)'
+        default: '5'
         required: false
       send_slack_notification:
         description: 'Post triage summary and fix-agent replies to Slack (always true for scheduled runs)'
@@ -134,6 +134,9 @@ jobs:
             "c8-orchestration-cluster-nightly-8.9-e2e.yml|8.9|e2e"
             "c8-orchestration-cluster-nightly-8.9-api-es.yml|8.9|api_es"
             "c8-orchestration-cluster-nightly-8.9-api-rdbms.yml|8.9|api_rdbms"
+            "c8-orchestration-cluster-nightly-8.10-api-es.yml|8.10|api_es"
+            "c8-orchestration-cluster-nightly-8.10-api-rdbms.yml|8.10|api_rdbms"
+            "c8-orchestration-cluster-nightly-8.10-e2e.yml|8.10|e2e"
           )
           SCOPE+=(
             "c8-orchestration-cluster-nightly-main-e2e.yml|main|e2e"
@@ -291,7 +294,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPO:     ${{ github.repository }}
-          DAILY_CAP: ${{ github.event.inputs.daily_cap || '4' }}
+          DAILY_CAP: ${{ github.event.inputs.daily_cap || '5' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Description

This PR adds 8.10 version for nightly triage/fix workflows.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [x] This PR does not need a linked issue

