### PR TITLE
fix: exclude RDBMS_SCHEMA_VERSION from purgeTables

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -73,8 +73,7 @@ public final class RdbmsTableNames {
           "PROCESS_DEF_VAR_NAME_LOOKUP",
           "VARIABLE",
           "WAIT_STATE",
-          "WEB_SESSION",
-          "RDBMS_SCHEMA_VERSION");
+          "WEB_SESSION");
 
   private RdbmsTableNames() {
     // Utility class - prevent instantiation

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
@@ -62,7 +62,7 @@ public class PurgerCompletenessIT {
   private List<String> getAllCamundaTableNames() {
     return jdbcTemplate
         .queryForList(
-            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')")
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK', 'RDBMS_SCHEMA_VERSION')")
         .stream()
         .map(row -> row.get("TABLE_NAME").toString())
         .toList();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

<!--
Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
-->

closes #

- [ ] This PR does not need a linked issue

