### PR TITLE
ci: port nightly startup-diagnostics fixes to remaining orchestration-cluster workflows

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -176,8 +176,48 @@ jobs:
         id: wait-for-services
         run: |
           echo "Checking if services are up..."
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            app_containers=(operate tasklist)
+          else
+            app_containers=(camunda)
+          fi
           ready=false
+          declare -A non_running
           for i in {1..90}; do
+            # Fail fast if an app container crashed, instead of waiting out the
+            # full ~15 min timeout. Resolve the container through compose rather
+            # than by bare name: some branches set container_name to
+            # operate-${DATABASE}, so `docker inspect operate` matches nothing
+            # there. --all is required or compose omits an already-exited
+            # container. Test Running rather than a status allowlist so a crash
+            # loop is caught too (restart: always surfaces as `restarting`, never
+            # `exited`) along with a container that was never created at all. Two
+            # consecutive observations keep a single legitimate restart from
+            # failing the job.
+            for c in "${app_containers[@]}"; do
+              cid="$(DATABASE=elasticsearch docker compose ps --all --quiet "$c" 2>/dev/null || true)"
+              running=""
+              if [[ -n "$cid" ]]; then
+                running="$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)"
+              fi
+              if [[ "$running" == "true" ]]; then
+                non_running["$c"]=0
+                continue
+              fi
+              non_running["$c"]=$(( ${non_running["$c"]:-0} + 1 ))
+              if (( ${non_running["$c"]} >= 2 )); then
+                if [[ -z "$cid" ]]; then
+                  echo "No container for service '$c' on two consecutive checks; it was never created or has been removed."
+                else
+                  echo "Container for service '$c' is not running on two consecutive checks; it will never become ready."
+                  docker inspect "$cid" --format 'Container {{.Name}}: status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} restartCount={{.RestartCount}}' || true
+                fi
+                DATABASE=elasticsearch docker compose logs --tail 200 "$c" || true
+                echo "Services failed to start: service '$c' is not running."
+                exit 1
+              fi
+            done
+
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")
@@ -212,12 +252,16 @@ jobs:
 
       - name: Print Docker logs before failing
         if: failure()
+        # DATABASE must be set: docker-compose.yml interpolates it into the
+        # camunda service's depends_on / env_file, so an unset value makes the
+        # compose project invalid ("depends on undefined service") and this
+        # diagnostic step errors out instead of printing the container logs.
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -614,6 +614,7 @@ jobs:
 
       - name: Wait for services to be ready
         id: wait-for-services
+        shell: bash
         run: |
           echo "Checking if services are up..."
           if [[ "$NON_STANDALONE" == "true" ]]; then

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -153,8 +153,48 @@ jobs:
         shell: bash
         run: |
           echo "Checking if services are up..."
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            app_containers=(operate tasklist)
+          else
+            app_containers=(camunda)
+          fi
           ready=false
+          declare -A non_running
           for i in {1..90}; do
+            # Fail fast if an app container crashed, instead of waiting out the
+            # full ~15 min timeout. Resolve the container through compose rather
+            # than by bare name: some branches set container_name to
+            # operate-${DATABASE}, so `docker inspect operate` matches nothing
+            # there. --all is required or compose omits an already-exited
+            # container. Test Running rather than a status allowlist so a crash
+            # loop is caught too (restart: always surfaces as `restarting`, never
+            # `exited`) along with a container that was never created at all. Two
+            # consecutive observations keep a single legitimate restart from
+            # failing the job.
+            for c in "${app_containers[@]}"; do
+              cid="$(DATABASE=elasticsearch docker compose ps --all --quiet "$c" 2>/dev/null || true)"
+              running=""
+              if [[ -n "$cid" ]]; then
+                running="$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)"
+              fi
+              if [[ "$running" == "true" ]]; then
+                non_running["$c"]=0
+                continue
+              fi
+              non_running["$c"]=$(( ${non_running["$c"]:-0} + 1 ))
+              if (( ${non_running["$c"]} >= 2 )); then
+                if [[ -z "$cid" ]]; then
+                  echo "No container for service '$c' on two consecutive checks; it was never created or has been removed."
+                else
+                  echo "Container for service '$c' is not running on two consecutive checks; it will never become ready."
+                  docker inspect "$cid" --format 'Container {{.Name}}: status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} restartCount={{.RestartCount}}' || true
+                fi
+                DATABASE=elasticsearch docker compose logs --tail 200 "$c" || true
+                echo "Services failed to start: service '$c' is not running."
+                exit 1
+              fi
+            done
+
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")
@@ -190,12 +230,16 @@ jobs:
       - name: Print Docker logs before failing
         if: failure()
         shell: bash
+        # DATABASE must be set: docker-compose.yml interpolates it into the
+        # camunda service's depends_on / env_file, so an unset value makes the
+        # compose project invalid ("depends on undefined service") and this
+        # diagnostic step errors out instead of printing the container logs.
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -572,8 +616,48 @@ jobs:
         id: wait-for-services
         run: |
           echo "Checking if services are up..."
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            app_containers=(operate tasklist)
+          else
+            app_containers=(camunda)
+          fi
           ready=false
+          declare -A non_running
           for i in {1..90}; do
+            # Fail fast if an app container crashed, instead of waiting out the
+            # full ~15 min timeout. Resolve the container through compose rather
+            # than by bare name: some branches set container_name to
+            # operate-${DATABASE}, so `docker inspect operate` matches nothing
+            # there. --all is required or compose omits an already-exited
+            # container. Test Running rather than a status allowlist so a crash
+            # loop is caught too (restart: always surfaces as `restarting`, never
+            # `exited`) along with a container that was never created at all. Two
+            # consecutive observations keep a single legitimate restart from
+            # failing the job.
+            for c in "${app_containers[@]}"; do
+              cid="$(DATABASE=elasticsearch docker compose ps --all --quiet "$c" 2>/dev/null || true)"
+              running=""
+              if [[ -n "$cid" ]]; then
+                running="$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)"
+              fi
+              if [[ "$running" == "true" ]]; then
+                non_running["$c"]=0
+                continue
+              fi
+              non_running["$c"]=$(( ${non_running["$c"]:-0} + 1 ))
+              if (( ${non_running["$c"]} >= 2 )); then
+                if [[ -z "$cid" ]]; then
+                  echo "No container for service '$c' on two consecutive checks; it was never created or has been removed."
+                else
+                  echo "Container for service '$c' is not running on two consecutive checks; it will never become ready."
+                  docker inspect "$cid" --format 'Container {{.Name}}: status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} restartCount={{.RestartCount}}' || true
+                fi
+                DATABASE=elasticsearch docker compose logs --tail 200 "$c" || true
+                echo "Services failed to start: service '$c' is not running."
+                exit 1
+              fi
+            done
+
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")
@@ -609,12 +693,16 @@ jobs:
       - name: Print Docker logs before failing
         if: failure()
         shell: bash
+        # DATABASE must be set: docker-compose.yml interpolates it into the
+        # camunda service's depends_on / env_file, so an unset value makes the
+        # compose project invalid ("depends on undefined service") and this
+        # diagnostic step errors out instead of printing the container logs.
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -958,6 +958,7 @@ jobs:
 
       - name: Wait for services to be ready
         id: wait-for-services
+        shell: bash
         run: |
           echo "Checking if services are up..."
           if [[ "$NON_STANDALONE" == "true" ]]; then
@@ -1036,6 +1037,7 @@ jobs:
 
       - name: Print Docker logs before failing
         if: failure()
+        shell: bash
         # DATABASE must be set: docker-compose.yml interpolates it into the
         # camunda service's depends_on / env_file, so an unset value makes the
         # compose project invalid ("depends on undefined service") and this

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -256,8 +256,48 @@ jobs:
         id: wait-for-services
         run: |
           echo "Checking if services are up..."
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            app_containers=(zeebe tasklist operate)
+          else
+            app_containers=(camunda)
+          fi
           ready=false
+          declare -A non_running
           for i in {1..90}; do
+            # Fail fast if an app container crashed, instead of waiting out the
+            # full ~15 min timeout. Resolve the container through compose rather
+            # than by bare name: some branches set container_name to
+            # operate-${DATABASE}, so `docker inspect operate` matches nothing
+            # there. --all is required or compose omits an already-exited
+            # container. Test Running rather than a status allowlist so a crash
+            # loop is caught too (restart: always surfaces as `restarting`, never
+            # `exited`) along with a container that was never created at all. Two
+            # consecutive observations keep a single legitimate restart from
+            # failing the job.
+            for c in "${app_containers[@]}"; do
+              cid="$(DATABASE=elasticsearch docker compose ps --all --quiet "$c" 2>/dev/null || true)"
+              running=""
+              if [[ -n "$cid" ]]; then
+                running="$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)"
+              fi
+              if [[ "$running" == "true" ]]; then
+                non_running["$c"]=0
+                continue
+              fi
+              non_running["$c"]=$(( ${non_running["$c"]:-0} + 1 ))
+              if (( ${non_running["$c"]} >= 2 )); then
+                if [[ -z "$cid" ]]; then
+                  echo "No container for service '$c' on two consecutive checks; it was never created or has been removed."
+                else
+                  echo "Container for service '$c' is not running on two consecutive checks; it will never become ready."
+                  docker inspect "$cid" --format 'Container {{.Name}}: status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} restartCount={{.RestartCount}}' || true
+                fi
+                DATABASE=elasticsearch docker compose logs --tail 200 "$c" || true
+                echo "Services failed to start: service '$c' is not running."
+                exit 1
+              fi
+            done
+
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")
@@ -293,13 +333,17 @@ jobs:
       - name: Print Docker logs before failing
         shell: bash
         if: failure()
+        # DATABASE must be set: docker-compose.yml interpolates it into the
+        # camunda service's depends_on / env_file, so an unset value makes the
+        # compose project invalid ("depends on undefined service") and this
+        # diagnostic step errors out instead of printing the container logs.
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
-            docker compose logs zeebe
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs zeebe
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -916,8 +960,48 @@ jobs:
         id: wait-for-services
         run: |
           echo "Checking if services are up..."
+          if [[ "$NON_STANDALONE" == "true" ]]; then
+            app_containers=(zeebe tasklist operate)
+          else
+            app_containers=(camunda)
+          fi
           ready=false
+          declare -A non_running
           for i in {1..90}; do
+            # Fail fast if an app container crashed, instead of waiting out the
+            # full ~15 min timeout. Resolve the container through compose rather
+            # than by bare name: some branches set container_name to
+            # operate-${DATABASE}, so `docker inspect operate` matches nothing
+            # there. --all is required or compose omits an already-exited
+            # container. Test Running rather than a status allowlist so a crash
+            # loop is caught too (restart: always surfaces as `restarting`, never
+            # `exited`) along with a container that was never created at all. Two
+            # consecutive observations keep a single legitimate restart from
+            # failing the job.
+            for c in "${app_containers[@]}"; do
+              cid="$(DATABASE=elasticsearch docker compose ps --all --quiet "$c" 2>/dev/null || true)"
+              running=""
+              if [[ -n "$cid" ]]; then
+                running="$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)"
+              fi
+              if [[ "$running" == "true" ]]; then
+                non_running["$c"]=0
+                continue
+              fi
+              non_running["$c"]=$(( ${non_running["$c"]:-0} + 1 ))
+              if (( ${non_running["$c"]} >= 2 )); then
+                if [[ -z "$cid" ]]; then
+                  echo "No container for service '$c' on two consecutive checks; it was never created or has been removed."
+                else
+                  echo "Container for service '$c' is not running on two consecutive checks; it will never become ready."
+                  docker inspect "$cid" --format 'Container {{.Name}}: status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} restartCount={{.RestartCount}}' || true
+                fi
+                DATABASE=elasticsearch docker compose logs --tail 200 "$c" || true
+                echo "Services failed to start: service '$c' is not running."
+                exit 1
+              fi
+            done
+
             if [[ "$NON_STANDALONE" == "true" ]]; then
               tasklist_status=$(curl -s -m 5 http://localhost:8080 || echo "Failed")
               operate_status=$(curl -s -m 5 http://localhost:8081 || echo "Failed")
@@ -952,13 +1036,17 @@ jobs:
 
       - name: Print Docker logs before failing
         if: failure()
+        # DATABASE must be set: docker-compose.yml interpolates it into the
+        # camunda service's depends_on / env_file, so an unset value makes the
+        # compose project invalid ("depends on undefined service") and this
+        # diagnostic step errors out instead of printing the container logs.
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
-            docker compose logs zeebe
-            docker compose logs tasklist
-            docker compose logs operate
+            DATABASE=elasticsearch docker compose logs zeebe
+            DATABASE=elasticsearch docker compose logs tasklist
+            DATABASE=elasticsearch docker compose logs operate
           else
-            docker compose logs camunda
+            DATABASE=elasticsearch docker compose logs camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 


### PR DESCRIPTION
## Description

#61421 fixed two diagnostic defects in the reusable orchestration-cluster workflows. The same two defects exist, unfixed, in five job locations across three workflows that inline their own copies of these steps instead of calling the reusables. Both jobs end at "Wait for services to be ready" with nothing but `Services failed to start in time.`

1. `Print Docker logs before failing` ran `docker compose logs <service>` without `DATABASE` set. `docker-compose.yml` interpolates `${DATABASE}` into the app service's `depends_on`/`env_file`, so the unset value makes the whole compose project invalid and the diagnostic step fails instead of printing anything.

2. The `Wait for services to be ready` loop polled a fixed 90x10s with no awareness of container state. A container that crashed 30 seconds in got polled for the remaining ~14 minutes and then reported as a generic timeout.

This ports both fixes from #61421 verbatim into the five affected job locations:

- `c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml` (1 job)
- `c8-orchestration-cluster-e2e-tests-on-demand.yml` (2 jobs)
- `c8-orchestration-cluster-e2e-tests-release.yml` (2 jobs)

These workflows already compute the equivalent of the reusable workflows' `${{ inputs.branch }}` check as a shell variable (`$NON_STANDALONE`, set via `$GITHUB_ENV`), and every existing conditional in these jobs already keys off it. So the guard checks `$NON_STANDALONE` instead of the branch expression, matching each file's own convention. The container list mirrors what each job's existing `docker compose logs` branch already lists: `(operate tasklist)` for the API/E2E workflows, `(zeebe tasklist operate)` for the release workflow, which also runs a separate `zeebe` container.

Neither change masks a failure: a genuine startup crash still fails the run, now with the container's exit cause captured instead of after 15 minutes with nothing.

### What this does not fix

Two more workflows, `c8-orchestration-cluster-forward-compatibility-tests.yml` and `c8-orchestration-cluster-request-validation-nightly.yml`, have the same two defects but are outside this PR's scope. Issue #61441 lists exact affected lines only for the three files above, so this PR stays scoped to those.

## Checklist

- [ ] Enable backports when necessary. Not needed: these workflows are `workflow_dispatch`-only with a `branch`/`monorepo_release` input and exist only on `main`.
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow. Not yet done: `c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml` and `c8-orchestration-cluster-e2e-tests-on-demand.yml` should be dispatched against this branch in both standalone and `NON_STANDALONE` modes before merge. `c8-orchestration-cluster-e2e-tests-release.yml` gates real releases, so it should be checked by diffing its two job locations against the dispatched runs above rather than dispatched itself.
  - [ ] dispatched [on demand workflow](https://github.com/camunda/camunda/actions/runs/34204929815)
  - [ ] dispatched [api-test-branch-on-demand](https://github.com/camunda/camunda/actions/runs/34205409494)

## Files changed

- `.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml`
- `.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml`
- `.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml`

## Related issues

closes #61441
