### PR TITLE
fix: give the daily no-secondary-storage leg explicit gRPC/REST variants

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -99,7 +99,7 @@ jobs:
         variant:
           - key: grpc
             label: gRPC
-            load-test-load: ''
+            load-test-load: '--set global.preferRest.enabled=false'
             load-test-setup-helm-values: '--set elasticsearch.storage.requests=64Gi'
             secondary-storage-type: elasticsearch
           - key: rest

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -1,16 +1,16 @@
-# description: Runs a daily max-load stress test against main, currently in three variants: gRPC
-#              and REST (both against Elasticsearch), and no-secondary-storage (exporters
-#              disabled). After a 15-minute warmup, profiles the next 30 minutes of each variant
-#              via async-profiler. After a 3-hour soak: snapshots metrics as a GitHub artifact,
-#              posts a side-by-side summary table (with flamegraph links) to Slack (the scheduled
-#              run always posts; a manual run only when opted in via the post-to-slack input),
-#              then immediately deletes the namespaces to reduce cost.
+# description: Runs a daily max-load stress test against main, currently in four variants: gRPC
+#              and REST (both against Elasticsearch), and no-secondary-storage in both gRPC and
+#              REST flavors (exporters disabled). After a 15-minute warmup, profiles the next 30
+#              minutes of each variant via async-profiler. After a 3-hour soak: snapshots metrics
+#              as a GitHub artifact, posts a side-by-side summary table (with flamegraph links) to
+#              Slack (the scheduled run always posts; a manual run only when opted in via the
+#              post-to-slack input), then immediately deletes the namespaces to reduce cost.
 #              Naming pattern: medic-daily-YYYY-MM-DD-<sha>
 #              Each variant's full lifecycle (setup, warmup, profile, soak, collect-metrics,
 #              cleanup) is delegated to the reusable stress-load-test.yml workflow via a
 #              matrix — adding a variant is a one-line matrix entry, not a 6-job copy-paste.
-#              The no-secondary-storage variant only runs this daily `max` leg; it deliberately
-#              does not get its own multi-week weekly endurance rotation, since that long-horizon
+#              The no-secondary-storage variants only run this daily `max` leg; they deliberately
+#              don't get their own multi-week weekly endurance rotation, since that long-horizon
 #              engine coverage is not storage-specific and is already provided by the ES/OS/RDBMS
 #              weekly runs.
 # calls: stress-load-test.yml (per variant)
@@ -107,9 +107,14 @@ jobs:
             load-test-load: '--set global.preferRest.enabled=true'
             load-test-setup-helm-values: '--set elasticsearch.storage.requests=64Gi'
             secondary-storage-type: elasticsearch
-          - key: none
-            label: None
-            load-test-load: '--set load-tester.starter.rate=500'
+          - key: none-grpc
+            label: None-gRPC
+            load-test-load: '--set load-tester.starter.rate=500 --set global.preferRest.enabled=false'
+            load-test-setup-helm-values: ''
+            secondary-storage-type: none
+          - key: none-rest
+            label: None-REST
+            load-test-load: '--set load-tester.starter.rate=500 --set global.preferRest.enabled=true'
             load-test-setup-helm-values: ''
             secondary-storage-type: none
     uses: ./.github/workflows/stress-load-test.yml
@@ -146,7 +151,7 @@ jobs:
           # Keep in sync with the `run-variant` matrix above (key:label pairs) — this determines
           # the Slack summary table's column order, which is not guaranteed by artifact download
           # order. key here must match the -<key> suffix used to build the run-variant name above.
-          VARIANT_ORDER: 'grpc:gRPC rest:REST none:None'
+          VARIANT_ORDER: 'grpc:gRPC rest:REST none-grpc:None-gRPC none-rest:None-REST'
         run: |
           manifest='[]'
           for entry in $VARIANT_ORDER; do

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -371,7 +371,7 @@ Example running tests (naming pattern: `medic-y-<year>-<week>-<sha>-<variant>-re
 
 ### Daily load tests (stress test)
 
-Daily stress tests run against the state of the **main** branch via the [Daily load tests GitHub workflow](../.github/workflows/camunda-daily-load-tests.yml), in three variants: gRPC and REST (both against Elasticsearch), and no-secondary-storage (exporters disabled). All use the same [stress-load-test.yml](../.github/workflows/stress-load-test.yml) workflow and run for 3 hours.
+Daily stress tests run against the state of the **main** branch via the [Daily load tests GitHub workflow](../.github/workflows/camunda-daily-load-tests.yml), in four variants: gRPC and REST (both against Elasticsearch), and no-secondary-storage in both gRPC and REST flavors (exporters disabled). All use the same [stress-load-test.yml](../.github/workflows/stress-load-test.yml) workflow and run for 3 hours.
 
 **Goal:** Validating the reliability and performance of the current main under stress, and detecting newly introduced instabilities with a short feedback loop.
 


### PR DESCRIPTION
## Description

The `grpc` leg of the daily load test matrix passed no `load-test-load` override, so it silently inherited `global.preferRest.enabled` from the load tester's own chart default. [#61457](https://github.com/camunda/camunda/pull/61457) flipped that default to `true`, which made the "gRPC" daily leg complete jobs over REST as well, collapsing it into the same behavior as the "REST" leg and defeating the point of running both variants. Caught via [profiling a daily run](https://camunda.slack.com/archives/C0807665N8G/p1788853971339939) that showed a REST-heavy CPU profile for the gRPC variant.

This explicitly sets `global.preferRest.enabled=false` for the `grpc` leg, mirroring the explicit `global.preferRest.enabled=true` the `rest` leg already sets, so both stay pinned to their intended transport regardless of the load tester's own default.

The no-secondary-storage ("none") leg had the same latent issue: it never pinned `global.preferRest.enabled` either, so it also silently rode whatever the chart default was. It's now split into two explicit legs, `none-grpc` and `none-rest`, giving the no-secondary-storage path the same gRPC/REST coverage the Elasticsearch-backed path has, instead of depending on an implicit default.

Going from three to four variants also grows the Slack results table by one column. Simulated `post-load-test-results-to-slack.py`'s table with pessimistic values (7-digit counts, 5-digit floats) across all four variants: ~1,140 characters, comfortably under Slack's 3,000-character section-block limit - no change needed there.

## Verification

Manually dispatched the workflow from this branch to validate the new `none-grpc`/`none-rest` split end-to-end: [run 34208223639](https://github.com/camunda/camunda/actions/runs/34208223639) (~3.5 h, posts to `#reliability-testing-alerts` on completion).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

- [x] This PR does not need a linked issue
