### PR TITLE
fix: preserve RDBMS schema version during history purge

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -50,9 +50,8 @@ public class RdbmsSchemaVersionStore {
    * The table that tracks the RDBMS schema version applied by this application. An entry is
    * written/updated after every successful Liquibase migration run.
    */
-  private static final String SCHEMA_VERSION_TABLE = "RDBMS_SCHEMA_VERSION";
-
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSchemaVersionStore.class);
+
   private final DataSource dataSource;
   private final String prefix;
 
@@ -218,7 +217,7 @@ public class RdbmsSchemaVersionStore {
       return;
     }
 
-    final var tableName = prefix + SCHEMA_VERSION_TABLE;
+    final var tableName = prefix + RdbmsTableNames.SCHEMA_VERSION;
 
     try (final var connection = dataSource.getConnection()) {
       final var autoCommit = connection.getAutoCommit();
@@ -290,7 +289,7 @@ public class RdbmsSchemaVersionStore {
   @VisibleForTesting
   protected String readSchemaVersion(final Connection connection, final String prefix)
       throws SQLException {
-    final var tableName = prefix + SCHEMA_VERSION_TABLE;
+    final var tableName = prefix + RdbmsTableNames.SCHEMA_VERSION;
     if (!tableExists(connection, tableName)) {
       return null;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -15,6 +15,8 @@ import java.util.List;
  */
 public final class RdbmsTableNames {
 
+  public static final String SCHEMA_VERSION = "RDBMS_SCHEMA_VERSION";
+
   /**
    * List of all known RDBMS table names. The order of tables in this list will be used by the
    * RdbmsPurger to determine the order in which the tables are truncated. It is important to always
@@ -74,7 +76,7 @@ public final class RdbmsTableNames {
           "VARIABLE",
           "WAIT_STATE",
           "WEB_SESSION",
-          "RDBMS_SCHEMA_VERSION");
+          SCHEMA_VERSION);
 
   private RdbmsTableNames() {
     // Utility class - prevent instantiation

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -28,6 +28,10 @@ public class RdbmsPurger {
     }
 
     for (final String tableName : RdbmsTableNames.TABLE_NAMES) {
+      // Purge exported data, but retain metadata describing the schema that remains in place.
+      if (RdbmsTableNames.SCHEMA_VERSION.equals(tableName)) {
+        continue;
+      }
       purgeMapper.truncateTable(tableName);
     }
     if (vendorDatabaseProperties.disableFkBeforeTruncate()) {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/RdbmsPurgerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/RdbmsPurgerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static io.camunda.db.rdbms.RdbmsTableNames.SCHEMA_VERSION;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.PurgeMapper;
+import org.junit.jupiter.api.Test;
+
+class RdbmsPurgerTest {
+
+  @Test
+  void shouldPreserveSchemaVersion() {
+    // given
+    final var purgeMapper = mock(PurgeMapper.class);
+    final var purger = new RdbmsPurger(purgeMapper, mock(VendorDatabaseProperties.class));
+
+    // when
+    purger.purgeRdbms();
+
+    // then
+    verify(purgeMapper).truncateTable("PROCESS_INSTANCE");
+    verify(purgeMapper, never()).truncateTable(SCHEMA_VERSION);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.rdbms.db;
 
 import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static io.camunda.db.rdbms.RdbmsTableNames.SCHEMA_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -62,7 +63,9 @@ public class PurgerCompletenessIT {
   private List<String> getAllCamundaTableNames() {
     return jdbcTemplate
         .queryForList(
-            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK')")
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC' AND TABLE_NAME NOT IN ('DATABASECHANGELOG', 'DATABASECHANGELOGLOCK', '"
+                + SCHEMA_VERSION
+                + "')")
         .stream()
         .map(row -> row.get("TABLE_NAME").toString())
         .toList();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.it.rdbms.db;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static io.camunda.db.rdbms.RdbmsTableNames.SCHEMA_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.db.rdbms.RdbmsSchemaVersionStore;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
@@ -19,8 +19,8 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtensio
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
-import io.camunda.zeebe.util.VersionUtil;
 import java.time.OffsetDateTime;
+import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -35,9 +35,11 @@ public class PurgerIT {
 
   @TestTemplate
   public void shouldSaveAndFindProcessInstanceByKey(
-      final CamundaRdbmsTestApplication testApplication) {
+      final CamundaRdbmsTestApplication testApplication) throws Exception {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final DataSource dataSource = testApplication.bean(DataSource.class);
+    final String schemaVersionBeforePurge = readSchemaVersion(dataSource);
 
     ProcessInstanceFixtures.createAndSaveRandomProcessInstances(rdbmsWriters);
     ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions(rdbmsWriters);
@@ -56,9 +58,15 @@ public class PurgerIT {
                 .total())
         .isZero();
 
-    final var versionStore =
-        new RdbmsSchemaVersionStore(
-            testApplication.bean(javax.sql.DataSource.class), "", VersionUtil.getVersion());
-    assertThatCode(versionStore::checkCompatibility).doesNotThrowAnyException();
+    assertThat(readSchemaVersion(dataSource)).isEqualTo(schemaVersionBeforePurge);
+  }
+
+  private String readSchemaVersion(final DataSource dataSource) throws Exception {
+    try (final var connection = dataSource.getConnection();
+        final var statement = connection.createStatement();
+        final var result = statement.executeQuery("SELECT VERSION FROM " + SCHEMA_VERSION)) {
+      assertThat(result.next()).isTrue();
+      return result.getString(1);
+    }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.it.rdbms.db;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.db.rdbms.RdbmsSchemaVersionStore;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
@@ -16,6 +19,7 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtensio
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.zeebe.util.VersionUtil;
 import java.time.OffsetDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -51,5 +55,10 @@ public class PurgerIT {
                 .search(ProcessDefinitionQuery.of(b -> b))
                 .total())
         .isZero();
+
+    final var versionStore =
+        new RdbmsSchemaVersionStore(
+            testApplication.bean(javax.sql.DataSource.class), "", VersionUtil.getVersion());
+    assertThatCode(versionStore::checkCompatibility).doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## Description

RDBMS history purge currently truncates `RDBMS_SCHEMA_VERSION` together with exported data. The database schema remains migrated, but the next compatibility check sees `EXPORTER_POSITION` without a version row and incorrectly infers an 8.9 schema. On main, that rejects startup as an unsupported 8.9 to 8.11 upgrade.

### Root cause

`RDBMS_SCHEMA_VERSION` was introduced and added to `RdbmsTableNames.TABLE_NAMES` on May 5, 2026 in commit [`d910bfa1fff7`](https://github.com/camunda/camunda/commit/d910bfa1fff759fea46a2270bb87b880b2cf2253). That list means "all known RDBMS tables" for metrics and schema checks, but `RdbmsPurger` also treated it as "all tables safe to erase" and truncated every entry without exclusions.

The version table is schema metadata, not exported history. Purging its only row while leaving the migrated schema and `EXPORTER_POSITION` intact creates an inconsistent database state.

This made the RDBMS integration suite order-dependent:

- Green runs executed `RdbmsSchemaVersionStoreIT` before `PurgerIT`.
- The failing run executed `PurgerIT` first.
- The first version-store execution then failed its assertion for all six vendors.
- Failsafe retried the failed class three times. During those retries, the shared H2 application restarted and failed while creating `rdbmsSchemaManagerRegistry`, before a test method ran. This is why the final report showed `Run 3: RdbmsSchemaVersionStoreIT ? BeanCreation Error` rather than only the original line 42 assertion.

### Fix

Keep schema-version metadata outside the history purge, while retaining the table in the canonical table list used by metrics and schema checks. The regression coverage verifies compatibility immediately after purge on every supported database vendor.

## Verification

- `./mvnw verify -pl db/rdbms -DskipTests=false -Dquickly -T1C`
- `./mvnw -B -T1C -DforkCount=1 -DskipUTs -DskipChecks -Dit.test=PurgerIT -P rdbms -pl qa/acceptance-tests verify`
- `./mvnw -B -T1C -DforkCount=1 -DskipUTs -DskipChecks -Dit.test=PurgerCompletenessIT -P rdbms -pl qa/acceptance-tests verify`
- Negative control on the parent commit: the post-purge compatibility assertion fails for all six vendors with the original 8.9 to 8.11 exception.

## Related issues

- [ ] This PR does not need a linked issue