### PR TITLE
fix: match physical-tenant-prefixed process-instances URIs in load-test metric queries

### DIFF
--- a/load-tests/docs/scripts/queries.yaml
+++ b/load-tests/docs/scripts/queries.yaml
@@ -84,7 +84,7 @@ queries:
           or
           sum(rate(http_server_requests_seconds_count{
             method="POST",
-            uri="/v2/process-instances",
+            uri=~"/v2/process-instances|/physical-tenants/[^/]+/v2/process-instances",
             namespace="$NAMESPACE"
           }[$DURATION_S]) != 0)
         )
@@ -120,7 +120,7 @@ queries:
       sum(rate(http_server_requests_seconds_count{
         method="POST",
         namespace="$NAMESPACE",
-        uri="/v2/process-instances"
+        uri=~"/v2/process-instances|/physical-tenants/[^/]+/v2/process-instances"
       }[$DURATION_S]) != 0)
     higher_is_better: true
     format: float


### PR DESCRIPTION
The completion-ratio and starter-rate-per-second PromQL queries only matched HTTP submissions on `/v2/process-instances`, missing requests made via the physical-tenant-prefixed route `/physical-tenants/{physicalTenantId}/v2/process-instances`
## Related issues
- [x] This PR does not need a linked issue